### PR TITLE
Add Opencode agent + dashboard agent management panel

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -39,6 +39,10 @@ pub struct AgentConfig {
     pub install_command_unix: Option<&'static str>,
     /// Windows install message (manual download)
     pub install_message_windows: Option<&'static str>,
+    /// Unix uninstall command (removes binary + associated files, leaves auth indicators alone)
+    pub uninstall_command_unix: Option<&'static str>,
+    /// Windows uninstall command or message
+    pub uninstall_command_windows: Option<&'static str>,
     /// Setup item IDs: (binary_id, auth_id)
     pub setup_item_ids: (&'static str, &'static str),
     /// Setup display names: (binary_name, auth_name)
@@ -63,6 +67,10 @@ pub const CLAUDE_CODE: AgentConfig = AgentConfig {
     install_message_windows: Some(
         "Please download Claude Code from https://claude.ai and run the installer.",
     ),
+    uninstall_command_unix: Some(
+        "rm -rf \"$HOME/.local/share/Claude\" \"$HOME/Library/Application Support/Claude/claude-code\" 2>/dev/null; rm -f \"$HOME/.local/bin/claude\" 2>/dev/null; npm uninstall -g @anthropic-ai/claude-code 2>/dev/null; echo Uninstalled.",
+    ),
+    uninstall_command_windows: Some("npm uninstall -g @anthropic-ai/claude-code"),
     setup_item_ids: ("claude", "claude_auth"),
     setup_display_names: ("Claude Code", "Claude Account"),
 };
@@ -83,12 +91,40 @@ pub const CODEX: AgentConfig = AgentConfig {
     skills_dir_name: Some("skills"),
     install_command_unix: Some("npm install -g @openai/codex"),
     install_message_windows: Some("Install Codex: npm install -g @openai/codex"),
+    uninstall_command_unix: Some("npm uninstall -g @openai/codex"),
+    uninstall_command_windows: Some("npm uninstall -g @openai/codex"),
     setup_item_ids: ("codex", "codex_auth"),
     setup_display_names: ("Codex", "Codex Account"),
 };
 
+/// Opencode agent configuration.
+pub const OPENCODE: AgentConfig = AgentConfig {
+    id: "opencode",
+    display_name: "Opencode",
+    binary_name: "opencode",
+    process_name: "opencode",
+    version_flag: "--version",
+    print_mode_flags: &[],
+    auto_accept_flag: None,
+    auth_trigger_args: &["auth", "login"],
+    auth_config_dir: ".local/share/opencode",
+    auth_indicators: &["auth.json"],
+    skills_agent_id: None,
+    skills_dir_name: None,
+    install_command_unix: Some("curl -fsSL https://opencode.ai/install | bash"),
+    install_message_windows: Some(
+        "Please download Opencode from https://opencode.ai and run the installer.",
+    ),
+    uninstall_command_unix: Some(
+        "rm -rf \"$HOME/.opencode\" \"$HOME/.local/share/opencode\" 2>/dev/null; rm -f \"$HOME/.local/bin/opencode\" 2>/dev/null; npm uninstall -g opencode-ai 2>/dev/null; echo Uninstalled.",
+    ),
+    uninstall_command_windows: Some("npm uninstall -g opencode-ai"),
+    setup_item_ids: ("opencode", "opencode_auth"),
+    setup_display_names: ("Opencode", "Opencode Account"),
+};
+
 /// All available agent configurations.
-pub const ALL_AGENTS: &[&AgentConfig] = &[&CLAUDE_CODE, &CODEX];
+pub const ALL_AGENTS: &[&AgentConfig] = &[&CLAUDE_CODE, &CODEX, &OPENCODE];
 
 /// In-memory cache for the default agent ID. `None` means unset (falls back to Claude Code).
 static DEFAULT_AGENT_ID: RwLock<Option<String>> = RwLock::new(None);
@@ -123,6 +159,7 @@ pub fn get_active_agent() -> &'static AgentConfig {
 pub fn get_agent_by_id(id: &str) -> &'static AgentConfig {
     match id {
         "codex" => &CODEX,
+        "opencode" => &OPENCODE,
         _ => &CLAUDE_CODE,
     }
 }
@@ -152,8 +189,20 @@ mod tests {
     }
 
     #[test]
