### PR TITLE
Fix CommandError serialization, useAsyncState StrictMode bug, git pager blocking

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -126,6 +126,7 @@ fn get_branch_name(path: &std::path::Path) -> Result<String, CommandError> {
 fn get_commit_messages(path: &std::path::Path, base: &str) -> Result<String, String> {
     let output = create_command("git")
         .args([
+            "--no-pager",
             "log",
             &format!("{base}..HEAD"),
             "--pretty=format:%s",
@@ -141,7 +142,7 @@ fn get_commit_messages(path: &std::path::Path, base: &str) -> Result<String, Str
 
 fn get_diff_stat(path: &std::path::Path, base: &str) -> Result<String, String> {
     let output = create_command("git")
-        .args(["diff", &format!("{base}...HEAD"), "--stat"])
+        .args(["--no-pager", "diff", &format!("{base}...HEAD"), "--stat"])
         .current_dir(path)
         .output()
         .map_err(|e| e.to_string())?;
@@ -151,7 +152,7 @@ fn get_diff_stat(path: &std::path::Path, base: &str) -> Result<String, String> {
 
 fn get_diff(path: &std::path::Path, base: &str) -> Result<String, String> {
     let output = create_command("git")
-        .args(["diff", &format!("{base}...HEAD")])
+        .args(["--no-pager", "diff", &format!("{base}...HEAD")])
         .current_dir(path)
         .output()
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/git/stash.rs
+++ b/src-tauri/src/commands/git/stash.rs
@@ -93,7 +93,12 @@ pub async fn get_backups(
 
     // Format: hash|full_hash|message|timestamp|relative_time
     let output = create_command("git")
-        .args(["log", &format!("-{limit}"), "--format=%h|%H|%s|%ct|%cr"])
+        .args([
+            "--no-pager",
+            "log",
+            &format!("-{limit}"),
+            "--format=%h|%H|%s|%ct|%cr",
+        ])
         .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
@@ -148,7 +153,7 @@ pub async fn restore_backup(
 
     // Get the commit message of the target backup
     let msg_output = create_command("git")
-        .args(["log", "-1", "--format=%s", &commit_hash])
+        .args(["--no-pager", "log", "-1", "--format=%s", &commit_hash])
         .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/git/status.rs
+++ b/src-tauri/src/commands/git/status.rs
@@ -48,7 +48,7 @@ pub async fn check_git_has_changes(project_path: String) -> Result<bool, Command
 
     // Check for unpushed commits
     let unpushed = create_command("git")
-        .args(["log", "@{u}..", "--oneline"])
+        .args(["--no-pager", "log", "@{u}..", "--oneline"])
         .current_dir(&project)
         .output();
 
@@ -60,7 +60,7 @@ pub async fn check_git_has_changes(project_path: String) -> Result<bool, Command
         Err(_) => {
             // No upstream set, check if we have commits
             let commits = create_command("git")
-                .args(["log", "--oneline", "-1"])
+                .args(["--no-pager", "log", "--oneline", "-1"])
                 .current_dir(&project)
                 .output()
                 .map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -456,8 +456,10 @@ pub async fn list_github_repos(owner: String) -> Result<Vec<GitHubRepo>, Command
     }
 
     let json_str = String::from_utf8_lossy(&output.stdout);
-    let repos: Vec<GitHubRepo> = serde_json::from_str(&json_str)
-        .map_err(|e| CommandError::Other(format!("Failed to parse repo list: {e}")))?;
+    let repos: Vec<GitHubRepo> =
+        serde_json::from_str(&json_str).map_err(|e| CommandError::Other {
+            message: format!("Failed to parse repo list: {e}"),
+        })?;
 
     Ok(repos)
 }
@@ -506,8 +508,10 @@ pub async fn list_collaborator_repos() -> Result<Vec<GitHubRepo>, CommandError> 
     let json_str = String::from_utf8_lossy(&output.stdout);
 
     // The API returns an array of repo objects with different field names
-    let api_repos: Vec<GitHubApiRepo> = serde_json::from_str(&json_str)
-        .map_err(|e| CommandError::Other(format!("Failed to parse collaborator repo list: {e}")))?;
+    let api_repos: Vec<GitHubApiRepo> =
+        serde_json::from_str(&json_str).map_err(|e| CommandError::Other {
+            message: format!("Failed to parse collaborator repo list: {e}"),
+        })?;
 
     // Convert to our GitHubRepo format
     let repos: Vec<GitHubRepo> = api_repos

--- a/src-tauri/src/commands/health/deps.rs
+++ b/src-tauri/src/commands/health/deps.rs
@@ -237,8 +237,9 @@ pub async fn get_package_json(project_path: String) -> Result<String, CommandErr
         return Err(("package.json not found".to_string()).into());
     }
 
-    std::fs::read_to_string(&package_json_path)
-        .map_err(|e| CommandError::Io(format!("Failed to read package.json: {e}")))
+    std::fs::read_to_string(&package_json_path).map_err(|e| CommandError::Io {
+        message: format!("Failed to read package.json: {e}"),
+    })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/plugins/mod.rs
+++ b/src-tauri/src/commands/plugins/mod.rs
@@ -375,8 +375,9 @@ pub fn read_plugin_bundle(project_path: String, plugin_id: String) -> Result<Str
         return Err((format!("Plugin bundle not found: {}", bundle_path.display())).into());
     }
 
-    fs::read_to_string(&bundle_path)
-        .map_err(|e| CommandError::Io(format!("Failed to read plugin bundle: {e}")))
+    fs::read_to_string(&bundle_path).map_err(|e| CommandError::Io {
+        message: format!("Failed to read plugin bundle: {e}"),
+    })
 }
 
 /// Read a plugin's manifest

--- a/src-tauri/src/commands/plugins/plugin_storage.rs
+++ b/src-tauri/src/commands/plugins/plugin_storage.rs
@@ -42,8 +42,9 @@ pub fn read_plugin_storage(
     let content = fs::read_to_string(&storage_path)
         .map_err(|e| format!("Failed to read plugin storage: {e}"))?;
 
-    serde_json::from_str(&content)
-        .map_err(|e| CommandError::Other(format!("Failed to parse plugin storage: {e}")))
+    serde_json::from_str(&content).map_err(|e| CommandError::Other {
+        message: format!("Failed to parse plugin storage: {e}"),
+    })
 }
 
 /// Write plugin storage data
@@ -72,8 +73,9 @@ pub fn write_plugin_storage(
     let content = serde_json::to_string_pretty(&data)
         .map_err(|e| format!("Failed to serialize storage data: {e}"))?;
 
-    fs::write(&storage_path, content)
-        .map_err(|e| CommandError::Io(format!("Failed to write plugin storage: {e}")))
+    fs::write(&storage_path, content).map_err(|e| CommandError::Io {
+        message: format!("Failed to write plugin storage: {e}"),
+    })
 }
 
 /// Execute a shell command in a plugin's context

--- a/src-tauri/src/commands/publishing.rs
+++ b/src-tauri/src/commands/publishing.rs
@@ -160,9 +160,9 @@ pub async fn publish_to_staging(
             warn!(error = %stderr, "Push rejected - staging branch has diverged");
             // Retain the legacy PUSH_REJECTED sentinel so the frontend can
             // still discriminate this case via substring match.
-            return Err(CommandError::Other(format!(
+            return Err(CommandError::Other { message: format!(
                 "PUSH_REJECTED: Staging branch has diverged. Pull changes first or resolve conflicts.\n{stderr}"
-            )));
+            ) });
         }
         if !stderr.contains("Everything up-to-date") {
             error!(error = %stderr, "Failed to push to staging");
@@ -293,7 +293,9 @@ pub async fn publish_branch(
         // Check for common errors
         if stderr.contains("rejected") || stderr.contains("non-fast-forward") {
             warn!(error = %stderr, branch = %branch, "Push rejected");
-            return Err(CommandError::Other(format!("PUSH_REJECTED:{stderr}")));
+            return Err(CommandError::Other {
+                message: format!("PUSH_REJECTED:{stderr}"),
+            });
         }
         if stderr.contains("Permission denied") || stderr.contains("could not read Username") {
             error!(error = %stderr, branch = %branch, "Authentication error");

--- a/src-tauri/src/commands/templates.rs
+++ b/src-tauri/src/commands/templates.rs
@@ -61,10 +61,9 @@ pub async fn fetch_community_templates(
         return Err((format!("API returned status {}", response.status())).into());
     }
 
-    response
-        .text()
-        .await
-        .map_err(|e| CommandError::Other(format!("Failed to read response: {e}")))
+    response.text().await.map_err(|e| CommandError::Other {
+        message: format!("Failed to read response: {e}"),
+    })
 }
 
 /// Download a template zip from a signed URL to a temporary file.
@@ -103,5 +102,7 @@ pub async fn download_template_zip(url: String) -> Result<String, CommandError> 
     file_path
         .to_str()
         .map(|s| s.to_string())
-        .ok_or_else(|| CommandError::Other("Invalid temp file path".to_string()))
+        .ok_or_else(|| CommandError::Other {
+            message: "Invalid temp file path".to_string(),
+        })
 }

--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -28,28 +28,32 @@ pub enum CommandError {
     #[error("Not authenticated with {service}")]
     NotAuthenticated { service: String },
 
-    #[error("I/O error: {0}")]
-    Io(String),
+    #[error("I/O error: {message}")]
+    Io { message: String },
 
-    #[error("{0}")]
-    Other(String),
+    #[error("{message}")]
+    Other { message: String },
 }
 
 impl From<std::io::Error> for CommandError {
     fn from(err: std::io::Error) -> Self {
-        CommandError::Io(err.to_string())
+        CommandError::Io {
+            message: err.to_string(),
+        }
     }
 }
 
 impl From<String> for CommandError {
     fn from(s: String) -> Self {
-        CommandError::Other(s)
+        CommandError::Other { message: s }
     }
 }
 
 impl From<&str> for CommandError {
     fn from(s: &str) -> Self {
-        CommandError::Other(s.to_string())
+        CommandError::Other {
+            message: s.to_string(),
+        }
     }
 }
 
@@ -95,7 +99,7 @@ mod tests {
     fn from_string_maps_to_other() {
         let err: CommandError = "boom".to_string().into();
         match err {
-            CommandError::Other(msg) => assert_eq!(msg, "boom"),
+            CommandError::Other { message } => assert_eq!(message, "boom"),
             _ => panic!("expected Other variant"),
         }
     }
@@ -105,7 +109,7 @@ mod tests {
         let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
         let err: CommandError = io_err.into();
         match err {
-            CommandError::Io(msg) => assert!(msg.contains("missing")),
+            CommandError::Io { message } => assert!(message.contains("missing")),
             _ => panic!("expected Io variant"),
         }
     }

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -47,7 +47,9 @@ pub async fn run_with_timeout(
         }
         Ok(Err(io_err)) => {
             warn!(cmd = %label, error = %io_err, "external command spawn failed");
-            Err(CommandError::Io(io_err.to_string()))
+            Err(CommandError::Io {
+                message: io_err.to_string(),
+            })
         }
         Err(_) => {
             warn!(cmd = %label, timeout_secs, "external command timed out");
@@ -97,7 +99,7 @@ mod tests {
         let cmd = Command::new("definitely-not-a-real-binary-shipstudio");
         let err = run_with_timeout(cmd, "ghost", 5).await.unwrap_err();
         match err {
-            CommandError::Io(_) => {}
+            CommandError::Io { .. } => {}
             other => panic!("expected Io, got {other:?}"),
         }
     }

--- a/src/hooks/useAsyncState.ts
+++ b/src/hooks/useAsyncState.ts
@@ -52,12 +52,14 @@ export function useAsyncState<T, Args extends unknown[] = []>(
     onErrorRef.current = onError;
   }, [fn, onSuccess, onError]);
 
-  useEffect(
-    () => () => {
+  // Reset mountedRef on (re-)mount so StrictMode's double-effect cycle
+  // (mount → cleanup → remount) doesn't leave it permanently false.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
       mountedRef.current = false;
-    },
-    []
-  );
+    };
+  }, []);
 
   const execute = useCallback(async (...args: Args): Promise<T | null> => {
     setIsLoading(true);

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -12,8 +12,8 @@ export type CommandError =
   | { type: 'Process'; cmd: string; exit_code: number; stderr: string }
   | { type: 'Validation'; field: string; reason: string }
   | { type: 'NotAuthenticated'; service: string }
-  | { type: 'Io'; '0': string }
-  | { type: 'Other'; '0': string };
+  | { type: 'Io'; message: string }
+  | { type: 'Other'; message: string };
 
 /**
  * Best-effort coercion of an unknown caught value into a `CommandError`. Used
@@ -26,12 +26,12 @@ export function asCommandError(value: unknown): CommandError {
     return value as CommandError;
   }
   if (typeof value === 'string') {
-    return { type: 'Other', '0': value };
+    return { type: 'Other', message: value };
   }
   if (value instanceof Error) {
-    return { type: 'Other', '0': value.message };
+    return { type: 'Other', message: value.message };
   }
-  return { type: 'Other', '0': String(value) };
+  return { type: 'Other', message: String(value) };
 }
 
 /** Render a `CommandError` to a user-facing string. */
@@ -46,8 +46,8 @@ export function formatCommandError(err: CommandError): string {
     case 'NotAuthenticated':
       return `Not authenticated with ${err.service}`;
     case 'Io':
-      return `I/O error: ${err['0']}`;
+      return `I/O error: ${err.message}`;
     case 'Other':
-      return err['0'];
+      return err.message;
   }
 }


### PR DESCRIPTION
## Summary

- **CommandError serialization**: `Io(String)` and `Other(String)` newtype variants can't serialize with serde's internally tagged `#[serde(tag = "type")]`. Converted to struct variants `Io { message }` / `Other { message }`. This was causing "cannot serialize tagged newtype variant CommandError::Other" errors on the frontend for any command that hit an error path. Updated all Rust call sites and the TypeScript mirror.

- **useAsyncState StrictMode bug**: React 18 StrictMode's double-effect cycle (mount → cleanup → remount) set `mountedRef` to `false` during cleanup but never reset it on remount. Every async operation silently discarded its result — causing infinite loading spinners in Backups and potentially any component using `useAsyncState`/`useInvoke`.

- **Git pager blocking**: Added `--no-pager` to all `git log` and `git diff` subprocess calls. A custom `core.pager` config could cause `Command::output()` to block indefinitely when spawned in the Tauri async runtime.

## Test plan

- [x] `cargo test` — 178 passed
- [x] `vitest run` — 380 passed, 4 skipped
- [x] `tsc --noEmit` — clean
- [ ] Open Backups modal in a project — should load backup list instead of spinning forever
- [ ] Trigger an error in any Tauri command (e.g. revert on a project with no remote) — should show the actual error message, not "cannot serialize tagged newtype variant"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed async state handling to remain stable during React StrictMode cycles

* **Chores**
  * Refactored error handling structures for consistency across backend operations
  * Optimized git command invocations for improved output handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->