### PR TITLE
Windows auto-update

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -125,6 +125,8 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create latest-windows.json
+        env:
+          NOTES: ${{ steps.release_notes.outputs.notes }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           TAG="${{ github.ref_name }}"
@@ -133,23 +135,23 @@ jobs:
           SIG=$(cat artifacts/signature.txt)
           echo "windows-x86_64 signature: $SIG"
 
-          NOTES=$(cat << 'NOTES_EOF'
-          ${{ steps.release_notes.outputs.notes }}
-          NOTES_EOF
-          )
-          NOTES_JSON=$(echo "$NOTES" | sed 's/"/\\"/g' | tr '\n' ' ' | sed 's/  */ /g' | sed 's/^ *//;s/ *$//')
-
-          printf '%s\n' '{' \
-            "  \"version\": \"${VERSION}\"," \
-            "  \"notes\": \"${NOTES_JSON}\"," \
-            "  \"pub_date\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"," \
-            '  "platforms": {' \
-            '    "windows-x86_64": {' \
-            "      \"signature\": \"${SIG}\"," \
-            "      \"url\": \"https://github.com/${RELEASES_REPO}/releases/download/${TAG}/ShipStudio_windows-x86_64-setup.exe\"" \
-            '    }' \
-            '  }' \
-            '}' > latest-windows.json
+          jq -n \
+            --arg version "$VERSION" \
+            --arg notes "$NOTES" \
+            --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg sig "$SIG" \
+            --arg url "https://github.com/${RELEASES_REPO}/releases/download/${TAG}/ShipStudio_windows-x86_64-setup.exe" \
+            '{
+              version: $version,
+              notes: $notes,
+              pub_date: $pub_date,
+              platforms: {
+                "windows-x86_64": {
+                  signature: $sig,
+                  url: $url
+                }
+              }
+            }' > latest-windows.json
 
           echo "Generated latest-windows.json:"
           cat latest-windows.json

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -53,3 +53,148 @@ jobs:
           releaseBody: 'Windows release. See the main repository for full release notes.'
           releaseDraft: true
           prerelease: false
