### PR TITLE
Auto-remove crashing plugins, backups non-git handling

### DIFF
--- a/src/components/BackupsModal.tsx
+++ b/src/components/BackupsModal.tsx
@@ -38,7 +38,13 @@ export function BackupsModal({ projectPath, onRestore, onCreatePR }: BackupsModa
     execute: fetchBackups,
   } = useAsyncState<Backup[]>(() => getBackups(projectPath, 50), { initial: [] });
   const [actionError, setActionError] = useState<string | null>(null);
-  const error = actionError ?? (loadError ? loadError.message : null);
+  const rawError = actionError ?? (loadError ? loadError.message : null);
+  const isNotGitRepo =
+    rawError != null &&
+    (rawError.includes('not a git repository') ||
+      rawError.includes('Failed to get git log') ||
+      rawError.includes('does not have any commits'));
+  const error = isNotGitRepo ? null : rawError;
   const setError = setActionError;
   const [modalState, setModalState] = useState<ModalState>({ type: 'list' });
 
@@ -204,6 +210,11 @@ export function BackupsModal({ projectPath, onRestore, onCreatePR }: BackupsModa
             <SpinnerIcon size={20} className="spinner-icon" />
             <span>Loading backups...</span>
           </div>
+        ) : isNotGitRepo ? (
+          <EmptyState
+            title="Not a Git repo yet"
+            description="Once this project is connected to GitHub, you can restore to any previous version"
+          />
         ) : !backups || backups.length === 0 ? (
           <EmptyState
             title="No backups yet"

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,8 @@
 import { Component, ReactNode } from 'react';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { logger } from '../lib/logger';
+import { lookupBlobOwner, markPluginCrashed } from '../lib/plugin-loader';
+import { uninstallPlugin } from '../lib/plugins';
 
 interface Props {
   children: ReactNode;
@@ -23,6 +25,19 @@ export class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     logger.logError(error, { componentStack: errorInfo.componentStack ?? undefined });
+
+    // Auto-remove crashing plugins so they don't crash again on Continue
+    const stack = error.stack ?? '';
+    const blobMatch = /blob:[^\s:)]+/.exec(stack);
+    if (blobMatch) {
+      const owner = lookupBlobOwner(blobMatch[0]);
+      if (owner) {
+        markPluginCrashed(owner.pluginId);
+        void uninstallPlugin(owner.projectPath, owner.pluginId).catch((e) =>
+          console.error(`Failed to auto-remove plugin "${owner.pluginId}":`, e)
+        );
+      }
+    }
   }
 
   /** Check if the error likely originated from a plugin */

--- a/src/components/PluginSlot.tsx
+++ b/src/components/PluginSlot.tsx
@@ -16,7 +16,13 @@ import {
   type PluginAppActions,
   type PluginThemeData,
 } from '../contexts/PluginContext';
-import { execPluginShell, readPluginStorage, writePluginStorage } from '../lib/plugins';
+import {
+  execPluginShell,
+  readPluginStorage,
+  writePluginStorage,
+  uninstallPlugin,
+} from '../lib/plugins';
+import { markPluginCrashed, isPluginCrashed } from '../lib/plugin-loader';
 import { invoke } from '@tauri-apps/api/core';
 import type { LoadedPlugin } from '../hooks/usePlugins';
 
