### PR TITLE
Switch Vercel CLI install to Homebrew and batch brew packages

### DIFF
--- a/src-tauri/src/commands/setup.rs
+++ b/src-tauri/src/commands/setup.rs
@@ -206,7 +206,7 @@ pub async fn get_full_setup_status() -> FullSetupStatus {
             ("gh_auth", "GitHub Account", Some("gh")),
             ("claude", "Claude Code", None),
             ("claude_auth", "Claude Account", Some("claude")),
-            ("vercel", "Vercel CLI", Some("node")),
+            ("vercel", "Vercel CLI", Some("homebrew")),
             ("vercel_auth", "Vercel Account", Some("vercel")),
         ];
 
@@ -723,6 +723,7 @@ pub async fn install_node_via_brew(app: tauri::AppHandle) -> Result<(), String> 
 
     let output = Command::new(&brew)
         .args(["install", "node"])
+        .env("HOMEBREW_NO_AUTO_UPDATE", "1") // Skip auto-update for faster install
         .output()
         .map_err(|e| format!("Failed to run brew: {}", e))?;
 
@@ -755,6 +756,7 @@ pub async fn install_git_via_brew(app: tauri::AppHandle) -> Result<(), String> {
 
     let output = Command::new(&brew)
         .args(["install", "git"])
+        .env("HOMEBREW_NO_AUTO_UPDATE", "1") // Skip auto-update for faster install
         .output()
         .map_err(|e| format!("Failed to run brew: {}", e))?;
 
@@ -787,12 +789,84 @@ pub async fn install_gh_via_brew(app: tauri::AppHandle) -> Result<(), String> {
 
     let output = Command::new(&brew)
         .args(["install", "gh"])
+        .env("HOMEBREW_NO_AUTO_UPDATE", "1") // Skip auto-update for faster install
         .output()
         .map_err(|e| format!("Failed to run brew: {}", e))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("Failed to install GitHub CLI: {}", stderr));
+    }
+
+    Ok(())
+}
+
+/// Batch install multiple Homebrew packages in a single command.
+/// This is faster than individual installs because:
+/// 1. Auto-update only runs once
+/// 2. Homebrew can download bottles in parallel
+///
+/// Mapping from item IDs to brew package names:
+/// - node -> node
+/// - git -> git
+/// - gh -> gh
+/// - vercel -> vercel-cli
+#[tauri::command]
+pub async fn install_brew_packages(
+    app: tauri::AppHandle,
+    packages: Vec<String>,
+) -> Result<(), String> {
+    if packages.is_empty() {
+        return Ok(());
+    }
+
+    let _ = app.emit(
+        "setup-progress",
+        serde_json::json!({
+            "itemId": "brew_batch",
+            "message": format!("Installing {}...", packages.join(", "))
+        }),
+    );
+
+    if is_mock_mode() {
+        tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+        for pkg in &packages {
+            // Map brew package names back to item IDs for mock
+            let item_id = match pkg.as_str() {
+                "vercel-cli" => "vercel",
+                other => other,
+            };
+            mock_install(item_id);
+        }
+        return Ok(());
+    }
+
+    let brew = get_brew_command().ok_or("Homebrew not found")?;
+
+    // Map item IDs to actual brew package names
+    let brew_packages: Vec<&str> = packages
+        .iter()
+        .map(|p| match p.as_str() {
+            "vercel" => "vercel-cli",
+            other => other,
+        })
+        .collect();
+
+    let mut args = vec!["install"];
+    args.extend(brew_packages.iter().copied());
+
+    let output = Command::new(&brew)
+        .args(&args)
+        // Allow auto-update since it only runs once for all packages
+        .output()
+        .map_err(|e| format!("Failed to run brew: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "Failed to install packages: {}",
+            stderr.lines().next().unwrap_or("Unknown error")
+        ));
     }
 
     Ok(())

--- a/src-tauri/src/commands/vercel.rs
+++ b/src-tauri/src/commands/vercel.rs
@@ -219,34 +219,21 @@ pub async fn install_vercel_cli() -> Result<(), String> {
         return Ok(());
     }
 
-    // Install Vercel CLI globally via npm
-    let output = Command::new("npm")
-        .args(["install", "-g", "vercel"])
-        .env("PATH", get_extended_path())
+    // Install Vercel CLI via Homebrew (more reliable than npm -g)
+    let brew = crate::utils::get_brew_command()
+        .ok_or("[VERCEL_INSTALL_001] Homebrew not found. Please install Homebrew first.")?;
+
+    let output = Command::new(&brew)
+        .args(["install", "vercel-cli"])
+        // Skip auto-update to speed up install (can save 10-30 seconds)
+        .env("HOMEBREW_NO_AUTO_UPDATE", "1")
         .output()