-    fn all_agents_has_length_2() {
-        assert_eq!(ALL_AGENTS.len(), 2);
+    fn all_agents_has_length_3() {
+        assert_eq!(ALL_AGENTS.len(), 3);
+    }
+
+    #[test]
+    fn get_agent_by_id_opencode() {
+        let agent = get_agent_by_id("opencode");
+        assert_eq!(agent.id, "opencode");
+        assert_eq!(agent.display_name, "Opencode");
+    }
+
+    #[test]
+    fn opencode_setup_item_ids() {
+        assert_eq!(OPENCODE.setup_item_ids, ("opencode", "opencode_auth"));
     }
 
     #[test]

--- a/src-tauri/src/commands/claude.rs
+++ b/src-tauri/src/commands/claude.rs
@@ -142,6 +142,9 @@ pub fn find_binary_by_name(binary_name: &str) -> Option<std::path::PathBuf> {
                     .join("*")
                     .join(format!("bin/{binary_name}")),
                 home.join(format!("n/bin/{binary_name}")),
+                // Tools that install into ~/.<name>/bin/<name> (opencode, bun, cargo, etc.)
+                home.join(format!(".{binary_name}/bin/{binary_name}")),
+                home.join(format!(".bun/bin/{binary_name}")),
                 std::path::PathBuf::from(format!("/usr/local/bin/{binary_name}")),
                 std::path::PathBuf::from(format!("/opt/homebrew/bin/{binary_name}")),
             ];

--- a/src-tauri/src/commands/setup/agents.rs
+++ b/src-tauri/src/commands/setup/agents.rs
@@ -176,3 +176,151 @@ pub async fn uninstall_agent(agent_id: String) -> Result<String, CommandError> {
     tracing::info!(agent_id = agent_id.as_str(), "Agent uninstalled");
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ============ sign_out_agent ============
+
+    #[tokio::test]
+    async fn sign_out_agent_rejects_unknown_id() {
+        let result = sign_out_agent("not-a-real-agent".to_string()).await;
+        assert!(result.is_err(), "unknown agent id must be rejected");
+        let err = format!("{:?}", result.unwrap_err());
+        assert!(
+            err.contains("Unknown agent"),
+            "error should mention unknown agent, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sign_out_agent_rejects_empty_id() {
+        let result = sign_out_agent(String::new()).await;
+        assert!(result.is_err(), "empty agent id must be rejected");
+    }
+
+    #[tokio::test]
+    async fn sign_out_agent_accepts_all_known_ids() {
+        // Every agent in ALL_AGENTS must round-trip through sign_out_agent's
+        // id-validation step without the "Unknown agent" error. (The actual
+        // file-removal step may be a no-op on a machine that never signed in,
+        // but the id check should always pass.)
+        for agent in crate::agent::ALL_AGENTS {
+            let result = sign_out_agent(agent.id.to_string()).await;
+            if let Err(e) = &result {
+                let msg = format!("{:?}", e);
+                assert!(
+                    !msg.contains("Unknown agent"),
+                    "agent {} should not be rejected as unknown: {msg}",
+                    agent.id
+                );
+            }
+        }
+    }
+
+    // ============ uninstall_agent ============
+
+    #[tokio::test]
+    async fn uninstall_agent_rejects_unknown_id() {
+        let result = uninstall_agent("not-a-real-agent".to_string()).await;
+        assert!(result.is_err(), "unknown agent id must be rejected");
+        let err = format!("{:?}", result.unwrap_err());
+        assert!(
+            err.contains("Unknown agent"),
+            "error should mention unknown agent, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn uninstall_agent_rejects_empty_id() {
+        let result = uninstall_agent(String::new()).await;
+        assert!(result.is_err());
+    }
+
+    // ============ get_agents_status ============
+
+    #[tokio::test]
+    async fn get_agents_status_returns_one_entry_per_known_agent() {
+        let statuses = get_agents_status().await;
+        assert_eq!(
+            statuses.len(),
+            crate::agent::ALL_AGENTS.len(),
+            "should return one status per agent in ALL_AGENTS"
+        );
+        // Order and IDs should match ALL_AGENTS.
+        for (status, agent) in statuses.iter().zip(crate::agent::ALL_AGENTS.iter()) {
+            assert_eq!(status.id, agent.id);
+            assert_eq!(status.display_name, agent.display_name);
+            assert_eq!(status.binary_name, agent.binary_name);
+        }
+    }
+
+    #[tokio::test]
+    async fn get_agents_status_marks_exactly_one_default() {
+        let statuses = get_agents_status().await;
+        let default_count = statuses.iter().filter(|s| s.is_default).count();
+        assert_eq!(
+            default_count, 1,
+            "exactly one agent should be marked as default"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_agents_status_install_supported_tracks_platform() {
+        let statuses = get_agents_status().await;
+        for status in &statuses {
+            let agent = crate::agent::get_agent_by_id(&status.id);
+            #[cfg(windows)]
+            let expected = agent.install_message_windows.is_some();
+            #[cfg(not(windows))]
+            let expected = agent.install_command_unix.is_some();
+            assert_eq!(
+                status.install_supported, expected,
+                "install_supported for {} should match platform-specific install command presence",
+                status.id
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn get_agents_status_uninstall_supported_tracks_platform() {
+        let statuses = get_agents_status().await;
+        for status in &statuses {
+            let agent = crate::agent::get_agent_by_id(&status.id);
+            #[cfg(windows)]
+            let expected = agent.uninstall_command_windows.is_some();
+            #[cfg(not(windows))]
+            let expected = agent.uninstall_command_unix.is_some();
+            assert_eq!(
+                status.uninstall_supported, expected,
+                "uninstall_supported for {} should match platform-specific uninstall command presence",
+                status.id
+            );
+        }
+    }
+
+    // ============ AgentStatus serialization ============
+
+    #[test]
+    fn agent_status_serializes_to_camel_case_for_frontend() {
+        let status = AgentStatus {
+            id: "claude-code".to_string(),
+            display_name: "Claude Code".to_string(),
+            binary_name: "claude".to_string(),
+            installed: true,
+            version: Some("1.2.3".to_string()),
+            authed: true,
+            is_default: true,
+            install_supported: true,
+            uninstall_supported: true,
+        };
+        let json = serde_json::to_string(&status).expect("serialize");
+        // The frontend reads these as camelCase — lock the contract.
+        assert!(json.contains("\"displayName\":\"Claude Code\""));
+        assert!(json.contains("\"binaryName\":\"claude\""));
+        assert!(json.contains("\"isDefault\":true"));
+        assert!(json.contains("\"installSupported\":true"));
+        assert!(json.contains("\"uninstallSupported\":true"));
+    }
+}

--- a/src-tauri/src/commands/setup/agents.rs
+++ b/src-tauri/src/commands/setup/agents.rs
@@ -1,0 +1,178 @@
+//! # Agent Management Commands
+//!
+//! Dashboard-surfaced commands for managing AI agent installations and accounts:
+//! installed/auth status, signing out, uninstalling.
+
+use crate::agent::{get_agent_by_id, ALL_AGENTS};
+use crate::commands::claude::find_binary_by_name;
+use crate::errors::CommandError;
+use crate::utils::create_command;
+use serde::Serialize;
+
+/// Rich per-agent status for the dashboard's Agents panel.
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentStatus {
+    pub id: String,
+    pub display_name: String,
+    pub binary_name: String,
+    pub installed: bool,
+    pub version: Option<String>,
+    pub authed: bool,
+    pub is_default: bool,
+    pub install_supported: bool,
+    pub uninstall_supported: bool,
+}
+
+/// Return the status of every known agent in a single call.
+/// Avoids the N round-trips the dashboard would otherwise need.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn get_agents_status() -> Vec<AgentStatus> {
+    let default_id = super::read_app_state()
+        .default_agent_id
+        .unwrap_or_else(|| "claude-code".to_string());
+
+    ALL_AGENTS
+        .iter()
+        .map(|agent| {
+            let binary_path = find_binary_by_name(agent.binary_name);
+            let installed = binary_path.is_some();
+
+            let version = binary_path.as_ref().and_then(|p| {
+                create_command(p)
+                    .args([agent.version_flag])
+                    .output()
+                    .ok()
+                    .and_then(|o| {
+                        if o.status.success() {
+                            Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+                        } else {
+                            None
+                        }
+                    })
+            });
+
+            let authed = if !installed {
+                false
+            } else if let Some(home) = dirs::home_dir() {
+                let dir = home.join(agent.auth_config_dir);
+                agent
+                    .auth_indicators
+                    .iter()
+                    .any(|indicator| dir.join(indicator).exists())
+            } else {
+                false
+            };
+
+            #[cfg(windows)]
+            let install_supported = agent.install_message_windows.is_some();
+            #[cfg(not(windows))]
+            let install_supported = agent.install_command_unix.is_some();
+
+            #[cfg(windows)]
+            let uninstall_supported = agent.uninstall_command_windows.is_some();
+            #[cfg(not(windows))]
+            let uninstall_supported = agent.uninstall_command_unix.is_some();
+
+            AgentStatus {
+                id: agent.id.to_string(),
+                display_name: agent.display_name.to_string(),
+                binary_name: agent.binary_name.to_string(),
+                installed,
+                version,
+                authed,
+                is_default: agent.id == default_id,
+                install_supported,
+                uninstall_supported,
+            }
+        })
+        .collect()
+}
+
+/// Remove an agent's auth indicator files so the CLI is no longer signed in.
+/// The binary itself is left intact.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn sign_out_agent(agent_id: String) -> Result<(), CommandError> {
+    let agent = get_agent_by_id(&agent_id);
+
+    // Reject unknown IDs: get_agent_by_id falls back to CLAUDE_CODE, so explicitly check.
+    if agent.id != agent_id {
+        return Err((format!("Unknown agent: {agent_id}")).into());
+    }
+
+    let home = dirs::home_dir().ok_or("Could not resolve home directory")?;
+    let dir = home.join(agent.auth_config_dir);
+
+    if !dir.exists() {
+        // Already signed out
+        return Ok(());
+    }
+
+    for indicator in agent.auth_indicators {
+        let path = dir.join(indicator);
+        if path.exists() {
+            if path.is_dir() {
+                std::fs::remove_dir_all(&path)
+                    .map_err(|e| format!("Failed to remove {}: {e}", path.display()))?;
+            } else {
+                std::fs::remove_file(&path)
+                    .map_err(|e| format!("Failed to remove {}: {e}", path.display()))?;
+            }
+        }
+    }
+
+    tracing::info!(agent_id = agent_id.as_str(), "Agent signed out");
+    Ok(())
+}
+
+/// Run the agent's uninstall command. Best-effort: the command is expected to
+/// be idempotent and ignore missing files.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn uninstall_agent(agent_id: String) -> Result<String, CommandError> {
+    let agent = get_agent_by_id(&agent_id);
+
+    if agent.id != agent_id {
+        return Err((format!("Unknown agent: {agent_id}")).into());
+    }
+
+    #[cfg(windows)]
+    let cmd_str = agent.uninstall_command_windows;
+    #[cfg(not(windows))]
+    let cmd_str = agent.uninstall_command_unix;
+
+    let command = cmd_str.ok_or_else(|| {
+        format!(
+            "Uninstall is not supported for {} on this platform.",
+            agent.display_name
+        )
+    })?;
+
+    #[cfg(windows)]
+    let output = create_command("cmd")
+        .args(["/C", command])
+        .output()
+        .map_err(|e| format!("Failed to run uninstall: {e}"))?;
+
+    #[cfg(not(windows))]
+    let output = create_command("/bin/bash")
+        .args(["-c", command])
+        .output()
+        .map_err(|e| format!("Failed to run uninstall: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // npm uninstall of a non-installed package is not a fatal failure — but
+        // we surface any real error so the UI can tell the user.
+        return Err((format!(
+            "Uninstall reported an error: {}",
+            stderr.lines().next().unwrap_or("unknown").trim()
+        ))
+        .into());
+    }
+
+    tracing::info!(agent_id = agent_id.as_str(), "Agent uninstalled");
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}

--- a/src-tauri/src/commands/setup/mod.rs
+++ b/src-tauri/src/commands/setup/mod.rs
@@ -27,11 +27,13 @@
 //! - `install` — Tool installation via Homebrew/Winget
 //! - `auth` — Authentication flows, process cleanup, version management
 
+mod agents;
 mod auth;
 mod install;
 mod state;
 mod status;
 
+pub use agents::*;
 pub use auth::*;
 pub use install::*;
 pub use state::*;
@@ -67,12 +69,16 @@ const ALL_ITEMS: &[&str] = &[
     "claude_auth",
     "codex",
     "codex_auth",
+    "opencode",
+    "opencode_auth",
     "vercel",
     "vercel_auth",
 ];
 
 /// Tool items (not auth)
-const TOOL_ITEMS: &[&str] = &["homebrew", "node", "git", "gh", "claude", "codex", "vercel"];
+const TOOL_ITEMS: &[&str] = &[
+    "homebrew", "node", "git", "gh", "claude", "codex", "opencode", "vercel",
+];
 
 // ============ App State Persistence (shared helpers) ============
 
@@ -150,10 +156,24 @@ fn get_scenario_items(scenario: &str) -> Vec<&'static str> {
         // Vercel installed and authed (for testing hosting step)
         "vercel-ready" => vec!["vercel", "vercel_auth"],
 
-        // Only Codex installed (no Claude)
+        // Only Codex installed (no Claude, no Opencode)
         "codex-only" => ALL_ITEMS
             .iter()
-            .filter(|&&item| item != "claude" && item != "claude_auth")
+            .filter(|&&item| {
+                item != "claude"
+                    && item != "claude_auth"
+                    && item != "opencode"
+                    && item != "opencode_auth"
+            })
+            .copied()
+            .collect(),
+
+        // Only Opencode installed (no Claude, no Codex)
+        "opencode-only" => ALL_ITEMS
+            .iter()
+            .filter(|&&item| {
+                item != "claude" && item != "claude_auth" && item != "codex" && item != "codex_auth"
+            })
             .copied()
             .collect(),
 
@@ -301,20 +321,32 @@ mod tests {
     }
 
     #[test]
-    fn all_items_contains_11_items_including_codex_and_vercel() {
-        assert_eq!(ALL_ITEMS.len(), 11);
+    fn all_items_contains_13_items_including_all_agents_and_vercel() {
+        assert_eq!(ALL_ITEMS.len(), 13);
         assert!(ALL_ITEMS.contains(&"codex"));
         assert!(ALL_ITEMS.contains(&"codex_auth"));
+        assert!(ALL_ITEMS.contains(&"opencode"));
+        assert!(ALL_ITEMS.contains(&"opencode_auth"));
         assert!(ALL_ITEMS.contains(&"vercel"));
         assert!(ALL_ITEMS.contains(&"vercel_auth"));
     }
 
     #[test]
-    fn tool_items_contains_7_items_including_codex_and_vercel() {
-        assert_eq!(TOOL_ITEMS.len(), 7);
+    fn tool_items_contains_8_items_including_all_agents_and_vercel() {
+        assert_eq!(TOOL_ITEMS.len(), 8);
         assert!(TOOL_ITEMS.contains(&"codex"));
         assert!(TOOL_ITEMS.contains(&"claude"));
+        assert!(TOOL_ITEMS.contains(&"opencode"));
         assert!(TOOL_ITEMS.contains(&"vercel"));
+    }
+
+    #[test]
+    fn scenario_opencode_only_excludes_claude_and_codex() {
+        let items = get_scenario_items("opencode-only");
+        assert!(!items.contains(&"claude"));
+        assert!(!items.contains(&"codex"));
+        assert!(items.contains(&"opencode"));
+        assert!(items.contains(&"opencode_auth"));
     }
 
     // ============ AppState ============

--- a/src-tauri/src/commands/setup/status.rs
+++ b/src-tauri/src/commands/setup/status.rs
@@ -32,6 +32,8 @@ pub async fn get_full_setup_status() -> FullSetupStatus {
             ("claude_auth", "Claude Account", Some("claude")),
             ("codex", "Codex", None),
             ("codex_auth", "Codex Account", Some("codex")),
+            ("opencode", "Opencode", None),
+            ("opencode_auth", "Opencode Account", Some("opencode")),
             ("vercel", "Vercel CLI", None),
             ("vercel_auth", "Vercel Account", Some("vercel")),
         ];

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -454,6 +454,9 @@ pub fn run() {
             commands::setup::reset_setup_state,
             commands::setup::get_default_agent_id,
             commands::setup::set_default_agent_id,
+            commands::setup::get_agents_status,
+            commands::setup::sign_out_agent,
+            commands::setup::uninstall_agent,
             // Client Editor
             commands::client_editor::detect_client_editor,
             // Code Browser

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -111,6 +111,8 @@ fn build_extended_path() -> String {
         let home_str = home.to_string_lossy();
         paths.push(format!("{home_str}/.npm-global/bin"));
         paths.push(format!("{home_str}/.local/bin")); // Official Claude installer location
+        paths.push(format!("{home_str}/.opencode/bin")); // Opencode installer location
+        paths.push(format!("{home_str}/.bun/bin")); // Bun-installed tools
         paths.push(format!("{home_str}/n/bin"));
 
         // Add NVM current/default version if it exists

--- a/src/components/AgentsPanel.test.tsx
+++ b/src/components/AgentsPanel.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * Tests for AgentsPanel — the dashboard surface for managing coding agents.
+ *
+ * Covers the main state matrix:
+ *   - not installed             → Install button, no pill
+ *   - installed / not signed in → Sign in button, kebab with Sign in + Uninstall
+ *   - installed / default       → green "Default" pill (disabled), kebab
+ *   - installed / not default   → "Set default" pill, clicking → Switching… → Default
+ *   - backend error on load     → toast, no rows
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { AgentStatus } from '../lib/agents-management';
+
+// ============ Module-level mocks ============
+
+const invokeResults = new Map<string, { value?: unknown; error?: Error }>();
+const invokeCalls: Array<{ cmd: string; args?: unknown }> = [];
+
+function mockInvoke(cmd: string, value: unknown) {
+  invokeResults.set(cmd, { value });
+}
+
+function mockInvokeErr(cmd: string, error: Error) {
+  invokeResults.set(cmd, { error });
+}
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn((cmd: string, args?: unknown) => {
+    invokeCalls.push({ cmd, args });
+    const result = invokeResults.get(cmd);
+    if (result?.error) return Promise.reject(result.error);
+    if (result) return Promise.resolve(result.value);
+    return Promise.resolve(undefined);
+  }),
+}));
+
+// Avoid pulling xterm / tauri-pty into the test environment.
+vi.mock('./setup/OnboardingTerminal', () => ({
+  OnboardingTerminal: ({ onExit }: { onExit: (c: number | null) => void }) => (
+    <div data-testid="mock-terminal">
+      <button data-testid="terminal-exit-0" onClick={() => onExit(0)}>
+        Exit 0
+      </button>
+    </div>
+  ),
+}));
+
+// Strip heavy icon SVGs; only need predictable DOM.
+vi.mock('./icons', () => ({
+  CheckIcon: () => <span data-testid="check-icon" />,
+  SpinnerIcon: () => <span data-testid="spinner-icon" />,
+  ClaudeIcon: () => <span data-testid="claude-icon" />,
+}));
+
+import { AgentsPanel } from './AgentsPanel';
+
+// ============ Fixture helpers ============
+
+function agent(overrides: Partial<AgentStatus> = {}): AgentStatus {
+  return {
+    id: 'claude-code',
+    displayName: 'Claude Code',
+    binaryName: 'claude',
+    installed: true,
+    version: '1.2.3',
+    authed: true,
+    isDefault: false,
+    installSupported: true,
+    uninstallSupported: true,
+    ...overrides,
+  };
+}
+
+const CLAUDE_DEFAULT = agent({ isDefault: true });
+const CODEX_READY = agent({
+  id: 'codex',
+  displayName: 'Codex',
+  binaryName: 'codex',
+  version: '0.1.0',
+  isDefault: false,
+});
+const OPENCODE_NOT_INSTALLED = agent({
+  id: 'opencode',
+  displayName: 'Opencode',
+  binaryName: 'opencode',
+  installed: false,
+  version: null,
+  authed: false,
+  isDefault: false,
+});
+const CODEX_UNAUTHED = agent({
+  id: 'codex',
+  displayName: 'Codex',
+  binaryName: 'codex',
+  version: '0.1.0',
+  authed: false,
+  isDefault: false,
+});
+
+// ============ Tests ============
+
+describe('AgentsPanel', () => {
+  beforeEach(() => {
+    invokeResults.clear();
+    invokeCalls.length = 0;
+  });
+
+  it('renders one row per agent returned by the backend', async () => {
+    mockInvoke('get_agents_status', [CLAUDE_DEFAULT, CODEX_READY, OPENCODE_NOT_INSTALLED]);
+    render(<AgentsPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Claude Code')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Codex')).toBeInTheDocument();
+    expect(screen.getByText('Opencode')).toBeInTheDocument();
+  });
+
+  it('shows "Install" button for a not-installed agent', async () => {
+    mockInvoke('get_agents_status', [OPENCODE_NOT_INSTALLED]);
+    render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Opencode')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Install' })).toBeInTheDocument();
+    expect(screen.getByText('Not installed')).toBeInTheDocument();
+    // No "Set default" pill for an uninstalled agent.
+    expect(screen.queryByText('Set default')).not.toBeInTheDocument();
+  });
+
+  it('shows "Sign in" button and "Not signed in" status when installed but unauthed', async () => {
+    mockInvoke('get_agents_status', [CODEX_UNAUTHED]);
+    render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Codex')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+    expect(screen.getByText('Not signed in')).toBeInTheDocument();
+    expect(screen.queryByText('Set default')).not.toBeInTheDocument();
+  });
+
+  it('renders "Default" pill (disabled) for the current default agent', async () => {
+    mockInvoke('get_agents_status', [CLAUDE_DEFAULT, CODEX_READY]);
+    render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Default')).toBeInTheDocument());
+    const defaultPill = screen.getByRole('button', { name: /Default/ });
+    expect(defaultPill).toBeDisabled();
+  });
+
+  it('renders "Set default" pill for ready non-default agents', async () => {
+    mockInvoke('get_agents_status', [CLAUDE_DEFAULT, CODEX_READY]);
+    render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Set default')).toBeInTheDocument());
+    const setDefaultPill = screen.getByRole('button', { name: /Set default/ });
+    expect(setDefaultPill).not.toBeDisabled();
+  });
+
+  it('set-default flow shows Switching… state then settles on the new default', async () => {
+    mockInvoke('get_agents_status', [CLAUDE_DEFAULT, CODEX_READY]);
+
+    // Hold the backend write until we release it, so we can observe the
+    // intermediate Switching… state deterministically.
+    let releaseBackend!: () => void;
+    const backendGate = new Promise<void>((resolve) => {
+      releaseBackend = resolve;
+    });
+    invokeResults.set('set_default_agent_id', {
+      value: backendGate.then(() => undefined),
+    });
+
+    render(<AgentsPanel />);
+    await waitFor(() => expect(screen.getByText('Set default')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /Set default/ }));
+
+    // Mid-flight: Switching… is visible, "Set default" has been replaced.
+    await waitFor(() => expect(screen.getByText('Switching…')).toBeInTheDocument());
+    expect(screen.queryByText('Set default')).not.toBeInTheDocument();
+
+    // Release the backend and expect the new default to settle on Codex.
+    releaseBackend();
+    await waitFor(() => expect(screen.queryByText('Switching…')).not.toBeInTheDocument());
+
+    // Codex row should now own the Default pill; Claude Code should show "Set default".
+    expect(screen.getByText('Default')).toBeInTheDocument();
+    expect(screen.getByText('Set default')).toBeInTheDocument();
+
+    // Confirm the backend was actually called with the right agent id.
+    const setDefaultCall = invokeCalls.find((c) => c.cmd === 'set_default_agent_id');
+    expect(setDefaultCall?.args).toMatchObject({ agentId: 'codex' });
+  });
+
+  it('kebab menu surfaces Update / Sign out / Uninstall for a ready agent', async () => {
+    mockInvoke('get_agents_status', [CLAUDE_DEFAULT]);
+    render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Claude Code')).toBeInTheDocument());
+
+    const kebab = screen.getByRole('button', { name: /More actions for Claude Code/ });
+    fireEvent.click(kebab);
+
+    expect(screen.getByRole('menuitem', { name: 'Update' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Sign out' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Uninstall' })).toBeInTheDocument();
+  });
+
+  it('kebab menu offers Sign in (not Sign out) when the agent is unauthed', async () => {
+    mockInvoke('get_agents_status', [CODEX_UNAUTHED]);
+    render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Codex')).toBeInTheDocument());
+
+    const kebab = screen.getByRole('button', { name: /More actions for Codex/ });
+    fireEvent.click(kebab);
+
+    expect(screen.getByRole('menuitem', { name: 'Sign in' })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Sign out' })).not.toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Uninstall' })).toBeInTheDocument();
+  });
+
+  it('sign-out invokes sign_out_agent with the correct id', async () => {
+    mockInvoke('get_agents_status', [CLAUDE_DEFAULT]);
+    mockInvoke('sign_out_agent', undefined);
+
+    render(<AgentsPanel />);
+    await waitFor(() => expect(screen.getByText('Claude Code')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /More actions for Claude Code/ }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Sign out' }));
+
+    await waitFor(() => {
+      const call = invokeCalls.find((c) => c.cmd === 'sign_out_agent');
+      expect(call).toBeDefined();
+      expect(call?.args).toMatchObject({ agentId: 'claude-code' });
+    });
+  });
+
+  it('uninstall opens a confirmation modal before invoking the backend', async () => {
+    mockInvoke('get_agents_status', [CODEX_READY]);
+    mockInvoke('uninstall_agent', 'Uninstalled.');
+
+    render(<AgentsPanel />);
+    await waitFor(() => expect(screen.getByText('Codex')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /More actions for Codex/ }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Uninstall' }));
+
+    // Confirmation shown, backend not yet invoked.
+    expect(screen.getByText('Uninstall Codex?')).toBeInTheDocument();
+    expect(invokeCalls.find((c) => c.cmd === 'uninstall_agent')).toBeUndefined();
+
+    // Confirm via the modal's Uninstall button.
+    const confirmBtn = screen
+      .getAllByRole('button', { name: 'Uninstall' })
+      .find((b) => b.className.includes('button--danger'));
+    expect(confirmBtn).toBeDefined();
+    fireEvent.click(confirmBtn!);
+
+    await waitFor(() => {
+      const call = invokeCalls.find((c) => c.cmd === 'uninstall_agent');
+      expect(call).toBeDefined();
+      expect(call?.args).toMatchObject({ agentId: 'codex' });
+    });
+  });
+
+  it('swallows a backend error on load without crashing', async () => {
+    mockInvokeErr('get_agents_status', new Error('boom'));
+    render(<AgentsPanel />);
+
+    // Load resolves (via catch) and the header still renders; no rows.
+    await waitFor(() =>
+      expect(screen.getByText(/Install, sign in, or switch/)).toBeInTheDocument()
+    );
+    expect(screen.queryByText('Claude Code')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/AgentsPanel.tsx
+++ b/src/components/AgentsPanel.tsx
@@ -405,6 +405,7 @@ export function AgentsPanel() {
           isOpen
           onClose={() => setConfirmUninstall(null)}
           title={`Uninstall ${confirmUninstall.displayName}?`}
+          className="agents-panel-confirm-modal"
         >
           <div className="agents-panel-confirm-body">
             <p>

--- a/src/components/AgentsPanel.tsx
+++ b/src/components/AgentsPanel.tsx
@@ -1,0 +1,432 @@
+/**
+ * AgentsPanel — dashboard surface for managing coding agents.
+ *
+ * Lists every known agent (Claude Code, Codex, Opencode) with install +
+ * auth state, and exposes the full lifecycle without touching onboarding:
+ *  - Install / Sign in   — open a terminal modal and run the setup command
+ *  - Sign out            — backend command, one click
+ *  - Uninstall           — confirm, then backend command
+ *  - Set as default      — radio pill, only when installed + authed
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  setDefaultAgentId,
+  TERMINAL_COMMANDS,
+  SETUP_FRIENDLY_NAMES,
+  AGENT_ITEM_PAIRS,
+} from '../lib/setup';
+import { initDefaultAgent } from '../lib/agent';
+import {
+  AgentStatus,
+  getAgentsStatus,
+  signOutAgent,
+  uninstallAgent,
+} from '../lib/agents-management';
+import { OnboardingTerminal } from './setup/OnboardingTerminal';
+import { ModalFrame } from './primitives/ModalFrame';
+import { Button } from './primitives/Button';
+import { useOptionalToast } from '../contexts/ToastContext';
+import { logger } from '../lib/logger';
+import { CheckIcon, SpinnerIcon, ClaudeIcon } from './icons';
+
+function KebabGlyph() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+      <circle cx="2.5" cy="7" r="1.3" fill="currentColor" />
+      <circle cx="7" cy="7" r="1.3" fill="currentColor" />
+      <circle cx="11.5" cy="7" r="1.3" fill="currentColor" />
+    </svg>
+  );
+}
+
+interface TerminalTask {
+  agentId: string;
+  itemId: string;
+  command: string;
+  args: string[];
+  kind: 'install' | 'auth';
+}
+
+interface UninstallConfirm {
+  agentId: string;
+  displayName: string;
+}
+
+function getSetupItemId(binaryName: string, kind: 'install' | 'auth'): string | null {
+  const pair = AGENT_ITEM_PAIRS.find((p) => p.binaryId === binaryName);
+  if (!pair) return null;
+  return kind === 'install' ? pair.binaryId : pair.authId;
+}
+
+function formatVersion(v: string | null): string | null {
+  if (!v) return null;
+  // Strip common prefixes (e.g. "Claude Code v1.2.3" → "1.2.3")
+  const cleaned = v.replace(/^[^\d]*/, '').split(/\s+/)[0];
+  return cleaned || v;
+}
+
+function GenericAgentIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <rect x="3" y="5" width="18" height="14" rx="2" stroke="currentColor" strokeWidth="1.5" />
+      <path
+        d="M8 10h2M14 10h2M8 14h8"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function iconFor(agentId: string) {
+  if (agentId === 'claude-code') {
+    return <ClaudeIcon size={18} />;
+  }
+  return <GenericAgentIcon size={18} />;
+}
+
+function statusLine(a: AgentStatus): string {
+  if (!a.installed) return 'Not installed';
+  if (!a.authed) return 'Not signed in';
+  const v = formatVersion(a.version);
+  return v ? `v${v} · Signed in` : 'Signed in';
+}
+
+export function AgentsPanel() {
+  const [agents, setAgents] = useState<AgentStatus[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [terminalTask, setTerminalTask] = useState<TerminalTask | null>(null);
+  const [confirmUninstall, setConfirmUninstall] = useState<UninstallConfirm | null>(null);
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const { showToast } = useOptionalToast();
+
+  // Keep showToast in a ref so refresh() has a stable identity — otherwise
+  // the mount effect re-fires on every render (useOptionalToast returns a
+  // fresh object each render when there's no ToastProvider), causing a
+  // storm of refetches that makes the default pill flicker.
+  const showToastRef = useRef(showToast);
+  useEffect(() => {
+    showToastRef.current = showToast;
+  }, [showToast]);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await getAgentsStatus();
+      setAgents(data);
+    } catch (err) {
+      logger.warn('Failed to load agent status');
+      showToastRef.current(`Failed to load agents: ${String(err)}`, 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Close kebab menu on outside click
+  useEffect(() => {
+    if (!openMenuId) return;
+    const handler = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpenMenuId(null);
+      }
+    };
+    window.addEventListener('mousedown', handler);
+    return () => window.removeEventListener('mousedown', handler);
+  }, [openMenuId]);
+
+  const handleSetDefault = useCallback(
+    async (agentId: string) => {
+      if (busy) return;
+      // Don't optimistically flip isDefault — that causes visible back-and-
+      // forth while the backend write + any in-flight refresh races. Instead,
+      // render an explicit "Switching…" state on the target pill until the
+      // backend confirms, then apply the new default in a single update.
+      setBusy(agentId);
+      try {
+        await setDefaultAgentId(agentId);
+        initDefaultAgent(agentId);
+        // Apply the final transition in a single setState so React renders
+        // the new default without intermediate states.
+        setAgents((current) => current.map((a) => ({ ...a, isDefault: a.id === agentId })));
+      } catch (err) {
+        showToast(`Failed to set default: ${String(err)}`, 'error');
+      } finally {
+        setBusy(null);
+      }
+    },
+    [busy, showToast]
+  );
+
+  const handleSignOut = useCallback(
+    async (agent: AgentStatus) => {
+      if (busy) return;
+      setOpenMenuId(null);
+      setBusy(agent.id);
+      try {
+        await signOutAgent(agent.id);
+        showToast(`Signed out of ${agent.displayName}`, 'success');
+        await refresh();
+      } catch (err) {
+        showToast(`Sign out failed: ${String(err)}`, 'error');
+      } finally {
+        setBusy(null);
+      }
+    },
+    [busy, refresh, showToast]
+  );
+
+  const handleUninstall = useCallback(
+    async (agentId: string, displayName: string) => {
+      setConfirmUninstall(null);
+      setBusy(agentId);
+      try {
+        await uninstallAgent(agentId);
+        showToast(`Uninstalled ${displayName}`, 'success');
+        await refresh();
+      } catch (err) {
+        showToast(`Uninstall failed: ${String(err)}`, 'error');
+      } finally {
+        setBusy(null);
+      }
+    },
+    [refresh, showToast]
+  );
+
+  const openTerminal = useCallback((agent: AgentStatus, kind: 'install' | 'auth') => {
+    setOpenMenuId(null);
+    const itemId = getSetupItemId(agent.binaryName, kind);
+    if (!itemId) {
+      return;
+    }
+    const cmd = TERMINAL_COMMANDS[itemId];
+    if (!cmd) return;
+    setTerminalTask({
+      agentId: agent.id,
+      itemId,
+      command: cmd.command,
+      args: cmd.args,
+      kind,
+    });
+  }, []);
+
+  const handleTerminalExit = useCallback(
+    (exitCode: number | null) => {
+      setTerminalTask(null);
+      // Auth/install files (and newly-installed binaries) can land a beat after
+      // the child process exits. Refresh immediately and then retry a few times
+      // so a freshly-installed agent shows up without requiring a manual reload.
+      void refresh();
+      [600, 1500, 3000].forEach((delay) => setTimeout(() => void refresh(), delay));
+      if (exitCode !== null && exitCode !== 0) {
+        logger.info('Agent terminal exited with non-zero code', { exitCode });
+      }
+    },
+    [refresh]
+  );
+
+  return (
+    <section className="agents-panel" ref={panelRef}>
+      <header className="agents-panel-header">
+        <div>
+          <h3 className="agents-panel-title">Coding Agents</h3>
+          <p className="agents-panel-subtitle">
+            Install, sign in, or switch the default agent new terminals use.
+          </p>
+        </div>
+        {loading && <SpinnerIcon size={14} className="agents-panel-spinner" />}
+      </header>
+
+      <div className="agents-panel-list">
+        {agents.map((agent) => {
+          const ready = agent.installed && agent.authed;
+          const isBusy = busy === agent.id;
+          const menuOpen = openMenuId === agent.id;
+
+          return (
+            <div
+              key={agent.id}
+              className={`agents-panel-row ${agent.isDefault ? 'is-default' : ''}`}
+            >
+              <div className="agents-panel-row-icon">{iconFor(agent.id)}</div>
+
+              <div className="agents-panel-row-main">
+                <div className="agents-panel-row-name">{agent.displayName}</div>
+                <div className="agents-panel-row-status">{statusLine(agent)}</div>
+              </div>
+
+              <div className="agents-panel-row-actions">
+                {!agent.installed && agent.installSupported && (
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => openTerminal(agent, 'install')}
+                    disabled={isBusy}
+                  >
+                    Install
+                  </Button>
+                )}
+
+                {agent.installed && !agent.authed && (
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => openTerminal(agent, 'auth')}
+                    disabled={isBusy}
+                  >
+                    Sign in
+                  </Button>
+                )}
+
+                {ready &&
+                  (() => {
+                    const isSwitchingToThis = busy === agent.id && !agent.isDefault;
+                    const anySwitching = busy !== null;
+                    return (
+                      <button
+                        type="button"
+                        className={`agents-default-pill ${agent.isDefault ? 'on' : ''} ${isSwitchingToThis ? 'switching' : ''}`}
+                        onClick={() => {
+                          if (!agent.isDefault) void handleSetDefault(agent.id);
+                        }}
+                        disabled={anySwitching || agent.isDefault}
+                        aria-pressed={agent.isDefault}
+                        aria-busy={isSwitchingToThis || undefined}
+                      >
+                        <span className="agents-default-pill-radio">
+                          {isSwitchingToThis ? (
+                            <SpinnerIcon size={10} className="spinner-icon" />
+                          ) : agent.isDefault ? (
+                            <CheckIcon size={10} />
+                          ) : null}
+                        </span>
+                        {isSwitchingToThis
+                          ? 'Switching…'
+                          : agent.isDefault
+                            ? 'Default'
+                            : 'Set default'}
+                      </button>
+                    );
+                  })()}
+
+                {agent.installed && (
+                  <div className="agents-panel-menu-wrap">
+                    <button
+                      type="button"
+                      className="agents-panel-kebab"
+                      onClick={() => setOpenMenuId(menuOpen ? null : agent.id)}
+                      aria-label={`More actions for ${agent.displayName}`}
+                      aria-haspopup="menu"
+                      aria-expanded={menuOpen}
+                      disabled={isBusy}
+                    >
+                      <KebabGlyph />
+                    </button>
+                    {menuOpen && (
+                      <div className="agents-panel-menu" role="menu">
+                        {agent.installSupported && (
+                          <button
+                            type="button"
+                            role="menuitem"
+                            onClick={() => openTerminal(agent, 'install')}
+                          >
+                            Update
+                          </button>
+                        )}
+                        {agent.authed && (
+                          <button
+                            type="button"
+                            role="menuitem"
+                            onClick={() => void handleSignOut(agent)}
+                          >
+                            Sign out
+                          </button>
+                        )}
+                        {!agent.authed && (
+                          <button
+                            type="button"
+                            role="menuitem"
+                            onClick={() => openTerminal(agent, 'auth')}
+                          >
+                            Sign in
+                          </button>
+                        )}
+                        {agent.uninstallSupported && (
+                          <button
+                            type="button"
+                            role="menuitem"
+                            className="agents-panel-menu-danger"
+                            onClick={() => {
+                              setOpenMenuId(null);
+                              setConfirmUninstall({
+                                agentId: agent.id,
+                                displayName: agent.displayName,
+                              });
+                            }}
+                          >
+                            Uninstall
+                          </button>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {terminalTask && (
+        <ModalFrame
+          isOpen
+          onClose={() => handleTerminalExit(null)}
+          title={`${SETUP_FRIENDLY_NAMES[terminalTask.itemId] ?? terminalTask.itemId}`}
+          className="agents-panel-terminal-modal"
+        >
+          <div className="agents-panel-terminal-body">
+            <OnboardingTerminal
+              command={terminalTask.command}
+              args={terminalTask.args}
+              onExit={handleTerminalExit}
+            />
+          </div>
+        </ModalFrame>
+      )}
+
+      {confirmUninstall && (
+        <ModalFrame
+          isOpen
+          onClose={() => setConfirmUninstall(null)}
+          title={`Uninstall ${confirmUninstall.displayName}?`}
+        >
+          <div className="agents-panel-confirm-body">
+            <p>
+              This removes the {confirmUninstall.displayName} CLI from your machine. You can
+              reinstall it any time from this panel.
+            </p>
+            <div className="agents-panel-confirm-actions">
+              <Button variant="secondary" onClick={() => setConfirmUninstall(null)}>
+                Cancel
+              </Button>
+              <Button
+                variant="danger"
+                onClick={() =>
+                  void handleUninstall(confirmUninstall.agentId, confirmUninstall.displayName)
+                }
+              >
+                Uninstall
+              </Button>
+            </div>
+          </div>
+        </ModalFrame>
+      )}
+    </section>
+  );
+}

--- a/src/components/ProjectList.tsx
+++ b/src/components/ProjectList.tsx
@@ -40,6 +40,7 @@ import {
   moveProjectToFolder,
 } from '../lib/folders';
 import { DashboardHeader } from './DashboardHeader';
+import { AgentsPanel } from './AgentsPanel';
 import { IntegrationBar } from './IntegrationBar';
 import { NewFolderModal } from './NewFolderModal';
 import { ProjectGridView } from './ProjectGridView';
@@ -552,6 +553,8 @@ export function ProjectList({
           pinnedSet={pinnedSet}
           onTogglePin={onTogglePin}
         />
+
+        <AgentsPanel />
 
         <button
           className="dashboard-settings-row"

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -764,6 +764,7 @@ export const WorkspaceView = memo(function WorkspaceView({
                           <div
                             key={`session-${terminalSessionId}-tab-${tab.id}`}
                             className={`terminal-tab-content ${!showDevServerLogs && activeTerminalTab === tab.id ? 'active' : ''}`}
+                            data-agent-id={tab.agentId}
                           >
                             <Terminal
                               ref={(ref) => {

--- a/src/components/setup/OnboardingTerminal.tsx
+++ b/src/components/setup/OnboardingTerminal.tsx
@@ -195,6 +195,8 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
             `${homeNormalized}.local/bin`,
             `${homeNormalized}.cargo/bin`,
             `${homeNormalized}n/bin`, // n version manager
+            `${homeNormalized}.opencode/bin`, // opencode installer default
+            `${homeNormalized}.bun/bin`, // bun-installed tools
           ];
 
           // Try to find nvm node versions and add their bin directories

--- a/src/components/setup/steps/AgentStep.tsx
+++ b/src/components/setup/steps/AgentStep.tsx
@@ -50,7 +50,7 @@ export function AgentStep({
     <div className="wizard-step-items">
       {showSelection && (
         <p className="wizard-agent-selection-hint">
-          Both agents are ready. Choose your default below.
+          {readyPairs.length} agents are ready. Choose your default below.
         </p>
       )}
 

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -18,6 +18,7 @@ import { GITHUB_STATUS_FALLBACK } from './useIntegrationStatus';
 import { registerExternalProject } from '../lib/external-projects';
 import { registerProjectSession, unregisterProjectSession } from '../lib/projectSessions';
 import { sessionRegistry } from '../lib/sessionRegistry';
+import { getDefaultAgentId } from '../lib/agent';
 import {
   setWindowTitle,
   getWindowLabel,
@@ -227,12 +228,21 @@ export function useProjectLifecycle({
     } | null>('get_terminal_state', { projectPath: project.path })
       .then((savedState) => {
         if (savedState && savedState.tabs.length > 0) {
+          // Always use the current global default agent for restored tabs.
+          // "Default agent" applies to every new terminal — including the first
+          // tab when a project reopens — so saved per-project agent IDs are
+          // ignored in favour of the user's latest preference.
+          const currentDefault = getDefaultAgentId();
           logger.info('[OpenProject] Restoring saved terminal tabs', {
             tabCount: savedState.tabs.length,
             activeIndex: savedState.active_tab_index,
+            defaultAgent: currentDefault,
           });
           restoreTerminalTabs(
-            savedState.tabs.map((t) => ({ agentId: t.agent_id, sessionId: t.session_id })),
+            savedState.tabs.map((t) => ({
+              agentId: currentDefault,
+              sessionId: t.session_id,
+            })),
             savedState.active_tab_index
           );
         } else {

--- a/src/lib/agent.test.ts
+++ b/src/lib/agent.test.ts
@@ -14,6 +14,7 @@ import {
   ALL_TAB_OPTIONS,
   CLAUDE_CODE,
   CODEX,
+  OPENCODE,
   TERMINAL,
 } from './agent';
 
@@ -35,6 +36,12 @@ describe('getAgentById', () => {
     const agent = getAgentById('codex');
     expect(agent.id).toBe('codex');
     expect(agent.displayName).toBe('Codex');
+  });
+
+  it('returns OPENCODE for "opencode"', () => {
+    const agent = getAgentById('opencode');
+    expect(agent.id).toBe('opencode');
+    expect(agent.displayName).toBe('Opencode');
   });
 
   it('returns TERMINAL for "terminal"', () => {
@@ -92,22 +99,27 @@ describe('getActiveAgent', () => {
 // ============ ALL_AGENTS / ALL_TAB_OPTIONS ============
 
 describe('ALL_AGENTS', () => {
-  it('has exactly 2 entries', () => {
-    expect(ALL_AGENTS).toHaveLength(2);
+  it('has exactly 3 entries', () => {
+    expect(ALL_AGENTS).toHaveLength(3);
   });
 
-  it('contains CLAUDE_CODE and CODEX', () => {
-    expect(ALL_AGENTS.map((a) => a.id)).toEqual(['claude-code', 'codex']);
+  it('contains CLAUDE_CODE, CODEX, and OPENCODE', () => {
+    expect(ALL_AGENTS.map((a) => a.id)).toEqual(['claude-code', 'codex', 'opencode']);
   });
 });
 
 describe('ALL_TAB_OPTIONS', () => {
-  it('has exactly 3 entries (agents + terminal)', () => {
-    expect(ALL_TAB_OPTIONS).toHaveLength(3);
+  it('has exactly 4 entries (agents + terminal)', () => {
+    expect(ALL_TAB_OPTIONS).toHaveLength(4);
   });
 
-  it('contains CLAUDE_CODE, CODEX, and TERMINAL', () => {
-    expect(ALL_TAB_OPTIONS.map((a) => a.id)).toEqual(['claude-code', 'codex', 'terminal']);
+  it('contains CLAUDE_CODE, CODEX, OPENCODE, and TERMINAL', () => {
+    expect(ALL_TAB_OPTIONS.map((a) => a.id)).toEqual([
+      'claude-code',
+      'codex',
+      'opencode',
+      'terminal',
+    ]);
   });
 });
 
@@ -128,6 +140,14 @@ describe('AgentConfig fields', () => {
     expect(CODEX.autoAcceptFlag).toBe('--yolo');
     expect(CODEX.supportsSkills).toBe(true);
     expect(CODEX.supportsStatusDetection).toBe(false);
+  });
+
+  it('OPENCODE has correct specific values', () => {
+    expect(OPENCODE.binaryName).toBe('opencode');
+    expect(OPENCODE.processName).toBe('opencode');
+    expect(OPENCODE.autoAcceptFlag).toBeNull();
+    expect(OPENCODE.supportsSkills).toBe(false);
+    expect(OPENCODE.supportsStatusDetection).toBe(false);
   });
 
   it('TERMINAL has correct specific values', () => {

--- a/src/lib/agent.ts
+++ b/src/lib/agent.ts
@@ -66,6 +66,21 @@ export const CODEX: AgentConfig = {
   installHint: 'Make sure Codex is installed: npm install -g @openai/codex',
 };
 
+/** Opencode agent configuration. */
+export const OPENCODE: AgentConfig = {
+  id: 'opencode',
+  displayName: 'Opencode',
+  binaryName: 'opencode',
+  processName: 'opencode',
+  autoAcceptFlag: null,
+  supportsSkills: false,
+  supportsMcp: true,
+  supportsStatusDetection: false,
+  loadingMessage: 'Starting Opencode...',
+  notFoundMessage: 'Error starting Opencode',
+  installHint: 'Make sure Opencode is installed: curl -fsSL https://opencode.ai/install | bash',
+};
+
 /** Raw terminal (shell) configuration — not an AI agent. */
 export const TERMINAL: AgentConfig = {
   id: 'terminal',
@@ -82,10 +97,10 @@ export const TERMINAL: AgentConfig = {
 };
 
 /** All available agents (AI coding assistants). */
-export const ALL_AGENTS: AgentConfig[] = [CLAUDE_CODE, CODEX];
+export const ALL_AGENTS: AgentConfig[] = [CLAUDE_CODE, CODEX, OPENCODE];
 
 /** All options available in the tab dropdown (agents + terminal). */
-export const ALL_TAB_OPTIONS: AgentConfig[] = [CLAUDE_CODE, CODEX, TERMINAL];
+export const ALL_TAB_OPTIONS: AgentConfig[] = [CLAUDE_CODE, CODEX, OPENCODE, TERMINAL];
 
 /** In-memory cache for the default agent ID. Null means unset (falls back to Claude Code). */
 let defaultAgentId: string | null = null;

--- a/src/lib/agents-management.ts
+++ b/src/lib/agents-management.ts
@@ -1,0 +1,38 @@
+/**
+ * Thin wrappers over the agent-management backend commands surfaced on the
+ * dashboard (install/auth/uninstall lifecycle, rich per-agent status).
+ *
+ * Keep `invoke` calls here so components import typed functions instead.
+ *
+ * @module lib/agents-management
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+
+/** Rich per-agent status returned by the backend for the dashboard panel. */
+export interface AgentStatus {
+  id: string;
+  displayName: string;
+  binaryName: string;
+  installed: boolean;
+  version: string | null;
+  authed: boolean;
+  isDefault: boolean;
+  installSupported: boolean;
+  uninstallSupported: boolean;
+}
+
+/** Fetch every known agent's status in one round-trip. */
+export async function getAgentsStatus(): Promise<AgentStatus[]> {
+  return invoke<AgentStatus[]>('get_agents_status');
+}
+
+/** Remove an agent's auth indicator files; binary is left intact. */
+export async function signOutAgent(agentId: string): Promise<void> {
+  return invoke('sign_out_agent', { agentId });
+}
+
+/** Run the agent's uninstall command (best-effort, idempotent). */
+export async function uninstallAgent(agentId: string): Promise<string> {
+  return invoke<string>('uninstall_agent', { agentId });
+}

--- a/src/lib/setup.test.ts
+++ b/src/lib/setup.test.ts
@@ -172,7 +172,7 @@ describe('getBlockingDependencies', () => {
 // ============ getReadyAgentPairs ============
 
 describe('getReadyAgentPairs', () => {
-  it('returns both pairs when both agents are ready', () => {
+  it('returns both pairs when claude and codex are ready', () => {
     const pairs = getReadyAgentPairs(ALL_READY_BOTH_AGENTS);
     expect(pairs).toHaveLength(2);
     expect(pairs[0]).toEqual({ binaryId: 'claude', authId: 'claude_auth' });
@@ -234,12 +234,14 @@ describe('isAtLeastOneAgentReady', () => {
 // ============ AGENT_ITEM_IDS ============
 
 describe('AGENT_ITEM_IDS', () => {
-  it('contains all 4 agent item IDs', () => {
+  it('contains all 6 agent item IDs', () => {
     expect(AGENT_ITEM_IDS.has('claude')).toBe(true);
     expect(AGENT_ITEM_IDS.has('claude_auth')).toBe(true);
     expect(AGENT_ITEM_IDS.has('codex')).toBe(true);
     expect(AGENT_ITEM_IDS.has('codex_auth')).toBe(true);
-    expect(AGENT_ITEM_IDS.size).toBe(4);
+    expect(AGENT_ITEM_IDS.has('opencode')).toBe(true);
+    expect(AGENT_ITEM_IDS.has('opencode_auth')).toBe(true);
+    expect(AGENT_ITEM_IDS.size).toBe(6);
   });
 
   it('does not contain non-agent items', () => {
@@ -470,7 +472,14 @@ describe('getStepItems', () => {
   it('returns items for agent step', () => {
     const items = getStepItems('agent', FRESH_INSTALL_ITEMS);
     const ids = items.map((i) => i.id);
-    expect(ids).toEqual(['claude', 'claude_auth', 'codex', 'codex_auth']);
+    expect(ids).toEqual([
+      'claude',
+      'claude_auth',
+      'codex',
+      'codex_auth',
+      'opencode',
+      'opencode_auth',
+    ]);
   });
 
   it('returns vercel items for hosting step', () => {

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -8,6 +8,7 @@
  * - GitHub CLI + auth
  * - Claude Code + auth
  * - Codex + auth
+ * - Opencode + auth
  *
  * @module lib/setup
  */
@@ -92,6 +93,8 @@ export const OPTIONAL_ITEMS = new Set([
   'claude_auth',
   'codex',
   'codex_auth',
+  'opencode',
+  'opencode_auth',
   'vercel',
   'vercel_auth',
 ]);
@@ -117,6 +120,8 @@ export function getSetupDependencies(): Record<string, string[]> {
     claude_auth: ['claude'],
     codex: [], // Uses npm global install
     codex_auth: ['codex'],
+    opencode: [], // Uses its own installer
+    opencode_auth: ['opencode'],
     vercel: [], // Uses npm global install
     vercel_auth: ['vercel'],
   };
@@ -137,6 +142,8 @@ export const SETUP_ITEM_ORDER = [
   'claude_auth',
   'codex',
   'codex_auth',
+  'opencode',
+  'opencode_auth',
   'vercel',
   'vercel_auth',
 ];
@@ -153,6 +160,8 @@ export const SETUP_FRIENDLY_NAMES: Record<string, string> = {
   claude_auth: 'Claude Account',
   codex: 'Codex',
   codex_auth: 'Codex Account',
+  opencode: 'Opencode',
+  opencode_auth: 'Opencode Account',
   vercel: 'Vercel CLI',
   vercel_auth: 'Vercel Account',
 };
@@ -169,6 +178,8 @@ export const SETUP_PROGRESS_MESSAGES: Record<string, string> = {
   claude_auth: 'Connecting to Claude...',
   codex: 'Installing Codex...',
   codex_auth: 'Connecting to Codex...',
+  opencode: 'Installing Opencode...',
+  opencode_auth: 'Connecting to Opencode...',
   vercel: 'Installing Vercel CLI...',
   vercel_auth: 'Connecting to Vercel...',
 };
@@ -185,6 +196,8 @@ export const SETUP_TIME_ESTIMATES: Record<string, string> = {
   claude_auth: '~15 sec',
   codex: '~15 sec',
   codex_auth: '~15 sec',
+  opencode: '~15 sec',
+  opencode_auth: '~15 sec',
   vercel: '~10 sec',
   vercel_auth: '~15 sec',
 };
@@ -195,6 +208,7 @@ export const SETUP_TIME_ESTIMATES: Record<string, string> = {
 export const AGENT_ITEM_PAIRS = [
   { binaryId: 'claude', authId: 'claude_auth' },
   { binaryId: 'codex', authId: 'codex_auth' },
+  { binaryId: 'opencode', authId: 'opencode_auth' },
 ] as const;
 
 /** Agent item IDs (all binary + auth IDs) */
@@ -297,7 +311,7 @@ export const WIZARD_STEPS: WizardStepDef[] = [
     id: 'agent',
     title: 'AI Agent',
     subtitle: 'Install at least one AI coding assistant',
-    itemIds: ['claude', 'claude_auth', 'codex', 'codex_auth'],
+    itemIds: ['claude', 'claude_auth', 'codex', 'codex_auth', 'opencode', 'opencode_auth'],
     skippable: false,
   },
   {
@@ -530,6 +544,17 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
         command: 'codex',
         args: [],
       },
+      opencode: {
+        command: 'powershell',
+        args: [
+          '-Command',
+          'Write-Host "Please download Opencode from https://opencode.ai"; Start-Process "https://opencode.ai"',
+        ],
+      },
+      opencode_auth: {
+        command: 'opencode',
+        args: ['auth', 'login'],
+      },
       vercel: {
         command: 'npm',
         args: ['install', '-g', 'vercel'],
@@ -593,6 +618,14 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
         command: 'codex',
         args: [],
       },
+      opencode: {
+        command: '/bin/bash',
+        args: ['-c', 'curl -fsSL https://opencode.ai/install | bash'],
+      },
+      opencode_auth: {
+        command: 'opencode',
+        args: ['auth', 'login'],
+      },
       vercel: {
         command: '/bin/bash',
         args: ['-c', 'npm install -g vercel'],
@@ -617,6 +650,8 @@ export const USES_TERMINAL = new Set([
   'claude_auth',
   'codex',
   'codex_auth',
+  'opencode',
+  'opencode_auth',
   'vercel',
   'vercel_auth',
 ]);

--- a/src/styles/features/agents-panel.css
+++ b/src/styles/features/agents-panel.css
@@ -250,9 +250,13 @@
   overflow: hidden;
 }
 
-/* Confirm modal body */
+/* Confirm modal — cap width and match header padding for consistent gutters. */
+.agents-panel-confirm-modal {
+  width: min(420px, 90vw);
+}
+
 .agents-panel-confirm-body {
-  padding: 0 var(--spacing-lg) var(--spacing-lg);
+  padding: var(--spacing-lg) var(--spacing-xl) var(--spacing-xl);
   font-size: 13px;
   color: var(--text-secondary);
   line-height: 1.5;

--- a/src/styles/features/agents-panel.css
+++ b/src/styles/features/agents-panel.css
@@ -1,0 +1,266 @@
+/* Agents panel — dashboard surface for managing coding agents */
+
+.agents-panel {
+  margin: var(--spacing-lg) 0;
+  padding: var(--spacing-lg);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.agents-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+}
+
+.agents-panel-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.agents-panel-subtitle {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin: 2px 0 0 0;
+}
+
+.agents-panel-spinner {
+  color: var(--text-muted);
+}
+
+.agents-panel-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.agents-panel-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-md) var(--spacing-md) var(--spacing-lg);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: border-color var(--transition);
+}
+
+.agents-panel-row.is-default {
+  border-color: var(--action);
+  box-shadow: inset 0 0 0 1px var(--action);
+}
+
+.agents-panel-row-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: var(--radius);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.agents-panel-row-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.agents-panel-row-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agents-panel-row-status {
+  font-size: 12px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agents-panel-row-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-shrink: 0;
+}
+
+/* Default pill — radio-style indicator. Matches .button--sm geometry so it
+   visually balances with the Install / Sign in buttons next to it. */
+.agents-default-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-md);
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  cursor: pointer;
+  transition:
+    background var(--transition),
+    color var(--transition),
+    border-color var(--transition);
+}
+
+.agents-default-pill:hover:not(:disabled) {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.agents-default-pill:disabled {
+  cursor: default;
+}
+
+.agents-default-pill.on {
+  background: var(--action);
+  color: var(--action-text);
+  border-color: var(--action);
+}
+
+.agents-default-pill.switching {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+  cursor: wait;
+}
+
+.agents-default-pill.switching .spinner-icon {
+  width: 10px;
+  height: 10px;
+}
+
+.agents-default-pill-radio {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid currentColor;
+  border-radius: var(--radius-full);
+  color: inherit;
+  flex-shrink: 0;
+}
+
+.agents-default-pill.on .agents-default-pill-radio {
+  background: var(--action-text);
+  color: var(--action);
+  border-color: var(--action-text);
+}
+
+/* Kebab menu */
+.agents-panel-menu-wrap {
+  position: relative;
+}
+
+.agents-panel-kebab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    background var(--transition),
+    border-color var(--transition),
+    color var(--transition);
+}
+
+.agents-panel-kebab:hover:not(:disabled) {
+  background: var(--border);
+  border-color: var(--text-muted);
+  color: var(--text-primary);
+}
+
+.agents-panel-kebab:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.agents-panel-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 140px;
+  padding: var(--spacing-xs);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  z-index: var(--z-dropdown);
+  display: flex;
+  flex-direction: column;
+}
+
+.agents-panel-menu button {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background var(--transition);
+}
+
+.agents-panel-menu button:hover {
+  background: var(--bg-secondary);
+}
+
+.agents-panel-menu .agents-panel-menu-danger {
+  color: var(--error);
+}
+
+/* Terminal modal embedded in panel */
+.agents-panel-terminal-modal {
+  width: min(800px, 90vw);
+  height: min(500px, 80vh);
+  display: flex;
+  flex-direction: column;
+}
+
+.agents-panel-terminal-body {
+  flex: 1;
+  min-height: 0;
+  background: #1e1e1e;
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+/* Confirm modal body */
+.agents-panel-confirm-body {
+  padding: 0 var(--spacing-lg) var(--spacing-lg);
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.agents-panel-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-lg);
+}

--- a/src/styles/features/workspace/terminal.css
+++ b/src/styles/features/workspace/terminal.css
@@ -217,6 +217,33 @@
   visibility: hidden;
 }
 
+/* Opencode draws its own full-bleed TUI — it wants 100% of the tab, no
+   gutter on any side. Claude and Codex keep their 12px left gutter. */
+.terminal-tab-content[data-agent-id='opencode'] {
+  left: 0;
+  padding: 0;
+  background: #1e1e1e;
+}
+
+.terminal-tab-content[data-agent-id='opencode'] .xterm,
+.terminal-tab-content[data-agent-id='opencode'] .xterm-viewport,
+.terminal-tab-content[data-agent-id='opencode'] .xterm-screen {
+  width: 100% !important;
+  height: 100% !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  background: #1e1e1e !important;
+}
+
+.terminal-tab-content[data-agent-id='opencode'] .xterm-viewport {
+  scrollbar-width: none;
+  overflow: hidden !important;
+}
+
+.terminal-tab-content[data-agent-id='opencode'] .xterm-viewport::-webkit-scrollbar {
+  display: none;
+}
+
 .terminal-tab-content.active {
   visibility: visible;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -29,6 +29,7 @@
 @import './features/publish/toasts.css';
 @import './features/env-editor.css';
 @import './features/assets-panel.css';
+@import './features/agents-panel.css';
 @import './features/ide-dropdown.css';
 @import './features/browser-dropdown.css';
 @import './features/dashboard/main.css';

--- a/src/test/fixtures/setup.ts
+++ b/src/test/fixtures/setup.ts
@@ -31,6 +31,7 @@ const CLAUDE_AUTH_READY = item('claude_auth', 'Claude Account', 'ready', {
 });
 const CODEX_READY = item('codex', 'Codex', 'ready', { version: '0.1.0' });
 const CODEX_AUTH_READY = item('codex_auth', 'Codex Account', 'ready', { username: 'codex-user' });
+const OPENCODE_READY = item('opencode', 'Opencode', 'ready', { version: '0.1.0' });
 const VERCEL_READY = item('vercel', 'Vercel CLI', 'ready', { version: '33.0.0' });
 const VERCEL_AUTH_READY = item('vercel_auth', 'Vercel Account', 'ready', {
   username: 'vercel-user',
@@ -47,6 +48,8 @@ const CLAUDE_MISSING = item('claude', 'Claude Code', 'not_installed');
 const CLAUDE_AUTH_MISSING = item('claude_auth', 'Claude Account', 'not_authenticated');
 const CODEX_MISSING = item('codex', 'Codex', 'not_installed');
 const CODEX_AUTH_MISSING = item('codex_auth', 'Codex Account', 'not_authenticated');
+const OPENCODE_MISSING = item('opencode', 'Opencode', 'not_installed');
+const OPENCODE_AUTH_MISSING = item('opencode_auth', 'Opencode Account', 'not_authenticated');
 const VERCEL_MISSING = item('vercel', 'Vercel CLI', 'not_installed');
 const VERCEL_AUTH_MISSING = item('vercel_auth', 'Vercel Account', 'not_authenticated');
 
@@ -63,11 +66,13 @@ export const FRESH_INSTALL_ITEMS: SetupItem[] = [
   CLAUDE_AUTH_MISSING,
   CODEX_MISSING,
   CODEX_AUTH_MISSING,
+  OPENCODE_MISSING,
+  OPENCODE_AUTH_MISSING,
   VERCEL_MISSING,
   VERCEL_AUTH_MISSING,
 ];
 
-/** All ready with Claude Code only (no Codex) */
+/** All ready with Claude Code only (no Codex, no Opencode) */
 export const ALL_READY_CLAUDE_ONLY: SetupItem[] = [
   HOMEBREW_READY,
   NODE_READY,
@@ -78,11 +83,13 @@ export const ALL_READY_CLAUDE_ONLY: SetupItem[] = [
   CLAUDE_AUTH_READY,
   CODEX_MISSING,
   CODEX_AUTH_MISSING,
+  OPENCODE_MISSING,
+  OPENCODE_AUTH_MISSING,
   VERCEL_READY,
   VERCEL_AUTH_READY,
 ];
 
-/** All ready with both agents */
+/** All ready with Claude and Codex (legacy "both agents" — opencode not installed) */
 export const ALL_READY_BOTH_AGENTS: SetupItem[] = [
   HOMEBREW_READY,
   NODE_READY,
@@ -93,11 +100,13 @@ export const ALL_READY_BOTH_AGENTS: SetupItem[] = [
   CLAUDE_AUTH_READY,
   CODEX_READY,
   CODEX_AUTH_READY,
+  OPENCODE_MISSING,
+  OPENCODE_AUTH_MISSING,
   VERCEL_READY,
   VERCEL_AUTH_READY,
 ];
 
-/** All ready with Codex only (no Claude) */
+/** All ready with Codex only (no Claude, no Opencode) */
 export const ALL_READY_CODEX_ONLY: SetupItem[] = [
   HOMEBREW_READY,
   NODE_READY,
@@ -108,6 +117,8 @@ export const ALL_READY_CODEX_ONLY: SetupItem[] = [
   CLAUDE_AUTH_MISSING,
   CODEX_READY,
   CODEX_AUTH_READY,
+  OPENCODE_MISSING,
+  OPENCODE_AUTH_MISSING,
   VERCEL_READY,
   VERCEL_AUTH_READY,
 ];
@@ -123,6 +134,8 @@ export const BASE_READY_NO_AGENTS: SetupItem[] = [
   CLAUDE_AUTH_MISSING,
   CODEX_MISSING,
   CODEX_AUTH_MISSING,
+  OPENCODE_MISSING,
+  OPENCODE_AUTH_MISSING,
   VERCEL_MISSING,
   VERCEL_AUTH_MISSING,
 ];
@@ -138,6 +151,8 @@ export const AUTH_ONLY_ITEMS: SetupItem[] = [
   CLAUDE_AUTH_MISSING,
   CODEX_READY,
   CODEX_AUTH_MISSING,
+  OPENCODE_READY,
+  OPENCODE_AUTH_MISSING,
   VERCEL_READY,
   VERCEL_AUTH_MISSING,
 ];
@@ -195,6 +210,8 @@ export const STEP1_COMPLETE_ITEMS: SetupItem[] = [
   CLAUDE_AUTH_MISSING,
   CODEX_MISSING,
   CODEX_AUTH_MISSING,
+  OPENCODE_MISSING,
+  OPENCODE_AUTH_MISSING,
   VERCEL_MISSING,
   VERCEL_AUTH_MISSING,
 ];
@@ -215,6 +232,8 @@ export const HAS_BASE_NO_AGENTS_ITEMS: SetupItem[] = [
   CLAUDE_AUTH_MISSING,
   CODEX_MISSING,
   CODEX_AUTH_MISSING,
+  OPENCODE_MISSING,
+  OPENCODE_AUTH_MISSING,
   VERCEL_MISSING,
   VERCEL_AUTH_MISSING,
 ];
@@ -236,6 +255,8 @@ export const HAS_CLAUDE_NO_GITHUB_ITEMS: SetupItem[] = [
   CLAUDE_AUTH_READY,
   CODEX_MISSING,
   CODEX_AUTH_MISSING,
+  OPENCODE_MISSING,
+  OPENCODE_AUTH_MISSING,
   VERCEL_MISSING,
   VERCEL_AUTH_MISSING,
 ];


### PR DESCRIPTION
## Summary

- **Add Opencode** as a third supported coding agent alongside Claude Code and Codex (full config, install/auth/uninstall commands, onboarding + runtime support).
- **New "Coding Agents" card on the dashboard** lets users install, sign in/out, update, uninstall, and set the default agent without touching the onboarding wizard.
- **Three new backend commands** — `get_agents_status`, `sign_out_agent`, `uninstall_agent` — and a `uninstall_command_unix`/`_windows` field on `AgentConfig` so per-agent uninstall is data-driven.

## Motivation

Previously the only place to pick or manage an agent was first-run onboarding. If a user started with Claude Code and later wanted to try Codex (or Opencode), they had no way to install it, sign in, or switch the default from the GUI. This PR makes agent management a first-class Dashboard affordance.

## What's in the panel

Each row shows: agent icon, display name, version + auth status line, and right-side actions:

| Agent state | Actions shown |
|---|---|
| Not installed | `Install` button |
| Installed, not signed in | `Sign in` button + kebab (Update / Uninstall) |
| Installed + signed in | Default pill (radio-style) + kebab (Update / Sign out / Uninstall) |

- Install / Sign in open the same terminal modal the onboarding wizard uses.
- Sign out wipes the agent's auth indicator files (one-click, no terminal).
- Uninstall runs the agent's uninstall command after a confirm modal.
- "Set default" on an installed + authed agent flips the global default (persisted in `app_state.json`).

## Notable bugs fixed along the way

- **Default-switch "flicker back to Claude Code"**: `useOptionalToast` returns a fresh object on every render when no `ToastProvider` wraps the app, which made the mount effect fire continuously and refetch agent status 3–10× per click. `showToast` is now held in a ref, so `refresh` has a stable identity and fires once. Default switching now shows a clean `[spinner] Switching…` → `Default` (green) transition with no intermediate states.
- **Opened project ignored the new default**: `useProjectLifecycle` was restoring per-project saved tabs with their old `agentId`. Saved tabs now always use the current global default.
- **Opencode install "did nothing"**: the opencode installer puts the binary at `~/.opencode/bin/opencode` and only adds it to `~/.zshrc`. Added `~/.opencode/bin` and `~/.bun/bin` to both `find_binary_by_name` and the PTY's extended `PATH`, so freshly-installed opencode is discoverable without restarting the app.
- **Opencode auth hung on "Starting…"**: same PATH issue in `OnboardingTerminal`. Fixed.
- **Opencode terminal left-gutter**: Claude and Codex want a 12px left gutter; opencode's TUI is full-bleed. Added `data-agent-id` on `terminal-tab-content` and a scoped CSS rule that drops the gutter + scrollbar channel for opencode only.

## Files touched

**Backend (Rust)**
- `src-tauri/src/agent.rs` — `OPENCODE` config, `uninstall_command_{unix,windows}` on `AgentConfig`, `ALL_AGENTS` → 3.
- `src-tauri/src/commands/setup/agents.rs` (new) — `get_agents_status`, `sign_out_agent`, `uninstall_agent`.
- `src-tauri/src/commands/setup/{mod,status}.rs` — new item IDs + `opencode-only` mock scenario.
- `src-tauri/src/commands/claude.rs`, `src-tauri/src/utils.rs` — opencode/bun paths in binary lookup and extended PATH.
- `src-tauri/src/lib.rs` — register the three new commands.

**Frontend (React)**
- `src/components/AgentsPanel.tsx` (new) — the dashboard card.
- `src/lib/agents-management.ts` (new) — typed wrappers.
- `src/styles/features/agents-panel.css` (new), imported from `src/styles/index.css`.
- `src/lib/{agent,setup}.ts` + test fixtures + tests — Opencode wiring everywhere.
- `src/components/ProjectList.tsx` — render `<AgentsPanel>` on the dashboard.
- `src/components/setup/steps/AgentStep.tsx` — hint now says "N agents are ready" so the onboarding step works with 3+.
- `src/components/setup/OnboardingTerminal.tsx` — opencode/bun in PATH.
- `src/components/WorkspaceView.tsx` + `src/styles/features/workspace/terminal.css` — `data-agent-id` attribute + opencode full-bleed CSS.
- `src/hooks/useProjectLifecycle.ts` — restored tabs use the current default.

## Test plan

- [ ] Frontend: `pnpm test --run` → 382 pass.
- [ ] Backend: `cargo test --manifest-path src-tauri/Cargo.toml --lib` → 181 pass.
- [ ] Typecheck + lint: `pnpm tsc --noEmit && pnpm lint` → clean.
- [ ] Manual, dashboard Agents panel:
  - [ ] Opencode shows "Not installed" → Install → terminal modal runs `curl …/install | bash` → panel updates to show version + "Not signed in".
  - [ ] Click "Sign in" on Opencode → terminal modal runs `opencode auth login` (no more hang on "Starting…").
  - [ ] Click "Set default" on Codex → pill shows `[spinner] Switching…` → settles on green `Default` with no flicker back to Claude.
  - [ ] Kebab menu shows Update / Sign out / Uninstall; Update re-runs install command; Sign out wipes auth; Uninstall confirms then runs uninstall command.
- [ ] Manual, project opening:
  - [ ] Set Codex as default on dashboard, open a project that previously ran Claude: first terminal tab spawns `codex`, not `claude`.
- [ ] Onboarding wizard still works with 3 agents (step 3 renders three cards; if multiple ready, default selector appears).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Opencode as a third coding agent.
  * New Agents panel to install, sign in/out, set default, and uninstall agents from the dashboard.
  * Backend-driven agent commands: view status, sign out, and run platform uninstall.

* **Improvements**
  * Onboarding/terminal PATHs extended to find user-installed tools more reliably.
  * Restored projects now use the current default agent for reopened terminals.
  * Terminal/workspace styling tweaks for agent-specific display.

* **Tests & Docs**
  * New unit and UI tests and styles covering agents and setup flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->