+
+      - name: Find and stage updater artifacts
+        shell: bash
+        run: |
+          BUNDLE_DIR="src-tauri/target/release/bundle/nsis"
+          echo "Looking in $BUNDLE_DIR"
+          ls -la "$BUNDLE_DIR" || true
+
+          EXE_FILE=$(find "$BUNDLE_DIR" -name "*-setup.exe" -type f | head -1)
+          SIG_FILE=$(find "$BUNDLE_DIR" -name "*-setup.exe.sig" -type f | head -1)
+
+          if [ -z "$EXE_FILE" ] || [ -z "$SIG_FILE" ]; then
+            echo "Error: missing expected artifacts"
+            echo "  exe: $EXE_FILE"
+            echo "  sig: $SIG_FILE"
+            exit 1
+          fi
+
+          echo "Found exe: $EXE_FILE"
+          echo "Found sig: $SIG_FILE"
+
+          # Stable asset names for predictable download URLs
+          mkdir -p artifacts
+          cp "$EXE_FILE" "artifacts/ShipStudio_windows-x86_64-setup.exe"
+          cp "$SIG_FILE" "artifacts/ShipStudio_windows-x86_64-setup.exe.sig"
+          cat "$SIG_FILE" > "artifacts/signature.txt"
+
+          ls -la artifacts/
+
+      - name: Upload updater artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: updater-windows-x86_64
+          path: artifacts/
+          if-no-files-found: error
+
+  create-manifest:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo for release notes
+        uses: actions/checkout@v4
+
+      - name: Download updater artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: updater-windows-x86_64
+          path: artifacts
+
+      - name: List downloaded artifacts
+        run: |
+          echo "Downloaded artifacts:"
+          find artifacts -type f
+
+      - name: Get version from tag
+        id: version
+        run: |
+          # v0.5.0-win -> 0.5.0
+          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${VERSION%-win}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Read release notes
+        id: release_notes
+        run: |
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          awk '/^## What/{if(found)exit; found=1; next} found{print}' RELEASE_NOTES.md | sed 's/^- /• /' >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create latest-windows.json
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ github.ref_name }}"
+          RELEASES_REPO="ship-studio/releases"
+
+          SIG=$(cat artifacts/signature.txt)
+          echo "windows-x86_64 signature: $SIG"
+
+          NOTES=$(cat << 'NOTES_EOF'
+          ${{ steps.release_notes.outputs.notes }}
+          NOTES_EOF
+          )
+          NOTES_JSON=$(echo "$NOTES" | sed 's/"/\\"/g' | tr '\n' ' ' | sed 's/  */ /g' | sed 's/^ *//;s/ *$//')
+
+          printf '%s\n' '{' \
+            "  \"version\": \"${VERSION}\"," \
+            "  \"notes\": \"${NOTES_JSON}\"," \
+            "  \"pub_date\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"," \
+            '  "platforms": {' \
+            '    "windows-x86_64": {' \
+            "      \"signature\": \"${SIG}\"," \
+            "      \"url\": \"https://github.com/${RELEASES_REPO}/releases/download/${TAG}/ShipStudio_windows-x86_64-setup.exe\"" \
+            '    }' \
+            '  }' \
+            '}' > latest-windows.json
+
+          echo "Generated latest-windows.json:"
+          cat latest-windows.json
+
+          python3 -c "import json; json.load(open('latest-windows.json'))" && echo "JSON is valid"
+
+      # Carry forward macOS manifest so macOS auto-update keeps working
+      # when this Windows release flips the "latest" alias
+      - name: Carry forward macOS manifest file
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_PAT }}
+        run: |
+          mkdir -p carry-forward
+          gh release download \
+            --repo ship-studio/releases \
+            --pattern "latest.json" \
+            --dir carry-forward
+          ls -la carry-forward/
+
+      - name: Upload artifacts to main repo draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: |
+            artifacts/ShipStudio_windows-x86_64-setup.exe
+            artifacts/ShipStudio_windows-x86_64-setup.exe.sig
+            latest-windows.json
+          draft: true
+
+      # Draft release in public repo - manual publish gate for Windows.
+      # Includes carry-forward macOS manifest so "latest" alias flip
+      # doesn't drop macOS auto-update.
+      - name: Create draft release in public ship-studio/releases repo
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_PAT }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          VERSION="${{ steps.version.outputs.version }}"
+
+          gh release create "$TAG" \
+            --repo ship-studio/releases \
+            --title "Ship Studio v${VERSION} (Windows)" \
+            --notes "Auto-updater release for Ship Studio v${VERSION} Windows. See the main repository for full release notes." \
+            --draft \
+            artifacts/ShipStudio_windows-x86_64-setup.exe \
+            artifacts/ShipStudio_windows-x86_64-setup.exe.sig \
+            latest-windows.json \
+            carry-forward/latest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,6 +256,7 @@ jobs:
             --dir carry-forward
           ls -la carry-forward/
 
+      # Upload to the PRIVATE main repo (for reference/backup)
       - name: Upload updater tarballs to main repo release
         uses: softprops/action-gh-release@v2
         with:
@@ -275,6 +276,7 @@ jobs:
           TAG="${{ github.ref_name }}"
           VERSION="${{ steps.version.outputs.version }}"
 
+          # Create the release in the public repo (auto-published, no draft)
           gh release create "$TAG" \
             --repo ship-studio/releases \
             --title "Ship Studio v${VERSION}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,8 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create latest.json
