### PR TITLE
Add community template gallery to New Project modal

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -28,6 +28,7 @@ pub mod setup;
 pub mod skills;
 pub mod static_server;
 pub mod support;
+pub mod templates;
 pub mod window;
 
 // Re-export all commands for easy access in lib.rs
@@ -57,4 +58,5 @@ pub use setup::*;
 pub use skills::*;
 pub use static_server::*;
 pub use support::*;
+pub use templates::*;
 pub use window::*;

--- a/src-tauri/src/commands/templates.rs
+++ b/src-tauri/src/commands/templates.rs
@@ -1,0 +1,103 @@
+//! # Template Gallery Commands
+//!
+//! Fetches community templates from the Ship Studio API and downloads template zips.
+
+const TEMPLATES_API_URL: &str = "https://www.ship.studio/api/v1/templates";
+
+/// Fetch community templates from the Ship Studio API.
+/// Accepts optional query parameters that map to the API spec.
+/// Returns the raw JSON string so the frontend can parse it.
+#[tauri::command]
+pub async fn fetch_community_templates(
+    search: Option<String>,
+    category: Option<String>,
+    sort: Option<String>,
+    pricing: Option<String>,
+    limit: Option<u32>,
+    offset: Option<u32>,
+) -> Result<String, String> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+
+    let mut url =
+        reqwest::Url::parse(TEMPLATES_API_URL).map_err(|e| format!("Invalid URL: {e}"))?;
+
+    {
+        let mut params = url.query_pairs_mut();
+        if let Some(s) = &search {
+            if !s.is_empty() {
+                params.append_pair("search", s);
+            }
+        }
+        if let Some(c) = &category {
+            params.append_pair("category", c);
+        }
+        if let Some(s) = &sort {
+            params.append_pair("sort", s);
+        }
+        if let Some(p) = &pricing {
+            params.append_pair("pricing", p);
+        }
+        if let Some(l) = limit {
+            params.append_pair("limit", &l.to_string());
+        }
+        if let Some(o) = offset {
+            params.append_pair("offset", &o.to_string());
+        }
+    }
+
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch templates: {e}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!("API returned status {}", response.status()));
+    }
+
+    response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read response: {e}"))
+}
+
+/// Download a template zip from a signed URL to a temporary file.
+/// Returns the path to the downloaded file.
+#[tauri::command]
+pub async fn download_template_zip(url: String) -> Result<String, String> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(120))
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to download template: {e}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!("Download failed with status {}", response.status()));
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| format!("Failed to read download: {e}"))?;
+
+    let tmp_dir = std::env::temp_dir().join("shipstudio-templates");
+    std::fs::create_dir_all(&tmp_dir).map_err(|e| format!("Failed to create temp dir: {e}"))?;
+
+    let file_name = format!("{}.zip", uuid::Uuid::new_v4());
+    let file_path = tmp_dir.join(&file_name);
+
+    std::fs::write(&file_path, &bytes).map_err(|e| format!("Failed to write template zip: {e}"))?;
+
+    file_path
+        .to_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| "Invalid temp file path".to_string())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -388,6 +388,9 @@ pub fn run() {
             commands::pty::get_system_env,
             commands::pty::register_external_pty,
             commands::pty::unregister_external_pty,
+            // Community Templates
+            commands::templates::fetch_community_templates,
+            commands::templates::download_template_zip,
             // Setup/Onboarding
             commands::setup::get_full_setup_status,
             commands::setup::install_homebrew,

--- a/src/components/CreateProject.tsx
+++ b/src/components/CreateProject.tsx
@@ -11,11 +11,13 @@
  * @module components/CreateProject
  */
 
-import { useState, useRef } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { trackEvent } from '../lib/analytics';
+import { logger } from '../lib/logger';
 import { UploadIcon } from './icons';
 import { useProjectCreation, TEMPLATES, STEPS, STATUS_MESSAGES } from '../hooks/useProjectCreation';
-import { useClickOutside } from '../hooks/useClickOutside';
+import { TemplateGallery, type CommunityTemplate } from './TemplateGallery';
 
 /** Props for the CreateProject component */
 interface CreateProjectProps {
@@ -53,20 +55,97 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
     handleDrop,
     handleFileSelect,
     handleRemoveZip,
+    setZipPath,
+    setZipFileName,
     saveDefaultTemplate,
     defaultTemplateId,
   } = useProjectCreation({ onComplete, onCancel });
 
-  const [dropdownOpen, setDropdownOpen] = useState(false);
   const [setAsDefaultChecked, setSetAsDefaultChecked] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  useClickOutside(dropdownRef, () => setDropdownOpen(false), dropdownOpen);
 
-  const handleContinue = () => {
-    if (setAsDefaultChecked && selectedTemplate) {
-      saveDefaultTemplate(selectedTemplate.id);
+  // Tab state: "scratch" = start from scratch, "template" = community templates
+  const [activeTab, setActiveTab] = useState<'scratch' | 'template'>('scratch');
+
+  // Community templates from API
+  const [communityTemplates, setCommunityTemplates] = useState<CommunityTemplate[]>([]);
+  const [communityLoading, setCommunityLoading] = useState(true);
+  const [communitySearch, setCommunitySearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [selectedCommunityId, setSelectedCommunityId] = useState<string | null>(null);
+  const [downloading, setDownloading] = useState(false);
+
+  // Debounce search input — hit the API server-side
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(communitySearch), 300);
+    return () => clearTimeout(timer);
+  }, [communitySearch]);
+
+  // Fetch templates from API (server-side search)
+  const fetchTemplates = useCallback(() => {
+    setCommunityLoading(true);
+    const params: Record<string, string | number> = {};
+    if (debouncedSearch) params.search = debouncedSearch;
+    invoke<string>('fetch_community_templates', params)
+      .then((raw) => {
+        const data = JSON.parse(raw) as { templates: CommunityTemplate[] };
+        setCommunityTemplates(data.templates);
+      })
+      .catch(() => {
+        // Silently fail — user sees empty state
+      })
+      .finally(() => setCommunityLoading(false));
+  }, [debouncedSearch]);
+
+  // Fetch on mount and when search changes
+  useEffect(() => {
+    fetchTemplates();
+  }, [fetchTemplates]);
+
+  // Re-fetch every 50 minutes to keep signed zip_urls fresh (they expire after 1 hour)
+  useEffect(() => {
+    const interval = setInterval(fetchTemplates, 50 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, [fetchTemplates]);
+
+  const handleCommunitySelect = (template: CommunityTemplate) => {
+    setSelectedCommunityId(template.id === selectedCommunityId ? null : template.id);
+  };
+
+  const selectedCommunityTemplate =
+    communityTemplates.find((t) => t.id === selectedCommunityId) ?? null;
+
+  const handleContinue = async () => {
+    if (activeTab === 'scratch') {
+      if (setAsDefaultChecked && selectedTemplate) {
+        saveDefaultTemplate(selectedTemplate.id);
+      }
+      rawHandleContinue();
+      return;
     }
-    rawHandleContinue();
+
+    // Template tab — community template selected
+    if (selectedCommunityTemplate?.zip_url) {
+      setDownloading(true);
+      try {
+        const tempPath = await invoke<string>('download_template_zip', {
+          url: selectedCommunityTemplate.zip_url,
+        });
+        setZipPath(tempPath);
+        setZipFileName(selectedCommunityTemplate.name + '.zip');
+        rawHandleContinue();
+      } catch (err) {
+        // Show error inline — don't block the modal
+        logger.error('Failed to download community template', { error: err });
+      } finally {
+        setDownloading(false);
+      }
+      return;
+    }
+
+    // Template tab — zip upload selected
+    if (hasZipTemplate) {
+      rawHandleContinue();
+    }
   };
 
   const renderContent = () => {
@@ -159,132 +238,140 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
             </button>
           </div>
 
-          <div className="template-select-wrapper" ref={dropdownRef}>
+          <div className="create-tabs">
             <button
               type="button"
-              className={`template-select-trigger ${hasZipTemplate ? 'dimmed' : ''}`}
-              onClick={() => setDropdownOpen(!dropdownOpen)}
+              className={`create-tab ${activeTab === 'scratch' ? 'active' : ''}`}
+              onClick={() => setActiveTab('scratch')}
             >
-              <span>{selectedTemplate?.name ?? 'Select a template'}</span>
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                style={{
-                  transform: dropdownOpen ? 'rotate(180deg)' : undefined,
-                  transition: 'transform 0.15s',
-                }}
-              >
-                <polyline points="6 9 12 15 18 9" />
-              </svg>
+              Start from Scratch
             </button>
-            {dropdownOpen && (
-              <div className="template-select-menu">
+            <button
+              type="button"
+              className={`create-tab ${activeTab === 'template' ? 'active' : ''}`}
+              onClick={() => setActiveTab('template')}
+            >
+              Start from Template
+            </button>
+          </div>
+
+          {activeTab === 'scratch' && (
+            <>
+              <div className="stack-grid">
                 {TEMPLATES.map((template) => (
                   <button
                     key={template.id}
                     type="button"
-                    className={`template-select-option ${selectedTemplate?.id === template.id && !hasZipTemplate ? 'selected' : ''}`}
+                    className={`stack-card ${selectedTemplate?.id === template.id && !hasZipTemplate ? 'stack-card-selected' : ''}`}
                     onClick={() => {
                       handleTemplateSelect(template);
                       void trackEvent('template_selected', {
                         template_id: template.id,
                         $screen_name: 'Create Project',
                       });
-                      setDropdownOpen(false);
                       setSetAsDefaultChecked(false);
                     }}
                   >
-                    <div className="template-option-text">
-                      <span className="template-option-name">{template.name}</span>
-                      <span className="template-option-desc">{template.description}</span>
-                    </div>
+                    <span className="stack-card-name">{template.name}</span>
+                    <span className="stack-card-desc">{template.description}</span>
                     {selectedTemplate?.id === template.id && !hasZipTemplate && (
-                      <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2.5"
-                      >
-                        <polyline points="20 6 9 17 4 12" />
-                      </svg>
+                      <div className="stack-card-check">
+                        <svg
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="3"
+                        >
+                          <polyline points="20 6 9 17 4 12" />
+                        </svg>
+                      </div>
                     )}
                   </button>
                 ))}
               </div>
-            )}
-          </div>
 
-          {selectedTemplate && selectedTemplate.id !== defaultTemplateId && !hasZipTemplate && (
-            <button
-              type="button"
-              className={`template-default-toggle ${setAsDefaultChecked ? 'active' : ''}`}
-              onClick={() => setSetAsDefaultChecked(!setAsDefaultChecked)}
-            >
-              {setAsDefaultChecked ? 'Will be your default' : 'Set as default?'}
-            </button>
+              {selectedTemplate && selectedTemplate.id !== defaultTemplateId && !hasZipTemplate && (
+                <button
+                  type="button"
+                  className={`template-default-toggle ${setAsDefaultChecked ? 'active' : ''}`}
+                  onClick={() => setSetAsDefaultChecked(!setAsDefaultChecked)}
+                >
+                  {setAsDefaultChecked ? 'Will be your default' : 'Set as default?'}
+                </button>
+              )}
+            </>
           )}
 
-          <div className="template-divider">
-            <span>or use a template</span>
-          </div>
-
-          {!hasZipTemplate ? (
-            <div
-              ref={dropZoneRef}
-              className={`template-dropzone ${isDragging ? 'dragging' : ''}`}
-              onDragEnter={handleDragEnter}
-              onDragOver={handleDragOver}
-              onDragLeave={handleDragLeave}
-              onDrop={handleDrop}
-              onClick={() => fileInputRef.current?.click()}
-            >
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".zip"
-                onChange={handleFileSelect}
-                style={{ display: 'none' }}
+          {activeTab === 'template' && (
+            <>
+              <TemplateGallery
+                templates={communityTemplates}
+                loading={communityLoading}
+                onSelect={handleCommunitySelect}
+                selectedId={selectedCommunityId}
+                searchQuery={communitySearch}
+                onSearchChange={setCommunitySearch}
               />
-              <UploadIcon size={24} />
-              <p>Drop a template .zip file here</p>
-              <span>or click to browse</span>
-            </div>
-          ) : (
-            <div className="template-zip-selected">
-              <div className="template-zip-info">
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                >
-                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                  <polyline points="14 2 14 8 20 8" />
-                </svg>
-                <span>{displayZipName}</span>
+
+              <div className="template-divider">
+                <span>or upload a template</span>
               </div>
-              <button type="button" className="template-zip-remove" onClick={handleRemoveZip}>
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
+
+              {!hasZipTemplate ? (
+                <div
+                  ref={dropZoneRef}
+                  className={`template-dropzone ${isDragging ? 'dragging' : ''}`}
+                  onDragEnter={handleDragEnter}
+                  onDragOver={handleDragOver}
+                  onDragLeave={handleDragLeave}
+                  onDrop={handleDrop}
+                  onClick={() => fileInputRef.current?.click()}
                 >
-                  <line x1="18" y1="6" x2="6" y2="18" />
-                  <line x1="6" y1="6" x2="18" y2="18" />
-                </svg>
-              </button>
-            </div>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".zip"
+                    onChange={handleFileSelect}
+                    style={{ display: 'none' }}
+                  />
+                  <UploadIcon size={24} />
+                  <p>Drop a template .zip file here</p>
+                  <span>or click to browse</span>
+                </div>
+              ) : (
+                <div className="template-zip-selected">
+                  <div className="template-zip-info">
+                    <svg
+                      width="20"
+                      height="20"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
+                      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                      <polyline points="14 2 14 8 20 8" />
+                    </svg>
+                    <span>{displayZipName}</span>
+                  </div>
+                  <button type="button" className="template-zip-remove" onClick={handleRemoveZip}>
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
+                      <line x1="18" y1="6" x2="6" y2="18" />
+                      <line x1="6" y1="6" x2="18" y2="18" />
+                    </svg>
+                  </button>
+                </div>
+              )}
+            </>
           )}
 
           {error && <p className="error">{error}</p>}
@@ -296,10 +383,15 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
             <button
               type="button"
               className="btn-primary"
-              disabled={!selectedTemplate && !hasZipTemplate}
-              onClick={handleContinue}
+              disabled={
+                downloading ||
+                (activeTab === 'scratch'
+                  ? !selectedTemplate && !hasZipTemplate
+                  : !selectedCommunityId && !hasZipTemplate)
+              }
+              onClick={() => void handleContinue()}
             >
-              Continue
+              {downloading ? 'Downloading...' : 'Continue'}
             </button>
           </div>
         </div>

--- a/src/components/TemplateGallery.tsx
+++ b/src/components/TemplateGallery.tsx
@@ -1,0 +1,251 @@
+import { useState, useRef, useCallback } from 'react';
+
+/** Shape of a community template from the API */
+export interface CommunityTemplate {
+  id: string;
+  name: string;
+  tagline: string;
+  category: string;
+  thumbnail_url: string | null;
+  zip_url: string | null;
+  creator: {
+    display_name: string;
+  };
+}
+
+interface TemplateGalleryProps {
+  templates: CommunityTemplate[];
+  loading: boolean;
+  onSelect: (template: CommunityTemplate) => void;
+  selectedId: string | null;
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+}
+
+function SkeletonCard() {
+  return (
+    <div className="tg-card tg-card-skeleton">
+      <div className="tg-card-thumb tg-skeleton-shimmer" />
+      <div className="tg-card-body">
+        <div className="tg-skeleton-line tg-skeleton-line-title tg-skeleton-shimmer" />
+        <div className="tg-skeleton-line tg-skeleton-line-desc tg-skeleton-shimmer" />
+        <div className="tg-skeleton-line tg-skeleton-line-author tg-skeleton-shimmer" />
+      </div>
+    </div>
+  );
+}
+
+function TemplateCard({
+  template,
+  selected,
+  onSelect,
+}: {
+  template: CommunityTemplate;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`tg-card ${selected ? 'tg-card-selected' : ''}`}
+      onClick={onSelect}
+    >
+      <div className="tg-card-thumb">
+        {template.thumbnail_url ? (
+          <img src={template.thumbnail_url} alt={template.name} draggable={false} />
+        ) : (
+          <div className="tg-card-thumb-placeholder">
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            >
+              <rect x="3" y="3" width="18" height="18" rx="2" />
+              <path d="M3 9h18" />
+              <path d="M9 21V9" />
+            </svg>
+          </div>
+        )}
+      </div>
+      <div className="tg-card-body">
+        <span className="tg-card-name">{template.name}</span>
+        <span className="tg-card-desc">{template.tagline}</span>
+        <span className="tg-card-author">by {template.creator.display_name}</span>
+      </div>
+      {selected && (
+        <div className="tg-card-check">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </div>
+      )}
+    </button>
+  );
+}
+
+export function TemplateGallery({
+  templates,
+  loading,
+  onSelect,
+  selectedId,
+  searchQuery,
+  onSearchChange,
+}: TemplateGalleryProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollButtons = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  const handleScroll = useCallback(() => {
+    updateScrollButtons();
+  }, [updateScrollButtons]);
+
+  const scroll = (direction: 'left' | 'right') => {
+    const el = scrollRef.current;
+    if (!el) return;
+    // 3 cards fill clientWidth (with 2 inner gaps of 10px).
+    // The next set of 3 starts at clientWidth + 10px (the gap after card 3).
+    const amount = el.clientWidth + 10;
+    el.scrollBy({ left: direction === 'left' ? -amount : amount, behavior: 'smooth' });
+  };
+
+  // Update scroll buttons when templates load
+  const carouselRefCallback = useCallback(
+    (node: HTMLDivElement | null) => {
+      (scrollRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      if (node) {
+        // Wait a frame for layout
+        requestAnimationFrame(updateScrollButtons);
+      }
+    },
+    [updateScrollButtons]
+  );
+
+  const showEmpty = !loading && templates.length === 0;
+
+  return (
+    <div className="tg-container">
+      <div className="tg-search-wrapper">
+        <svg
+          className="tg-search-icon"
+          width="15"
+          height="15"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+        <input
+          type="text"
+          className="tg-search-input"
+          placeholder="Search community templates..."
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
+        />
+        {searchQuery && (
+          <button type="button" className="tg-search-clear" onClick={() => onSearchChange('')}>
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      <div className="tg-carousel-wrapper">
+        {!loading && canScrollLeft && (
+          <button
+            type="button"
+            className="tg-scroll-btn tg-scroll-left"
+            onClick={() => scroll('left')}
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <polyline points="15 18 9 12 15 6" />
+            </svg>
+          </button>
+        )}
+
+        <div className="tg-carousel" ref={carouselRefCallback} onScroll={handleScroll}>
+          {loading && (
+            <>
+              <SkeletonCard />
+              <SkeletonCard />
+              <SkeletonCard />
+            </>
+          )}
+
+          {!loading &&
+            templates.map((t) => (
+              <TemplateCard
+                key={t.id}
+                template={t}
+                selected={selectedId === t.id}
+                onSelect={() => onSelect(t)}
+              />
+            ))}
+
+          {showEmpty && (
+            <div className="tg-empty">
+              <span>No templates found</span>
+            </div>
+          )}
+        </div>
+
+        {!loading && canScrollRight && (
+          <button
+            type="button"
+            className="tg-scroll-btn tg-scroll-right"
+            onClick={() => scroll('right')}
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useProjectCreation.ts
+++ b/src/hooks/useProjectCreation.ts
@@ -626,6 +626,10 @@ export function useProjectCreation({ onComplete, onCancel }: UseProjectCreationP
     handleFileSelect,
     handleRemoveZip,
 
+    // Zip state setters (for community template download flow)
+    setZipPath,
+    setZipFileName,
+
     // Default template
     saveDefaultTemplate,
     defaultTemplateId,

--- a/src/styles/create-project.css
+++ b/src/styles/create-project.css
@@ -39,7 +39,7 @@
   border: 1px solid var(--border);
   border-radius: 16px;
   width: 90%;
-  max-width: 520px;
+  max-width: 580px;
   max-height: 90vh;
   overflow-y: auto;
   animation: slideUp 0.2s ease-out;
@@ -96,6 +96,101 @@
 .create-modal-close:hover {
   background: var(--bg-tertiary);
   color: var(--text-primary);
+}
+
+/* Tabs */
+.create-tabs {
+  display: flex;
+  gap: 0;
+  margin-bottom: 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.create-tab {
+  flex: 1;
+  padding: 10px 0;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
+}
+
+.create-tab:hover {
+  color: var(--text-secondary);
+  background: transparent;
+}
+
+.create-tab.active {
+  color: var(--text-primary);
+  border-bottom-color: var(--text-primary);
+  background: transparent;
+}
+
+/* Stack Grid (Start from Scratch) */
+.stack-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.stack-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 14px 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  cursor: pointer;
+  text-align: left;
+  transition:
+    border-color 0.15s,
+    background-color 0.15s,
+    box-shadow 0.15s;
+}
+
+.stack-card:hover {
+  border-color: var(--text-muted);
+  background: var(--bg-tertiary);
+}
+
+.stack-card-selected {
+  border-color: var(--action);
+}
+
+.stack-card-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.stack-card-desc {
+  font-size: 11px;
+  color: var(--text-secondary);
+  line-height: 1.3;
+}
+
+.stack-card-check {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--action);
+  color: var(--action-text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* Form styles */
@@ -246,111 +341,13 @@
   margin: 0;
 }
 
-/* Template Selection Dropdown */
-.template-select-wrapper {
-  position: relative;
-  margin-bottom: 0;
-}
-
-.template-select-trigger {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: 12px 14px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  color: var(--text-primary);
-  font-size: 15px;
-  cursor: pointer;
-  transition:
-    border-color 0.15s,
-    box-shadow 0.15s;
-  text-align: left;
-}
-
-.template-select-trigger:hover {
-  border-color: var(--text-muted);
-}
-
-.template-select-trigger.dimmed {
-  color: var(--text-muted);
-}
-
-.template-select-trigger svg {
-  flex-shrink: 0;
-  color: var(--text-muted);
-}
-
-.template-select-menu {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  right: 0;
-  max-height: 200px;
-  overflow-y: auto;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-  z-index: 10;
-}
-
-.template-select-option {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: 10px 14px;
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  text-align: left;
-  color: var(--text-primary);
-  transition: background 0.1s;
-}
-
-.template-select-option:hover {
-  background: var(--bg-tertiary);
-}
-
-.template-select-option.selected {
-  color: var(--accent);
-}
-
-.template-select-option svg {
-  flex-shrink: 0;
-  color: var(--accent);
-}
-
-.template-option-text {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.template-option-name {
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.template-option-desc {
-  font-size: 12px;
-  color: var(--text-secondary);
-}
-
-.template-select-option.selected .template-option-desc {
-  color: var(--text-secondary);
-}
-
 .template-default-toggle {
   width: 100%;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 10px 14px;
-  margin-top: 8px;
+  margin-top: 16px;
   margin-bottom: 0;
   font-size: 13px;
   color: var(--text-muted);
@@ -498,4 +495,285 @@
 .template-zip-remove:hover {
   background: var(--bg-tertiary);
   color: var(--text-primary);
+}
+
+/* ── Template Gallery ── */
+
+.tg-container {
+  margin-bottom: 4px;
+}
+
+.tg-search-wrapper {
+  position: relative;
+  margin-bottom: 12px;
+}
+
+.tg-search-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.create-modal-content input.tg-search-input {
+  width: 100%;
+  padding: 10px 34px 10px 40px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 13px;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+  box-sizing: border-box;
+}
+
+.create-modal-content input.tg-search-input:focus {
+  outline: none;
+  border-color: var(--text-muted);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.05);
+}
+
+.create-modal-content input.tg-search-input::placeholder {
+  color: var(--text-muted);
+}
+
+.tg-search-clear {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background-color 0.15s,
+    color 0.15s;
+}
+
+.tg-search-clear:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+/* Carousel */
+
+.tg-carousel-wrapper {
+  position: relative;
+}
+
+.tg-carousel {
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  padding: 2px 0;
+}
+
+.tg-carousel::-webkit-scrollbar {
+  display: none;
+}
+
+.tg-scroll-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  transition:
+    background-color 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+}
+
+.tg-scroll-btn:hover {
+  background: var(--bg-tertiary);
+  border-color: var(--text-muted);
+  color: var(--text-primary);
+}
+
+.tg-scroll-left {
+  left: -14px;
+}
+
+.tg-scroll-right {
+  right: -14px;
+}
+
+/* Cards */
+
+.tg-card {
+  flex: 0 0 calc((100% - 20px) / 3);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    background-color 0.15s,
+    box-shadow 0.15s;
+  text-align: left;
+  padding: 0;
+  position: relative;
+}
+
+.tg-card:hover {
+  border-color: var(--text-muted);
+  background: var(--bg-tertiary);
+}
+
+.tg-card-selected {
+  border-color: var(--action);
+}
+
+.tg-card-thumb {
+  width: 100%;
+  height: 80px;
+  background: var(--bg-tertiary);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tg-card-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.tg-card-thumb-placeholder {
+  color: var(--text-muted);
+}
+
+.tg-card-body {
+  padding: 8px 10px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tg-card-name {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tg-card-desc {
+  font-size: 11px;
+  color: var(--text-secondary);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-height: 1.3;
+}
+
+.tg-card-author {
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.tg-card-check {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--action);
+  color: var(--action-text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Skeleton */
+
+@keyframes tg-shimmer {
+  0% {
+    background-position: -200px 0;
+  }
+  100% {
+    background-position: 200px 0;
+  }
+}
+
+.tg-skeleton-shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--bg-tertiary) 0%,
+    rgba(255, 255, 255, 0.06) 50%,
+    var(--bg-tertiary) 100%
+  );
+  background-size: 200px 100%;
+  animation: tg-shimmer 1.5s ease-in-out infinite;
+}
+
+.tg-card-skeleton {
+  pointer-events: none;
+}
+
+.tg-card-skeleton .tg-card-thumb {
+  background: none;
+}
+
+.tg-skeleton-line {
+  border-radius: 4px;
+  height: 10px;
+}
+
+.tg-skeleton-line-title {
+  width: 70%;
+  height: 12px;
+  margin-bottom: 2px;
+}
+
+.tg-skeleton-line-desc {
+  width: 90%;
+}
+
+.tg-skeleton-line-author {
+  width: 50%;
+  height: 8px;
+  margin-top: 4px;
+}
+
+/* Empty state */
+
+.tg-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 80px;
+  width: 100%;
+  color: var(--text-muted);
+  font-size: 13px;
 }


### PR DESCRIPTION
## Summary
- Restructure New Project modal into two tabs: **Start from Scratch** (3x2 card grid of built-in stacks) and **Start from Template** (searchable carousel of community templates + zip upload)
- Add `TemplateGallery` component with horizontal carousel, skeleton loaders, search bar, and scroll navigation
- Add Rust backend commands for fetching templates from ship.studio API (with server-side search/filter/sort/pagination) and downloading template zips from signed URLs
- Wire full create-from-community-template flow: select → download zip → extract → install deps
- Auto-refresh template list every 50 min to keep signed URLs fresh (1-hour expiry)
- Clean up dead dropdown CSS and unused imports

## Test plan
- [x] TypeScript compiles cleanly
- [x] Rust compiles cleanly
- [x] All 291 existing tests pass
- [x] Lint and format pass (pre-commit hooks)
- [ ] Manual: Open New Project modal, verify "Start from Scratch" tab shows 3x2 card grid
- [ ] Manual: Switch to "Start from Template" tab, verify templates load with thumbnails
- [ ] Manual: Search templates, verify server-side filtering works with debounce
- [ ] Manual: Select a community template, click Continue, verify zip downloads and project creates
- [ ] Manual: Verify carousel scroll arrows work and show 3 cards per page
- [ ] Manual: Verify skeleton loaders show while templates are loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browse and search community-created templates when creating a project
  * Download and use community templates as project starting points
  * New tabbed interface to choose between scratch or template-based project creation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->