### PR TITLE
Isolate plugin crashes so they can't take down the app

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -25,6 +25,22 @@ export class ErrorBoundary extends Component<Props, State> {
     logger.logError(error, { componentStack: errorInfo.componentStack ?? undefined });
   }
 
+  /** Check if the error likely originated from a plugin */
+  private isPluginError(): boolean {
+    const msg = this.state.error?.message ?? '';
+    const stack = this.state.error?.stack ?? '';
+    return (
+      msg.includes('Plugin context') ||
+      msg.includes('plugin-sdk') ||
+      stack.includes('blob:') ||
+      stack.includes('usePluginContext')
+    );
+  }
+
+  handleContinue = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
   handleRestart = async () => {
     try {
       await relaunch();
@@ -74,26 +90,58 @@ export class ErrorBoundary extends Component<Props, State> {
             Something went wrong
           </h1>
           <p style={{ fontSize: '14px', color: '#888', margin: '0 0 24px 0', maxWidth: '400px' }}>
-            {this.state.error?.message || 'An unexpected error occurred'}
+            {this.isPluginError()
+              ? 'A plugin crashed. You can continue without it or restart the app.'
+              : this.state.error?.message || 'An unexpected error occurred'}
           </p>
-          <button
-            onClick={() => void this.handleRestart()}
-            style={{
-              backgroundColor: '#2472c8',
-              color: 'white',
-              border: 'none',
-              borderRadius: '6px',
-              padding: '10px 20px',
-              fontSize: '14px',
-              fontWeight: 500,
-              cursor: 'pointer',
-              transition: 'background-color 150ms',
-            }}
-            onMouseOver={(e) => (e.currentTarget.style.backgroundColor = '#1e5fa8')}
-            onMouseOut={(e) => (e.currentTarget.style.backgroundColor = '#2472c8')}
-          >
-            Restart App
-          </button>
+          <div style={{ display: 'flex', gap: '12px' }}>
+            {this.isPluginError() && (
+              <button
+                onClick={this.handleContinue}
+                style={{
+                  backgroundColor: '#2472c8',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '6px',
+                  padding: '10px 20px',
+                  fontSize: '14px',
+                  fontWeight: 500,
+                  cursor: 'pointer',
+                  transition: 'background-color 150ms',
+                }}
+                onMouseOver={(e) => (e.currentTarget.style.backgroundColor = '#1e5fa8')}
+                onMouseOut={(e) => (e.currentTarget.style.backgroundColor = '#2472c8')}
+              >
+                Continue
+              </button>
+            )}
+            <button
+              onClick={() => void this.handleRestart()}
+              style={{
+                backgroundColor: this.isPluginError() ? '#3a3a3a' : '#2472c8',
+                color: 'white',
+                border: 'none',
+                borderRadius: '6px',
+                padding: '10px 20px',
+                fontSize: '14px',
+                fontWeight: 500,
+                cursor: 'pointer',
+                transition: 'background-color 150ms',
+              }}
+              onMouseOver={(e) =>
+                (e.currentTarget.style.backgroundColor = this.isPluginError()
+                  ? '#4a4a4a'
+                  : '#1e5fa8')
+              }
+              onMouseOut={(e) =>
+                (e.currentTarget.style.backgroundColor = this.isPluginError()
+                  ? '#3a3a3a'
+                  : '#2472c8')
+              }
+            >
+              Restart App
+            </button>
+          </div>
           {this.state.error && (
             <details
               style={{

--- a/src/components/PluginSlot.tsx
+++ b/src/components/PluginSlot.tsx
@@ -115,6 +115,58 @@ function PluginErrorFallback({
   );
 }
 
+/**
+ * Outermost isolation boundary — wraps the entire plugin render including
+ * the Context.Provider. Catches errors that escape the inner PluginErrorBoundary
+ * (e.g. plugins bundling their own React, errors during Provider setup, or
+ * dual-React-instance edge cases).
+ */
+class PluginIsolationBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error) {
+    console.error(
+      `[PluginIsolation] Plugin "${this.props.pluginId}" crashed (outer boundary):`,
+      error
+    );
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.compact) {
+        return (
+          <span
+            className="plugin-error-indicator"
+            title={`${this.props.pluginName} crashed: ${this.state.error?.message || 'Unknown error'}`}
+          >
+            !
+          </span>
+        );
+      }
+
+      return (
+        <PluginErrorFallback
+          pluginName={this.props.pluginName}
+          error={this.state.error}
+          onRetry={this.handleRetry}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}
+
 /** Error boundary that isolates plugin crashes */
 class PluginErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
@@ -267,6 +319,8 @@ function SafePluginWrapper({
 export function PluginSlot({ name, plugins, project, actions, theme }: PluginSlotProps) {
   if (plugins.length === 0) return null;
 
+  const compact = name === 'toolbar' || name === 'preview';
+
   return (
     <>
       {plugins.map((plugin) => {
@@ -280,31 +334,38 @@ export function PluginSlot({ name, plugins, project, actions, theme }: PluginSlo
           theme,
           plugin.info.manifest.required_commands || []
         );
-        // Expose context on namespaced map for raw-JS plugins
+
+        // Expose context on window globals for raw-JS and legacy plugins.
+        // Must be synchronous (before plugin component renders) so plugins
+        // that read the legacy global during their first render can find it.
         const pluginsMap = ((
           window as unknown as Record<string, unknown>
         ).__SHIPSTUDIO_PLUGINS__ ??= {}) as Record<string, PluginContextValue>;
         pluginsMap[plugin.info.manifest.id] = ctx;
-        // Legacy single-global write for v0 compat (last-writer-wins)
         exposePluginContext(ctx);
 
-        const compact = name === 'toolbar' || name === 'preview';
-
         return (
-          <PluginContext.Provider key={plugin.info.manifest.id} value={ctx}>
-            <PluginErrorBoundary
-              pluginId={plugin.info.manifest.id}
-              pluginName={plugin.info.manifest.name}
-              compact={compact}
-            >
-              <SafePluginWrapper
-                Component={SlotComponent}
+          <PluginIsolationBoundary
+            key={plugin.info.manifest.id}
+            pluginId={plugin.info.manifest.id}
+            pluginName={plugin.info.manifest.name}
+            compact={compact}
+          >
+            <PluginContext.Provider value={ctx}>
+              <PluginErrorBoundary
                 pluginId={plugin.info.manifest.id}
                 pluginName={plugin.info.manifest.name}
                 compact={compact}
-              />
-            </PluginErrorBoundary>
-          </PluginContext.Provider>
+              >
+                <SafePluginWrapper
+                  Component={SlotComponent}
+                  pluginId={plugin.info.manifest.id}
+                  pluginName={plugin.info.manifest.name}
+                  compact={compact}
+                />
+              </PluginErrorBoundary>
+            </PluginContext.Provider>
+          </PluginIsolationBoundary>
         );
       })}
     </>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,16 +26,19 @@ import 'overlayscrollbars/overlayscrollbars.css';
 exposeReactGlobals(React, ReactDOM);
 exposePluginContextRef();
 
-// Global safety net: catch unhandled errors from plugin blob: URLs.
+// Global safety net: catch unhandled errors from plugins.
 // Plugins that bundle their own React can throw errors that escape React error
 // boundaries entirely. This prevents those from crashing the whole app.
 window.addEventListener('error', (event) => {
-  if (event.filename?.startsWith('blob:')) {
+  const err = event.error as { message?: string } | undefined;
+  const msg: string = (typeof err?.message === 'string' ? err.message : event.message) ?? '';
+  const isPluginError =
+    event.filename?.startsWith('blob:') ||
+    msg.includes('Plugin context') ||
+    msg.includes('plugin-sdk');
+  if (isPluginError) {
     event.preventDefault();
-    console.error(
-      '[Ship Studio] Plugin error caught by global handler:',
-      event.error || event.message
-    );
+    console.error('[Ship Studio] Plugin error caught by global handler:', msg);
   }
 });
 window.addEventListener('unhandledrejection', (event) => {


### PR DESCRIPTION
## Summary

- **PluginIsolationBoundary**: New outer error boundary wrapping each plugin's entire render tree (including the Context.Provider). Catches errors that escape the inner PluginErrorBoundary — e.g. plugins bundling their own React, context setup failures, dual-React-instance edge cases.
- **Global ErrorBoundary recovery**: Detects plugin-related crashes and shows "Continue" + "Restart App" instead of only "Restart App". Users can dismiss and keep working.
- **Window-level error handler**: Expanded to catch plugin context errors that React re-throws in dev mode, preventing them from reaching the global boundary.

## Context

Plugins like Netlify that bundle their own React or have context issues throw "Plugin context not available", which escapes React error boundaries and crashes the entire app — forcing users to restart.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 380 passed
- [ ] Install a known-crashing plugin (e.g. Netlify) → should show "!" in toolbar or inline error, not full-screen crash
- [ ] If error does reach global boundary → "Continue" button lets user dismiss and keep working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin-related errors now display targeted messaging with a "Continue" option, allowing recovery without restarting the app.

* **Bug Fixes**
  * Strengthened error isolation for plugins to catch and recover from crashes more reliably.
  * Enhanced plugin-error detection in the global error handler for better categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->