### PR TITLE
Add HelpModal component and integrate Claude skills listing

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod pty;
 pub mod publishing;
 pub mod pull_requests;
 pub mod setup;
+pub mod skills;
 pub mod vercel;
 pub mod window;
 
@@ -36,5 +37,6 @@ pub use pty::*;
 pub use publishing::*;
 pub use pull_requests::*;
 pub use setup::*;
+pub use skills::*;
 pub use vercel::*;
 pub use window::*;

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -1,0 +1,240 @@
+/**
+ * Skills command module for reading Claude Code skills.
+ *
+ * Reads user-defined skills from installed Claude plugins.
+ * Skills are stored in:
+ * - ~/.claude/plugins/cache/{marketplace}/{plugin}/{version}/skills/{skill-name}/SKILL.md
+ */
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+/// Represents a Claude skill
+#[derive(Debug, Serialize, Clone)]
+pub struct ClaudeSkill {
+    /// Skill name (command without the leading /)
+    pub name: String,
+    /// Short description extracted from the skill file
+    pub description: String,
+    /// The plugin this skill belongs to
+    pub plugin: String,
+    /// Whether this is a user-level or project-level skill
+    pub scope: String,
+}
+
+/// Plugin installation info from installed_plugins.json
+#[derive(Debug, Deserialize)]
+struct PluginInstall {
+    scope: String,
+    #[serde(rename = "installPath")]
+    install_path: String,
+    #[serde(rename = "projectPath")]
+    project_path: Option<String>,
+}
+
+/// Structure of installed_plugins.json
+#[derive(Debug, Deserialize)]
+struct InstalledPlugins {
+    plugins: HashMap<String, Vec<PluginInstall>>,
+}
+
+/// Parse SKILL.md frontmatter to extract name and description
+fn parse_skill_md(content: &str) -> Option<(String, String)> {
+    // SKILL.md has YAML frontmatter between --- markers
+    let content = content.trim();
+    if !content.starts_with("---") {
+        return None;
+    }
+
+    // Find the closing ---
+    let rest = &content[3..];
+    let end_marker = rest.find("---")?;
+    let frontmatter = &rest[..end_marker];
+
+    let mut name = None;
+    let mut description = None;
+
+    for line in frontmatter.lines() {
+        let line = line.trim();
+        if line.starts_with("name:") {
+            name = Some(line[5..].trim().to_string());
+        } else if line.starts_with("description:") {
+            let desc = line[12..].trim().to_string();
+            // Truncate long descriptions
+            description = Some(if desc.len() > 80 {
+                format!("{}...", &desc[..77])
+            } else {
+                desc
+            });
+        }
+    }
+
+    match (name, description) {
+        (Some(n), Some(d)) => Some((n, d)),
+        (Some(n), None) => Some((n, "Custom skill".to_string())),
+        _ => None,
+    }
+}
+
+/// Read skills from a plugin's skills directory
+fn read_skills_from_plugin(
+    plugin_path: &str,
+    plugin_name: &str,
+    scope: &str,
+) -> Vec<ClaudeSkill> {
+    let mut skills = Vec::new();
+    let skills_dir = PathBuf::from(plugin_path).join("skills");
+
+    if !skills_dir.exists() || !skills_dir.is_dir() {
+        return skills;
+    }
+
+    if let Ok(entries) = fs::read_dir(&skills_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+
+            // Look for SKILL.md (case-insensitive)
+            let skill_md = path.join("SKILL.md");
+            let skill_md_lower = path.join("skill.md");
+
+            let skill_file = if skill_md.exists() {
+                Some(skill_md)
+            } else if skill_md_lower.exists() {
+                Some(skill_md_lower)
+            } else {
+                None
+            };
+
+            if let Some(skill_file) = skill_file {
+                if let Ok(content) = fs::read_to_string(&skill_file) {
+                    if let Some((name, description)) = parse_skill_md(&content) {
+                        skills.push(ClaudeSkill {
+                            name,
+                            description,
+                            plugin: plugin_name.to_string(),
+                            scope: scope.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // Sort skills alphabetically
+    skills.sort_by(|a, b| a.name.cmp(&b.name));
+    skills
+}
+
+/// List all available Claude skills from installed plugins
+#[tauri::command]
+pub fn list_claude_skills(project_path: Option<String>) -> Vec<ClaudeSkill> {
+    let mut all_skills = Vec::new();
+
+    // Get the path to installed_plugins.json
+    let Some(home) = dirs::home_dir() else {
+        return all_skills;
+    };
+
+    let plugins_json = home
+        .join(".claude")
+        .join("plugins")
+        .join("installed_plugins.json");
+
+    if !plugins_json.exists() {
+        return all_skills;
+    }
+
+    // Read and parse installed_plugins.json
+    let Ok(content) = fs::read_to_string(&plugins_json) else {
+        return all_skills;
+    };
+
+    let Ok(installed): Result<InstalledPlugins, _> = serde_json::from_str(&content) else {
+        return all_skills;
+    };
+
+    // Process each installed plugin
+    for (plugin_id, installs) in installed.plugins {
+        // Extract a friendly plugin name from the ID (e.g., "example-skills@anthropic-agent-skills" -> "example-skills")
+        let plugin_name = plugin_id.split('@').next().unwrap_or(&plugin_id);
+
+        for install in installs {
+            // For project-scoped plugins, only include if we're in that project
+            if install.scope == "project" {
+                if let Some(ref proj_path) = project_path {
+                    if let Some(ref plugin_proj_path) = install.project_path {
+                        if proj_path != plugin_proj_path {
+                            continue;
+                        }
+                    }
+                } else {
+                    // No project path provided, skip project-scoped plugins
+                    continue;
+                }
+            }
+
+            let plugin_skills =
+                read_skills_from_plugin(&install.install_path, plugin_name, &install.scope);
+            all_skills.extend(plugin_skills);
+        }
+    }
+
+    // Sort all skills alphabetically
+    all_skills.sort_by(|a, b| a.name.cmp(&b.name));
+    all_skills
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_skill_md() {
+        let content = r#"---
+name: brand-guidelines
+description: Applies brand colors and typography to artifacts.
+license: MIT
+---
+
+# Brand Styling
+
+Content here...
+"#;
+        let result = parse_skill_md(content);
+        assert!(result.is_some());
+        let (name, desc) = result.unwrap();
+        assert_eq!(name, "brand-guidelines");
+        assert_eq!(desc, "Applies brand colors and typography to artifacts.");
+    }
+
+    #[test]
+    fn test_parse_skill_md_no_description() {
+        let content = r#"---
+name: my-skill
+---
+"#;
+        let result = parse_skill_md(content);
+        assert!(result.is_some());
+        let (name, desc) = result.unwrap();
+        assert_eq!(name, "my-skill");
+        assert_eq!(desc, "Custom skill");
+    }
+
+    #[test]
+    fn test_parse_skill_md_long_description() {
+        let content = r#"---
+name: verbose-skill
+description: This is a very long description that should be truncated because it exceeds the maximum allowed length of eighty characters.
+---
+"#;
+        let result = parse_skill_md(content);
+        assert!(result.is_some());
+        let (_, desc) = result.unwrap();
+        assert!(desc.ends_with("..."));
+        assert!(desc.len() <= 83);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -167,6 +167,8 @@ pub fn run() {
             // Claude integration
             commands::claude::check_claude_cli_status,
             commands::claude::install_claude_cli,
+            // Claude skills
+            commands::skills::list_claude_skills,
             // Vercel integration
             commands::vercel::check_vercel_cli_status,
             commands::vercel::get_vercel_username,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ import { ConnectOverlay } from './components/ConnectOverlay';
 import { CodeHealthPanel, CodeHealthPanelRef } from './components/CodeHealthPanel';
 import { ScreenshotToast, ScreenshotPreviewModal } from './components/ScreenshotPreview';
 import { NotificationSettingsModal } from './components/NotificationSettingsModal';
+import { HelpModal } from './components/HelpModal';
 import {
   NotificationSettings,
   loadNotificationSettings,
@@ -81,6 +82,7 @@ import {
   PinIcon,
   ExpandIcon,
   ArrowLeftIcon,
+  HelpIcon,
 } from './components/icons';
 import { startDevServer, Project, DevServerHandle, getAutoAcceptMode } from './lib/project';
 import {
@@ -354,6 +356,9 @@ function App() {
   // Conflict resolution modal state
   const [showConflictResolution, setShowConflictResolution] = useState(false);
 
+  // Help modal state
+  const [showHelpModal, setShowHelpModal] = useState(false);
+
   // Workspace tab state (preview/branches/prs)
   const [workspaceTab, setWorkspaceTab] = useState<'preview' | 'branches' | 'prs'>('preview');
 
@@ -397,6 +402,23 @@ function App() {
     void invoke<{ vscode: boolean; cursor: boolean }>('check_ide_availability')
       .then(setIdeAvailability)
       .catch(() => setIdeAvailability({ vscode: false, cursor: false }));
+  }, []);
+
+  // Keyboard shortcut for help modal (Cmd+/ or F1)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Cmd+/ (Mac) or Ctrl+/ (Windows) or F1
+      if (
+        ((e.metaKey || e.ctrlKey) && e.key === '/') ||
+        e.key === 'F1'
+      ) {
+        e.preventDefault();
+        setShowHelpModal(true);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
 
   // Open project in IDE
@@ -1766,6 +1788,13 @@ function App() {
                           <path d="M13.73 21a2 2 0 0 1-3.46 0" />
                         </svg>
                       </button>
+                      <button
+                        className="workspace-tab icon-only"
+                        onClick={() => setShowHelpModal(true)}
+                        title="Help & Commands"
+                      >
+                        <HelpIcon size={12} />
+                      </button>
                     </div>
 
                     {/* Compact mode controls - visible only at narrow widths via CSS */}
@@ -2188,6 +2217,13 @@ function App() {
             onClose={() => setShowNotificationSettings(false)}
           />
         )}
+
+        {/* Help Modal */}
+        <HelpModal
+          isOpen={showHelpModal}
+          onClose={() => setShowHelpModal(false)}
+          projectPath={currentProject?.path}
+        />
 
         {/* Submit for Review Modal */}
         {showSubmitReview && (

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -1,0 +1,251 @@
+/**
+ * HelpModal component for displaying Claude CLI commands and Ship Studio tips.
+ *
+ * Shows a glossary of available slash commands for Claude Code,
+ * user's custom skills, keyboard shortcuts, and helpful tips.
+ *
+ * @module components/HelpModal
+ */
+
+import { useEffect, useState } from 'react';
+import { CloseIcon } from './icons';
+import { listClaudeSkills, ClaudeSkill } from '../lib/claude';
+
+interface HelpModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Optional project path to include project-level skills */
+  projectPath?: string;
+}
+
+export function HelpModal({ isOpen, onClose, projectPath }: HelpModalProps) {
+  const [skills, setSkills] = useState<ClaudeSkill[]>([]);
+  const [isLoadingSkills, setIsLoadingSkills] = useState(false);
+
+  // Handle Escape key to close
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  // Fetch skills when modal opens
+  useEffect(() => {
+    if (!isOpen) return;
+
+    setIsLoadingSkills(true);
+    listClaudeSkills(projectPath)
+      .then(setSkills)
+      .catch((err) => {
+        console.error('Failed to load skills:', err);
+        setSkills([]);
+      })
+      .finally(() => setIsLoadingSkills(false));
+  }, [isOpen, projectPath]);
+
+  if (!isOpen) return null;
+
+  const userSkills = skills.filter((s) => s.scope === 'user');
+  const projectSkills = skills.filter((s) => s.scope === 'project');
+
+  return (
+    <div className="modal-overlay" onMouseDown={onClose}>
+      <div className="modal help-modal" onMouseDown={(e) => e.stopPropagation()}>
+        <div className="help-modal-header">
+          <h3>Help & Commands</h3>
+          <button className="help-close-btn" onClick={onClose}>
+            <CloseIcon size={16} />
+          </button>
+        </div>
+
+        <div className="help-modal-body">
+          {/* Custom Skills Section - shown first if user has any */}
+          {skills.length > 0 && (
+            <>
+              <div className="help-section">
+                <div className="help-section-title">Your Skills</div>
+                <div className="help-command-list">
+                  {userSkills.map((skill) => (
+                    <div key={`${skill.plugin}-${skill.name}`} className="help-command">
+                      <span className="help-command-name">/{skill.name}</span>
+                      <span className="help-command-desc">{skill.description}</span>
+                    </div>
+                  ))}
+                  {projectSkills.map((skill) => (
+                    <div key={`${skill.plugin}-${skill.name}`} className="help-command">
+                      <span className="help-command-name">/{skill.name}</span>
+                      <span className="help-command-desc">
+                        {skill.description}
+                        <span className="help-skill-badge">project</span>
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className="help-divider" />
+            </>
+          )}
+
+          {isLoadingSkills && skills.length === 0 && (
+            <>
+              <div className="help-section">
+                <div className="help-section-title">Your Skills</div>
+                <div className="help-loading">Loading skills...</div>
+              </div>
+              <div className="help-divider" />
+            </>
+          )}
+
+          {/* Session Commands */}
+          <div className="help-section">
+            <div className="help-section-title">Session</div>
+            <div className="help-command-list">
+              <div className="help-command">
+                <span className="help-command-name">/clear</span>
+                <span className="help-command-desc">Clear conversation history</span>
+              </div>
+              <div className="help-command">
+                <span className="help-command-name">/compact</span>
+                <span className="help-command-desc">Toggle compact output mode</span>
+              </div>
+              <div className="help-command">
+                <span className="help-command-name">/cost</span>
+                <span className="help-command-desc">Show token usage and cost</span>
+              </div>
+              <div className="help-command">
+                <span className="help-command-name">/status</span>
+                <span className="help-command-desc">Show current session status</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="help-divider" />
+
+          {/* Code Actions */}
+          <div className="help-section">
+            <div className="help-section-title">Code Actions</div>
+            <div className="help-command-list">
+              <div className="help-command">
+                <span className="help-command-name">/init</span>
+                <span className="help-command-desc">Initialize project with CLAUDE.md</span>
+              </div>
+              <div className="help-command">
+                <span className="help-command-name">/review</span>
+                <span className="help-command-desc">Review code changes</span>
+              </div>
+              <div className="help-command">
+                <span className="help-command-name">/pr-comments</span>
+                <span className="help-command-desc">View PR comments from GitHub</span>
+              </div>
+              <div className="help-command">
+                <span className="help-command-name">/bug</span>
+                <span className="help-command-desc">Report a bug to Anthropic</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="help-divider" />
+
+          {/* Configuration Commands */}
+          <div className="help-section">
+            <div className="help-section-title">Configuration</div>
+            <div className="help-command-list">
+              <div className="help-command">
+                <span className="help-command-name">/config</span>
+                <span className="help-command-desc">Open configuration settings</span>
+              </div>
+              <div className="help-command">
+                <span className="help-command-name">/model</span>
+                <span className="help-command-desc">Change AI model</span>
+              </div>
+              <div className="help-command">
+                <span className="help-command-name">/permissions</span>
+                <span className="help-command-desc">Manage tool permissions</span>
+              </div>
+              <div className="help-command">
+                <span className="help-command-name">/memory</span>
+                <span className="help-command-desc">Edit CLAUDE.md memory file</span>
+              </div>
+              <div className="help-command">
+                <span className="help-command-name">/mcp</span>
+                <span className="help-command-desc">Manage MCP servers</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="help-divider" />
+
+          {/* Utility Commands */}
+          <div className="help-section">
+            <div className="help-section-title">Utility</div>
+            <div className="help-command-list">
+              <div className="help-command">
+                <span className="help-command-name">/help</span>
+                <span className="help-command-desc">Show all available commands</span>
+              </div>
+              <div className="help-command">
+                <span className="help-command-name">/doctor</span>
+                <span className="help-command-desc">Run diagnostics</span>
+              </div>
+              <div className="help-command">
+                <span className="help-command-name">/login</span>
+                <span className="help-command-desc">Log in to your account</span>
+              </div>
+              <div className="help-command">
+                <span className="help-command-name">/logout</span>
+                <span className="help-command-desc">Log out of your account</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="help-divider" />
+
+          {/* Ship Studio Tips */}
+          <div className="help-section">
+            <div className="help-section-title">Ship Studio Tips</div>
+            <div className="help-tip-list">
+              <div className="help-tip">
+                Drag files onto the terminal to paste their paths
+              </div>
+              <div className="help-tip">
+                Use <span className="help-shortcut">Shift</span> +{' '}
+                <span className="help-shortcut">Enter</span> for multiline input
+              </div>
+              <div className="help-tip">
+                Status dot shows Claude state: thinking, waiting, or idle
+              </div>
+              <div className="help-tip">
+                Use numbered tabs to run multiple Claude sessions
+              </div>
+            </div>
+          </div>
+
+          <div className="help-divider" />
+
+          {/* Example Prompts */}
+          <div className="help-section">
+            <div className="help-section-title">Example Prompts</div>
+            <div className="help-example-list">
+              <div className="help-example">"Fix the TypeScript errors in this file"</div>
+              <div className="help-example">"Add tests for the authentication flow"</div>
+              <div className="help-example">"Refactor this component to use hooks"</div>
+            </div>
+          </div>
+        </div>
+
+        <div className="help-footer">
+          <span className="help-footer-hint">
+            Press <span className="help-shortcut">Esc</span> to close
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -875,6 +875,25 @@ export function SendIcon({ size = 14 }: IconProps) {
   );
 }
 
+export function HelpIcon({ size = 14 }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  );
+}
+
 export function FullPageIcon({ size = 14 }: IconProps) {
   return (
     <svg

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -35,3 +35,24 @@ export async function checkClaudeCliStatus(): Promise<ClaudeCliStatus> {
 export async function installClaudeCli(): Promise<void> {
   return invoke('install_claude_cli');
 }
+
+/** Represents a Claude skill (custom command) */
+export interface ClaudeSkill {
+  /** Skill name (command without the leading /) */
+  name: string;
+  /** Short description of what the skill does */
+  description: string;
+  /** The plugin this skill belongs to */
+  plugin: string;
+  /** Whether this is a "user" or "project" scoped skill */
+  scope: string;
+}
+
+/**
+ * List available Claude skills from installed plugins.
+ * @param projectPath - Optional project path to include project-level skills
+ * @returns Array of available skills
+ */
+export async function listClaudeSkills(projectPath?: string): Promise<ClaudeSkill[]> {
+  return invoke<ClaudeSkill[]>('list_claude_skills', { projectPath });
+}

--- a/src/styles/help-modal.css
+++ b/src/styles/help-modal.css
@@ -1,0 +1,181 @@
+/* Help Modal Styles */
+
+.help-modal {
+  width: 90%;
+  max-width: 520px;
+  max-height: 85vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.help-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.help-modal-header h3 {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.help-close-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.help-close-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.help-modal-body {
+  padding: 20px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.help-section {
+  margin-bottom: 24px;
+}
+
+.help-section:last-child {
+  margin-bottom: 0;
+}
+
+.help-section-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 12px;
+}
+
+.help-command-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.help-command {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.help-command-name {
+  font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+  font-size: 12px;
+  color: var(--accent);
+  min-width: 80px;
+  flex-shrink: 0;
+}
+
+.help-command-desc {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.help-tip-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.help-tip {
+  font-size: 13px;
+  color: var(--text-secondary);
+  padding-left: 16px;
+  position: relative;
+  line-height: 1.4;
+}
+
+.help-tip::before {
+  content: '\2022';
+  position: absolute;
+  left: 0;
+  color: var(--text-muted);
+}
+
+.help-shortcut {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: 'SF Mono', Monaco, monospace;
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin: 0 2px;
+}
+
+.help-example-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.help-example {
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+  border: 1px solid var(--border);
+}
+
+.help-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 20px 0;
+}
+
+.help-footer {
+  padding: 12px 20px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--bg-tertiary);
+}
+
+.help-footer-hint {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.help-skill-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  margin-left: 8px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.help-loading {
+  font-size: 13px;
+  color: var(--text-muted);
+  font-style: italic;
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -25,3 +25,4 @@
 @import './health.css';
 @import './diff-modal.css';
 @import './compact-mode.css';
+@import './help-modal.css';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Help modal with comprehensive documentation accessible via keyboard shortcuts (Cmd+/ on Mac, Ctrl+/ on Windows, or F1) and a Help button in the toolbar.
  * Integrated Claude plugin skills discovery into the Help modal, displaying available user and project-specific skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->