### PR TITLE
Blank project template, compact mode fixes, CSTAR secret

### DIFF
--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -87,9 +87,16 @@ fn ensure_gitignore_has_shipstudio_sync(project: &std::path::Path) -> Result<(),
     Ok(())
 }
 
-/// Check if a directory is a valid project (has package.json or HTML files)
+/// Check if a directory is a valid project.
+/// Accepts any directory inside ~/ShipStudio that has project files,
+/// a .gitignore (blank projects), or a .shipstudio metadata folder.
 fn is_valid_project(path: &std::path::Path) -> bool {
-    path.is_dir() && (path.join("package.json").exists() || detection::has_html_files(path))
+    path.is_dir()
+        && (path.join("package.json").exists()
+            || detection::has_html_files(path)
+            || path.join(".gitignore").exists()
+            || path.join(".shipstudio").exists()
+            || path.join(".git").exists())
 }
 
 // ============ Tauri Commands ============

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -442,13 +442,23 @@ pub async fn ensure_gitignore_has_shipstudio(project_path: String) -> Result<(),
 /// Creates a blank project directory with a .gitignore.
 #[tauri::command]
 pub async fn create_blank_project(project_path: String) -> Result<(), String> {
-    let project = validate_project_path(&project_path)?;
+    // Can't use validate_project_path because the directory doesn't exist yet.
+    // Instead, validate that the parent is within ~/ShipStudio.
+    let path = std::path::Path::new(&project_path);
+    let home = dirs::home_dir().ok_or("Could not find home directory")?;
+    let shipstudio_dir = home.join("ShipStudio");
+    let parent = path.parent().ok_or("Invalid project path")?;
+    let canonical_parent =
+        dunce::canonicalize(parent).map_err(|e| format!("Invalid parent path: {e}"))?;
+    if !canonical_parent.starts_with(&shipstudio_dir) {
+        return Err("Project must be inside ~/ShipStudio".to_string());
+    }
 
-    std::fs::create_dir_all(&project)
+    std::fs::create_dir_all(path)
         .map_err(|e| format!("Failed to create project directory: {e}"))?;
 
     // Add .shipstudio/ to gitignore
-    let gitignore = project.join(".gitignore");
+    let gitignore = path.join(".gitignore");
     std::fs::write(&gitignore, ".shipstudio/\n")
         .map_err(|e| format!("Failed to create .gitignore: {e}"))?;
 

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -439,6 +439,22 @@ pub async fn ensure_gitignore_has_shipstudio(project_path: String) -> Result<(),
     Ok(())
 }
 
