### PR TITLE
Improve preview panel UI layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,7 +55,6 @@ import {
   BranchIcon,
   PullRequestIcon,
   EyeIcon,
-  EyeOffIcon,
   PanelRightIcon,
   PlusIcon,
   ImageIcon,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1134,27 +1134,27 @@ function App() {
                   >
                     {isCropCapturing ? <div className="capture-spinner" /> : <CropIcon size={14} />}
                   </button>
-                  {isPreviewHidden && (
-                    <>
-                      <button
-                        className="show-preview-btn"
-                        onClick={() => setIsPreviewHidden(false)}
-                        title="Show Preview"
-                      >
-                        <PanelRightIcon size={14} />
-                        <span>Show Preview</span>
-                      </button>
-                      <button
-                        className="show-preview-btn"
-                        onClick={() => void openUrl(`http://localhost:${devServerPort}`)}
-                        title="Open in Browser"
-                      >
-                        <ExternalLinkIcon size={14} />
-                        <span>Open in Browser</span>
-                      </button>
-                    </>
-                  )}
                 </div>
+                {isPreviewHidden && (
+                  <div className="preview-hidden-actions">
+                    <button
+                      className="show-preview-btn"
+                      onClick={() => void openUrl(`http://localhost:${devServerPort}`)}
+                      title="Open in Browser"
+                    >
+                      <ExternalLinkIcon size={14} />
+                      <span>Open in Browser</span>
+                    </button>
+                    <button
+                      className="show-preview-btn"
+                      onClick={() => setIsPreviewHidden(false)}
+                      title="Show Preview"
+                    >
+                      <PanelRightIcon size={14} />
+                      <span>Show Preview</span>
+                    </button>
+                  </div>
+                )}
               </div>
               <div className="terminal-tabs-bar">
                 <div className="terminal-tabs">
@@ -1265,14 +1265,6 @@ function App() {
                       <span>Preview</span>
                     </button>
                     <button
-                      className="workspace-tab open-in-browser-btn"
-                      onClick={() => void openUrl(`http://localhost:${devServerPort}`)}
-                      title="Open in Browser"
-                    >
-                      <ExternalLinkIcon size={14} />
-                      <span>Open in Browser</span>
-                    </button>
-                    <button
                       className={`workspace-tab ${workspaceTab === 'branches' ? 'active' : ''}`}
                       onClick={() => setWorkspaceTab('branches')}
                     >
@@ -1287,32 +1279,48 @@ function App() {
                       <span>PRs</span>
                     </button>
                   </div>
-                  <button
-                    className="hide-preview-btn"
-                    onClick={() => setIsPreviewHidden(true)}
-                    title="Hide Preview"
-                  >
-                    <EyeOffIcon size={14} />
-                  </button>
+                  <div className="preview-tabs-divider" />
+                  <div className="preview-actions">
+                    <button
+                      className="preview-action-btn"
+                      onClick={() => void openUrl(`http://localhost:${devServerPort}`)}
+                      title="Open in Browser"
+                    >
+                      <ExternalLinkIcon size={14} />
+                      <span>Open in Browser</span>
+                    </button>
+                    <button
+                      className="preview-action-btn"
+                      onClick={() => setIsPreviewHidden(true)}
+                      title="Hide Preview"
+                    >
+                      <PanelRightIcon size={14} />
+                      <span>Hide Preview</span>
+                    </button>
+                  </div>
                 </div>
               ) : (
                 <div className="preview-tabs-bar preview-tabs-bar-simple">
                   <span className="preview-label">Preview</span>
-                  <button
-                    className="open-in-browser-btn"
-                    onClick={() => void openUrl(`http://localhost:${devServerPort}`)}
-                    title="Open in Browser"
-                  >
-                    <ExternalLinkIcon size={14} />
-                    <span>Open in Browser</span>
-                  </button>
-                  <button
-                    className="hide-preview-btn"
-                    onClick={() => setIsPreviewHidden(true)}
-                    title="Hide Preview"
-                  >
-                    <EyeOffIcon size={14} />
-                  </button>
+                  <div className="preview-tabs-divider" />
+                  <div className="preview-actions">
+                    <button
+                      className="preview-action-btn"
+                      onClick={() => void openUrl(`http://localhost:${devServerPort}`)}
+                      title="Open in Browser"
+                    >
+                      <ExternalLinkIcon size={14} />
+                      <span>Open in Browser</span>
+                    </button>
+                    <button
+                      className="preview-action-btn"
+                      onClick={() => setIsPreviewHidden(true)}
+                      title="Hide Preview"
+                    >
+                      <PanelRightIcon size={14} />
+                      <span>Hide Preview</span>
+                    </button>
+                  </div>
                 </div>
               )}
 

--- a/src/styles/workspace.css
+++ b/src/styles/workspace.css
@@ -127,6 +127,7 @@
 .workspace-tabs {
   display: flex;
   gap: 6px;
+  margin-left: auto;
 }
 
 .workspace-tab {
@@ -169,16 +170,15 @@
 .preview-tabs-bar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 0 16px 0 8px;
+  padding: 0 12px 0 8px;
   min-height: 48px;
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
+  gap: 4px;
 }
 
 .preview-tabs-bar-simple {
-  justify-content: flex-start;
   padding: 0 12px;
 }
 
@@ -241,17 +241,66 @@
   border-color: var(--border);
 }
 
+/* Preview Tabs Divider */
+.preview-tabs-divider {
+  width: 1px;
+  height: 20px;
+  background: var(--border);
+  margin: 0 8px;
+  flex-shrink: 0;
+}
+
+/* Preview Actions Container */
+.preview-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Preview Action Buttons */
+.preview-action-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  outline: none;
+  white-space: nowrap;
+}
+
+.preview-action-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.preview-action-btn svg {
+  flex-shrink: 0;
+}
+
+/* Preview Hidden Actions (when preview is collapsed) */
+.preview-hidden-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 /* Show Preview Button (when preview is hidden) */
 .show-preview-btn {
   display: flex;
   align-items: center;
   gap: 6px;
   padding: 6px 12px;
-  margin-left: 8px;
-  background: transparent;
-  border: 1px dashed var(--border);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
   border-radius: 6px;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
@@ -261,9 +310,7 @@
 
 .show-preview-btn:hover {
   color: var(--text-primary);
-  background: var(--bg-tertiary);
-  border-style: solid;
-  border-color: var(--border);
+  background: var(--bg-hover);
 }
 
 .show-preview-btn svg {


### PR DESCRIPTION
## Summary
- Reorganize preview tabs bar: tabs now grouped on right with actions
- Replace eyeball icon with "Hide Preview" button matching "Show Preview"
- Add vertical divider between tabs and action buttons
- Style action buttons with solid borders and grey backgrounds
- Move "Show Preview" / "Open in Browser" buttons to right side of terminal toolbar

## Test plan
- [ ] Open a project in workspace
- [ ] Click "Hide Preview" - verify it hides the preview pane
- [ ] Verify "Show Preview" and "Open in Browser" buttons appear on right side of terminal toolbar
- [ ] Click "Show Preview" - verify preview reappears
- [ ] Verify tabs (Preview, Branches, PRs) are grouped on the right with the action buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reorganized preview controls into dedicated action groups for clearer grouping and consistent placement.
  * Added a subtle divider and consolidated action buttons (open/hide/show) into a unified preview actions area.
  * Adjusted workspace/preview spacing and alignment, refined button visuals, hover states, and spacing for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->