-        .map_err(|e| format!("[VERCEL_INSTALL_001] Failed to run npm: {}", e))?;
+        .map_err(|e| format!("[VERCEL_INSTALL_002] Failed to run brew: {}", e))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-
-        // Parse common npm install errors
-        let combined = format!("{} {}", stdout, stderr).to_lowercase();
-        if combined.contains("eacces") || combined.contains("permission denied") {
-            return Err(
-                "[VERCEL_INSTALL_002] Permission denied installing Vercel CLI.\n\
-                Try running: sudo npm install -g vercel"
-                    .to_string(),
-            );
-        }
-        if combined.contains("npm err!") && combined.contains("network") {
-            return Err("[VERCEL_INSTALL_003] Network error during installation.\n\
-                Please check your internet connection."
-                .to_string());
-        }
-
         return Err(format!(
-            "[VERCEL_INSTALL_004] Failed to install Vercel CLI: {}",
+            "[VERCEL_INSTALL_003] Failed to install Vercel CLI: {}",
             stderr.lines().next().unwrap_or("Unknown error")
         ));
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -265,6 +265,7 @@ pub fn run() {
             commands::setup::install_node_via_brew,
             commands::setup::install_git_via_brew,
             commands::setup::install_gh_via_brew,
+            commands::setup::install_brew_packages,
             commands::setup::start_github_auth,
             commands::setup::start_claude_auth,
             commands::setup::check_claude_auth_status,

--- a/src/components/setup/OnboardingScreen.tsx
+++ b/src/components/setup/OnboardingScreen.tsx
@@ -17,11 +17,9 @@ import {
   SetupItem,
   FullSetupStatus,
   getFullSetupStatus,
-  installNode,
-  installGit,
-  installGh,
   checkClaudeAuthStatus,
-  installVercel,
+  installBrewPackages,
+  BREW_PACKAGES,
   TERMINAL_COMMANDS,
   USES_TERMINAL,
   SETUP_FRIENDLY_NAMES,
@@ -203,21 +201,24 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
 
       // Non-terminal items - run via backend
       try {
-        switch (itemId) {
-          case 'node':
-            await installNode();
-            break;
-          case 'git':
-            await installGit();
-            break;
-          case 'gh':
-            await installGh();
-            break;
-          case 'vercel':
-            await installVercel();
-            break;
-          default:
-            console.warn('Unknown item:', itemId);
+        // Check if this is a brew package - if so, batch install all missing brew packages
+        if (BREW_PACKAGES.has(itemId)) {
+          // Find all missing brew packages to install in one command
+          const missingBrewPackages = items
+            .filter((item) => BREW_PACKAGES.has(item.id) && item.status !== 'ready')
+            .map((item) => item.id);
+
+          // Mark all of them as in_progress
+          for (const pkgId of missingBrewPackages) {
+            if (pkgId !== itemId) {
+              updateItemStatus(pkgId, { status: 'in_progress', errorMessage: undefined });
+            }
+          }
+
+          // Batch install all missing brew packages
+          await installBrewPackages(missingBrewPackages);
+        } else {
+          console.warn('Unknown item:', itemId);
         }
 
         // Installation complete, refresh status
@@ -228,17 +229,28 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
         const errorMessage = err instanceof Error ? err.message : String(err);
         // Show the actual error message so users can troubleshoot
         // Strip error codes like [VERCEL_INSTALL_002] for cleaner display
-        const cleanedMessage = errorMessage
-          .replace(/\[[\w_]+\]\s*/g, '')
-          .trim();
-        updateItemStatus(itemId, {
-          status: 'error',
-          errorMessage: cleanedMessage || 'Something went wrong. Click to try again.',
-        });
+        const cleanedMessage = errorMessage.replace(/\[[\w_]+\]\s*/g, '').trim();
+
+        // If this was a batch brew install, reset all in_progress brew items
+        if (BREW_PACKAGES.has(itemId)) {
+          for (const item of items) {
+            if (BREW_PACKAGES.has(item.id) && item.status === 'in_progress') {
+              updateItemStatus(item.id, {
+                status: 'error',
+                errorMessage: cleanedMessage || 'Something went wrong. Click to try again.',
+              });
+            }
+          }
+        } else {
+          updateItemStatus(itemId, {
+            status: 'error',
+            errorMessage: cleanedMessage || 'Something went wrong. Click to try again.',
+          });
+        }
         setActiveItemId(null);
       }
     },
-    [activeItemId, terminalConfig, updateItemStatus, fetchStatus]
+    [activeItemId, terminalConfig, updateItemStatus, fetchStatus, items]
   );
 
   // Check if all required items are ready (optional items can be skipped)

--- a/src/components/setup/SetupChecklist.tsx
+++ b/src/components/setup/SetupChecklist.tsx
@@ -3,6 +3,9 @@
  *
  * Handles the display and action delegation for each item,
  * respecting dependencies and blocked states.
+ *
+ * Brew-installed packages (node, git, gh, vercel) that need installing
+ * are collapsed into a single combined row for a cleaner UX.
  */
 
 import { SetupItem } from './SetupItem';
@@ -10,6 +13,8 @@ import {
   SetupItem as SetupItemType,
   SETUP_ITEM_ORDER,
   OPTIONAL_ITEMS,
+  SETUP_FRIENDLY_NAMES,
+  BREW_PACKAGES,
   getBlockingDependencies,
 } from '../../lib/setup';
 
@@ -23,6 +28,18 @@ interface SetupChecklistProps {
   activeItemId?: string | null;
   /** Whether a terminal is currently active */
   terminalActive?: boolean;
+}
+
+/**
+ * Join names with commas and "&" for the last item.
+ * e.g., ["GitHub CLI", "Vercel CLI"] → "GitHub CLI & Vercel CLI"
+ * e.g., ["Node.js", "Git", "Vercel CLI"] → "Node.js, Git & Vercel CLI"
+ */
+function joinNames(names: string[]): string {
+  if (names.length === 0) return '';
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} & ${names[1]}`;
+  return `${names.slice(0, -1).join(', ')} & ${names[names.length - 1]}`;
 }
 
 export function SetupChecklist({
@@ -42,24 +59,109 @@ export function SetupChecklist({
   // Disable all buttons if any action is in progress or terminal is active
   const isAnyActionInProgress = activeItemId !== null || terminalActive === true;
 
+  // Separate brew items into ready vs missing
+  const readyBrewItems = sortedItems.filter(
+    (item) => BREW_PACKAGES.has(item.id) && item.status === 'ready'
+  );
+  const missingBrewItems = sortedItems.filter(
+    (item) => BREW_PACKAGES.has(item.id) && item.status !== 'ready'
+  );
+  const nonBrewItems = sortedItems.filter((item) => !BREW_PACKAGES.has(item.id));
+
+  // Check if missing brew items are blocked (homebrew not installed)
+  const brewItemsBlocked = missingBrewItems.some((item) => {
+    const blockedBy = getBlockingDependencies(item.id, items);
+    return blockedBy.length > 0;
+  });
+
+  // Determine combined row status
+  const getCombinedStatus = (): SetupItemType['status'] => {
+    if (brewItemsBlocked) return 'blocked';
+    if (missingBrewItems.some((i) => i.status === 'in_progress')) return 'in_progress';
+    if (missingBrewItems.some((i) => i.status === 'error')) return 'error';
+    return 'not_installed';
+  };
+
+  // Get error message from any errored brew item
+  const getCombinedError = (): string | undefined => {
+    const errored = missingBrewItems.find((i) => i.status === 'error');
+    return errored?.errorMessage;
+  };
+
+  // Build the combined virtual item for missing brew packages
+  const combinedBrewItem: SetupItemType | null =
+    missingBrewItems.length >= 2
+      ? {
+          id: missingBrewItems[0].id, // Use first item's ID to trigger batch install
+          friendlyName: joinNames(
+            missingBrewItems.map((i) => SETUP_FRIENDLY_NAMES[i.id] || i.friendlyName)
+          ),
+          status: getCombinedStatus(),
+          errorMessage: getCombinedError(),
+        }
+      : null;
+
+  // Build the final render list maintaining order:
+  // 1. Homebrew (non-brew item, but first)
+  // 2. Ready brew items (with checkmarks)
+  // 3. Combined missing brew row OR single missing brew item
+  // 4. Auth and other non-brew items
+  const renderItems: Array<{
+    item: SetupItemType;
+    isCombined: boolean;
+  }> = [];
+
+  // Add homebrew first (it's a non-brew item that should come first)
+  const homebrewItem = nonBrewItems.find((i) => i.id === 'homebrew');
+  if (homebrewItem) {
+    renderItems.push({ item: homebrewItem, isCombined: false });
+  }
+
+  // Add ready brew items individually
+  for (const item of readyBrewItems) {
+    renderItems.push({ item, isCombined: false });
+  }
+
+  // Add combined row or single missing brew item
+  if (combinedBrewItem) {
+    renderItems.push({ item: combinedBrewItem, isCombined: true });
+  } else if (missingBrewItems.length === 1) {
+    renderItems.push({ item: missingBrewItems[0], isCombined: false });
+  }
+
+  // Add remaining non-brew items (except homebrew which was already added)
+  for (const item of nonBrewItems) {
+    if (item.id === 'homebrew') continue;
+    renderItems.push({ item, isCombined: false });
+  }
+
   return (
     <div className="setup-checklist">
-      {sortedItems.map((item) => {
-        const blockedBy = getBlockingDependencies(item.id, items);
+      {renderItems.map(({ item, isCombined }) => {
+        const blockedBy = isCombined
+          ? brewItemsBlocked
+            ? [SETUP_FRIENDLY_NAMES['homebrew'] || 'Package Manager']
+            : []
+          : getBlockingDependencies(item.id, items);
         const isBlocked = blockedBy.length > 0 && item.status !== 'ready';
         const isOptional = OPTIONAL_ITEMS.has(item.id);
 
         // Override status to blocked if dependencies aren't ready
         const displayItem: SetupItemType = isBlocked ? { ...item, status: 'blocked' } : item;
 
+        // For combined row, check if any of the brew items is the active item
+        const isActive = isCombined
+          ? missingBrewItems.some((i) => activeItemId === i.id)
+          : activeItemId === item.id;
+
         return (
           <SetupItem
-            key={item.id}
+            key={isCombined ? 'brew-combined' : item.id}
             item={displayItem}
             blockedBy={blockedBy}
             onAction={() => onItemAction(item.id)}
             onSkip={isOptional && onItemSkip ? () => onItemSkip(item.id) : undefined}
-            isActionInProgress={activeItemId === item.id}
+            isActionInProgress={isActive}
             isAnyActionInProgress={isAnyActionInProgress}
             isOptional={isOptional}
           />

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -85,7 +85,7 @@ export const SETUP_DEPENDENCIES: Record<string, string[]> = {
   gh_auth: ['gh'],
   claude: [], // Uses its own installer, no Homebrew dependency
   claude_auth: ['claude'],
-  vercel: ['node'],
+  vercel: ['homebrew'], // Installed via brew install vercel-cli
   vercel_auth: ['vercel'],
 };
 
@@ -261,6 +261,20 @@ export async function resetSetupState(): Promise<void> {
 export async function installVercel(): Promise<void> {
   return invoke('install_vercel_cli');
 }
+
+/**
+ * Batch install multiple Homebrew packages in a single command.
+ * This is faster than individual installs because auto-update only runs once
+ * and Homebrew can download bottles in parallel.
+ *
+ * @param packages - Array of item IDs to install (e.g., ['node', 'git', 'gh', 'vercel'])
+ */
+export async function installBrewPackages(packages: string[]): Promise<void> {
+  return invoke('install_brew_packages', { packages });
+}
+
+/** Brew-installed packages that can be batched */
+export const BREW_PACKAGES = new Set(['node', 'git', 'gh', 'vercel']);
 
 /**
  * Start Vercel authentication flow (opens browser).


### PR DESCRIPTION
- Install Vercel CLI via `brew install vercel-cli` instead of `npm install -g vercel` to fix permission and PATH issues reported by users
- Add batch `install_brew_packages` command that installs all missing brew packages (node, git, gh, vercel-cli) in a single command
- Collapse missing brew packages into a single combined row in the onboarding checklist (e.g. "GitHub CLI & Vercel CLI")
- Show actual backend error messages instead of generic "Something went wrong"
- Add HOMEBREW_NO_AUTO_UPDATE=1 to individual brew installs as fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch installation for multiple Homebrew packages in a single operation.
  * Homebrew packages now display grouped in the setup checklist.

* **Improvements**
  * Vercel CLI installation now uses Homebrew instead of npm.
  * Setup performance improved by skipping Homebrew auto-updates during package installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->