### PR TITLE
Fix windows build: windows only variables had been renamed

### DIFF
--- a/src-tauri/src/commands/claude.rs
+++ b/src-tauri/src/commands/claude.rs
@@ -26,11 +26,10 @@ pub fn find_binary_by_name(binary_name: &str) -> Option<std::path::PathBuf> {
         return Some(path);
     }
 
-    let _exe_name = format!("{binary_name}.exe");
-    let _cmd_name = format!("{binary_name}.cmd");
-
     #[cfg(windows)]
     {
+        let exe_name = format!("{binary_name}.exe");
+        let cmd_name = format!("{binary_name}.cmd");
         // On Windows, also try with .exe extension
         if let Ok(path) = which::which(&exe_name) {
             return Some(path);


### PR DESCRIPTION
This fixes the build on windows
A pair of variables have probably been renamed to allow the macos build but wasn't renamed in windows-specific code (and in the end it was better to move this variables to the windows-specific code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->