### PR TITLE
Fix terminal freeze, autofocus, and surface install errors

### DIFF
--- a/src/components/CreateProject.tsx
+++ b/src/components/CreateProject.tsx
@@ -118,7 +118,9 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
 
           {error && (
             <div className="create-error">
-              <p style={{ whiteSpace: 'pre-line' }}>{error}</p>
+              <p style={{ whiteSpace: 'pre-line', maxHeight: '200px', overflowY: 'auto' }}>
+                {error}
+              </p>
               <div style={{ display: 'flex', gap: '8px' }}>
                 {currentStep === 'install' && createdProjectPath && (
                   <button className="btn-primary" onClick={() => void retryInstall()}>

--- a/src/components/ImportProject.tsx
+++ b/src/components/ImportProject.tsx
@@ -127,19 +127,41 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
 
   const waitForPtyExit = async (targetId: number): Promise<number | null> => {
     return new Promise((resolve, reject) => {
-      let unlisten: UnlistenFn | null = null;
+      let unlistenExit: UnlistenFn | null = null;
+      let unlistenOutput: UnlistenFn | null = null;
+      const outputLines: string[] = [];
+      const MAX_OUTPUT_LINES = 30;
 
-      void listen<{ id: number; code: number | null }>('pty-exit', (event) => {
+      // Capture process output so we can surface it on failure
+      void listen<{ id: number; data: string }>('pty-output', (event) => {
         if (event.payload.id === targetId) {
-          unlisten?.();
-          if (event.payload.code === 0 || event.payload.code === null) {
-            resolve(event.payload.code);
-          } else {
-            reject(new Error(`Process exited with code ${event.payload.code}`));
+          // Split into lines and keep a rolling window
+          const lines = event.payload.data.split(/\r?\n/).filter((l) => l.trim());
+          for (const line of lines) {
+            outputLines.push(line);
+            if (outputLines.length > MAX_OUTPUT_LINES) outputLines.shift();
           }
         }
       }).then((fn) => {
-        unlisten = fn;
+        unlistenOutput = fn;
+      });
+
+      void listen<{ id: number; code: number | null }>('pty-exit', (event) => {
+        if (event.payload.id === targetId) {
+          unlistenExit?.();
+          unlistenOutput?.();
+          if (event.payload.code === 0 || event.payload.code === null) {
+            resolve(event.payload.code);
+          } else {
+            const output = outputLines.join('\n').trim();
+            const msg = output
+              ? `Process exited with code ${event.payload.code}\n\n${output}`
+              : `Process exited with code ${event.payload.code}`;
+            reject(new Error(msg));
+          }
+        }
+      }).then((fn) => {
+        unlistenExit = fn;
       });
     });
   };
@@ -157,7 +179,8 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
         return "Git authentication failed. Make sure you're signed into GitHub.";
       }
     }
-    return msg;
+    // Strip the "Error: " prefix that comes from Error.toString()
+    return msg.replace(/^Error:\s*/, '');
   };
 
   /** Run package manager install via PTY, with a pre-check for permissions */
@@ -378,7 +401,9 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
 
           {error && (
             <div className="create-error">
-              <p style={{ whiteSpace: 'pre-line' }}>{error}</p>
+              <p style={{ whiteSpace: 'pre-line', maxHeight: '200px', overflowY: 'auto' }}>
+                {error}
+              </p>
               <div style={{ display: 'flex', gap: '8px' }}>
                 {currentStep === 'install' && importedProjectPath && (
                   <button className="btn-primary" onClick={() => void retryInstall()}>

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -350,6 +350,11 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     // Initial fit
     setTimeout(() => {
       fitAddon.fit();
+      // Auto-focus if this is the active tab — must happen after fit so
+      // xterm's textarea is properly sized and ready to receive input.
+      if (isActiveRef.current) {
+        term.focus();
+      }
     }, 0);
 
     terminalRef.current = term;
@@ -570,12 +575,17 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         // Buffer early output to detect resume failures on exit
         let outputBuffer = '';
 
-        // Write data to xterm, or buffer it if the terminal is hidden
-        const writeToTerminal = (data: string | Uint8Array) => {
+        // Write data to xterm, or buffer it if the terminal is hidden.
+        // Note: tauri-pty's read command returns Vec<u8> from Rust, which Tauri
+        // serializes as a JSON number[]. We must convert to Uint8Array for both
+        // xterm.write() and TextDecoder.decode() to work.
+        const writeToTerminal = (data: string | Uint8Array | number[]) => {
+          const normalized = Array.isArray(data) ? new Uint8Array(data) : data;
           if (isActiveRef.current) {
-            terminalRef.current?.write(data);
+            terminalRef.current?.write(normalized);
           } else {
-            const str = typeof data === 'string' ? data : new TextDecoder().decode(data);
+            const str =
+              typeof normalized === 'string' ? normalized : new TextDecoder().decode(normalized);
             hiddenBufferRef.current.push(str);
             hiddenBufferSizeRef.current += str.length;
             // Cap buffer to prevent memory growth

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -609,7 +609,8 @@ export const WorkspaceView = memo(function WorkspaceView({
     };
   }, [terminalTabs, activeTerminalTab, closeTerminalTab]);
 
-  // Focus the active terminal tab when switching
+  // Focus the active terminal tab when switching between existing tabs.
+  // For brand-new tabs, the Terminal component auto-focuses itself after init.
   useEffect(() => {
     const ref = terminalRefsMap.current.get(activeTerminalTab);
     if (ref) {

--- a/src/hooks/useProjectCreation.ts
+++ b/src/hooks/useProjectCreation.ts
@@ -184,19 +184,40 @@ export function useProjectCreation({ onComplete, onCancel }: UseProjectCreationP
 
   const waitForPtyExit = async (targetId: number): Promise<number | null> => {
     return new Promise((resolve, reject) => {
-      let unlisten: UnlistenFn | null = null;
+      let unlistenExit: UnlistenFn | null = null;
+      let unlistenOutput: UnlistenFn | null = null;
+      const outputLines: string[] = [];
+      const MAX_OUTPUT_LINES = 30;
 
-      void listen<{ id: number; code: number | null }>('pty-exit', (event) => {
+      // Capture process output so we can surface it on failure
+      void listen<{ id: number; data: string }>('pty-output', (event) => {
         if (event.payload.id === targetId) {
-          unlisten?.();
-          if (event.payload.code === 0 || event.payload.code === null) {
-            resolve(event.payload.code);
-          } else {
-            reject(new Error(`Process exited with code ${event.payload.code}`));
+          const lines = event.payload.data.split(/\r?\n/).filter((l) => l.trim());
+          for (const line of lines) {
+            outputLines.push(line);
+            if (outputLines.length > MAX_OUTPUT_LINES) outputLines.shift();
           }
         }
       }).then((fn) => {
-        unlisten = fn;
+        unlistenOutput = fn;
+      });
+
+      void listen<{ id: number; code: number | null }>('pty-exit', (event) => {
+        if (event.payload.id === targetId) {
+          unlistenExit?.();
+          unlistenOutput?.();
+          if (event.payload.code === 0 || event.payload.code === null) {
+            resolve(event.payload.code);
+          } else {
+            const output = outputLines.join('\n').trim();
+            const msg = output
+              ? `Process exited with code ${event.payload.code}\n\n${output}`
+              : `Process exited with code ${event.payload.code}`;
+            reject(new Error(msg));
+          }
+        }
+      }).then((fn) => {
+        unlistenExit = fn;
       });
     });
   };
@@ -217,7 +238,8 @@ export function useProjectCreation({ onComplete, onCancel }: UseProjectCreationP
         return 'Xcode Command Line Tools license has not been accepted. Open Terminal and run:\nsudo xcodebuild -license accept\n\nThen try creating the project again.';
       }
     }
-    return msg;
+    // Strip the "Error: " prefix that comes from Error.toString()
+    return msg.replace(/^Error:\s*/, '');
   };
 
   /** Run npm install via PTY, with a pre-check for permissions */


### PR DESCRIPTION
## Summary
- **Fix terminal freeze on tab switch** — Rust PTY `read` returns `Vec<u8>` which Tauri serializes as a JSON `number[]`. When a tab became inactive, `writeToTerminal` called `TextDecoder.decode()` on this plain array → TypeError. The error propagated through tauri-pty's `EventEmitter2.fire()` (no try/catch) into the `readData()` loop, killing it permanently. Fix: normalize `number[]` to `Uint8Array`.
- **Fix new tab autofocus** — When Cmd+T created a new tab, the focus effect ran before the xterm instance was initialized. Fix: Terminal auto-focuses itself after `fit()` during init when it's the active tab.
- **Surface actual error output on import/create failure** — Previously showed only "Process exited with code 254" with zero context. Now captures the last 30 lines of process output and displays them in a scrollable error area. Applied to both ImportProject and CreateProject flows.

## Test plan
- [ ] Open app, create multiple terminal tabs, switch between them — no freeze
- [ ] Cmd+T creates a new tab that is immediately focused and ready for input
- [ ] Import a project that fails `npm install` — verify actual npm error output is shown instead of just exit code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now include captured command output for improved diagnostics when operations fail
  * Error display areas in project creation and import dialogs are now scrollable with constrained height and improved text formatting
  * Terminal input now auto-focuses properly after initialization for better usability
  * Enhanced compatibility with different command output formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->