@@ -43,76 +49,8 @@ interface ErrorBoundaryProps {
   pluginId: string;
   pluginName: string;
   compact: boolean;
+  onCrash?: () => void;
   children: ReactNode;
-}
-
-/** Inline fallback for expanded (non-toolbar) plugin errors */
-function PluginErrorFallback({
-  pluginName,
-  error,
-  onRetry,
-}: {
-  pluginName: string;
-  error: Error | null;
-  onRetry: () => void;
-}) {
-  const [showDetails, setShowDetails] = useState(false);
-
-  return (
-    <div style={{ padding: '8px 12px', color: 'var(--text-secondary)', fontSize: '12px' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-        <span style={{ color: 'var(--error)' }}>!</span>
-        <span>
-          <strong>{pluginName}</strong> crashed: {error?.message || 'Unknown error'}
-        </span>
-      </div>
-      <div style={{ display: 'flex', gap: '8px', marginTop: '4px' }}>
-        <button
-          onClick={() => setShowDetails((v) => !v)}
-          style={{
-            background: 'none',
-            border: 'none',
-            color: 'var(--text-muted)',
-            cursor: 'pointer',
-            padding: 0,
-            fontSize: '11px',
-            textDecoration: 'underline',
-          }}
-        >
-          {showDetails ? 'Hide Details' : 'Details'}
-        </button>
-        <button
-          onClick={onRetry}
-          style={{
-            background: 'none',
-            border: 'none',
-            color: 'var(--accent)',
-            cursor: 'pointer',
-            padding: 0,
-            fontSize: '11px',
-            textDecoration: 'underline',
-          }}
-        >
-          Retry
-        </button>
-      </div>
-      {showDetails && error?.stack && (
-        <pre
-          style={{
-            marginTop: '4px',
-            fontSize: '10px',
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-all',
-            color: 'var(--text-muted)',
-            maxHeight: '120px',
-            overflow: 'auto',
-          }}
-        >
-          {error.stack}
-        </pre>
-      )}
-    </div>
-  );
 }
 
 /**
@@ -136,33 +74,11 @@ class PluginIsolationBoundary extends Component<ErrorBoundaryProps, ErrorBoundar
       `[PluginIsolation] Plugin "${this.props.pluginId}" crashed (outer boundary):`,
       error
     );
+    this.props.onCrash?.();
   }
 
-  handleRetry = () => {
-    this.setState({ hasError: false, error: null });
-  };
-
   render() {
-    if (this.state.hasError) {
-      if (this.props.compact) {
-        return (
-          <span
-            className="plugin-error-indicator"
-            title={`${this.props.pluginName} crashed: ${this.state.error?.message || 'Unknown error'}`}
-          >
-            !
-          </span>
-        );
-      }
-
-      return (
-        <PluginErrorFallback
-          pluginName={this.props.pluginName}
-          error={this.state.error}
-          onRetry={this.handleRetry}
-        />
-      );
-    }
+    if (this.state.hasError) return null;
     return this.props.children;
   }
 }
@@ -180,33 +96,11 @@ class PluginErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySta
 
   componentDidCatch(error: Error) {
     console.error(`Plugin ${this.props.pluginId} crashed:`, error);
+    this.props.onCrash?.();
   }
 
-  handleRetry = () => {
-    this.setState({ hasError: false, error: null });
-  };
-
   render() {
-    if (this.state.hasError) {
-      if (this.props.compact) {
-        return (
-          <span
-            className="plugin-error-indicator"
-            title={`${this.props.pluginName} crashed: ${this.state.error?.message || 'Unknown error'}\n\n${this.state.error?.stack || ''}`}
-          >
-            !
-          </span>
-        );
-      }
-
-      return (
-        <PluginErrorFallback
-          pluginName={this.props.pluginName}
-          error={this.state.error}
-          onRetry={this.handleRetry}
-        />
-      );
-    }
+    if (this.state.hasError) return null;
     return this.props.children;
   }
 }
@@ -260,54 +154,30 @@ function buildContext(
 function SafePluginWrapper({
   Component: PluginComponent,
   pluginId,
-  pluginName,
-  compact,
+  onCrash,
 }: {
   Component: ComponentType;
   pluginId: string;
-  pluginName: string;
-  compact: boolean;
+  onCrash?: () => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [caughtError, setCaughtError] = useState<Error | null>(null);
+  const [crashed, setCrashed] = useState(false);
 
   useEffect(() => {
     function handleError(event: ErrorEvent) {
-      // Only intercept errors from plugin blob: URLs
       if (!event.filename?.startsWith('blob:')) return;
-
-      // Check if this error is within our plugin's container
-      // (blob URLs don't include plugin IDs, so catch all blob errors
-      // and rely on the error boundary for per-plugin attribution)
       event.preventDefault();
       event.stopImmediatePropagation();
       console.error(`Plugin "${pluginId}" error caught by safety wrapper:`, event.error);
-      setCaughtError(event.error instanceof Error ? event.error : new Error(event.message));
+      setCrashed(true);
+      onCrash?.();
     }
 
     window.addEventListener('error', handleError);
     return () => window.removeEventListener('error', handleError);
-  }, [pluginId]);
+  }, [pluginId, onCrash]);
 
-  if (caughtError) {
-    if (compact) {
-      return (
-        <span
-          className="plugin-error-indicator"
-          title={`${pluginName} crashed: ${caughtError.message}`}
-        >
-          !
-        </span>
-      );
-    }
-    return (
-      <PluginErrorFallback
-        pluginName={pluginName}
-        error={caughtError}
-        onRetry={() => setCaughtError(null)}
-      />
-    );
-  }
+  if (crashed) return null;
 
   return (
     <div ref={containerRef} style={{ display: 'contents' }}>
@@ -324,11 +194,17 @@ export function PluginSlot({ name, plugins, project, actions, theme }: PluginSlo
   return (
     <>
       {plugins.map((plugin) => {
+        const pluginId = plugin.info.manifest.id;
+        const pluginName = plugin.info.manifest.name;
+
+        // Skip plugins that already crashed this session
+        if (isPluginCrashed(pluginId)) return null;
+
         const SlotComponent = plugin.module.slots[name];
         if (!SlotComponent) return null;
 
         const ctx = buildContext(
-          plugin.info.manifest.id,
+          pluginId,
           project,
           actions,
           theme,
@@ -336,32 +212,45 @@ export function PluginSlot({ name, plugins, project, actions, theme }: PluginSlo
         );
 
         // Expose context on window globals for raw-JS and legacy plugins.
-        // Must be synchronous (before plugin component renders) so plugins
-        // that read the legacy global during their first render can find it.
         const pluginsMap = ((
           window as unknown as Record<string, unknown>
         ).__SHIPSTUDIO_PLUGINS__ ??= {}) as Record<string, PluginContextValue>;
-        pluginsMap[plugin.info.manifest.id] = ctx;
+        pluginsMap[pluginId] = ctx;
         exposePluginContext(ctx);
+
+        const handleCrash = () => {
+          // 1. Block immediately so next render skips this plugin
+          markPluginCrashed(pluginId);
+          // 2. Toast the user
+          actions.showToast(`"${pluginName}" crashed and was removed.`, 'error');
+          // 3. Uninstall from disk (async, best-effort)
+          const projectPath = project?.path;
+          if (projectPath) {
+            void uninstallPlugin(projectPath, pluginId).catch((e) =>
+              console.error(`Failed to auto-remove plugin "${pluginId}":`, e)
+            );
+          }
+        };
 
         return (
           <PluginIsolationBoundary
-            key={plugin.info.manifest.id}
-            pluginId={plugin.info.manifest.id}
-            pluginName={plugin.info.manifest.name}
+            key={pluginId}
+            pluginId={pluginId}
+            pluginName={pluginName}
             compact={compact}
+            onCrash={handleCrash}
           >
             <PluginContext.Provider value={ctx}>
               <PluginErrorBoundary
-                pluginId={plugin.info.manifest.id}
-                pluginName={plugin.info.manifest.name}
+                pluginId={pluginId}
+                pluginName={pluginName}
                 compact={compact}
+                onCrash={handleCrash}
               >
                 <SafePluginWrapper
                   Component={SlotComponent}
-                  pluginId={plugin.info.manifest.id}
-                  pluginName={plugin.info.manifest.name}
-                  compact={compact}
+                  pluginId={pluginId}
+                  onCrash={handleCrash}
                 />
               </PluginErrorBoundary>
             </PluginContext.Provider>

--- a/src/hooks/useAsyncState.ts
+++ b/src/hooks/useAsyncState.ts
@@ -72,7 +72,14 @@ export function useAsyncState<T, Args extends unknown[] = []>(
       }
       return result;
     } catch (e) {
-      const err = e instanceof Error ? e : new Error(String(e));
+      const err =
+        e instanceof Error
+          ? e
+          : new Error(
+              typeof e === 'object' && e !== null && 'message' in e
+                ? String((e as { message: unknown }).message)
+                : String(e)
+            );
       if (mountedRef.current) {
         setError(err);
         onErrorRef.current?.(err);

--- a/src/lib/plugin-loader.ts
+++ b/src/lib/plugin-loader.ts
@@ -141,6 +141,34 @@ export function unloadPluginModule(projectPath: string, pluginId: string): void 
   }
 }
 
+/** Plugins that crashed at render time. Checked synchronously by PluginSlot to skip them. */
+const crashedPlugins = new Set<string>();
+
+/** Mark a plugin as crashed so it's immediately skipped on next render. */
+export function markPluginCrashed(pluginId: string): void {
+  crashedPlugins.add(pluginId);
+}
+
+/** Check if a plugin has been marked as crashed. */
+export function isPluginCrashed(pluginId: string): boolean {
+  return crashedPlugins.has(pluginId);
+}
+
+/**
+ * Look up which plugin owns a blob URL.
+ * Returns `{ projectPath, pluginId }` or null if not found.
+ */
+export function lookupBlobOwner(blobUrl: string): { projectPath: string; pluginId: string } | null {
+  const base = blobUrl.split('#')[0];
+  for (const [key, url] of blobUrlCache) {
+    if (url === base) {
+      const sep = key.indexOf(':');
+      return { projectPath: key.slice(0, sep), pluginId: key.slice(sep + 1) };
+    }
+  }
+  return null;
+}
+
 /**
  * Expose React and ReactDOM as window globals for plugins.
  *

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,7 +17,8 @@ import ReactDOM from 'react-dom/client';
 import { reactErrorHandler } from '@sentry/react';
 import App from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
-import { exposeReactGlobals } from './lib/plugin-loader';
+import { exposeReactGlobals, lookupBlobOwner, markPluginCrashed } from './lib/plugin-loader';
+import { uninstallPlugin } from './lib/plugins';
 import { exposePluginContextRef } from './contexts/PluginContext';
 import { OverlayScrollbars } from 'overlayscrollbars';
 import 'overlayscrollbars/overlayscrollbars.css';
@@ -28,7 +29,7 @@ exposePluginContextRef();
 
 // Global safety net: catch unhandled errors from plugins.
 // Plugins that bundle their own React can throw errors that escape React error
-// boundaries entirely. This prevents those from crashing the whole app.
+// boundaries entirely. This catches them and auto-removes the crashing plugin.
 window.addEventListener('error', (event) => {
   const err = event.error as { message?: string } | undefined;
   const msg: string = (typeof err?.message === 'string' ? err.message : event.message) ?? '';
@@ -36,9 +37,19 @@ window.addEventListener('error', (event) => {
     event.filename?.startsWith('blob:') ||
     msg.includes('Plugin context') ||
     msg.includes('plugin-sdk');
-  if (isPluginError) {
-    event.preventDefault();
-    console.error('[Ship Studio] Plugin error caught by global handler:', msg);
+  if (!isPluginError) return;
+
+  event.preventDefault();
+  console.error('[Ship Studio] Plugin error caught by global handler:', msg);
+
+  // Identify and auto-remove the crashing plugin
+  const blobUrl = event.filename?.startsWith('blob:') ? event.filename : null;
+  const owner = blobUrl ? lookupBlobOwner(blobUrl) : null;
+  if (owner) {
+    markPluginCrashed(owner.pluginId);
+    void uninstallPlugin(owner.projectPath, owner.pluginId).catch((e) =>
+      console.error(`Failed to auto-remove plugin "${owner.pluginId}":`, e)
+    );
   }
 });
 window.addEventListener('unhandledrejection', (event) => {


### PR DESCRIPTION
## Summary

Supersedes #43 (closed — had merge conflicts with #42).

**Plugin crash auto-remove:**
- In-memory `crashedPlugins` blocklist (`markPluginCrashed` / `isPluginCrashed`) so crashed plugins are **immediately** skipped on next render — no async delay
- `PluginSlot.handleCrash`: marks crashed → toasts user → uninstalls from disk
- `ErrorBoundary.componentDidCatch`: extracts blob URL from stack → identifies plugin → marks + uninstalls (catches errors that escape PluginSlot boundaries)
- `window.addEventListener('error')`: same for errors that bypass React entirely
- Removed `PluginErrorFallback` — crashed plugins render null and get uninstalled, no retry UI

**Backups:**
- Show "Not a Git repo yet" for non-git projects instead of `[object Object]`
- `useAsyncState`: extract `.message` from CommandError objects in catch block

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 380 passed
- [ ] Install crashing plugin → first crash shows toast "crashed and was removed" → Continue works → plugin doesn't crash again
- [ ] Open Backups on non-git project → "Not a Git repo yet"

🤖 Generated with [Claude Code](https://claude.com/claude-code)