+/// Creates a blank project directory with a .gitignore.
+#[tauri::command]
+pub async fn create_blank_project(project_path: String) -> Result<(), String> {
+    let project = validate_project_path(&project_path)?;
+
+    std::fs::create_dir_all(&project)
+        .map_err(|e| format!("Failed to create project directory: {e}"))?;
+
+    // Add .shipstudio/ to gitignore
+    let gitignore = project.join(".gitignore");
+    std::fs::write(&gitignore, ".shipstudio/\n")
+        .map_err(|e| format!("Failed to create .gitignore: {e}"))?;
+
+    Ok(())
+}
+
 /// Removes the .git directory from a project so it starts fresh (not connected to template repo).
 #[tauri::command]
 pub async fn remove_git_history(project_path: String) -> Result<(), String> {

--- a/src-tauri/src/commands/support.rs
+++ b/src-tauri/src/commands/support.rs
@@ -11,7 +11,10 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use tracing::debug;
 
-const CSTAR_IDENTITY_SECRET: &str = env!("CSTAR_IDENTITY_SECRET");
+const CSTAR_IDENTITY_SECRET: &str = match option_env!("CSTAR_IDENTITY_SECRET") {
+    Some(v) => v,
+    None => "",
+};
 
 type HmacSha256 = Hmac<Sha256>;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -251,6 +251,7 @@ pub fn run() {
             commands::projects::get_branch_prefix_preference,
             commands::projects::set_branch_prefix_preference,
             commands::projects::ensure_gitignore_has_shipstudio,
+            commands::projects::create_blank_project,
             commands::projects::remove_git_history,
             commands::projects::delete_project,
             commands::projects::clear_project_cache,

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -537,8 +537,8 @@ export const WorkspaceView = memo(function WorkspaceView({
     setIsCropMode,
   ]);
 
-  // Generic projects (Tauri apps, CLI tools, etc.) don't have a web preview
-  const isWebProject = projectType !== 'generic';
+  // Generic/unknown projects (Tauri apps, CLI tools, blank projects, etc.) don't have a web preview
+  const isWebProject = projectType !== 'generic' && projectType !== 'unknown';
 
   // Track terminal tab titles from PTY title changes
   const [tabTitles, setTabTitles] = useState<Map<number, string>>(new Map());

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -540,6 +540,13 @@ export const WorkspaceView = memo(function WorkspaceView({
   // Generic/unknown projects (Tauri apps, CLI tools, blank projects, etc.) don't have a web preview
   const isWebProject = projectType !== 'generic' && projectType !== 'unknown';
 
+  // Switch to code tab for non-web projects (blank, generic) since preview is unavailable
+  useEffect(() => {
+    if (!isWebProject && workspaceTab === 'preview') {
+      setWorkspaceTab('code');
+    }
+  }, [isWebProject, workspaceTab, setWorkspaceTab]);
+
   // Track terminal tab titles from PTY title changes
   const [tabTitles, setTabTitles] = useState<Map<number, string>>(new Map());
   const handleTabTitleChange = useCallback(

--- a/src/hooks/useProjectCreation.ts
+++ b/src/hooks/useProjectCreation.ts
@@ -74,6 +74,12 @@ export const TEMPLATES: Template[] = [
     description: 'A plain HTML starter — no framework, no build step',
     repo: 'https://github.com/ship-studio/html-starter',
   },
+  {
+    id: 'blank',
+    name: 'Blank Project',
+    description: 'An empty folder — start from scratch',
+    repo: '',
+  },
 ];
 
 /** Form wizard steps before creation starts */
@@ -332,38 +338,45 @@ export function useProjectCreation({ onComplete, onCancel }: UseProjectCreationP
       const shipstudioDir = await invoke<string>('ensure_shipstudio_dir');
       const projectPath = `${shipstudioDir}/${safeName}`;
 
-      // Clone template
-      const cloneId = await invoke<number>('spawn_pty', {
-        options: {
-          cwd: shipstudioDir,
-          command: 'git',
-          args: ['clone', selectedTemplate.repo, safeName],
-          rows: 10,
-          cols: 80,
-        },
-        windowLabel: getWindowLabel(),
-      });
-
-      await waitForPtyExit(cloneId);
-
-      // Remove .git folder so project starts fresh (not connected to template repo)
-      setCurrentStep('init');
-      await invoke('remove_git_history', { projectPath });
-
-      // Ensure .shipstudio/ is gitignored to prevent phantom changes
-      await invoke('ensure_gitignore_has_shipstudio', { projectPath: projectPath });
-
-      // Pre-install Vercel plugin (fire-and-forget, don't block creation)
-      installPlugin(projectPath, VERCEL_PLUGIN_REPO).catch(() => {});
-
-      // Install dependencies (skip for HTML-only templates with no package.json)
-      setCreatedProjectPath(projectPath);
-      if (selectedTemplate.id === 'html-basic') {
+      if (selectedTemplate.id === 'blank') {
+        // Blank project: just create the directory
+        await invoke('create_blank_project', { projectPath });
+        setCreatedProjectPath(projectPath);
         setCurrentStep('done');
       } else {
-        setCurrentStep('install');
-        await runNpmInstall(projectPath);
-        setCurrentStep('done');
+        // Clone template
+        const cloneId = await invoke<number>('spawn_pty', {
+          options: {
+            cwd: shipstudioDir,
+            command: 'git',
+            args: ['clone', selectedTemplate.repo, safeName],
+            rows: 10,
+            cols: 80,
+          },
+          windowLabel: getWindowLabel(),
+        });
+
+        await waitForPtyExit(cloneId);
+
+        // Remove .git folder so project starts fresh (not connected to template repo)
+        setCurrentStep('init');
+        await invoke('remove_git_history', { projectPath });
+
+        // Ensure .shipstudio/ is gitignored to prevent phantom changes
+        await invoke('ensure_gitignore_has_shipstudio', { projectPath: projectPath });
+
+        // Pre-install Vercel plugin (fire-and-forget, don't block creation)
+        installPlugin(projectPath, VERCEL_PLUGIN_REPO).catch(() => {});
+
+        // Install dependencies (skip for HTML-only templates with no package.json)
+        setCreatedProjectPath(projectPath);
+        if (selectedTemplate.id === 'html-basic') {
+          setCurrentStep('done');
+        } else {
+          setCurrentStep('install');
+          await runNpmInstall(projectPath);
+          setCurrentStep('done');
+        }
       }
 
       // Small delay before opening

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -1161,7 +1161,7 @@
 /* Medium screens - 2 column grid */
 @media (max-width: 700px) {
   .project-list.dashboard {
-    padding: 20px 16px;
+    padding: 44px 16px 20px;
   }
 
   .dashboard-header {
@@ -1184,7 +1184,7 @@
 /* Narrow screens - single column, compact header */
 @media (max-width: 550px) {
   .project-list.dashboard {
-    padding: 16px 12px;
+    padding: 44px 12px 16px;
   }
 
   .dashboard-header {

--- a/src/styles/workspace.css
+++ b/src/styles/workspace.css
@@ -838,8 +838,25 @@
 
   /* Simplify terminal toolbar — add left padding for macOS traffic lights */
   .terminal-toolbar {
-    padding: 6px 8px 6px 78px;
-    min-height: 36px;
+    padding: 4px 8px 4px 78px;
+    min-height: 28px;
+  }
+
+  /* Shrink toolbar buttons to align with macOS traffic lights */
+  .terminal-toolbar .show-preview-btn.icon-only {
+    width: 20px;
+    height: 20px;
+  }
+
+  .terminal-toolbar .show-preview-btn.icon-only svg {
+    width: 10px;
+    height: 10px;
+  }
+
+  .terminal-toolbar .health-toggle {
+    height: 20px;
+    padding: 0 6px;
+    font-size: 11px;
   }
 
   /* Terminal container adjustments */

--- a/src/styles/workspace.css
+++ b/src/styles/workspace.css
@@ -838,7 +838,7 @@
 
   /* Simplify terminal toolbar — add left padding for macOS traffic lights */
   .terminal-toolbar {
-    padding: 4px 8px 4px 78px;
+    padding: 6px 8px 6px 78px;
     min-height: 28px;
   }
 


### PR DESCRIPTION
## Summary
- **Blank Project template** — new "Blank Project" option in create wizard, creates empty folder with .gitignore, opens as terminal-only workspace
- **Blank projects show in grid** — `is_valid_project` now accepts dirs with .gitignore/.git/.shipstudio
- **Non-web projects default to code tab** — no more empty preview tab for blank/generic projects
- **Compact dashboard traffic light padding** — preserved 44px top padding at all breakpoints
- **Compact toolbar buttons shrunk** — restart/settings/health buttons align with macOS traffic lights
- **CSTAR_IDENTITY_SECRET optional** — `option_env!()` so dev builds work without the secret

## Test plan
- [ ] Create a blank project — should be instant, no clone/install
- [ ] Blank projects appear in the project grid
- [ ] Opening a blank project shows code tab, not preview
- [ ] Compact mode: buttons align with traffic lights
- [ ] Dashboard at narrow width: buttons don't overlap traffic lights
- [ ] `pnpm tauri dev` works without CSTAR_IDENTITY_SECRET set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create blank projects to start from scratch
  * Expanded project recognition to detect more directory types as valid projects

* **Bug Fixes**
  * Auto-switches from preview to code view when editing non-web projects

* **Style**
  * Improved responsive design for compact and mobile screens
  * Optimized terminal toolbar layout on narrow displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->