+        env:
+          NOTES: ${{ steps.release_notes.outputs.notes }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           TAG="${{ github.ref_name }}"
@@ -211,31 +213,29 @@ jobs:
           echo "aarch64 signature: $AARCH64_SIG"
           echo "x86_64 signature: $X86_64_SIG"
 
-          # Read release notes (escape for JSON)
-          NOTES=$(cat << 'NOTES_EOF'
-          ${{ steps.release_notes.outputs.notes }}
-          NOTES_EOF
-          )
-          # Escape newlines and quotes for JSON
-          NOTES_JSON=$(echo "$NOTES" | sed 's/"/\\"/g' | tr '\n' ' ' | sed 's/  */ /g' | sed 's/^ *//;s/ *$//')
-
-          # Create the manifest using printf to avoid YAML parsing issues
-          # URLs point to the PUBLIC releases repo so auto-updater can download
-          printf '%s\n' '{' \
-            "  \"version\": \"${VERSION}\"," \
-            "  \"notes\": \"${NOTES_JSON}\"," \
-            "  \"pub_date\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"," \
-            '  "platforms": {' \
-            '    "darwin-aarch64": {' \
-            "      \"signature\": \"${AARCH64_SIG}\"," \
-            "      \"url\": \"https://github.com/${RELEASES_REPO}/releases/download/${TAG}/ShipStudio_darwin-aarch64.app.tar.gz\"" \
-            '    },' \
-            '    "darwin-x86_64": {' \
-            "      \"signature\": \"${X86_64_SIG}\"," \
-            "      \"url\": \"https://github.com/${RELEASES_REPO}/releases/download/${TAG}/ShipStudio_darwin-x86_64.app.tar.gz\"" \
-            '    }' \
-            '  }' \
-            '}' > latest.json
+          jq -n \
+            --arg version "$VERSION" \
+            --arg notes "$NOTES" \
+            --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg aarch64_sig "$AARCH64_SIG" \
+            --arg aarch64_url "https://github.com/${RELEASES_REPO}/releases/download/${TAG}/ShipStudio_darwin-aarch64.app.tar.gz" \
+            --arg x86_64_sig "$X86_64_SIG" \
+            --arg x86_64_url "https://github.com/${RELEASES_REPO}/releases/download/${TAG}/ShipStudio_darwin-x86_64.app.tar.gz" \
+            '{
+              version: $version,
+              notes: $notes,
+              pub_date: $pub_date,
+              platforms: {
+                "darwin-aarch64": {
+                  signature: $aarch64_sig,
+                  url: $aarch64_url
+                },
+                "darwin-x86_64": {
+                  signature: $x86_64_sig,
+                  url: $x86_64_url
+                }
+              }
+            }' > latest.json
 
           echo "Generated latest.json:"
           cat latest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,7 +243,19 @@ jobs:
           # Validate JSON
           python3 -c "import json; json.load(open('latest.json'))" && echo "JSON is valid"
 
-      # Upload to the PRIVATE main repo (for reference/backup)
+      # Carry forward Windows manifest so Windows auto-update keeps working
+      # when this macOS release flips the "latest" alias
+      - name: Carry forward Windows manifest file
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_PAT }}
+        run: |
+          mkdir -p carry-forward
+          gh release download \
+            --repo ship-studio/releases \
+            --pattern "latest-windows.json" \
+            --dir carry-forward
+          ls -la carry-forward/
+
       - name: Upload updater tarballs to main repo release
         uses: softprops/action-gh-release@v2
         with:
@@ -254,7 +266,8 @@ jobs:
             latest.json
           draft: true
 
-      # Upload to the PUBLIC releases repo (for auto-updater)
+      # Upload to public repo for auto-updater. Includes carry-forward
+      # Windows manifest so "latest" alias flip doesn't drop Windows.
       - name: Create release in public releases repo
         env:
           GH_TOKEN: ${{ secrets.RELEASES_PAT }}
@@ -262,7 +275,6 @@ jobs:
           TAG="${{ github.ref_name }}"
           VERSION="${{ steps.version.outputs.version }}"
 
-          # Create the release in the public repo (auto-published, no draft)
           gh release create "$TAG" \
             --repo ship-studio/releases \
             --title "Ship Studio v${VERSION}" \
@@ -271,4 +283,5 @@ jobs:
             artifacts/updater-darwin-x86_64/ShipStudio_darwin-x86_64.app.tar.gz \
             artifacts/updater-darwin-aarch64/ShipStudio_darwin-aarch64.dmg \
             artifacts/updater-darwin-x86_64/ShipStudio_darwin-x86_64.dmg \
-            latest.json
+            latest.json \
+            carry-forward/latest-windows.json

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -97,7 +97,7 @@ After the workflow completes:
 
 ## Windows Releases
 
-Windows builds run on a separate workflow (`.github/workflows/release-windows.yml`) triggered by tags ending in `-win`. The macOS workflow explicitly excludes these tags, so the two pipelines are fully independent.
+Windows builds run on a separate workflow (`.github/workflows/release-windows.yml`) triggered by tags ending in `-win`. The macOS workflow explicitly excludes these tags, so the two build pipelines are independent, but **both workflows publish to the shared `ship-studio/releases` public repo** (see below for how they cooperate).
 
 ### How to publish a Windows build
 
