### PR TITLE
Add SvelteKit Basic template to project creation options

### DIFF
--- a/src-tauri/src/commands/health.rs
+++ b/src-tauri/src/commands/health.rs
@@ -27,6 +27,7 @@ const TYPECHECK_PATTERNS: &[&str] = &[
     "tsc:check",
     "check:types",
     "types:check",
+    "check", // SvelteKit uses "check" for svelte-check
 ];
 const FORMAT_PATTERNS: &[&str] = &[
     "format:check",
@@ -113,7 +114,16 @@ fn generate_suggestions(
 
     // Typecheck suggestions
     if existing_typecheck.is_none() {
-        if is_package_installed(package_json, "typescript") {
+        // SvelteKit uses svelte-check
+        if is_package_installed(package_json, "svelte-check") {
+            suggestions.push(ScriptSuggestion {
+                category: ScriptCategory::Typecheck,
+                script_name: "check".to_string(),
+                script_command: "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+                    .to_string(),
+                reason: "svelte-check is installed".to_string(),
+            });
+        } else if is_package_installed(package_json, "typescript") {
             suggestions.push(ScriptSuggestion {
                 category: ScriptCategory::Typecheck,
                 script_name: "typecheck".to_string(),

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -90,7 +90,33 @@ fn ensure_gitignore_has_shipstudio_sync(project: &std::path::Path) -> Result<(),
     Ok(())
 }
 
-fn scan_pages(dir: &std::path::Path, base_dir: &std::path::Path) -> Result<Vec<PageInfo>, String> {
+/// Detect if this is a SvelteKit project
+fn is_sveltekit_project(project_path: &std::path::Path) -> bool {
+    // Check for svelte.config.js or svelte.config.ts
+    if project_path.join("svelte.config.js").exists()
+        || project_path.join("svelte.config.ts").exists()
+    {
+        return true;
+    }
+
+    // Check package.json for @sveltejs/kit
+    let pkg_path = project_path.join("package.json");
+    if pkg_path.exists() {
+        if let Ok(contents) = std::fs::read_to_string(&pkg_path) {
+            if contents.contains("\"@sveltejs/kit\"") {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+/// Scan Next.js pages (app/ directory with page.tsx/js/jsx files)
+fn scan_nextjs_pages(
+    dir: &std::path::Path,
+    base_dir: &std::path::Path,
+) -> Result<Vec<PageInfo>, String> {
     let mut pages = Vec::new();
 
     if !dir.exists() {
@@ -109,7 +135,7 @@ fn scan_pages(dir: &std::path::Path, base_dir: &std::path::Path) -> Result<Vec<P
                 continue;
             }
 
-            let mut sub_pages = scan_pages(&path, base_dir)?;
+            let mut sub_pages = scan_nextjs_pages(&path, base_dir)?;
             pages.append(&mut sub_pages);
         } else {
             let file_name = entry.file_name().to_string_lossy().to_string();
@@ -132,6 +158,63 @@ fn scan_pages(dir: &std::path::Path, base_dir: &std::path::Path) -> Result<Vec<P
         }
     }
 
+    Ok(pages)
+}
+
+/// Scan SvelteKit pages (src/routes/ directory with +page.svelte files)
+fn scan_sveltekit_pages(
+    dir: &std::path::Path,
+    base_dir: &std::path::Path,
+) -> Result<Vec<PageInfo>, String> {
+    let mut pages = Vec::new();
+
+    if !dir.exists() {
+        return Ok(pages);
+    }
+
+    let entries = std::fs::read_dir(dir).map_err(|e| e.to_string())?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+
+        if path.is_dir() {
+            let dir_name = entry.file_name().to_string_lossy().to_string();
+            // Skip hidden directories and SvelteKit special directories
+            if dir_name.starts_with('.') {
+                continue;
+            }
+
+            let mut sub_pages = scan_sveltekit_pages(&path, base_dir)?;
+            pages.append(&mut sub_pages);
+        } else {
+            let file_name = entry.file_name().to_string_lossy().to_string();
+            // SvelteKit uses +page.svelte for page components
+            if file_name == "+page.svelte" {
+                let parent = path.parent().unwrap_or(&path);
+                let relative = parent.strip_prefix(base_dir).unwrap_or(parent);
+                let route = if relative.as_os_str().is_empty() {
+                    "/".to_string()
+                } else {
+                    format!("/{}", relative.to_string_lossy().replace('\\', "/"))
+                };
+
+                // Convert SvelteKit dynamic route syntax [slug] to :slug for display
+                let display_route = route.replace('[', ":").replace(']', "");
+
+                pages.push(PageInfo {
+                    route: display_route,
+                    file_path: path.to_string_lossy().to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(pages)
+}
+
+/// Sort pages with root first, then alphabetically
+fn sort_pages(pages: &mut Vec<PageInfo>) {
     pages.sort_by(|a, b| {
         if a.route == "/" {
             return std::cmp::Ordering::Less;
@@ -141,8 +224,6 @@ fn scan_pages(dir: &std::path::Path, base_dir: &std::path::Path) -> Result<Vec<P
         }
         a.route.cmp(&b.route)
     });
-
-    Ok(pages)
 }
 
 // ============ Tauri Commands ============
@@ -233,7 +314,8 @@ pub async fn get_dashboard_projects() -> Result<Vec<DashboardProject>, String> {
             };
             let last_opened = metadata.as_ref().and_then(|m| m.last_opened);
             let auto_accept_mode = metadata.as_ref().and_then(|m| m.auto_accept_mode);
-            let hide_main_branch_warning = metadata.as_ref().and_then(|m| m.hide_main_branch_warning);
+            let hide_main_branch_warning =
+                metadata.as_ref().and_then(|m| m.hide_main_branch_warning);
 
             // Ensure .shipstudio/ is gitignored
             let _ = ensure_gitignore_has_shipstudio_sync(&path);
@@ -272,21 +354,38 @@ pub async fn get_dashboard_projects() -> Result<Vec<DashboardProject>, String> {
     Ok(projects)
 }
 
-/// Scans a Next.js project's app directory for page routes.
+/// Scans a project's pages/routes directory for page routes.
+/// Supports both Next.js (app/ directory) and SvelteKit (src/routes/ directory).
 #[tauri::command]
 pub async fn list_pages(project_path: String) -> Result<Vec<PageInfo>, String> {
     let project = validate_project_path(&project_path)?;
-    let app_dir = project.join("app");
 
+    // Check if this is a SvelteKit project
+    if is_sveltekit_project(&project) {
+        let routes_dir = project.join("src").join("routes");
+        if routes_dir.exists() {
+            let mut pages = scan_sveltekit_pages(&routes_dir, &routes_dir)?;
+            sort_pages(&mut pages);
+            return Ok(pages);
+        }
+        return Ok(Vec::new());
+    }
+
+    // Default to Next.js app router
+    let app_dir = project.join("app");
     if !app_dir.exists() {
         let src_app_dir = project.join("src").join("app");
         if !src_app_dir.exists() {
             return Ok(Vec::new());
         }
-        return scan_pages(&src_app_dir, &src_app_dir);
+        let mut pages = scan_nextjs_pages(&src_app_dir, &src_app_dir)?;
+        sort_pages(&mut pages);
+        return Ok(pages);
     }
 
-    scan_pages(&app_dir, &app_dir)
+    let mut pages = scan_nextjs_pages(&app_dir, &app_dir)?;
+    sort_pages(&mut pages);
+    Ok(pages)
 }
 
 #[tauri::command]
@@ -523,6 +622,7 @@ pub async fn clear_project_cache(project_path: String) -> Result<(), String> {
     // List of cache directories to clear
     let cache_dirs = [
         ".next",               // Next.js build cache
+        ".svelte-kit",         // SvelteKit build cache
         "node_modules/.cache", // Various build tool caches (babel, eslint, etc.)
         ".turbo",              // Turborepo cache
         ".swc",                // SWC compiler cache
@@ -618,7 +718,10 @@ pub async fn get_hide_main_branch_warning(project_path: String) -> Result<bool, 
 
 /// Sets whether the main branch warning banner should be hidden for this project
 #[tauri::command]
-pub async fn set_hide_main_branch_warning(project_path: String, hidden: bool) -> Result<(), String> {
+pub async fn set_hide_main_branch_warning(
+    project_path: String,
+    hidden: bool,
+) -> Result<(), String> {
     let project = validate_project_path(&project_path)?;
     let shipstudio_dir = project.join(".shipstudio");
     let metadata_path = shipstudio_dir.join("project.json");

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -193,10 +193,30 @@ fn scan_sveltekit_pages(
             if file_name == "+page.svelte" {
                 let parent = path.parent().unwrap_or(&path);
                 let relative = parent.strip_prefix(base_dir).unwrap_or(parent);
-                let route = if relative.as_os_str().is_empty() {
+
+                // Filter out route group directories (parenthesized like "(marketing)")
+                // These are for organization only and don't affect the URL path
+                let filtered_components: Vec<_> = relative
+                    .components()
+                    .filter_map(|c| {
+                        if let std::path::Component::Normal(s) = c {
+                            let segment = s.to_string_lossy();
+                            // Skip route groups: directories starting with '(' and ending with ')'
+                            if segment.starts_with('(') && segment.ends_with(')') {
+                                None
+                            } else {
+                                Some(segment.to_string())
+                            }
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+
+                let route = if filtered_components.is_empty() {
                     "/".to_string()
                 } else {
-                    format!("/{}", relative.to_string_lossy().replace('\\', "/"))
+                    format!("/{}", filtered_components.join("/"))
                 };
 
                 // Convert SvelteKit dynamic route syntax [slug] to :slug for display

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -142,10 +142,30 @@ fn scan_nextjs_pages(
             if file_name == "page.tsx" || file_name == "page.js" || file_name == "page.jsx" {
                 let parent = path.parent().unwrap_or(&path);
                 let relative = parent.strip_prefix(base_dir).unwrap_or(parent);
-                let route = if relative.as_os_str().is_empty() {
+
+                // Filter out route group directories (parenthesized like "(dashboard)")
+                // These are for organization only and don't affect the URL path
+                let filtered_components: Vec<_> = relative
+                    .components()
+                    .filter_map(|c| {
+                        if let std::path::Component::Normal(s) = c {
+                            let segment = s.to_string_lossy();
+                            // Skip route groups: directories starting with '(' and ending with ')'
+                            if segment.starts_with('(') && segment.ends_with(')') {
+                                None
+                            } else {
+                                Some(segment.to_string())
+                            }
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+
+                let route = if filtered_components.is_empty() {
                     "/".to_string()
                 } else {
-                    format!("/{}", relative.to_string_lossy().replace('\\', "/"))
+                    format!("/{}", filtered_components.join("/"))
                 };
 
                 let display_route = route.replace('[', ":").replace(']', "");

--- a/src/components/CreateProject.tsx
+++ b/src/components/CreateProject.tsx
@@ -43,6 +43,12 @@ const TEMPLATES: Template[] = [
     description: 'A minimal Next.js starter with Tailwind CSS',
     repo: 'https://github.com/ship-studio/static-marketing-site-starter',
   },
+  {
+    id: 'sveltekit-basic',
+    name: 'SvelteKit Basic',
+    description: 'A minimal SvelteKit starter with Tailwind CSS',
+    repo: 'https://github.com/ship-studio/sveltekit-static-marketing-site-starter',
+  },
 ];
 
 /** Form wizard steps before creation starts */

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -186,6 +186,9 @@ export async function getHideMainBranchWarning(projectPath: string): Promise<boo
  * @param projectPath - Absolute path to the project directory
  * @param hidden - Whether to hide the banner
  */
-export async function setHideMainBranchWarning(projectPath: string, hidden: boolean): Promise<void> {
+export async function setHideMainBranchWarning(
+  projectPath: string,
+  hidden: boolean
+): Promise<void> {
   return invoke<void>('set_hide_main_branch_warning', { projectPath, hidden });
 }

--- a/src/styles/main-branch-banner.css
+++ b/src/styles/main-branch-banner.css
@@ -70,7 +70,7 @@
   opacity: 1;
 }
 
-.main-branch-banner-checkbox input[type="checkbox"] {
+.main-branch-banner-checkbox input[type='checkbox'] {
   appearance: none;
   -webkit-appearance: none;
   width: 14px;
@@ -82,12 +82,12 @@
   transition: all 0.15s;
 }
 
-.main-branch-banner-checkbox input[type="checkbox"]:hover {
+.main-branch-banner-checkbox input[type='checkbox']:hover {
   border-color: rgba(251, 191, 36, 0.6);
   background: rgba(245, 158, 11, 0.1);
 }
 
-.main-branch-banner-checkbox input[type="checkbox"]:checked {
+.main-branch-banner-checkbox input[type='checkbox']:checked {
   background: #f59e0b;
   border-color: #f59e0b;
   display: flex;
@@ -95,7 +95,7 @@
   justify-content: center;
 }
 
-.main-branch-banner-checkbox input[type="checkbox"]:checked::after {
+.main-branch-banner-checkbox input[type='checkbox']:checked::after {
   content: '';
   width: 4px;
   height: 8px;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SvelteKit projects are auto-detected and supported.
  * SvelteKit routes are discovered and listed in project pages.
  * New "SvelteKit Basic" project template.
  * Type-check suggestions now prefer svelte-check for SvelteKit projects.

* **Bug Fixes / Chores**
  * Project cache clearing also removes SvelteKit build caches.

* **Stability**
  * Page lists are consistently ordered with root ("/") prioritized.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->