### PR TITLE
Fix project-switch crash, restructure rail layout, add project picker

### DIFF
--- a/src-tauri/src/commands/projects/sessions.rs
+++ b/src-tauri/src/commands/projects/sessions.rs
@@ -113,23 +113,23 @@ pub async fn suspend_project_session(project_path: String) -> Result<u32, Comman
     Ok(killed)
 }
 
-/// Fully remove a project session from the registry. Kills PTYs first.
-/// Used when the user closes a session entirely (not just suspends).
+/// Fully remove a project session from the registry.
+///
+/// Does NOT kill PTYs — the frontend's existing cleanup flow
+/// (`stopServer` → `kill_window_pty` → `kill_port`) already handles
+/// PTY teardown with proper ordering and nav-version guards. Killing
+/// PTYs here raced with that flow and, in dev mode, could `kill -9`
+/// processes in the Tauri dev server's process tree.
 ///
 /// Note: this does NOT unpin the project — that's a separate `unpin_project`
 /// call. A user might want to close a session while leaving the pin in place
 /// so it can be reactivated later.
 #[tauri::command]
 #[tracing::instrument]
-pub async fn unregister_project_session(project_path: String) -> Result<u32, CommandError> {
-    let killed = kill_project_pty_internal(&project_path);
+pub async fn unregister_project_session(project_path: String) -> Result<(), CommandError> {
     state_unregister_session(&project_path);
-    tracing::info!(
-        "Unregistered session: project={}, killed_ptys={}",
-        project_path,
-        killed
-    );
-    Ok(killed)
+    tracing::info!("Unregistered session: project={}", project_path,);
+    Ok(())
 }
 
 /// Bump the session's last-activity timestamp. Cheap, safe to call frequently

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -865,40 +865,45 @@ function AppContents({ initialProjectPath }: AppProps) {
   if (view === 'projects') {
     return (
       <>
-        <ProjectRail
-          rows={pinnedProjects.rows}
-          onPinClick={handleRailClick}
-          onUnpin={handleRailUnpin}
-          onReorder={(orderedPaths) => void pinnedProjects.reorder(orderedPaths)}
-        />
-        <ProjectsView
-          onSelectProject={handleSelectProjectCallback}
-          onCreateProject={handleCreateProject}
-          onImportProject={handleImportProject}
-          onImportLocalFolder={handleImportLocalFolderCallback}
-          isGitHubAuthenticated={integrations.github.cliStatus.authenticated}
-          githubUsername={integrations.github.username}
-          isAuthCheckDone={isInitialCheckDone}
-          onGitHubConnect={handleGitHubConnectFromOverlay}
-          showCreateModal={showCreateModal}
-          onCloseCreateModal={handleCloseCreateModal}
-          onProjectCreated={handleProjectCreated}
-          importView={importView}
-          setImportView={setImportView}
-          onProjectImported={handleProjectImported}
-          authTerminalConfig={authTerminalConfig}
-          closeAuthTerminal={closeAuthTerminal}
-          onAuthTerminalExit={handleAuthTerminalExitForProjects}
-          pluginProject={pluginProject}
-          pluginActions={pluginActions}
-          pluginTheme={pluginTheme}
-          getSlotPlugins={getSlotPlugins}
-          projectsLoading={projectsLoading}
-          onLoadingChange={setProjectsLoading}
-          cleanupStatus={cleanupStatus}
-          pinnedSet={pinnedProjects.pinnedSet}
-          onTogglePin={(path, pinned) => void handleTogglePin(path, pinned)}
-        />
+        <div className="projects-with-rail">
+          {pinnedProjects.rows.length > 0 && (
+            <ProjectRail
+              rows={pinnedProjects.rows}
+              onPinClick={handleRailClick}
+              onUnpin={handleRailUnpin}
+              onReorder={(orderedPaths) => void pinnedProjects.reorder(orderedPaths)}
+            />
+          )}
+          <ProjectsView
+            onSelectProject={handleSelectProjectCallback}
+            onCreateProject={handleCreateProject}
+            onImportProject={handleImportProject}
+            onImportLocalFolder={handleImportLocalFolderCallback}
+            isGitHubAuthenticated={integrations.github.cliStatus.authenticated}
+            githubUsername={integrations.github.username}
+            isAuthCheckDone={isInitialCheckDone}
+            onGitHubConnect={handleGitHubConnectFromOverlay}
+            showCreateModal={showCreateModal}
+            onCloseCreateModal={handleCloseCreateModal}
+            onProjectCreated={handleProjectCreated}
+            importView={importView}
+            setImportView={setImportView}
+            onProjectImported={handleProjectImported}
+            authTerminalConfig={authTerminalConfig}
+            closeAuthTerminal={closeAuthTerminal}
+            onAuthTerminalExit={handleAuthTerminalExitForProjects}
+            pluginProject={pluginProject}
+            pluginActions={pluginActions}
+            pluginTheme={pluginTheme}
+            getSlotPlugins={getSlotPlugins}
+            projectsLoading={projectsLoading}
+            onLoadingChange={setProjectsLoading}
+            cleanupStatus={cleanupStatus}
+            pinnedSet={pinnedProjects.pinnedSet}
+            onTogglePin={(path, pinned) => void handleTogglePin(path, pinned)}
+          />
+        </div>
+        {/* .projects-with-rail */}
         {toasts.length > 0 && (
           <div className="toast-container">
             {toasts.map((t) => (
@@ -942,14 +947,18 @@ function AppContents({ initialProjectPath }: AppProps) {
       </>
     );
   }
-  return (
-    <ToastContext.Provider value={toastsProps}>
+  const railElement =
+    pinnedProjects.rows.length > 0 ? (
       <ProjectRail
         rows={pinnedProjects.rows}
         onPinClick={handleRailClick}
         onUnpin={handleRailUnpin}
         onReorder={(orderedPaths) => void pinnedProjects.reorder(orderedPaths)}
       />
+    ) : null;
+
+  return (
+    <ToastContext.Provider value={toastsProps}>
       <WorkspaceView
         currentProject={currentProject}
         previewRef={previewRef}
@@ -969,6 +978,7 @@ function AppContents({ initialProjectPath }: AppProps) {
         pluginActions={pluginActions}
         pluginTheme={pluginTheme}
         handleEnterCompactMode={handleEnterCompactMode}
+        rail={railElement}
       />
       {quitConfirmModal}
     </ToastContext.Provider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -377,11 +377,12 @@ function AppContents({ initialProjectPath }: AppProps) {
     await enterCompactMode();
   };
 
-  const { pinnedProjects, handleTogglePin, handleRailClick, handleRailUnpin } = useProjectRail({
-    currentProjectPath: currentProject?.path ?? null,
-    handleSelectProject,
-    showToast,
-  });
+  const { pinnedProjects, handleTogglePin, handleRailClick, handleRailUnpin, handleAddProject } =
+    useProjectRail({
+      currentProjectPath: currentProject?.path ?? null,
+      handleSelectProject,
+      showToast,
+    });
 
   // App setup, onboarding, HMR recovery, auto-open, keyboard shortcuts
   const { projectsLoading, setProjectsLoading } = useAppSetup({
@@ -872,6 +873,7 @@ function AppContents({ initialProjectPath }: AppProps) {
               onPinClick={handleRailClick}
               onUnpin={handleRailUnpin}
               onReorder={(orderedPaths) => void pinnedProjects.reorder(orderedPaths)}
+              onAddProject={handleAddProject}
             />
           )}
           <ProjectsView
@@ -954,6 +956,7 @@ function AppContents({ initialProjectPath }: AppProps) {
         onPinClick={handleRailClick}
         onUnpin={handleRailUnpin}
         onReorder={(orderedPaths) => void pinnedProjects.reorder(orderedPaths)}
+        onAddProject={handleAddProject}
       />
     ) : null;
 

--- a/src/components/ProjectRail.tsx
+++ b/src/components/ProjectRail.tsx
@@ -321,7 +321,7 @@ export function ProjectRail({
     }
   }, [rows]);
 
-  // Close picker on click outside
+  // Close picker on click outside or Escape
   useEffect(() => {
     if (!showPicker) return;
     const handleClickOutside = (e: MouseEvent) => {
@@ -329,8 +329,15 @@ export function ProjectRail({
         setShowPicker(false);
       }
     };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setShowPicker(false);
+    };
     document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    window.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      window.removeEventListener('keydown', handleKey);
+    };
   }, [showPicker]);
 
   // Don't render anything if there are no pins. Reduces visual noise for
@@ -394,9 +401,14 @@ export function ProjectRail({
             spellCheck={false}
           />
           <ul className="project-rail-picker-list">
-            {pickerProjects
-              .filter((p) => p.name.toLowerCase().includes(pickerFilter.toLowerCase()))
-              .map((p) => (
+            {(() => {
+              const filtered = pickerProjects.filter((p) =>
+                p.name.toLowerCase().includes(pickerFilter.toLowerCase())
+              );
+              if (filtered.length === 0) {
+                return <li className="project-rail-picker-empty">No projects found</li>;
+              }
+              return filtered.map((p) => (
                 <li key={p.path}>
                   <button
                     className="project-rail-picker-item"
@@ -408,9 +420,8 @@ export function ProjectRail({
                     {p.name}
                   </button>
                 </li>
-              ))}
-            {pickerProjects.filter((p) => p.name.toLowerCase().includes(pickerFilter.toLowerCase()))
-              .length === 0 && <li className="project-rail-picker-empty">No projects found</li>}
+              ));
+            })()}
           </ul>
         </div>
       )}

--- a/src/components/ProjectRail.tsx
+++ b/src/components/ProjectRail.tsx
@@ -24,7 +24,7 @@
 
 import { useEffect, useRef, useState, useLayoutEffect, useCallback } from 'react';
 import type { PinnedProjectRow } from '../hooks/usePinnedProjects';
-import { getProjectThumbnail } from '../lib/project';
+import { getProjectThumbnail, listProjects } from '../lib/project';
 import { logger } from '../lib/logger';
 
 interface ProjectRailProps {
@@ -38,6 +38,8 @@ interface ProjectRailProps {
   /** Reorder handler — receives the new ordered list of project paths.
    *  Must contain exactly the same set as `rows` (no adds/removes). */
   onReorder?: (orderedPaths: string[]) => void;
+  /** Called when the user picks a project from the "+" picker. Pins it and opens it. */
+  onAddProject?: (projectPath: string) => void;
 }
 
 /**
@@ -59,7 +61,13 @@ interface PendingDrag {
   startY: number;
 }
 
-export function ProjectRail({ rows, onPinClick, onUnpin, onReorder }: ProjectRailProps) {
+export function ProjectRail({
+  rows,
+  onPinClick,
+  onUnpin,
+  onReorder,
+  onAddProject,
+}: ProjectRailProps) {
   // State drives re-renders for visual feedback (item fade, drop indicator,
   // body class). Refs hold the SAME values for use inside document-level
   // event listeners — without refs, listener closures would capture stale
@@ -77,6 +85,21 @@ export function ProjectRail({ rows, onPinClick, onUnpin, onReorder }: ProjectRai
   const pendingDragRef = useRef<PendingDrag | null>(null);
   const rowsRef = useRef(rows);
   const onReorderRef = useRef(onReorder);
+
+  // Context menu state (lifted from RailItem so it renders outside the list)
+  const [contextMenu, setContextMenu] = useState<{
+    projectPath: string;
+    x: number;
+    y: number;
+  } | null>(null);
+
+  // "Add project" picker state
+  const [showPicker, setShowPicker] = useState(false);
+  const [pickerProjects, setPickerProjects] = useState<{ name: string; path: string }[]>([]);
+  const [pickerFilter, setPickerFilter] = useState('');
+  const [pickerPos, setPickerPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const pickerRef = useRef<HTMLDivElement>(null);
+  const addBtnRef = useRef<HTMLButtonElement>(null);
   // Mirror props into refs so the once-mounted document listeners read the
   // latest values without re-binding. Done in a layout effect so the refs
   // are up-to-date before any subsequent pointer event runs.
@@ -262,6 +285,54 @@ export function ProjectRail({ rows, onPinClick, onUnpin, onReorder }: ProjectRai
     [dragSource, onPinClick]
   );
 
+  // Close context menu on outside click / escape.
+  useEffect(() => {
+    if (!contextMenu) return;
+    const close = () => setContextMenu(null);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+    window.addEventListener('click', close);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('click', close);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [contextMenu]);
+
+  const handleItemContextMenu = useCallback((projectPath: string, x: number, y: number) => {
+    setContextMenu({ projectPath, x, y });
+  }, []);
+
+  // Open the project picker: fetch all projects and filter out already-pinned ones.
+  const openPicker = useCallback(async () => {
+    try {
+      const all = await listProjects();
+      const pinnedPaths = new Set(rows.map((r) => r.projectPath));
+      setPickerProjects(all.filter((p) => !pinnedPaths.has(p.path)));
+      setPickerFilter('');
+      if (addBtnRef.current) {
+        const rect = addBtnRef.current.getBoundingClientRect();
+        setPickerPos({ top: rect.top, left: rect.right + 8 });
+      }
+      setShowPicker(true);
+    } catch (e) {
+      logger.error('[ProjectRail] Failed to load projects for picker', { error: e });
+    }
+  }, [rows]);
+
+  // Close picker on click outside
+  useEffect(() => {
+    if (!showPicker) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setShowPicker(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showPicker]);
+
   // Don't render anything if there are no pins. Reduces visual noise for
   // users who haven't discovered the feature yet — they only see the rail
   // after pinning their first project.
@@ -278,7 +349,7 @@ export function ProjectRail({ rows, onPinClick, onUnpin, onReorder }: ProjectRai
             row={row}
             registerElement={registerItemElement}
             onClick={handleClick}
-            onUnpin={onUnpin}
+            onContextMenu={handleItemContextMenu}
             isDragging={dragSource === row.projectPath}
             isDropTarget={dropTarget === row.projectPath && dragSource !== row.projectPath}
             dropSide={dropSide}
@@ -289,7 +360,80 @@ export function ProjectRail({ rows, onPinClick, onUnpin, onReorder }: ProjectRai
             suppressClickAfterDrag={dragSource !== null}
           />
         ))}
+        {onAddProject && (
+          <li>
+            <button
+              ref={addBtnRef}
+              className="project-rail-add"
+              onClick={() => void openPicker()}
+              title="Pin another project"
+              aria-label="Pin another project"
+            >
+              +
+            </button>
+          </li>
+        )}
       </ul>
+
+      {showPicker && onAddProject && (
+        <div
+          className="project-rail-picker"
+          ref={pickerRef}
+          style={{ top: pickerPos.top, left: pickerPos.left }}
+        >
+          <input
+            className="project-rail-picker-search"
+            type="text"
+            placeholder="Search projects..."
+            value={pickerFilter}
+            onChange={(e) => setPickerFilter(e.target.value)}
+            autoFocus
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+          />
+          <ul className="project-rail-picker-list">
+            {pickerProjects
+              .filter((p) => p.name.toLowerCase().includes(pickerFilter.toLowerCase()))
+              .map((p) => (
+                <li key={p.path}>
+                  <button
+                    className="project-rail-picker-item"
+                    onClick={() => {
+                      setShowPicker(false);
+                      onAddProject(p.path);
+                    }}
+                  >
+                    {p.name}
+                  </button>
+                </li>
+              ))}
+            {pickerProjects.filter((p) => p.name.toLowerCase().includes(pickerFilter.toLowerCase()))
+              .length === 0 && <li className="project-rail-picker-empty">No projects found</li>}
+          </ul>
+        </div>
+      )}
+
+      {contextMenu && (
+        <div
+          className="project-rail-menu"
+          style={{ top: contextMenu.y, left: contextMenu.x }}
+          onClick={(e) => e.stopPropagation()}
+          role="menu"
+        >
+          <button
+            className="project-rail-menu-item danger"
+            onClick={() => {
+              const path = contextMenu.projectPath;
+              setContextMenu(null);
+              onUnpin(path);
+            }}
+          >
+            Unpin from sidebar
+          </button>
+        </div>
+      )}
     </div>
   );
 }
@@ -298,7 +442,7 @@ interface RailItemProps {
   row: PinnedProjectRow;
   registerElement: (projectPath: string, el: HTMLElement | null) => void;
   onClick: (projectPath: string) => void;
-  onUnpin: (projectPath: string) => void;
+  onContextMenu: (projectPath: string, x: number, y: number) => void;
   isDragging: boolean;
   isDropTarget: boolean;
   /** When this row is the drop target, which side the indicator is on. */
@@ -312,7 +456,7 @@ function RailItem({
   row,
   registerElement,
   onClick,
-  onUnpin,
+  onContextMenu,
   isDragging,
   isDropTarget,
   dropSide,
@@ -326,7 +470,6 @@ function RailItem({
   const [thumbnail, setThumbnail] = useState<string | null>(
     () => thumbnailCache.get(row.projectPath) ?? null
   );
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const itemRef = useRef<HTMLDivElement>(null);
 
   // Register this item's DOM node with the rail so pointermove hit-testing
@@ -363,25 +506,10 @@ function RailItem({
     };
   }, [row.projectPath]);
 
-  // Close context menu on outside click / escape.
-  useEffect(() => {
-    if (!contextMenu) return;
-    const close = () => setContextMenu(null);
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') close();
-    };
-    window.addEventListener('click', close);
-    window.addEventListener('keydown', onKey);
-    return () => {
-      window.removeEventListener('click', close);
-      window.removeEventListener('keydown', onKey);
-    };
-  }, [contextMenu]);
-
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    setContextMenu({ x: e.clientX, y: e.clientY });
+    onContextMenu(row.projectPath, e.clientX, e.clientY);
   };
 
   const tooltip = buildTooltip(row);
@@ -448,24 +576,6 @@ function RailItem({
           </span>
         )}
       </div>
-      {contextMenu && (
-        <div
-          className="project-rail-menu"
-          style={{ top: contextMenu.y, left: contextMenu.x }}
-          onClick={(e) => e.stopPropagation()}
-          role="menu"
-        >
-          <button
-            className="project-rail-menu-item danger"
-            onClick={() => {
-              setContextMenu(null);
-              onUnpin(row.projectPath);
-            }}
-          >
-            Unpin from sidebar
-          </button>
-        </div>
-      )}
     </li>
   );
 }

--- a/src/components/WorkspaceHeader.tsx
+++ b/src/components/WorkspaceHeader.tsx
@@ -190,170 +190,172 @@ export function WorkspaceHeader({
     }
   };
 
-  return (
-    <>
-      <div
-        className="workspace-titlebar"
-        onMouseDown={handleDrag}
-        onDoubleClick={handleDoubleClick}
+  const titlebar = (
+    <div className="workspace-titlebar" onMouseDown={handleDrag} onDoubleClick={handleDoubleClick}>
+      <button className="back-link" onClick={onBackToProjects}>
+        ← Projects
+      </button>
+      <h1>{projectName}</h1>
+      <button
+        className="project-path"
+        onClick={() => projectPath && void openInFinder(projectPath)}
+        title="Open in Finder"
       >
-        <button className="back-link" onClick={onBackToProjects}>
-          ← Projects
-        </button>
-        <h1>{projectName}</h1>
-        <button
-          className="project-path"
-          onClick={() => projectPath && void openInFinder(projectPath)}
-          title="Open in Finder"
-        >
-          {projectPath}
-        </button>
-      </div>
-      <header className="workspace-header">
-        {/* Left side — utility buttons + plugin toolbar slots */}
-        <div className="workspace-header-left">
-          <button
-            className={`toolbar-icon-btn ${isEducationMode ? 'active' : ''}`}
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleEducationMode();
-            }}
-            title="Learn Mode"
-            data-education-id="education-button"
-          >
-            <GraduationCapIcon size={12} />
-            <span>Learn Mode</span>
-          </button>
-          <button
-            className="toolbar-icon-btn"
-            onClick={onOpenBackupsModal}
-            title="Backups"
-            data-education-id="backups-button"
-          >
-            <HistoryIcon size={12} />
-          </button>
-          <button
-            className="toolbar-icon-btn"
-            onClick={onOpenEnvEditor}
-            title="Environment Variables"
-            data-education-id="env-button"
-          >
-            <DollarIcon size={12} />
-          </button>
-          <button
-            className="toolbar-icon-btn"
-            onClick={() => setIsSupportPanelOpen(true)}
-            title="Support"
-            data-education-id="support-button"
-          >
-            <HelpIcon size={12} />
-          </button>
-          <button
-            className="toolbar-icon-btn"
-            onClick={onOpenAssetsPanel}
-            title="Assets"
-            data-education-id="assets-button"
-          >
-            <ImageIcon size={12} />
-          </button>
-          <button
-            className="toolbar-icon-btn"
-            onClick={onOpenPluginManager}
-            title="Manage Plugins"
-            data-education-id="plugin-manager"
-          >
-            <PuzzleIcon size={12} />
-          </button>
-          <div
-            className="ide-dropdown-container"
-            onMouseEnter={() => setShowIdeDropdown(true)}
-            onMouseLeave={() => setShowIdeDropdown(false)}
-            data-education-id="ide-button"
-          >
-            <button className="toolbar-icon-btn" title="Open in IDE">
-              <CodeIcon size={12} />
-            </button>
-            {showIdeDropdown && (
-              <div className="ide-dropdown">
-                <div className="ide-dropdown-inner">
-                  {ideAvailability.vscode && (
-                    <button onClick={() => void openInIde('vscode')} disabled={openingIde !== null}>
-                      <VSCodeIcon size={14} />
-                      {openingIde === 'vscode' ? 'Opening...' : 'VS Code'}
-                    </button>
-                  )}
-                  {ideAvailability.cursor && (
-                    <button onClick={() => void openInIde('cursor')} disabled={openingIde !== null}>
-                      <CursorIcon size={14} />
-                      {openingIde === 'cursor' ? 'Opening...' : 'Cursor'}
-                    </button>
-                  )}
-                  {!ideAvailability.vscode && !ideAvailability.cursor && (
-                    <div className="ide-dropdown-empty">No IDEs found</div>
-                  )}
-                </div>
-              </div>
-            )}
-          </div>
-          <PluginSlot
-            name="toolbar"
-            plugins={toolbarPlugins.regular}
-            project={pluginProject}
-            actions={pluginActions}
-            theme={pluginTheme}
-          />
-        </div>
-
-        {/* Right side — client editor, hosting plugin, GitHub, Publish */}
-        <div className="workspace-header-right">
-          <ClientEditorButton projectPath={projectPath} />
-          <PluginSlot
-            name="toolbar"
-            plugins={toolbarPlugins.hosting}
-            project={pluginProject}
-            actions={pluginActions}
-            theme={pluginTheme}
-          />
-          <PluginSlot
-            name="publish"
-            plugins={getSlotPlugins('publish')}
-            project={pluginProject}
-            actions={pluginActions}
-            theme={pluginTheme}
-          />
-          <span data-education-id="github-button">
-            <GitHubButton
-              githubState={integrations.github}
-              projectStatus={integrations.projectGithub}
-              projectPath={projectPath}
-              projectName={projectName}
-              onStatusChange={onGitHubStatusChange}
-              onGitHubConnect={onGitHubConnect}
-              onModalClose={focusActiveTerminal}
-            />
-          </span>
-          <PublishBranchDropdown
-            currentBranch={currentBranch || 'main'}
-            projectGithubStatus={integrations.projectGithub}
-            projectPath={projectPath}
-            hasChangesToSync={hasUncommittedChanges}
-            onStatusChange={onPublishStatusChange}
-            onModalClose={focusActiveTerminal}
-            isPublishing={isPublishing}
-            setIsPublishing={setIsPublishing}
-            onPublishError={onPublishError}
-            onCreatePR={onCreatePR}
-            forceOpen={forcePublishOpen}
-            onForceOpenHandled={onForcePublishOpenHandled}
-          />
-        </div>
-      </header>
-      <SupportPanel
-        isOpen={isSupportPanelOpen}
-        onClose={() => setIsSupportPanelOpen(false)}
-        projectPath={projectPath}
-        projectName={projectName}
-      />
-    </>
+        {projectPath}
+      </button>
+    </div>
   );
+
+  const toolbar = (
+    <header className="workspace-header">
+      {/* Left side — utility buttons + plugin toolbar slots */}
+      <div className="workspace-header-left">
+        <button
+          className={`toolbar-icon-btn ${isEducationMode ? 'active' : ''}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleEducationMode();
+          }}
+          title="Learn Mode"
+          data-education-id="education-button"
+        >
+          <GraduationCapIcon size={12} />
+          <span>Learn Mode</span>
+        </button>
+        <button
+          className="toolbar-icon-btn"
+          onClick={onOpenBackupsModal}
+          title="Backups"
+          data-education-id="backups-button"
+        >
+          <HistoryIcon size={12} />
+        </button>
+        <button
+          className="toolbar-icon-btn"
+          onClick={onOpenEnvEditor}
+          title="Environment Variables"
+          data-education-id="env-button"
+        >
+          <DollarIcon size={12} />
+        </button>
+        <button
+          className="toolbar-icon-btn"
+          onClick={() => setIsSupportPanelOpen(true)}
+          title="Support"
+          data-education-id="support-button"
+        >
+          <HelpIcon size={12} />
+        </button>
+        <button
+          className="toolbar-icon-btn"
+          onClick={onOpenAssetsPanel}
+          title="Assets"
+          data-education-id="assets-button"
+        >
+          <ImageIcon size={12} />
+        </button>
+        <button
+          className="toolbar-icon-btn"
+          onClick={onOpenPluginManager}
+          title="Manage Plugins"
+          data-education-id="plugin-manager"
+        >
+          <PuzzleIcon size={12} />
+        </button>
+        <div
+          className="ide-dropdown-container"
+          onMouseEnter={() => setShowIdeDropdown(true)}
+          onMouseLeave={() => setShowIdeDropdown(false)}
+          data-education-id="ide-button"
+        >
+          <button className="toolbar-icon-btn" title="Open in IDE">
+            <CodeIcon size={12} />
+          </button>
+          {showIdeDropdown && (
+            <div className="ide-dropdown">
+              <div className="ide-dropdown-inner">
+                {ideAvailability.vscode && (
+                  <button onClick={() => void openInIde('vscode')} disabled={openingIde !== null}>
+                    <VSCodeIcon size={14} />
+                    {openingIde === 'vscode' ? 'Opening...' : 'VS Code'}
+                  </button>
+                )}
+                {ideAvailability.cursor && (
+                  <button onClick={() => void openInIde('cursor')} disabled={openingIde !== null}>
+                    <CursorIcon size={14} />
+                    {openingIde === 'cursor' ? 'Opening...' : 'Cursor'}
+                  </button>
+                )}
+                {!ideAvailability.vscode && !ideAvailability.cursor && (
+                  <div className="ide-dropdown-empty">No IDEs found</div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+        <PluginSlot
+          name="toolbar"
+          plugins={toolbarPlugins.regular}
+          project={pluginProject}
+          actions={pluginActions}
+          theme={pluginTheme}
+        />
+      </div>
+
+      {/* Right side — client editor, hosting plugin, GitHub, Publish */}
+      <div className="workspace-header-right">
+        <ClientEditorButton projectPath={projectPath} />
+        <PluginSlot
+          name="toolbar"
+          plugins={toolbarPlugins.hosting}
+          project={pluginProject}
+          actions={pluginActions}
+          theme={pluginTheme}
+        />
+        <PluginSlot
+          name="publish"
+          plugins={getSlotPlugins('publish')}
+          project={pluginProject}
+          actions={pluginActions}
+          theme={pluginTheme}
+        />
+        <span data-education-id="github-button">
+          <GitHubButton
+            githubState={integrations.github}
+            projectStatus={integrations.projectGithub}
+            projectPath={projectPath}
+            projectName={projectName}
+            onStatusChange={onGitHubStatusChange}
+            onGitHubConnect={onGitHubConnect}
+            onModalClose={focusActiveTerminal}
+          />
+        </span>
+        <PublishBranchDropdown
+          currentBranch={currentBranch || 'main'}
+          projectGithubStatus={integrations.projectGithub}
+          projectPath={projectPath}
+          hasChangesToSync={hasUncommittedChanges}
+          onStatusChange={onPublishStatusChange}
+          onModalClose={focusActiveTerminal}
+          isPublishing={isPublishing}
+          setIsPublishing={setIsPublishing}
+          onPublishError={onPublishError}
+          onCreatePR={onCreatePR}
+          forceOpen={forcePublishOpen}
+          onForceOpenHandled={onForcePublishOpenHandled}
+        />
+      </div>
+    </header>
+  );
+
+  const supportPanel = (
+    <SupportPanel
+      isOpen={isSupportPanelOpen}
+      onClose={() => setIsSupportPanelOpen(false)}
+      projectPath={projectPath}
+      projectName={projectName}
+    />
+  );
+
+  return { titlebar, toolbar, supportPanel };
 }

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -287,6 +287,8 @@ export interface WorkspaceViewProps {
   pluginActions: WorkspacePluginActions;
   pluginTheme: PluginThemeData;
   handleEnterCompactMode: () => Promise<void>;
+  /** Optional left rail rendered below the titlebar. */
+  rail?: React.ReactNode;
 }
 
 export const WorkspaceView = memo(function WorkspaceView({
@@ -308,6 +310,7 @@ export const WorkspaceView = memo(function WorkspaceView({
   pluginActions,
   pluginTheme,
   handleEnterCompactMode,
+  rail,
 }: WorkspaceViewProps) {
   // Destructure domain groups for readability in JSX
   const {
@@ -597,467 +600,484 @@ export const WorkspaceView = memo(function WorkspaceView({
     }
   }, [activeTerminalTab, terminalRefsMap]);
 
+  const header = WorkspaceHeader({
+    projectPath: currentProject.path,
+    projectName: currentProject.name,
+    onBackToProjects: () => void handleBackToProjects(),
+    isEducationMode,
+    onToggleEducationMode: () => setIsEducationMode(!isEducationMode),
+    onOpenPluginManager: pluginManagerModal.open,
+    onOpenAssetsPanel: assetsPanelModal.open,
+    onOpenEnvEditor: envEditorModal.open,
+    onOpenBackupsModal: backupsModal.open,
+    integrations,
+    onGitHubStatusChange: handleGitHubStatusChange,
+    onGitHubConnect: handleGitHubConnect,
+    focusActiveTerminal,
+    currentBranch,
+    hasUncommittedChanges,
+    isPublishing,
+    setIsPublishing,
+    onPublishError: handlePublishError,
+    onPublishStatusChange: () => {
+      void handleGitHubStatusChange();
+      void fetchBranchInfo(currentProject.path);
+    },
+    onCreatePR: () => setShowSubmitReview(currentBranch || 'main'),
+    forcePublishOpen,
+    onForcePublishOpenHandled: () => setForcePublishOpen(false),
+    getSlotPlugins,
+    pluginProject,
+    pluginActions,
+    pluginTheme,
+  });
+
   return (
     <>
       <div className="app workspace">
         <UpdateBanner />
-        <WorkspaceHeader
-          projectPath={currentProject.path}
-          projectName={currentProject.name}
-          onBackToProjects={() => void handleBackToProjects()}
-          isEducationMode={isEducationMode}
-          onToggleEducationMode={() => setIsEducationMode(!isEducationMode)}
-          onOpenPluginManager={pluginManagerModal.open}
-          onOpenAssetsPanel={assetsPanelModal.open}
-          onOpenEnvEditor={envEditorModal.open}
-          onOpenBackupsModal={backupsModal.open}
-          integrations={integrations}
-          onGitHubStatusChange={handleGitHubStatusChange}
-          onGitHubConnect={handleGitHubConnect}
-          focusActiveTerminal={focusActiveTerminal}
-          currentBranch={currentBranch}
-          hasUncommittedChanges={hasUncommittedChanges}
-          isPublishing={isPublishing}
-          setIsPublishing={setIsPublishing}
-          onPublishError={handlePublishError}
-          onPublishStatusChange={() => {
-            void handleGitHubStatusChange();
-            void fetchBranchInfo(currentProject.path);
-          }}
-          onCreatePR={() => setShowSubmitReview(currentBranch || 'main')}
-          forcePublishOpen={forcePublishOpen}
-          onForcePublishOpenHandled={() => setForcePublishOpen(false)}
-          getSlotPlugins={getSlotPlugins}
-          pluginProject={pluginProject}
-          pluginActions={pluginActions}
-          pluginTheme={pluginTheme}
-        />
+        {header.titlebar}
 
-        {(currentBranch === 'main' || currentBranch === 'master') && (
-          <MainBranchBanner
-            projectPath={currentProject.path}
-            onCreateBranch={() => setWorkspaceTab('branches')}
-          />
-        )}
+        <div className="workspace-body">
+          {rail}
+          <div className="workspace-main">
+            {header.toolbar}
 
-        <div className="workspace-content">
-          <SplitPane
-            defaultSplit={28}
-            minLeft={20}
-            minRight={35}
-            rightCollapsed={isPreviewHidden}
-            left={
-              <div className="terminal-pane">
-                <HealthIndicatorBar
-                  projectPath={currentProject.path}
-                  healthPanelRef={healthPanelRef}
-                  onAskClaude={sendToClaude}
-                  onHealthOutput={handleHealthOutput}
-                  isWebProject={isWebProject}
-                  customDevCommand={customDevCommand}
-                  hasDevServer={hasDevServer}
-                  projectType={projectType}
-                  isRestartingDevServer={isRestartingDevServer}
-                  isPreviewHidden={isPreviewHidden}
-                  devServerPort={devServerPort}
-                  onRestartDevServer={handleRestartDevServer}
-                  onOpenDevCommand={devCommandModal.open}
-                  onOpenProjectSettings={projectSettingsModal.open}
-                  onEnterCompactMode={handleEnterCompactMode}
-                  onShowPreview={() => setIsPreviewHidden(false)}
-                />
-                {/* Terminal view - hidden in compact mode when viewing branches/PRs */}
-                <div
-                  className={`compact-terminal-view ${compactView !== 'terminal' ? 'compact-hidden' : ''}`}
-                >
-                  <div className="terminal-tabs-bar">
-                    <div className="terminal-tabs" data-education-id="terminal-tabs">
-                      <TerminalTabSelector
-                        tabs={terminalTabs}
-                        activeTabId={activeTerminalTab}
-                        tabTitles={tabTitles}
-                        attentionTabs={attentionTabs}
-                        maxTabs={maxTerminalTabs}
-                        onSelectTab={(tabId) => {
-                          setShowDevServerLogs(false);
-                          setShowHealthLogs(false);
-                          setActiveTerminalTab(tabId);
-                          setAttentionTabs((prev) => {
-                            const next = new Set(prev);
-                            next.delete(tabId);
-                            return next;
-                          });
-                        }}
-                        onAddTab={addTerminalTab}
-                        onCloseTab={closeTerminalTab}
-                        onSwitchAgent={(tabId, agentId) => {
-                          setTabTitles((prev) => {
-                            const next = new Map(prev);
-                            next.delete(tabId);
-                            return next;
-                          });
-                          switchTabAgent(tabId, agentId);
-                        }}
-                      />
-                    </div>
-                    <div className="terminal-logs-tabs">
-                      {(isWebProject || hasDevServer) && (
-                        <>
-                          <button
-                            className={`workspace-tab icon-only ${showDevServerLogs && !showHealthLogs ? 'active' : ''}`}
-                            onClick={() => {
-                              setShowDevServerLogs(true);
+            {(currentBranch === 'main' || currentBranch === 'master') && (
+              <MainBranchBanner
+                projectPath={currentProject.path}
+                onCreateBranch={() => setWorkspaceTab('branches')}
+              />
+            )}
+
+            <div className="workspace-content">
+              <SplitPane
+                defaultSplit={28}
+                minLeft={20}
+                minRight={35}
+                rightCollapsed={isPreviewHidden}
+                left={
+                  <div className="terminal-pane">
+                    <HealthIndicatorBar
+                      projectPath={currentProject.path}
+                      healthPanelRef={healthPanelRef}
+                      onAskClaude={sendToClaude}
+                      onHealthOutput={handleHealthOutput}
+                      isWebProject={isWebProject}
+                      customDevCommand={customDevCommand}
+                      hasDevServer={hasDevServer}
+                      projectType={projectType}
+                      isRestartingDevServer={isRestartingDevServer}
+                      isPreviewHidden={isPreviewHidden}
+                      devServerPort={devServerPort}
+                      onRestartDevServer={handleRestartDevServer}
+                      onOpenDevCommand={devCommandModal.open}
+                      onOpenProjectSettings={projectSettingsModal.open}
+                      onEnterCompactMode={handleEnterCompactMode}
+                      onShowPreview={() => setIsPreviewHidden(false)}
+                    />
+                    {/* Terminal view - hidden in compact mode when viewing branches/PRs */}
+                    <div
+                      className={`compact-terminal-view ${compactView !== 'terminal' ? 'compact-hidden' : ''}`}
+                    >
+                      <div className="terminal-tabs-bar">
+                        <div className="terminal-tabs" data-education-id="terminal-tabs">
+                          <TerminalTabSelector
+                            tabs={terminalTabs}
+                            activeTabId={activeTerminalTab}
+                            tabTitles={tabTitles}
+                            attentionTabs={attentionTabs}
+                            maxTabs={maxTerminalTabs}
+                            onSelectTab={(tabId) => {
+                              setShowDevServerLogs(false);
                               setShowHealthLogs(false);
+                              setActiveTerminalTab(tabId);
+                              setAttentionTabs((prev) => {
+                                const next = new Set(prev);
+                                next.delete(tabId);
+                                return next;
+                              });
                             }}
-                            title="View dev server logs"
-                            data-education-id="server-logs"
-                          >
-                            <TerminalIcon size={12} />
-                          </button>
-                          <button
-                            className={`workspace-tab icon-only ${showHealthLogs ? 'active' : ''}`}
-                            onClick={() => {
-                              setShowDevServerLogs(true);
-                              setShowHealthLogs(true);
+                            onAddTab={addTerminalTab}
+                            onCloseTab={closeTerminalTab}
+                            onSwitchAgent={(tabId, agentId) => {
+                              setTabTitles((prev) => {
+                                const next = new Map(prev);
+                                next.delete(tabId);
+                                return next;
+                              });
+                              switchTabAgent(tabId, agentId);
                             }}
-                            title="View health check logs"
-                            data-education-id="health-logs"
+                          />
+                        </div>
+                        <div className="terminal-logs-tabs">
+                          {(isWebProject || hasDevServer) && (
+                            <>
+                              <button
+                                className={`workspace-tab icon-only ${showDevServerLogs && !showHealthLogs ? 'active' : ''}`}
+                                onClick={() => {
+                                  setShowDevServerLogs(true);
+                                  setShowHealthLogs(false);
+                                }}
+                                title="View dev server logs"
+                                data-education-id="server-logs"
+                              >
+                                <TerminalIcon size={12} />
+                              </button>
+                              <button
+                                className={`workspace-tab icon-only ${showHealthLogs ? 'active' : ''}`}
+                                onClick={() => {
+                                  setShowDevServerLogs(true);
+                                  setShowHealthLogs(true);
+                                }}
+                                title="View health check logs"
+                                data-education-id="health-logs"
+                              >
+                                <ActivityIcon size={12} />
+                              </button>
+                            </>
+                          )}
+                          <ToolbarDropdown
+                            agent={getActiveTabAgent()}
+                            autoAcceptMode={autoAcceptMode}
+                            onNotificationSettings={() => setShowNotificationSettings(true)}
+                            onSkills={skillsModal.open}
+                            onMcp={mcpModal.open}
+                            onAutoAcceptToggle={handleToolbarAutoAcceptToggle}
+                            onHelp={helpModal.open}
+                            terminalPlugins={getSlotPlugins('terminal')}
+                            pluginProject={pluginProject}
+                            pluginActions={pluginActions}
+                            pluginTheme={pluginTheme}
+                          />
+                        </div>
+
+                        {/* Compact mode controls - visible only at narrow widths via CSS */}
+                        <CompactModeToggle
+                          isPinned={isPinned}
+                          onPinToggle={handlePinToggle}
+                          onExpandToFull={handleExpandToFull}
+                        />
+                      </div>
+                      <div className="terminal-content" data-education-id="claude-terminal">
+                        {terminalTabs.map((tab) => (
+                          <div
+                            key={`session-${terminalSessionId}-tab-${tab.id}`}
+                            className={`terminal-tab-content ${!showDevServerLogs && activeTerminalTab === tab.id ? 'active' : ''}`}
                           >
-                            <ActivityIcon size={12} />
-                          </button>
-                        </>
-                      )}
-                      <ToolbarDropdown
-                        agent={getActiveTabAgent()}
-                        autoAcceptMode={autoAcceptMode}
-                        onNotificationSettings={() => setShowNotificationSettings(true)}
-                        onSkills={skillsModal.open}
-                        onMcp={mcpModal.open}
-                        onAutoAcceptToggle={handleToolbarAutoAcceptToggle}
-                        onHelp={helpModal.open}
-                        terminalPlugins={getSlotPlugins('terminal')}
-                        pluginProject={pluginProject}
-                        pluginActions={pluginActions}
-                        pluginTheme={pluginTheme}
-                      />
+                            <Terminal
+                              ref={(ref) => {
+                                if (ref) {
+                                  terminalRefsMap.current.set(tab.id, ref);
+                                }
+                              }}
+                              agent={getAgentById(tab.agentId)}
+                              projectPath={currentProject.path}
+                              onExit={handleTerminalExit}
+                              autoAcceptMode={autoAcceptMode}
+                              onStatusChange={createTabStatusHandler(tab.id)}
+                              onTitleChange={handleTabTitleChange(tab.id)}
+                              sessionName={tab.sessionId}
+                              isActive={!showDevServerLogs && activeTerminalTab === tab.id}
+                              shouldResume={tab.shouldResume}
+                            />
+                          </div>
+                        ))}
+                        {showDevServerLogs && !showHealthLogs && (
+                          <div className="terminal-tab-content active">
+                            <DevServerLogs
+                              output={devServerOutput}
+                              outputVersion={devServerOutputVersion}
+                            />
+                          </div>
+                        )}
+                        {showHealthLogs && (
+                          <div className="terminal-tab-content active">
+                            <DevServerLogs
+                              output={healthOutput}
+                              outputVersion={healthOutputVersion}
+                            />
+                          </div>
+                        )}
+                      </div>
                     </div>
 
-                    {/* Compact mode controls - visible only at narrow widths via CSS */}
-                    <CompactModeToggle
+                    <CompactBranchPRView
+                      compactView={compactView}
+                      setCompactView={setCompactView}
                       isPinned={isPinned}
                       onPinToggle={handlePinToggle}
                       onExpandToFull={handleExpandToFull}
+                      projectPath={currentProject.path}
+                      currentBranch={currentBranch || ''}
+                      branches={branches}
+                      openPRs={openPRs}
+                      integrations={integrations}
+                      onBranchSwitchFromBranches={(branchName) =>
+                        void handleBranchSwitch(branchName)
+                      }
+                      onBranchSwitchFromPR={(branchName) => {
+                        void handleBranchSwitch(branchName);
+                        // TODO: chain off handleBranchSwitch promise instead of arbitrary timeout
+                        setTimeout(() => void handleRestartDevServer(), 1500);
+                      }}
+                      onSubmitForReview={(branchName) => setShowSubmitReview(branchName)}
+                      onRefresh={() => void fetchBranchInfo(currentProject.path)}
+                      onResolveConflicts={(headBranch, baseBranch) =>
+                        void handleResolveConflicts(headBranch, baseBranch)
+                      }
                     />
                   </div>
-                  <div className="terminal-content" data-education-id="claude-terminal">
-                    {terminalTabs.map((tab) => (
-                      <div
-                        key={`session-${terminalSessionId}-tab-${tab.id}`}
-                        className={`terminal-tab-content ${!showDevServerLogs && activeTerminalTab === tab.id ? 'active' : ''}`}
-                      >
-                        <Terminal
-                          ref={(ref) => {
-                            if (ref) {
-                              terminalRefsMap.current.set(tab.id, ref);
+                }
+                right={
+                  <div className="preview-pane">
+                    {/* Preview/Branches/PRs Tabs - always show all tabs */}
+                    <div className="preview-tabs-bar">
+                      {/* Branch Indicator - only show when GitHub is connected and we have branch info */}
+                      {integrations.projectGithub?.status === 'connected' && currentBranch && (
+                        <BranchIndicator
+                          currentBranch={currentBranch}
+                          hasUncommittedChanges={hasUncommittedChanges}
+                          changedFiles={changedFiles}
+                          projectPath={currentProject.path}
+                          isOnBranchesTab={workspaceTab === 'branches' || workspaceTab === 'prs'}
+                          isWebProject={isWebProject}
+                          onClick={() => {
+                            if (workspaceTab === 'branches' || workspaceTab === 'prs') {
+                              setWorkspaceTab(isWebProject ? 'preview' : 'code');
+                            } else {
+                              setWorkspaceTab('branches');
                             }
                           }}
-                          agent={getAgentById(tab.agentId)}
-                          projectPath={currentProject.path}
-                          onExit={handleTerminalExit}
-                          autoAcceptMode={autoAcceptMode}
-                          onStatusChange={createTabStatusHandler(tab.id)}
-                          onTitleChange={handleTabTitleChange(tab.id)}
-                          sessionName={tab.sessionId}
-                          isActive={!showDevServerLogs && activeTerminalTab === tab.id}
-                          shouldResume={tab.shouldResume}
+                          onDiscard={() => {
+                            void checkGitStatus(currentProject.path);
+                          }}
+                          onSave={() => setForcePublishOpen(true)}
                         />
-                      </div>
-                    ))}
-                    {showDevServerLogs && !showHealthLogs && (
-                      <div className="terminal-tab-content active">
-                        <DevServerLogs
-                          output={devServerOutput}
-                          outputVersion={devServerOutputVersion}
-                        />
-                      </div>
-                    )}
-                    {showHealthLogs && (
-                      <div className="terminal-tab-content active">
-                        <DevServerLogs output={healthOutput} outputVersion={healthOutputVersion} />
-                      </div>
-                    )}
-                  </div>
-                </div>
-
-                <CompactBranchPRView
-                  compactView={compactView}
-                  setCompactView={setCompactView}
-                  isPinned={isPinned}
-                  onPinToggle={handlePinToggle}
-                  onExpandToFull={handleExpandToFull}
-                  projectPath={currentProject.path}
-                  currentBranch={currentBranch || ''}
-                  branches={branches}
-                  openPRs={openPRs}
-                  integrations={integrations}
-                  onBranchSwitchFromBranches={(branchName) => void handleBranchSwitch(branchName)}
-                  onBranchSwitchFromPR={(branchName) => {
-                    void handleBranchSwitch(branchName);
-                    // TODO: chain off handleBranchSwitch promise instead of arbitrary timeout
-                    setTimeout(() => void handleRestartDevServer(), 1500);
-                  }}
-                  onSubmitForReview={(branchName) => setShowSubmitReview(branchName)}
-                  onRefresh={() => void fetchBranchInfo(currentProject.path)}
-                  onResolveConflicts={(headBranch, baseBranch) =>
-                    void handleResolveConflicts(headBranch, baseBranch)
-                  }
-                />
-              </div>
-            }
-            right={
-              <div className="preview-pane">
-                {/* Preview/Branches/PRs Tabs - always show all tabs */}
-                <div className="preview-tabs-bar">
-                  {/* Branch Indicator - only show when GitHub is connected and we have branch info */}
-                  {integrations.projectGithub?.status === 'connected' && currentBranch && (
-                    <BranchIndicator
-                      currentBranch={currentBranch}
-                      hasUncommittedChanges={hasUncommittedChanges}
-                      changedFiles={changedFiles}
-                      projectPath={currentProject.path}
-                      isOnBranchesTab={workspaceTab === 'branches' || workspaceTab === 'prs'}
-                      isWebProject={isWebProject}
-                      onClick={() => {
-                        if (workspaceTab === 'branches' || workspaceTab === 'prs') {
-                          setWorkspaceTab(isWebProject ? 'preview' : 'code');
-                        } else {
-                          setWorkspaceTab('branches');
-                        }
-                      }}
-                      onDiscard={() => {
-                        void checkGitStatus(currentProject.path);
-                      }}
-                      onSave={() => setForcePublishOpen(true)}
-                    />
-                  )}
-                  <div style={{ flex: 1 }} />
-                  <div className="workspace-tabs">
-                    {isWebProject && (
-                      <button
-                        className={`workspace-tab ${workspaceTab === 'preview' ? 'active' : ''}`}
-                        onClick={() => setWorkspaceTab('preview')}
-                      >
-                        <EyeIcon size={14} />
-                        <span>Preview</span>
-                      </button>
-                    )}
-                    <button
-                      className={`workspace-tab ${workspaceTab === 'code' ? 'active' : ''}`}
-                      onClick={() => setWorkspaceTab('code')}
-                    >
-                      <CodeIcon size={14} />
-                      <span>Code</span>
-                    </button>
-                    {integrations.projectGithub?.status === 'connected' && (
-                      <>
+                      )}
+                      <div style={{ flex: 1 }} />
+                      <div className="workspace-tabs">
+                        {isWebProject && (
+                          <button
+                            className={`workspace-tab ${workspaceTab === 'preview' ? 'active' : ''}`}
+                            onClick={() => setWorkspaceTab('preview')}
+                          >
+                            <EyeIcon size={14} />
+                            <span>Preview</span>
+                          </button>
+                        )}
                         <button
-                          className={`workspace-tab ${workspaceTab === 'branches' ? 'active' : ''}`}
-                          onClick={() => setWorkspaceTab('branches')}
-                          data-education-id="branches-tab"
+                          className={`workspace-tab ${workspaceTab === 'code' ? 'active' : ''}`}
+                          onClick={() => setWorkspaceTab('code')}
                         >
-                          <BranchIcon size={14} />
-                          <span>Branches</span>
+                          <CodeIcon size={14} />
+                          <span>Code</span>
                         </button>
-                        <button
-                          className={`workspace-tab ${workspaceTab === 'prs' ? 'active' : ''}`}
-                          onClick={() => setWorkspaceTab('prs')}
-                          data-education-id="prs-tab"
-                        >
-                          <PullRequestIcon size={14} />
-                          <span>PRs</span>
-                        </button>
-                      </>
-                    )}
-                  </div>
-                  <div className="preview-tabs-divider" />
-                  <div className="preview-actions">
-                    {isWebProject && (
-                      <>
+                        {integrations.projectGithub?.status === 'connected' && (
+                          <>
+                            <button
+                              className={`workspace-tab ${workspaceTab === 'branches' ? 'active' : ''}`}
+                              onClick={() => setWorkspaceTab('branches')}
+                              data-education-id="branches-tab"
+                            >
+                              <BranchIcon size={14} />
+                              <span>Branches</span>
+                            </button>
+                            <button
+                              className={`workspace-tab ${workspaceTab === 'prs' ? 'active' : ''}`}
+                              onClick={() => setWorkspaceTab('prs')}
+                              data-education-id="prs-tab"
+                            >
+                              <PullRequestIcon size={14} />
+                              <span>PRs</span>
+                            </button>
+                          </>
+                        )}
+                      </div>
+                      <div className="preview-tabs-divider" />
+                      <div className="preview-actions">
+                        {isWebProject && (
+                          <>
+                            <button
+                              className="preview-action-btn-icon"
+                              onClick={() => void handleEnterCompactMode()}
+                              title="Compact Mode"
+                              data-education-id="compact-button"
+                            >
+                              <CompactIcon size={12} />
+                            </button>
+                            <span data-education-id="browser-button">
+                              <BrowserDropdown
+                                url={`http://localhost:${devServerPort}`}
+                                buttonClassName="preview-action-btn-icon"
+                                iconOnly
+                              />
+                            </span>
+                          </>
+                        )}
                         <button
                           className="preview-action-btn-icon"
-                          onClick={() => void handleEnterCompactMode()}
-                          title="Compact Mode"
-                          data-education-id="compact-button"
+                          onClick={() => setIsPreviewHidden(true)}
+                          title="Hide Panel"
+                          data-education-id="hide-preview"
                         >
-                          <CompactIcon size={12} />
+                          <PanelRightIcon size={12} />
                         </button>
-                        <span data-education-id="browser-button">
-                          <BrowserDropdown
-                            url={`http://localhost:${devServerPort}`}
-                            buttonClassName="preview-action-btn-icon"
-                            iconOnly
-                          />
-                        </span>
-                      </>
-                    )}
-                    <button
-                      className="preview-action-btn-icon"
-                      onClick={() => setIsPreviewHidden(true)}
-                      title="Hide Panel"
-                      data-education-id="hide-preview"
-                    >
-                      <PanelRightIcon size={12} />
-                    </button>
-                  </div>
-                </div>
+                      </div>
+                    </div>
 
-                {/* Tab content */}
-                {workspaceTab === 'preview' && isWebProject && (
-                  <div style={{ flex: 1, display: 'flex' }}>
-                    <Preview
-                      key={`${currentProject.path}-${devServerPort}`}
-                      ref={previewRef}
-                      port={devServerPort}
-                      projectPath={currentProject.path}
-                      isStaticProject={projectType === 'statichtml'}
-                      onServerReady={handlePreviewReady}
-                      onPageChange={setCurrentPreviewPage}
-                      isCropMode={isCropMode}
-                      onCropStart={handleCropStart}
-                      onCropComplete={handleCropComplete}
-                      onCropCancel={handleCropCancel}
-                      isBranchSwitching={isBranchSwitching}
-                      isDevServerRestarting={isRestartingDevServer}
-                      onSendToClaude={sendToClaude}
-                      previewPlugins={
-                        <PluginSlot
-                          name="preview"
-                          plugins={getSlotPlugins('preview')}
-                          project={pluginProject}
-                          actions={pluginActions}
-                          theme={pluginTheme}
+                    {/* Tab content */}
+                    {workspaceTab === 'preview' && isWebProject && (
+                      <div style={{ flex: 1, display: 'flex' }}>
+                        <Preview
+                          key={`${currentProject.path}-${devServerPort}`}
+                          ref={previewRef}
+                          port={devServerPort}
+                          projectPath={currentProject.path}
+                          isStaticProject={projectType === 'statichtml'}
+                          onServerReady={handlePreviewReady}
+                          onPageChange={setCurrentPreviewPage}
+                          isCropMode={isCropMode}
+                          onCropStart={handleCropStart}
+                          onCropComplete={handleCropComplete}
+                          onCropCancel={handleCropCancel}
+                          isBranchSwitching={isBranchSwitching}
+                          isDevServerRestarting={isRestartingDevServer}
+                          onSendToClaude={sendToClaude}
+                          previewPlugins={
+                            <PluginSlot
+                              name="preview"
+                              plugins={getSlotPlugins('preview')}
+                              project={pluginProject}
+                              actions={pluginActions}
+                              theme={pluginTheme}
+                            />
+                          }
+                          toolbarExtra={
+                            <div className="agent-toolbar">
+                              <button
+                                className="agent-capture-btn"
+                                onClick={() => void handleCaptureScreenshot()}
+                                disabled={isCapturing || isCropMode}
+                                title="Screenshot preview for Claude (⌘⇧S)"
+                                data-education-id="screenshot-button"
+                              >
+                                {isCapturing ? (
+                                  <div className="capture-spinner" />
+                                ) : (
+                                  <CameraIcon size={14} />
+                                )}
+                                <span className="capture-shortcut">&#8984;&#8679;S</span>
+                              </button>
+                              <button
+                                className={`agent-capture-btn ${isCropMode ? 'active' : ''}`}
+                                onClick={() => setIsCropMode(!isCropMode)}
+                                disabled={isCapturing || isCropCapturing}
+                                title="Crop screenshot for Claude (⌘⇧C)"
+                                data-education-id="crop-button"
+                              >
+                                {isCropCapturing ? (
+                                  <div className="capture-spinner" />
+                                ) : (
+                                  <CropIcon size={14} />
+                                )}
+                                <span className="capture-shortcut">&#8984;&#8679;C</span>
+                              </button>
+                            </div>
+                          }
                         />
-                      }
-                      toolbarExtra={
-                        <div className="agent-toolbar">
-                          <button
-                            className="agent-capture-btn"
-                            onClick={() => void handleCaptureScreenshot()}
-                            disabled={isCapturing || isCropMode}
-                            title="Screenshot preview for Claude (⌘⇧S)"
-                            data-education-id="screenshot-button"
-                          >
-                            {isCapturing ? (
-                              <div className="capture-spinner" />
-                            ) : (
-                              <CameraIcon size={14} />
-                            )}
-                            <span className="capture-shortcut">&#8984;&#8679;S</span>
-                          </button>
-                          <button
-                            className={`agent-capture-btn ${isCropMode ? 'active' : ''}`}
-                            onClick={() => setIsCropMode(!isCropMode)}
-                            disabled={isCapturing || isCropCapturing}
-                            title="Crop screenshot for Claude (⌘⇧C)"
-                            data-education-id="crop-button"
-                          >
-                            {isCropCapturing ? (
-                              <div className="capture-spinner" />
-                            ) : (
-                              <CropIcon size={14} />
-                            )}
-                            <span className="capture-shortcut">&#8984;&#8679;C</span>
-                          </button>
-                        </div>
-                      }
+                      </div>
+                    )}
+                    {workspaceTab === 'code' && (
+                      <div style={{ flex: 1, display: 'flex', minHeight: 0, overflow: 'hidden' }}>
+                        <CodeTab projectPath={currentProject.path} onSendToAgent={sendToClaude} />
+                      </div>
+                    )}
+                    <BranchPRTabContainer
+                      workspaceTab={workspaceTab}
+                      setWorkspaceTab={setWorkspaceTab}
+                      isWebProject={isWebProject}
+                      integrations={integrations}
+                      branches={branches}
+                      openPRs={openPRs}
+                      currentBranch={currentBranch}
+                      projectPath={currentProject.path}
+                      handleBranchSwitch={handleBranchSwitch}
+                      handleRestartDevServer={handleRestartDevServer}
+                      setShowSubmitReview={setShowSubmitReview}
+                      fetchBranchInfo={fetchBranchInfo}
+                      handleResolveConflicts={handleResolveConflicts}
+                      handleGitHubConnect={handleGitHubConnect}
                     />
                   </div>
-                )}
-                {workspaceTab === 'code' && (
-                  <div style={{ flex: 1, display: 'flex', minHeight: 0, overflow: 'hidden' }}>
-                    <CodeTab projectPath={currentProject.path} onSendToAgent={sendToClaude} />
-                  </div>
-                )}
-                <BranchPRTabContainer
-                  workspaceTab={workspaceTab}
-                  setWorkspaceTab={setWorkspaceTab}
-                  isWebProject={isWebProject}
-                  integrations={integrations}
-                  branches={branches}
-                  openPRs={openPRs}
-                  currentBranch={currentBranch}
+                }
+              />
+            </div>
+
+            {/* Compact footer - visible only at narrow window widths via CSS */}
+            <div className="compact-footer-container">
+              {/* Compact publish dropdown - uses controlled mode (forceOpen synced with state)
+              The button is hidden via CSS; only the dropdown menu appears */}
+              <div className="compact-publish-dropdown">
+                <PublishBranchDropdown
+                  currentBranch={currentBranch || 'main'}
+                  projectGithubStatus={integrations.projectGithub}
                   projectPath={currentProject.path}
-                  handleBranchSwitch={handleBranchSwitch}
-                  handleRestartDevServer={handleRestartDevServer}
-                  setShowSubmitReview={setShowSubmitReview}
-                  fetchBranchInfo={fetchBranchInfo}
-                  handleResolveConflicts={handleResolveConflicts}
-                  handleGitHubConnect={handleGitHubConnect}
+                  hasChangesToSync={hasUncommittedChanges}
+                  onStatusChange={() => {
+                    void handleGitHubStatusChange();
+                    void fetchBranchInfo(currentProject.path);
+                  }}
+                  onModalClose={() => {
+                    setIsCompactPublishOpen(false);
+                    focusActiveTerminal();
+                  }}
+                  isPublishing={isPublishing}
+                  setIsPublishing={setIsPublishing}
+                  onPublishError={handlePublishError}
+                  onCreatePR={() => setShowSubmitReview(currentBranch || 'main')}
+                  forceOpen={isCompactPublishOpen}
+                  onForceOpenHandled={() => {}}
+                  excludeClickOutsideSelector=".compact-publish-btn"
                 />
               </div>
-            }
-          />
-        </div>
-
-        {/* Compact footer - visible only at narrow window widths via CSS */}
-        <div className="compact-footer-container">
-          {/* Compact publish dropdown - uses controlled mode (forceOpen synced with state)
-              The button is hidden via CSS; only the dropdown menu appears */}
-          <div className="compact-publish-dropdown">
-            <PublishBranchDropdown
-              currentBranch={currentBranch || 'main'}
-              projectGithubStatus={integrations.projectGithub}
-              projectPath={currentProject.path}
-              hasChangesToSync={hasUncommittedChanges}
-              onStatusChange={() => {
-                void handleGitHubStatusChange();
-                void fetchBranchInfo(currentProject.path);
-              }}
-              onModalClose={() => {
-                setIsCompactPublishOpen(false);
-                focusActiveTerminal();
-              }}
-              isPublishing={isPublishing}
-              setIsPublishing={setIsPublishing}
-              onPublishError={handlePublishError}
-              onCreatePR={() => setShowSubmitReview(currentBranch || 'main')}
-              forceOpen={isCompactPublishOpen}
-              onForceOpenHandled={() => {}}
-              excludeClickOutsideSelector=".compact-publish-btn"
-            />
+              <CompactActionsRow
+                serverHealth={
+                  projectType === 'statichtml' || projectType === 'generic' || hasDevServer
+                    ? 'healthy'
+                    : isRestartingDevServer
+                      ? 'starting'
+                      : 'unhealthy'
+                }
+                currentBranch={currentBranch}
+                hasUncommittedChanges={hasUncommittedChanges}
+                prStatus={openPRs.find((pr) => pr.headRef === currentBranch) ? 'open' : 'none'}
+                isGitHubConnected={integrations.projectGithub?.status === 'connected'}
+                isSynced={!hasUncommittedChanges}
+                onRestartServer={() => void handleRestartDevServer()}
+                onOpenAssets={assetsPanelModal.open}
+                onOpenEnvEditor={envEditorModal.open}
+                onCreateRepo={() => {
+                  // Button only shows when GitHub not connected, so prompt GitHub connection
+                  void handleGitHubConnect();
+                }}
+                onSwitchBranch={() => {
+                  // Toggle between terminal and branches view in compact mode
+                  setCompactView(compactView === 'branches' ? 'terminal' : 'branches');
+                }}
+                onCreatePR={() => {
+                  // Toggle between terminal and PRs view in compact mode
+                  setCompactView(compactView === 'prs' ? 'terminal' : 'prs');
+                }}
+                onPublish={() => setIsCompactPublishOpen((prev) => !prev)}
+              />
+            </div>
           </div>
-          <CompactActionsRow
-            serverHealth={
-              projectType === 'statichtml' || projectType === 'generic' || hasDevServer
-                ? 'healthy'
-                : isRestartingDevServer
-                  ? 'starting'
-                  : 'unhealthy'
-            }
-            currentBranch={currentBranch}
-            hasUncommittedChanges={hasUncommittedChanges}
-            prStatus={openPRs.find((pr) => pr.headRef === currentBranch) ? 'open' : 'none'}
-            isGitHubConnected={integrations.projectGithub?.status === 'connected'}
-            isSynced={!hasUncommittedChanges}
-            onRestartServer={() => void handleRestartDevServer()}
-            onOpenAssets={assetsPanelModal.open}
-            onOpenEnvEditor={envEditorModal.open}
-            onCreateRepo={() => {
-              // Button only shows when GitHub not connected, so prompt GitHub connection
-              void handleGitHubConnect();
-            }}
-            onSwitchBranch={() => {
-              // Toggle between terminal and branches view in compact mode
-              setCompactView(compactView === 'branches' ? 'terminal' : 'branches');
-            }}
-            onCreatePR={() => {
-              // Toggle between terminal and PRs view in compact mode
-              setCompactView(compactView === 'prs' ? 'terminal' : 'prs');
-            }}
-            onPublish={() => setIsCompactPublishOpen((prev) => !prev)}
-          />
+          {/* .workspace-main */}
         </div>
+        {/* .workspace-body */}
 
+        {header.supportPanel}
         <WorkspaceModals
           projectPath={currentProject.path}
           currentProjectPath={currentProject.path}

--- a/src/hooks/useProjectRail.ts
+++ b/src/hooks/useProjectRail.ts
@@ -34,6 +34,8 @@ export interface UseProjectRailReturn {
   handleRailClick: (projectPath: string) => void;
   /** Unpin a project from the rail's context menu. */
   handleRailUnpin: (projectPath: string) => void;
+  /** Pin a project from the picker and open it. */
+  handleAddProject: (projectPath: string) => void;
 }
 
 /**
@@ -99,5 +101,16 @@ export function useProjectRail({
     [handleTogglePin]
   );
 
-  return { pinnedProjects, handleTogglePin, handleRailClick, handleRailUnpin };
+  const handleAddProject = useCallback(
+    (projectPath: string) => {
+      void (async () => {
+        await handleTogglePin(projectPath, true);
+        const projectName = projectPath.split('/').pop() ?? 'project';
+        void handleSelectProject({ name: projectName, path: projectPath, thumbnail: null });
+      })();
+    },
+    [handleTogglePin, handleSelectProject]
+  );
+
+  return { pinnedProjects, handleTogglePin, handleRailClick, handleRailUnpin, handleAddProject };
 }

--- a/src/hooks/useProjectRail.ts
+++ b/src/hooks/useProjectRail.ts
@@ -11,7 +11,7 @@
  * @module hooks/useProjectRail
  */
 
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import type { Project } from '../lib/project';
 import { usePinnedProjects, type UsePinnedProjectsReturn } from './usePinnedProjects';
 import { logger } from '../lib/logger';
@@ -38,30 +38,12 @@ export interface UseProjectRailReturn {
   handleAddProject: (projectPath: string) => void;
 }
 
-/**
- * The `has-project-rail` body class drives the global left-padding that
- * keeps content out from under the fixed-position rail. Applied here
- * (rather than per-view) because the rail is a sibling of every view.
- */
-const BODY_CLASS = 'has-project-rail';
-
 export function useProjectRail({
   currentProjectPath,
   handleSelectProject,
   showToast,
 }: UseProjectRailParams): UseProjectRailReturn {
   const pinnedProjects = usePinnedProjects(currentProjectPath);
-
-  useEffect(() => {
-    if (pinnedProjects.hasPins) {
-      document.body.classList.add(BODY_CLASS);
-    } else {
-      document.body.classList.remove(BODY_CLASS);
-    }
-    return () => {
-      document.body.classList.remove(BODY_CLASS);
-    };
-  }, [pinnedProjects.hasPins]);
 
   const handleTogglePin = useCallback(
     async (projectPath: string, shouldPin: boolean) => {

--- a/src/lib/projectSessions.ts
+++ b/src/lib/projectSessions.ts
@@ -62,10 +62,11 @@ export async function suspendProjectSession(projectPath: string): Promise<number
  * Fully remove a session from the registry. Kills PTYs first.
  * Distinct from `unpinProject` — callers may want to close a session while
  * leaving the pin in place (so it can be cold-started later).
- * Returns the number of PTYs killed.
+ * PTY cleanup is handled separately by the existing cleanup flow
+ * (stopServer → kill_window_pty → kill_port).
  */
-export async function unregisterProjectSession(projectPath: string): Promise<number> {
-  return invoke<number>('unregister_project_session', { projectPath });
+export async function unregisterProjectSession(projectPath: string): Promise<void> {
+  return invoke<void>('unregister_project_session', { projectPath });
 }
 
 /**

--- a/src/styles/features/project-rail.css
+++ b/src/styles/features/project-rail.css
@@ -16,7 +16,6 @@
   align-items: center;
   padding: var(--spacing-sm) 0;
   user-select: none;
-  overflow-y: auto;
 }
 
 /* On the projects view the rail starts at the top of the window (no
@@ -258,6 +257,91 @@ body.rail-drag-active iframe {
 .project-rail-menu-item.danger:hover {
   background: var(--error);
   color: #ffffff;
+}
+
+/* "+" button — last item in the rail list. */
+.project-rail-add {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-md);
+  border: 2px dashed var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 22px;
+  font-weight: 300;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.project-rail-add:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* Project picker popover — positioned by JS via style prop. */
+.project-rail-picker {
+  position: fixed;
+  width: 220px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  z-index: var(--z-tooltip);
+  overflow: hidden;
+}
+
+.project-rail-picker-search {
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: none;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 13px;
+  outline: none;
+}
+
+.project-rail-picker-search::placeholder {
+  color: var(--text-muted);
+}
+
+.project-rail-picker-list {
+  list-style: none;
+  margin: 0;
+  padding: var(--spacing-xs);
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.project-rail-picker-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.project-rail-picker-item:hover {
+  background: var(--bg-primary);
+}
+
+.project-rail-picker-empty {
+  padding: var(--spacing-sm) var(--spacing-md);
+  color: var(--text-muted);
+  font-size: 13px;
 }
 
 /* Projects view wrapper: rail + dashboard in a row. */

--- a/src/styles/features/project-rail.css
+++ b/src/styles/features/project-rail.css
@@ -1,31 +1,28 @@
 /**
- * ProjectRail — fixed left sidebar of pinned projects.
+ * ProjectRail — left sidebar column of pinned projects.
  *
- * Layout slot: rendered as a sibling of the main app container; the rail's
- * presence is what gives the workspace its left padding (see `.app--with-rail`
- * modifier defined here).
- *
- * Width is fixed to keep the workspace layout calculations predictable —
- * Preview iframe sizing, terminal fit, etc. all assume a stable canvas width.
+ * In the workspace view the rail sits inside `.workspace-body` (a flex row
+ * below the titlebar). In the projects view it sits inside
+ * `.projects-with-rail`. Both cases: the rail is a flex child, not fixed.
  */
 
 .project-rail {
-  position: fixed;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  width: 56px;
+  width: 77px;
+  flex-shrink: 0;
   background: var(--bg-secondary);
   border-right: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   align-items: center;
-  /* Top padding leaves clearance for the macOS traffic-light buttons
-   * (they live at ~y=12, ~14px tall; we want the first pin to start
-   * comfortably below them). Bottom padding is the normal small gap. */
-  padding: 44px 0 var(--spacing-sm);
-  z-index: var(--z-dropdown);
+  padding: var(--spacing-sm) 0;
   user-select: none;
+  overflow-y: auto;
+}
+
+/* On the projects view the rail starts at the top of the window (no
+ * titlebar above it), so add padding to clear macOS traffic lights. */
+.projects-with-rail > .project-rail {
+  padding-top: 44px;
 }
 
 .project-rail-list {
@@ -47,8 +44,8 @@
 
 .project-rail-item-wrapper {
   position: relative;
-  width: 40px;
-  height: 40px;
+  width: 48px;
+  height: 48px;
   transition: opacity 0.15s ease;
 }
 
@@ -117,35 +114,29 @@ body.rail-drag-active iframe {
 
 .project-rail-item {
   position: relative;
-  width: 40px;
-  height: 40px;
+  width: 48px;
+  height: 48px;
   padding: 0;
   background: transparent;
-  border: 1px solid var(--border);
+  border: 2px solid transparent;
   border-radius: var(--radius-md);
   cursor: pointer;
   overflow: hidden;
   display: block;
-  transition:
-    transform 0.15s ease,
-    border-color 0.15s ease,
-    box-shadow 0.15s ease;
+  transition: border-color 0.15s ease;
 }
 
 .project-rail-item:hover {
   border-color: var(--accent);
-  transform: translateY(-1px);
 }
 
 .project-rail-item:focus-visible {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px var(--accent);
 }
 
 .project-rail-item.is-current {
   border-color: var(--action);
-  box-shadow: 0 0 0 1px var(--action);
 }
 
 .project-rail-thumb {
@@ -269,11 +260,9 @@ body.rail-drag-active iframe {
   color: #ffffff;
 }
 
-/*
- * Layout shift: when the rail has at least one pin, push the rest of the
- * app over by 56px. The body-level class is toggled in App.tsx so this
- * applies to every view (projects, workspace, etc.) without per-view CSS.
- */
-body.has-project-rail {
-  padding-left: 56px;
+/* Projects view wrapper: rail + dashboard in a row. */
+.projects-with-rail {
+  display: flex;
+  height: 100%;
+  width: 100%;
 }

--- a/src/styles/features/workspace/compact.css
+++ b/src/styles/features/workspace/compact.css
@@ -2,8 +2,8 @@
 /* When window is narrow (<= 550px), show only terminal + compact footer */
 
 @media (max-width: 550px) {
-  /* Hide workspace header and titlebar in compact mode */
-  .workspace-titlebar,
+  /* Hide workspace header (Learn Mode toolbar) in compact mode.
+   * Titlebar stays visible so traffic lights and back-link work normally. */
   .workspace-header {
     display: none;
   }
@@ -35,10 +35,9 @@
     min-height: 36px;
   }
 
-  /* Simplify terminal toolbar — add left padding for macOS traffic lights */
+  /* Hide terminal toolbar — titlebar stays visible instead */
   .terminal-toolbar {
-    padding: 6px 8px 6px 78px;
-    min-height: 28px;
+    display: none;
   }
 
   /* Shrink toolbar buttons to align with macOS traffic lights */

--- a/src/styles/features/workspace/main.css
+++ b/src/styles/features/workspace/main.css
@@ -78,6 +78,22 @@
   border-bottom: 1px solid var(--border);
 }
 
+/* Two-column row below the titlebar: optional rail + main content. */
+.workspace-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.workspace-main {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
 .workspace-content {
   flex: 1;
   display: flex;


### PR DESCRIPTION
## Summary

- **Fix dev server crash on back-to-projects**: `unregisterProjectSession` was calling `kill -9` on PTYs before the existing cleanup flow ran, racing with it and killing `pnpm tauri dev` in dev mode. Removed the redundant PTY kill — the existing `stopServer` → `kill_window_pty` → `kill_port` flow already handles teardown properly.

- **Restructure workspace layout for the pinned-projects rail**: Changed from `position: fixed` + body padding hacks to a proper flex layout. Titlebar stays full-width on top, then a `workspace-body` flex row contains the optional rail column + main content column. Works identically in normal and compact mode.

- **Keep titlebar visible in compact mode**: Previously compact mode hid the titlebar, which meant the rail needed special handling. Now the titlebar stays visible and the terminal toolbar is hidden instead, so the rail layout is consistent across modes.

- **Add "+" button to the rail**: Appears as the last item in the pin list. Opens a searchable picker popover listing unpinned projects. Selecting one pins it and opens it.

- **Fix context menu clipping**: Lifted context menu state from individual RailItem components to the parent ProjectRail, rendering the menu outside the `<ul>` at the same level as the picker (both use `position: fixed`) so they aren't clipped by `overflow: hidden` on ancestor containers.

- **Rail styling tweaks**: Wider rail (77px, clears traffic lights), larger thumbnails (48px), simpler hover/active states (2px border, no translateY).

## Test plan

- [x] `cargo test` — 178 passed
- [x] `pnpm test` — 380 passed, 4 skipped (pre-existing jsdom pointer event limitation)
- [x] `tsc --noEmit` — clean
- [ ] Manual: Open a project, click back → dev server should NOT crash
- [ ] Manual: Pin projects, verify rail appears below titlebar in both normal and compact mode
- [ ] Manual: Click "+" in rail, search and select a project → pins and opens it
- [ ] Manual: Right-click a pin → "Unpin from sidebar" menu appears above all content
- [ ] Manual: Verify titlebar spans full width with rail visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "add project" (+) button to the project rail with a searchable project picker.

* **Improvements**
  * Project rail now renders only when there are pinned projects and integrates into workspace layout.
  * Redesigned project rail visuals, larger touch targets, and picker/context-menu behavior.
  * Workspace header and layout reorganized into discrete titlebar/toolbar/support slots.
  * Compact view: terminal toolbar hidden on small screens; layout tweaks for two-column workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->