@@ -109,8 +109,75 @@ git push origin v0.5.0-win
 
 GitHub Actions will:
 1. Build the Tauri app on a `windows-latest` runner
-2. Produce a Windows installer (NSIS/MSI)
-3. Create a **draft release** in the main repo with the artifacts
+2. Produce a Windows NSIS installer (`*-setup.exe`) signed with a minisign `.sig` alongside - in Tauri v2 the installer itself IS the update bundle, no `.nsis.zip` wrapper
+3. Create a **draft release** in the main repo with the artifacts (reference/backup)
+4. Read release notes from `RELEASE_NOTES.md`
+5. Generate `latest-windows.json` with the `windows-x86_64` platform entry pointing to the NSIS setup `.exe`
+6. Carry forward `latest.json` from the previous public release (so macOS auto-update keeps working after this release flips the "latest" alias)
+7. Create a **draft** release in `ship-studio/releases` containing the Windows artifacts plus the carried-forward macOS manifest
+
+### Publishing a Windows release to users
+
+Unlike macOS (which auto-publishes to `ship-studio/releases`), **Windows releases land as drafts in the public repo** and need a manual publish step before they reach users:
+
+1. Go to https://github.com/ship-studio/releases/releases
+2. Find the draft labelled "Ship Studio vX.Y.Z (Windows)"
+3. Verify the attached assets (`.exe` installer + `.sig` + `latest-windows.json` + carried-forward `latest.json`)
+4. Click **Publish release**
+
+Until you do this, Windows auto-update stays on the previous published Windows version - the draft is invisible to GitHub's `/releases/latest/download/` alias.
+
+**Why a manual gate for Windows:** Windows builds are still being stabilized and we want human review before every release goes to users. Once the pipeline has proven itself, this step can be flipped to auto-publish by removing `--draft` from `gh release create` in `release-windows.yml`.
+
+### Per-platform manifest architecture
+
+Tauri v2's updater uses a single manifest file per endpoint with a single top-level `version` field. A shared manifest with both macOS and Windows entries breaks staggered releases (e.g. Windows at 0.4.5 while macOS is at 0.5.0 would cause update loops or missed updates on at least one platform).
+
+The fix is per-platform isolation via `{{target}}` substitution in `tauri.conf.json`:
+
+```json
+"endpoints": [
+  "https://github.com/ship-studio/releases/releases/latest/download/latest-{{target}}.json",
+  "https://github.com/ship-studio/releases/releases/latest/download/latest.json"
+]
+```
+
+- On **Windows**, `{{target}}` → `windows`, primary URL → `latest-windows.json`. Works directly
+- On **macOS**, `{{target}}` → `darwin`, primary URL → `latest-darwin.json` which **does not exist** → HTTP 404 → Tauri falls through to `latest.json` (the macOS manifest). Works via fallback
+- Tauri only falls through on non-2XX responses, so content-mismatch isn't a fallback trigger
+
+**Backward compatibility:** already-installed macOS clients (built before this change) have only the old single `latest.json` endpoint. The macOS workflow continues to upload `latest.json` with macOS-only entries forever, so those clients keep working. New macOS clients get the same `latest.json` via the fallback path - the only difference is one extra 404 request per update check (~50ms, negligible).
+
+Only two manifest files exist in the public repo:
+- `latest.json` - macOS (darwin) platforms
+- `latest-windows.json` - windows platforms
+
+No `latest-darwin.json` - it would be redundant since `latest.json` already contains the darwin entries and the HTTP fallthrough handles the 404 cleanly.
+
+### The carry-forward mechanism
+
+Because both workflows publish to the same public repo and GitHub's `/releases/latest/download/` alias serves whichever release was tagged most recently, every release must include the other platform's manifest file - otherwise a Windows release would hide `latest.json` until the next macOS release (and vice versa).
+
+Each workflow's `create-manifest` job:
+1. Generates the manifest file for its own platform
+2. Runs `gh release download` against `ship-studio/releases` to fetch the other platform's manifest from the previous "latest" release
+3. Uploads everything together
+
+### Verification
+
+After a Windows workflow run completes:
+
+- [ ] Draft release exists in the main repo
+- [ ] Draft release exists in `ship-studio/releases` with both Windows artifacts **and** the carried-forward `latest.json`
+- [ ] After manually publishing the public draft, `latest-windows.json` is valid and has a `windows-x86_64` platform entry:
+  ```bash
+  curl -sL https://github.com/ship-studio/releases/releases/latest/download/latest-windows.json | jq
+  ```
+- [ ] `latest.json` still exists at the public latest URL and still points at the most recent macOS bundle:
+  ```bash
+  curl -sL https://github.com/ship-studio/releases/releases/latest/download/latest.json | jq '.version'
+  ```
+- [ ] Install an older Windows build, tag a newer `-win`, verify the in-app update banner appears and applies cleanly
 
 ## Troubleshooting
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -93,11 +93,9 @@ After the workflow completes:
 - [ ] Publish the main repo draft release
 - [ ] Test auto-updater shows update available in-app
 
