### PR TITLE
Fix terminal double-typing on mount

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -710,7 +710,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         ptyDisposablesRef.current.push(exitDisposable);
 
         // Handle terminal input -> PTY
-        term.onData((data) => {
+        const inputDisposable = term.onData((data) => {
           ptyRef.current?.write(data);
           // When user sends input to an agent without title-based status detection,
           // assume it transitions to "thinking" (processing the request).
@@ -721,6 +721,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
             }
           }
         });
+        ptyDisposablesRef.current.push(inputDisposable);
 
         // Handle special key combinations
         term.attachCustomKeyEventHandler((event) => {


### PR DESCRIPTION
## Summary
- Fix bug where typing in the terminal produces duplicate characters (e.g., "can you" → "ccaann yyoouu")
- Root cause: `term.onData()` input handler wasn't storing its disposable, so on React StrictMode double-mount (or any effect re-run) a second handler got attached without the first being cleaned up
- Store the disposable in `ptyDisposablesRef` for proper cleanup, matching the pattern already used for `pty.onData()` and `pty.onExit()` handlers

## Test plan
- [ ] Open app, type in terminal — characters should appear once, not doubled
- [ ] Kill and restart the PTY — typing should still work correctly after reconnect
- [ ] Verify in dev mode (React StrictMode) that no double-typing occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal component event listener cleanup to ensure proper resource disposal during lifecycle, preventing potential memory leaks and improving application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->