### PR TITLE
Plugin crash isolation, auto-remove, backups non-git-repo handling

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -126,6 +126,7 @@ fn get_branch_name(path: &std::path::Path) -> Result<String, CommandError> {
 fn get_commit_messages(path: &std::path::Path, base: &str) -> Result<String, String> {
     let output = create_command("git")
         .args([
+            "--no-pager",
             "log",
             &format!("{base}..HEAD"),
             "--pretty=format:%s",
@@ -141,7 +142,7 @@ fn get_commit_messages(path: &std::path::Path, base: &str) -> Result<String, Str
 
 fn get_diff_stat(path: &std::path::Path, base: &str) -> Result<String, String> {
     let output = create_command("git")
-        .args(["diff", &format!("{base}...HEAD"), "--stat"])
+        .args(["--no-pager", "diff", &format!("{base}...HEAD"), "--stat"])
         .current_dir(path)
         .output()
         .map_err(|e| e.to_string())?;
@@ -151,7 +152,7 @@ fn get_diff_stat(path: &std::path::Path, base: &str) -> Result<String, String> {
 
 fn get_diff(path: &std::path::Path, base: &str) -> Result<String, String> {
     let output = create_command("git")
-        .args(["diff", &format!("{base}...HEAD")])
+        .args(["--no-pager", "diff", &format!("{base}...HEAD")])
         .current_dir(path)
         .output()
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/git/stash.rs
+++ b/src-tauri/src/commands/git/stash.rs
@@ -93,7 +93,12 @@ pub async fn get_backups(
 
     // Format: hash|full_hash|message|timestamp|relative_time
     let output = create_command("git")
-        .args(["log", &format!("-{limit}"), "--format=%h|%H|%s|%ct|%cr"])
+        .args([
+            "--no-pager",
+            "log",
+            &format!("-{limit}"),
+            "--format=%h|%H|%s|%ct|%cr",
+        ])
         .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
@@ -148,7 +153,7 @@ pub async fn restore_backup(
 
     // Get the commit message of the target backup
     let msg_output = create_command("git")
-        .args(["log", "-1", "--format=%s", &commit_hash])
+        .args(["--no-pager", "log", "-1", "--format=%s", &commit_hash])
         .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/git/status.rs
+++ b/src-tauri/src/commands/git/status.rs
@@ -48,7 +48,7 @@ pub async fn check_git_has_changes(project_path: String) -> Result<bool, Command
 
     // Check for unpushed commits
     let unpushed = create_command("git")
-        .args(["log", "@{u}..", "--oneline"])
+        .args(["--no-pager", "log", "@{u}..", "--oneline"])
         .current_dir(&project)
         .output();
 
@@ -60,7 +60,7 @@ pub async fn check_git_has_changes(project_path: String) -> Result<bool, Command
         Err(_) => {
             // No upstream set, check if we have commits
             let commits = create_command("git")
-                .args(["log", "--oneline", "-1"])
+                .args(["--no-pager", "log", "--oneline", "-1"])
                 .current_dir(&project)
                 .output()
                 .map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -456,8 +456,10 @@ pub async fn list_github_repos(owner: String) -> Result<Vec<GitHubRepo>, Command
     }
 
     let json_str = String::from_utf8_lossy(&output.stdout);
-    let repos: Vec<GitHubRepo> = serde_json::from_str(&json_str)
-        .map_err(|e| CommandError::Other(format!("Failed to parse repo list: {e}")))?;
+    let repos: Vec<GitHubRepo> =
+        serde_json::from_str(&json_str).map_err(|e| CommandError::Other {
+            message: format!("Failed to parse repo list: {e}"),
+        })?;
 
     Ok(repos)
 }
@@ -506,8 +508,10 @@ pub async fn list_collaborator_repos() -> Result<Vec<GitHubRepo>, CommandError> 
     let json_str = String::from_utf8_lossy(&output.stdout);
 
     // The API returns an array of repo objects with different field names
-    let api_repos: Vec<GitHubApiRepo> = serde_json::from_str(&json_str)
-        .map_err(|e| CommandError::Other(format!("Failed to parse collaborator repo list: {e}")))?;
+    let api_repos: Vec<GitHubApiRepo> =
+        serde_json::from_str(&json_str).map_err(|e| CommandError::Other {
+            message: format!("Failed to parse collaborator repo list: {e}"),
+        })?;
 
     // Convert to our GitHubRepo format
     let repos: Vec<GitHubRepo> = api_repos

--- a/src-tauri/src/commands/health/deps.rs
+++ b/src-tauri/src/commands/health/deps.rs
@@ -237,8 +237,9 @@ pub async fn get_package_json(project_path: String) -> Result<String, CommandErr
         return Err(("package.json not found".to_string()).into());
     }
 
-    std::fs::read_to_string(&package_json_path)
-        .map_err(|e| CommandError::Io(format!("Failed to read package.json: {e}")))
+    std::fs::read_to_string(&package_json_path).map_err(|e| CommandError::Io {
+        message: format!("Failed to read package.json: {e}"),
+    })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/plugins/mod.rs
+++ b/src-tauri/src/commands/plugins/mod.rs
@@ -375,8 +375,9 @@ pub fn read_plugin_bundle(project_path: String, plugin_id: String) -> Result<Str
         return Err((format!("Plugin bundle not found: {}", bundle_path.display())).into());
     }
 
-    fs::read_to_string(&bundle_path)
-        .map_err(|e| CommandError::Io(format!("Failed to read plugin bundle: {e}")))
+    fs::read_to_string(&bundle_path).map_err(|e| CommandError::Io {
+        message: format!("Failed to read plugin bundle: {e}"),
+    })
 }
 
 /// Read a plugin's manifest

--- a/src-tauri/src/commands/plugins/plugin_storage.rs
+++ b/src-tauri/src/commands/plugins/plugin_storage.rs
@@ -42,8 +42,9 @@ pub fn read_plugin_storage(
     let content = fs::read_to_string(&storage_path)
         .map_err(|e| format!("Failed to read plugin storage: {e}"))?;
 
-    serde_json::from_str(&content)
-        .map_err(|e| CommandError::Other(format!("Failed to parse plugin storage: {e}")))
+    serde_json::from_str(&content).map_err(|e| CommandError::Other {
+        message: format!("Failed to parse plugin storage: {e}"),
+    })
 }
 
 /// Write plugin storage data
@@ -72,8 +73,9 @@ pub fn write_plugin_storage(
     let content = serde_json::to_string_pretty(&data)
         .map_err(|e| format!("Failed to serialize storage data: {e}"))?;
 
-    fs::write(&storage_path, content)
-        .map_err(|e| CommandError::Io(format!("Failed to write plugin storage: {e}")))
+    fs::write(&storage_path, content).map_err(|e| CommandError::Io {
+        message: format!("Failed to write plugin storage: {e}"),
+    })
 }
 
 /// Execute a shell command in a plugin's context

--- a/src-tauri/src/commands/publishing.rs
+++ b/src-tauri/src/commands/publishing.rs
@@ -160,9 +160,9 @@ pub async fn publish_to_staging(
             warn!(error = %stderr, "Push rejected - staging branch has diverged");
             // Retain the legacy PUSH_REJECTED sentinel so the frontend can
             // still discriminate this case via substring match.
-            return Err(CommandError::Other(format!(
+            return Err(CommandError::Other { message: format!(
                 "PUSH_REJECTED: Staging branch has diverged. Pull changes first or resolve conflicts.\n{stderr}"
-            )));
+            ) });
         }
         if !stderr.contains("Everything up-to-date") {
             error!(error = %stderr, "Failed to push to staging");
@@ -293,7 +293,9 @@ pub async fn publish_branch(
         // Check for common errors
         if stderr.contains("rejected") || stderr.contains("non-fast-forward") {
             warn!(error = %stderr, branch = %branch, "Push rejected");
-            return Err(CommandError::Other(format!("PUSH_REJECTED:{stderr}")));
+            return Err(CommandError::Other {
+                message: format!("PUSH_REJECTED:{stderr}"),
+            });
         }
         if stderr.contains("Permission denied") || stderr.contains("could not read Username") {
             error!(error = %stderr, branch = %branch, "Authentication error");

--- a/src-tauri/src/commands/templates.rs
+++ b/src-tauri/src/commands/templates.rs
@@ -61,10 +61,9 @@ pub async fn fetch_community_templates(
         return Err((format!("API returned status {}", response.status())).into());
     }
 
-    response
-        .text()
-        .await
-        .map_err(|e| CommandError::Other(format!("Failed to read response: {e}")))
+    response.text().await.map_err(|e| CommandError::Other {
+        message: format!("Failed to read response: {e}"),
+    })
 }
 
 /// Download a template zip from a signed URL to a temporary file.
@@ -103,5 +102,7 @@ pub async fn download_template_zip(url: String) -> Result<String, CommandError> 
     file_path
         .to_str()
         .map(|s| s.to_string())
-        .ok_or_else(|| CommandError::Other("Invalid temp file path".to_string()))
+        .ok_or_else(|| CommandError::Other {
+            message: "Invalid temp file path".to_string(),
+        })
 }

--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -28,28 +28,32 @@ pub enum CommandError {
     #[error("Not authenticated with {service}")]
     NotAuthenticated { service: String },
 
-    #[error("I/O error: {0}")]
-    Io(String),
+    #[error("I/O error: {message}")]
+    Io { message: String },
 
-    #[error("{0}")]
-    Other(String),
+    #[error("{message}")]
+    Other { message: String },
 }
 
 impl From<std::io::Error> for CommandError {
     fn from(err: std::io::Error) -> Self {
-        CommandError::Io(err.to_string())
+        CommandError::Io {
+            message: err.to_string(),
+        }
     }
 }
 
 impl From<String> for CommandError {
     fn from(s: String) -> Self {
-        CommandError::Other(s)
+        CommandError::Other { message: s }
     }
 }
 
 impl From<&str> for CommandError {
     fn from(s: &str) -> Self {
-        CommandError::Other(s.to_string())
+        CommandError::Other {
+            message: s.to_string(),
+        }
     }
 }
 
@@ -95,7 +99,7 @@ mod tests {
     fn from_string_maps_to_other() {
         let err: CommandError = "boom".to_string().into();
         match err {
-            CommandError::Other(msg) => assert_eq!(msg, "boom"),
+            CommandError::Other { message } => assert_eq!(message, "boom"),
             _ => panic!("expected Other variant"),
         }
     }
@@ -105,7 +109,7 @@ mod tests {
         let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
         let err: CommandError = io_err.into();
         match err {
-            CommandError::Io(msg) => assert!(msg.contains("missing")),
+            CommandError::Io { message } => assert!(message.contains("missing")),
             _ => panic!("expected Io variant"),
         }
     }

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -47,7 +47,9 @@ pub async fn run_with_timeout(
         }
         Ok(Err(io_err)) => {
             warn!(cmd = %label, error = %io_err, "external command spawn failed");
-            Err(CommandError::Io(io_err.to_string()))
+            Err(CommandError::Io {
+                message: io_err.to_string(),
+            })
         }
         Err(_) => {
             warn!(cmd = %label, timeout_secs, "external command timed out");
@@ -97,7 +99,7 @@ mod tests {
         let cmd = Command::new("definitely-not-a-real-binary-shipstudio");
         let err = run_with_timeout(cmd, "ghost", 5).await.unwrap_err();
         match err {
-            CommandError::Io(_) => {}
+            CommandError::Io { .. } => {}
             other => panic!("expected Io, got {other:?}"),
         }
     }

--- a/src/components/BackupsModal.tsx
+++ b/src/components/BackupsModal.tsx
@@ -38,7 +38,13 @@ export function BackupsModal({ projectPath, onRestore, onCreatePR }: BackupsModa
     execute: fetchBackups,
   } = useAsyncState<Backup[]>(() => getBackups(projectPath, 50), { initial: [] });
   const [actionError, setActionError] = useState<string | null>(null);
-  const error = actionError ?? (loadError ? loadError.message : null);
+  const rawError = actionError ?? (loadError ? loadError.message : null);
+  const isNotGitRepo =
+    rawError != null &&
+    (rawError.includes('not a git repository') ||
+      rawError.includes('Failed to get git log') ||
+      rawError.includes('does not have any commits'));
+  const error = isNotGitRepo ? null : rawError;
   const setError = setActionError;
   const [modalState, setModalState] = useState<ModalState>({ type: 'list' });
 
@@ -204,6 +210,11 @@ export function BackupsModal({ projectPath, onRestore, onCreatePR }: BackupsModa
             <SpinnerIcon size={20} className="spinner-icon" />
             <span>Loading backups...</span>
           </div>
+        ) : isNotGitRepo ? (
+          <EmptyState
+            title="Not a Git repo yet"
+            description="Once this project is connected to GitHub, you can restore to any previous version"
+          />
         ) : !backups || backups.length === 0 ? (
           <EmptyState
             title="No backups yet"

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -25,6 +25,22 @@ export class ErrorBoundary extends Component<Props, State> {
     logger.logError(error, { componentStack: errorInfo.componentStack ?? undefined });
   }
 
+  /** Check if the error likely originated from a plugin */
+  private isPluginError(): boolean {
+    const msg = this.state.error?.message ?? '';
+    const stack = this.state.error?.stack ?? '';
+    return (
+      msg.includes('Plugin context') ||
+      msg.includes('plugin-sdk') ||
+      stack.includes('blob:') ||
+      stack.includes('usePluginContext')
+    );
+  }
+
+  handleContinue = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
   handleRestart = async () => {
     try {
       await relaunch();
@@ -74,26 +90,58 @@ export class ErrorBoundary extends Component<Props, State> {
             Something went wrong
           </h1>
           <p style={{ fontSize: '14px', color: '#888', margin: '0 0 24px 0', maxWidth: '400px' }}>
-            {this.state.error?.message || 'An unexpected error occurred'}
+            {this.isPluginError()
+              ? 'A plugin crashed. You can continue without it or restart the app.'
+              : this.state.error?.message || 'An unexpected error occurred'}
           </p>
-          <button
-            onClick={() => void this.handleRestart()}
-            style={{
-              backgroundColor: '#2472c8',
-              color: 'white',
-              border: 'none',
-              borderRadius: '6px',
-              padding: '10px 20px',
-              fontSize: '14px',
-              fontWeight: 500,
-              cursor: 'pointer',
-              transition: 'background-color 150ms',
-            }}
-            onMouseOver={(e) => (e.currentTarget.style.backgroundColor = '#1e5fa8')}
-            onMouseOut={(e) => (e.currentTarget.style.backgroundColor = '#2472c8')}
-          >
-            Restart App
-          </button>
+          <div style={{ display: 'flex', gap: '12px' }}>
+            {this.isPluginError() && (
+              <button
+                onClick={this.handleContinue}
+                style={{
+                  backgroundColor: '#2472c8',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '6px',
+                  padding: '10px 20px',
+                  fontSize: '14px',
+                  fontWeight: 500,
+                  cursor: 'pointer',
+                  transition: 'background-color 150ms',
+                }}
+                onMouseOver={(e) => (e.currentTarget.style.backgroundColor = '#1e5fa8')}
+                onMouseOut={(e) => (e.currentTarget.style.backgroundColor = '#2472c8')}
+              >
+                Continue
+              </button>
+            )}
+            <button
+              onClick={() => void this.handleRestart()}
+              style={{
+                backgroundColor: this.isPluginError() ? '#3a3a3a' : '#2472c8',
+                color: 'white',
+                border: 'none',
+                borderRadius: '6px',
+                padding: '10px 20px',
+                fontSize: '14px',
+                fontWeight: 500,
+                cursor: 'pointer',
+                transition: 'background-color 150ms',
+              }}
+              onMouseOver={(e) =>
+                (e.currentTarget.style.backgroundColor = this.isPluginError()
+                  ? '#4a4a4a'
+                  : '#1e5fa8')
+              }
+              onMouseOut={(e) =>
+                (e.currentTarget.style.backgroundColor = this.isPluginError()
+                  ? '#3a3a3a'
+                  : '#2472c8')
+              }
+            >
+              Restart App
+            </button>
+          </div>
           {this.state.error && (
             <details
               style={{

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,8 @@
 import { Component, ReactNode } from 'react';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { logger } from '../lib/logger';
+import { lookupBlobOwner } from '../lib/plugin-loader';
+import { uninstallPlugin } from '../lib/plugins';
 
 interface Props {
   children: ReactNode;
@@ -23,6 +25,19 @@ export class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     logger.logError(error, { componentStack: errorInfo.componentStack ?? undefined });
+
+    // Auto-remove crashing plugins by extracting blob URLs from the stack trace
+    const stack = error.stack ?? '';
+    const blobMatch = /blob:[^\s:)]+/.exec(stack);
+    if (blobMatch) {
+      const owner = lookupBlobOwner(blobMatch[0]);
+      if (owner) {
+        console.warn(`[ErrorBoundary] Auto-removing crashed plugin "${owner.pluginId}"`);
+        void uninstallPlugin(owner.projectPath, owner.pluginId).catch((e) =>
+          console.error(`Failed to auto-remove plugin "${owner.pluginId}":`, e)
+        );
+      }
+    }
   }
 
   /** Check if the error likely originated from a plugin */
@@ -91,7 +106,7 @@ export class ErrorBoundary extends Component<Props, State> {
           </h1>
           <p style={{ fontSize: '14px', color: '#888', margin: '0 0 24px 0', maxWidth: '400px' }}>
             {this.isPluginError()
-              ? 'A plugin crashed. You can continue without it or restart the app.'
+              ? 'A plugin crashed and was removed. Click Continue to keep working.'
               : this.state.error?.message || 'An unexpected error occurred'}
           </p>
           <div style={{ display: 'flex', gap: '12px' }}>

--- a/src/components/PluginSlot.tsx
+++ b/src/components/PluginSlot.tsx
@@ -16,7 +16,12 @@ import {
   type PluginAppActions,
   type PluginThemeData,
 } from '../contexts/PluginContext';
-import { execPluginShell, readPluginStorage, writePluginStorage } from '../lib/plugins';
+import {
+  execPluginShell,
+  readPluginStorage,
+  writePluginStorage,
+  uninstallPlugin,
+} from '../lib/plugins';
 import { invoke } from '@tauri-apps/api/core';
 import type { LoadedPlugin } from '../hooks/usePlugins';
 
@@ -43,76 +48,42 @@ interface ErrorBoundaryProps {
   pluginId: string;
   pluginName: string;
   compact: boolean;
+  /** Called when the boundary catches — auto-uninstalls the plugin and toasts. */
+  onCrash?: () => void;
   children: ReactNode;
 }
 
-/** Inline fallback for expanded (non-toolbar) plugin errors */
-function PluginErrorFallback({
-  pluginName,
-  error,
-  onRetry,
-}: {
-  pluginName: string;
-  error: Error | null;
-  onRetry: () => void;
-}) {
-  const [showDetails, setShowDetails] = useState(false);
+/**
+ * Outermost isolation boundary — wraps the entire plugin render including
+ * the Context.Provider. Catches errors that escape the inner PluginErrorBoundary
+ * (e.g. plugins bundling their own React, errors during Provider setup, or
+ * dual-React-instance edge cases).
+ */
+class PluginIsolationBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
 
-  return (
-    <div style={{ padding: '8px 12px', color: 'var(--text-secondary)', fontSize: '12px' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-        <span style={{ color: 'var(--error)' }}>!</span>
-        <span>
-          <strong>{pluginName}</strong> crashed: {error?.message || 'Unknown error'}
-        </span>
-      </div>
-      <div style={{ display: 'flex', gap: '8px', marginTop: '4px' }}>
-        <button
-          onClick={() => setShowDetails((v) => !v)}
-          style={{
-            background: 'none',
-            border: 'none',
-            color: 'var(--text-muted)',
-            cursor: 'pointer',
-            padding: 0,
-            fontSize: '11px',
-            textDecoration: 'underline',
-          }}
-        >
-          {showDetails ? 'Hide Details' : 'Details'}
-        </button>
-        <button
-          onClick={onRetry}
-          style={{
-            background: 'none',
-            border: 'none',
-            color: 'var(--accent)',
-            cursor: 'pointer',
-            padding: 0,
-            fontSize: '11px',
-            textDecoration: 'underline',
-          }}
-        >
-          Retry
-        </button>
-      </div>
-      {showDetails && error?.stack && (
-        <pre
-          style={{
-            marginTop: '4px',
-            fontSize: '10px',
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-all',
-            color: 'var(--text-muted)',
-            maxHeight: '120px',
-            overflow: 'auto',
-          }}
-        >
-          {error.stack}
-        </pre>
-      )}
-    </div>
-  );
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error) {
+    console.error(
+      `[PluginIsolation] Plugin "${this.props.pluginId}" crashed (outer boundary):`,
+      error
+    );
+    this.props.onCrash?.();
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // Render nothing — the plugin is being auto-removed
+      return null;
+    }
+    return this.props.children;
+  }
 }
 
 /** Error boundary that isolates plugin crashes */
@@ -128,32 +99,13 @@ class PluginErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySta
 
   componentDidCatch(error: Error) {
     console.error(`Plugin ${this.props.pluginId} crashed:`, error);
+    this.props.onCrash?.();
   }
-
-  handleRetry = () => {
-    this.setState({ hasError: false, error: null });
-  };
 
   render() {
     if (this.state.hasError) {
-      if (this.props.compact) {
-        return (
-          <span
-            className="plugin-error-indicator"
-            title={`${this.props.pluginName} crashed: ${this.state.error?.message || 'Unknown error'}\n\n${this.state.error?.stack || ''}`}
-          >
-            !
-          </span>
-        );
-      }
-
-      return (
-        <PluginErrorFallback
-          pluginName={this.props.pluginName}
-          error={this.state.error}
-          onRetry={this.handleRetry}
-        />
-      );
+      // Render nothing — the plugin is being auto-removed
+      return null;
     }
     return this.props.children;
   }
@@ -208,54 +160,30 @@ function buildContext(
 function SafePluginWrapper({
   Component: PluginComponent,
   pluginId,
-  pluginName,
-  compact,
+  onCrash,
 }: {
   Component: ComponentType;
   pluginId: string;
-  pluginName: string;
-  compact: boolean;
+  onCrash?: () => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [caughtError, setCaughtError] = useState<Error | null>(null);
+  const [caughtError, setCaughtError] = useState(false);
 
   useEffect(() => {
     function handleError(event: ErrorEvent) {
-      // Only intercept errors from plugin blob: URLs
       if (!event.filename?.startsWith('blob:')) return;
-
-      // Check if this error is within our plugin's container
-      // (blob URLs don't include plugin IDs, so catch all blob errors
-      // and rely on the error boundary for per-plugin attribution)
       event.preventDefault();
       event.stopImmediatePropagation();
       console.error(`Plugin "${pluginId}" error caught by safety wrapper:`, event.error);
-      setCaughtError(event.error instanceof Error ? event.error : new Error(event.message));
+      setCaughtError(true);
+      onCrash?.();
     }
 
     window.addEventListener('error', handleError);
     return () => window.removeEventListener('error', handleError);
-  }, [pluginId]);
+  }, [pluginId, onCrash]);
 
-  if (caughtError) {
-    if (compact) {
-      return (
-        <span
-          className="plugin-error-indicator"
-          title={`${pluginName} crashed: ${caughtError.message}`}
-        >
-          !
-        </span>
-      );
-    }
-    return (
-      <PluginErrorFallback
-        pluginName={pluginName}
-        error={caughtError}
-        onRetry={() => setCaughtError(null)}
-      />
-    );
-  }
+  if (caughtError) return null;
 
   return (
     <div ref={containerRef} style={{ display: 'contents' }}>
@@ -267,44 +195,69 @@ function SafePluginWrapper({
 export function PluginSlot({ name, plugins, project, actions, theme }: PluginSlotProps) {
   if (plugins.length === 0) return null;
 
+  const compact = name === 'toolbar' || name === 'preview';
+
   return (
     <>
       {plugins.map((plugin) => {
         const SlotComponent = plugin.module.slots[name];
         if (!SlotComponent) return null;
 
+        const pluginId = plugin.info.manifest.id;
+        const pluginName = plugin.info.manifest.name;
+
         const ctx = buildContext(
-          plugin.info.manifest.id,
+          pluginId,
           project,
           actions,
           theme,
           plugin.info.manifest.required_commands || []
         );
-        // Expose context on namespaced map for raw-JS plugins
+
+        // Expose context on window globals for raw-JS and legacy plugins.
+        // Must be synchronous (before plugin component renders) so plugins
+        // that read the legacy global during their first render can find it.
         const pluginsMap = ((
           window as unknown as Record<string, unknown>
         ).__SHIPSTUDIO_PLUGINS__ ??= {}) as Record<string, PluginContextValue>;
-        pluginsMap[plugin.info.manifest.id] = ctx;
-        // Legacy single-global write for v0 compat (last-writer-wins)
+        pluginsMap[pluginId] = ctx;
         exposePluginContext(ctx);
 
-        const compact = name === 'toolbar' || name === 'preview';
+        const handleCrash = () => {
+          const projectPath = project?.path;
+          if (!projectPath) return;
+          actions.showToast(
+            `"${pluginName}" crashed and was removed. You can reinstall it from the plugin menu.`,
+            'error'
+          );
+          void uninstallPlugin(projectPath, pluginId).catch((e) =>
+            console.error(`Failed to auto-remove crashed plugin "${pluginId}":`, e)
+          );
+        };
 
         return (
-          <PluginContext.Provider key={plugin.info.manifest.id} value={ctx}>
-            <PluginErrorBoundary
-              pluginId={plugin.info.manifest.id}
-              pluginName={plugin.info.manifest.name}
-              compact={compact}
-            >
-              <SafePluginWrapper
-                Component={SlotComponent}
-                pluginId={plugin.info.manifest.id}
-                pluginName={plugin.info.manifest.name}
+          <PluginIsolationBoundary
+            key={pluginId}
+            pluginId={pluginId}
+            pluginName={pluginName}
+            compact={compact}
+            onCrash={handleCrash}
+          >
+            <PluginContext.Provider value={ctx}>
+              <PluginErrorBoundary
+                pluginId={pluginId}
+                pluginName={pluginName}
                 compact={compact}
-              />
-            </PluginErrorBoundary>
-          </PluginContext.Provider>
+                onCrash={handleCrash}
+              >
+                <SafePluginWrapper
+                  Component={SlotComponent}
+                  pluginId={pluginId}
+                  onCrash={handleCrash}
+                />
+              </PluginErrorBoundary>
+            </PluginContext.Provider>
+          </PluginIsolationBoundary>
         );
       })}
     </>

--- a/src/hooks/useAsyncState.ts
+++ b/src/hooks/useAsyncState.ts
@@ -52,12 +52,14 @@ export function useAsyncState<T, Args extends unknown[] = []>(
     onErrorRef.current = onError;
   }, [fn, onSuccess, onError]);
 
-  useEffect(
-    () => () => {
+  // Reset mountedRef on (re-)mount so StrictMode's double-effect cycle
+  // (mount → cleanup → remount) doesn't leave it permanently false.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
       mountedRef.current = false;
-    },
-    []
-  );
+    };
+  }, []);
 
   const execute = useCallback(async (...args: Args): Promise<T | null> => {
     setIsLoading(true);

--- a/src/hooks/useAsyncState.ts
+++ b/src/hooks/useAsyncState.ts
@@ -72,7 +72,14 @@ export function useAsyncState<T, Args extends unknown[] = []>(
       }
       return result;
     } catch (e) {
-      const err = e instanceof Error ? e : new Error(String(e));
+      const err =
+        e instanceof Error
+          ? e
+          : new Error(
+              typeof e === 'object' && e !== null && 'message' in e
+                ? String((e as { message: unknown }).message)
+                : String(e)
+            );
       if (mountedRef.current) {
         setError(err);
         onErrorRef.current?.(err);

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -12,8 +12,8 @@ export type CommandError =
   | { type: 'Process'; cmd: string; exit_code: number; stderr: string }
   | { type: 'Validation'; field: string; reason: string }
   | { type: 'NotAuthenticated'; service: string }
-  | { type: 'Io'; '0': string }
-  | { type: 'Other'; '0': string };
+  | { type: 'Io'; message: string }
+  | { type: 'Other'; message: string };
 
 /**
  * Best-effort coercion of an unknown caught value into a `CommandError`. Used
@@ -26,12 +26,12 @@ export function asCommandError(value: unknown): CommandError {
     return value as CommandError;
   }
   if (typeof value === 'string') {
-    return { type: 'Other', '0': value };
+    return { type: 'Other', message: value };
   }
   if (value instanceof Error) {
-    return { type: 'Other', '0': value.message };
+    return { type: 'Other', message: value.message };
   }
-  return { type: 'Other', '0': String(value) };
+  return { type: 'Other', message: String(value) };
 }
 
 /** Render a `CommandError` to a user-facing string. */
@@ -46,8 +46,8 @@ export function formatCommandError(err: CommandError): string {
     case 'NotAuthenticated':
       return `Not authenticated with ${err.service}`;
     case 'Io':
-      return `I/O error: ${err['0']}`;
+      return `I/O error: ${err.message}`;
     case 'Other':
-      return err['0'];
+      return err.message;
   }
 }

--- a/src/lib/plugin-loader.ts
+++ b/src/lib/plugin-loader.ts
@@ -142,6 +142,22 @@ export function unloadPluginModule(projectPath: string, pluginId: string): void 
 }
 
 /**
+ * Look up which plugin owns a blob URL.
+ * Returns `{ projectPath, pluginId }` or null if not found.
+ */
+export function lookupBlobOwner(blobUrl: string): { projectPath: string; pluginId: string } | null {
+  // Strip fragment (cache-busting `#t=...`) before comparing
+  const base = blobUrl.split('#')[0];
+  for (const [key, url] of blobUrlCache) {
+    if (url === base) {
+      const sep = key.indexOf(':');
+      return { projectPath: key.slice(0, sep), pluginId: key.slice(sep + 1) };
+    }
+  }
+  return null;
+}
+
+/**
  * Expose React and ReactDOM as window globals for plugins.
  *
  * Plugins mark react/react-dom as externals that resolve to these globals,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,16 +26,19 @@ import 'overlayscrollbars/overlayscrollbars.css';
 exposeReactGlobals(React, ReactDOM);
 exposePluginContextRef();
 
-// Global safety net: catch unhandled errors from plugin blob: URLs.
+// Global safety net: catch unhandled errors from plugins.
 // Plugins that bundle their own React can throw errors that escape React error
 // boundaries entirely. This prevents those from crashing the whole app.
 window.addEventListener('error', (event) => {
-  if (event.filename?.startsWith('blob:')) {
+  const err = event.error as { message?: string } | undefined;
+  const msg: string = (typeof err?.message === 'string' ? err.message : event.message) ?? '';
+  const isPluginError =
+    event.filename?.startsWith('blob:') ||
+    msg.includes('Plugin context') ||
+    msg.includes('plugin-sdk');
+  if (isPluginError) {
     event.preventDefault();
-    console.error(
-      '[Ship Studio] Plugin error caught by global handler:',
-      event.error || event.message
-    );
+    console.error('[Ship Studio] Plugin error caught by global handler:', msg);
   }
 });
 window.addEventListener('unhandledrejection', (event) => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,7 +17,8 @@ import ReactDOM from 'react-dom/client';
 import { reactErrorHandler } from '@sentry/react';
 import App from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
-import { exposeReactGlobals } from './lib/plugin-loader';
+import { exposeReactGlobals, lookupBlobOwner } from './lib/plugin-loader';
+import { uninstallPlugin } from './lib/plugins';
 import { exposePluginContextRef } from './contexts/PluginContext';
 import { OverlayScrollbars } from 'overlayscrollbars';
 import 'overlayscrollbars/overlayscrollbars.css';
@@ -28,7 +29,9 @@ exposePluginContextRef();
 
 // Global safety net: catch unhandled errors from plugins.
 // Plugins that bundle their own React can throw errors that escape React error
-// boundaries entirely. This prevents those from crashing the whole app.
+// boundaries entirely. This catches them, auto-removes the plugin, and prevents
+// the app from crashing.
+const removedPlugins = new Set<string>();
 window.addEventListener('error', (event) => {
   const err = event.error as { message?: string } | undefined;
   const msg: string = (typeof err?.message === 'string' ? err.message : event.message) ?? '';
@@ -36,9 +39,20 @@ window.addEventListener('error', (event) => {
     event.filename?.startsWith('blob:') ||
     msg.includes('Plugin context') ||
     msg.includes('plugin-sdk');
-  if (isPluginError) {
-    event.preventDefault();
-    console.error('[Ship Studio] Plugin error caught by global handler:', msg);
+  if (!isPluginError) return;
+
+  event.preventDefault();
+  console.error('[Ship Studio] Plugin error caught by global handler:', msg);
+
+  // Identify and auto-remove the crashing plugin
+  const blobUrl = event.filename?.startsWith('blob:') ? event.filename : null;
+  const owner = blobUrl ? lookupBlobOwner(blobUrl) : null;
+  if (owner && !removedPlugins.has(owner.pluginId)) {
+    removedPlugins.add(owner.pluginId);
+    console.warn(`[Ship Studio] Auto-removing crashed plugin "${owner.pluginId}"`);
+    void uninstallPlugin(owner.projectPath, owner.pluginId).catch((e) =>
+      console.error(`Failed to auto-remove plugin "${owner.pluginId}":`, e)
+    );
   }
 });
 window.addEventListener('unhandledrejection', (event) => {


### PR DESCRIPTION
## Summary

- **Auto-remove crashing plugins**: When a plugin crashes, it's automatically uninstalled. The user sees "A plugin crashed and was removed. Click Continue to keep working." No restart required.
  - `ErrorBoundary.componentDidCatch`: extracts blob URL from error stack → looks up owning plugin → calls `uninstallPlugin`
  - `window.addEventListener('error')`: catches plugin errors that bypass React → same lookup + auto-remove
  - `PluginSlot` error boundaries: `onCrash` callback does the same at the boundary level
- **PluginIsolationBoundary**: Outer error boundary wrapping each plugin's full render tree
- **Backups on non-git projects**: Shows "Not a Git repo yet" instead of `[object Object]`
- **`[object Object]` error fix**: `useAsyncState` extracts `.message` from CommandError objects

## How auto-remove works

1. Plugin throws during render (e.g. "Plugin context not available")
2. Error reaches global `ErrorBoundary.componentDidCatch`
3. Regex extracts `blob:` URL from the error's stack trace
4. `lookupBlobOwner()` maps blob URL → `{projectPath, pluginId}` via the loader cache
5. `uninstallPlugin()` removes it from the registry + deletes plugin files
6. User clicks "Continue" → app re-renders → plugin is gone

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 380 passed
- [ ] Install Netlify plugin → crashes → shows "crashed and was removed" → Continue works → plugin gone
- [ ] Open Backups on non-git project → "Not a Git repo yet" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic isolation and removal of crashing plugins; crashed plugins are hidden and can be uninstalled automatically.
  * Conditional "Continue" recovery option for plugin-related errors (avoids full app restart).

* **Bug Fixes**
  * Backups modal now shows a clear "Not a Git repo yet" empty state instead of a generic error for non-git repos.
  * Improved detection to prevent plugin crashes from bringing down the whole app.

* **Improvements**
  * More consistent and user-friendly error messages and recovery flows across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->