----
-
 ## Windows Releases
 
-Windows builds run on a separate workflow (`.github/workflows/release-windows.yml`) triggered by tags ending in `-win`. The macOS workflow explicitly excludes these tags, so the two build pipelines are independent, but **both workflows publish to the shared `ship-studio/releases` public repo** (see below for how they cooperate).
+Windows builds run on a separate workflow (`.github/workflows/release-windows.yml`) triggered by tags ending in `-win`. The macOS workflow explicitly excludes these tags, so the two build pipelines are independent, but both workflows publish to the shared `ship-studio/releases` public repo.
 
 ### How to publish a Windows build
 
@@ -107,77 +105,24 @@ git tag v0.5.0-win
 git push origin v0.5.0-win
 ```
 
-GitHub Actions will:
-1. Build the Tauri app on a `windows-latest` runner
-2. Produce a Windows NSIS installer (`*-setup.exe`) signed with a minisign `.sig` alongside - in Tauri v2 the installer itself IS the update bundle, no `.nsis.zip` wrapper
-3. Create a **draft release** in the main repo with the artifacts (reference/backup)
-4. Read release notes from `RELEASE_NOTES.md`
-5. Generate `latest-windows.json` with the `windows-x86_64` platform entry pointing to the NSIS setup `.exe`
-6. Carry forward `latest.json` from the previous public release (so macOS auto-update keeps working after this release flips the "latest" alias)
-7. Create a **draft** release in `ship-studio/releases` containing the Windows artifacts plus the carried-forward macOS manifest
-
-### Publishing a Windows release to users
-
-Unlike macOS (which auto-publishes to `ship-studio/releases`), **Windows releases land as drafts in the public repo** and need a manual publish step before they reach users:
-
-1. Go to https://github.com/ship-studio/releases/releases
-2. Find the draft labelled "Ship Studio vX.Y.Z (Windows)"
-3. Verify the attached assets (`.exe` installer + `.sig` + `latest-windows.json` + carried-forward `latest.json`)
-4. Click **Publish release**
-
-Until you do this, Windows auto-update stays on the previous published Windows version - the draft is invisible to GitHub's `/releases/latest/download/` alias.
-
-**Why a manual gate for Windows:** Windows builds are still being stabilized and we want human review before every release goes to users. Once the pipeline has proven itself, this step can be flipped to auto-publish by removing `--draft` from `gh release create` in `release-windows.yml`.
-
-### Per-platform manifest architecture
-
-Tauri v2's updater uses a single manifest file per endpoint with a single top-level `version` field. A shared manifest with both macOS and Windows entries breaks staggered releases (e.g. Windows at 0.4.5 while macOS is at 0.5.0 would cause update loops or missed updates on at least one platform).
-
-The fix is per-platform isolation via `{{target}}` substitution in `tauri.conf.json`:
-
-```json
-"endpoints": [
-  "https://github.com/ship-studio/releases/releases/latest/download/latest-{{target}}.json",
-  "https://github.com/ship-studio/releases/releases/latest/download/latest.json"
-]
-```
-
-- On **Windows**, `{{target}}` → `windows`, primary URL → `latest-windows.json`. Works directly
-- On **macOS**, `{{target}}` → `darwin`, primary URL → `latest-darwin.json` which **does not exist** → HTTP 404 → Tauri falls through to `latest.json` (the macOS manifest). Works via fallback
-- Tauri only falls through on non-2XX responses, so content-mismatch isn't a fallback trigger
-
-**Backward compatibility:** already-installed macOS clients (built before this change) have only the old single `latest.json` endpoint. The macOS workflow continues to upload `latest.json` with macOS-only entries forever, so those clients keep working. New macOS clients get the same `latest.json` via the fallback path - the only difference is one extra 404 request per update check (~50ms, negligible).
-
-Only two manifest files exist in the public repo:
-- `latest.json` - macOS (darwin) platforms
-- `latest-windows.json` - windows platforms
-
-No `latest-darwin.json` - it would be redundant since `latest.json` already contains the darwin entries and the HTTP fallthrough handles the 404 cleanly.
-
-### The carry-forward mechanism
-
-Because both workflows publish to the same public repo and GitHub's `/releases/latest/download/` alias serves whichever release was tagged most recently, every release must include the other platform's manifest file - otherwise a Windows release would hide `latest.json` until the next macOS release (and vice versa).
-
-Each workflow's `create-manifest` job:
-1. Generates the manifest file for its own platform
-2. Runs `gh release download` against `ship-studio/releases` to fetch the other platform's manifest from the previous "latest" release
-3. Uploads everything together
 
 ### Verification
 
 After a Windows workflow run completes:
 
 - [ ] Draft release exists in the main repo
-- [ ] Draft release exists in `ship-studio/releases` with both Windows artifacts **and** the carried-forward `latest.json`
-- [ ] After manually publishing the public draft, `latest-windows.json` is valid and has a `windows-x86_64` platform entry:
+- [ ] Draft release exists in `ship-studio/releases` with 2 Windows artifacts and 2 manifests (json)
+
+After manually publishing the public draft:
+
+- [ ] `latest-windows.json` exists, is valid and has a `windows-x86_64` platform entry:
   ```bash
   curl -sL https://github.com/ship-studio/releases/releases/latest/download/latest-windows.json | jq
   ```
-- [ ] `latest.json` still exists at the public latest URL and still points at the most recent macOS bundle:
+- [ ] `latest.json` still exists at the public latest URL and still points at the most recent macOS bundle (it should have the same content as the latest.json in the latest macOS release):
   ```bash
   curl -sL https://github.com/ship-studio/releases/releases/latest/download/latest.json | jq '.version'
   ```
-- [ ] Install an older Windows build, tag a newer `-win`, verify the in-app update banner appears and applies cleanly
 
 ## Troubleshooting
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,6 +40,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
+        "https://github.com/ship-studio/releases/releases/latest/download/latest-{{target}}.json",
         "https://github.com/ship-studio/releases/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDkwOERENTAzOURDNjlFNkYKUldSdm5zYWRBOVdOa0VQQ09QckxabTA3ejVOSHBlSUs3d1I2NG02TmkzOVBmVUZ5OUp3L3QwbUkK"


### PR DESCRIPTION
## Summary

Follow-up to #28 which set up the Windows build. Now wires Windows into the auto-updater and publishes to the shared `ship-studio/releases` public repo like we do for macOS.

The gotcha: GitHub's `/releases/latest/download/` alias flips to whichever release was tagged most recently, so Windows releases would hide `latest.json` from macOS clients (and vice versa). Fix is per-platform manifest files (`latest-windows.json` + `latest.json`) routed via `{{target}}` substitution in `tauri.conf.json`, with each workflow carrying forward the other platform's manifest.

Windows public releases land as drafts (manual publish gate) while we stabilize the pipeline. macOS still auto-publishes.

Code signing (SmartScreen warning) is out of scope here - next PR with Azure Trusted Signing.

See `RELEASING.md` for the process of drafting a new Windows release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated staging, validation and upload of Windows updater artifacts; draft releases are created in both public repos and include updater assets and manifests.
  * Release workflow now generates manifests more robustly and preserves existing per-platform manifests during publishing.

* **New Features**
  * Per-platform updater manifests (parameterized endpoints) with deterministic URLs and embedded signatures.
  * Carry‑forward of existing Windows and macOS manifests to maintain cross‑platform update continuity.

* **Documentation**
  * Updated release docs describing the new publish flow, manifest generation/validation, and manual verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->