### PR TITLE
Fix Home button bouncing back into project on first click

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1050,7 +1050,7 @@ function AppContents({ initialProjectPath }: AppProps) {
           <WorkspaceSidebar
             key="sidebar-project-loading"
             isHomeActive={false}
-            onGoHome={() => setView('projects')}
+            onGoHome={handleBackToProjects}
             onOpenProjectPicker={() => setIsProjectPickerOpen(true)}
             projects={pinnedProjects.rows}
             currentProjectPath={currentProject?.path ?? null}
@@ -1117,7 +1117,7 @@ function AppContents({ initialProjectPath }: AppProps) {
         onSelectProject={handleRailClick}
         onCloseProject={handleCloseProject}
         onSelectProjectTab={handleSelectProjectTab}
-        onGoHome={() => setView('projects')}
+        onGoHome={handleBackToProjects}
         onOpenProjectPicker={() => setIsProjectPickerOpen(true)}
         isProjectDevServerRunning={isServerRunning}
       />


### PR DESCRIPTION
## Summary
- The workspace Home button called `setView('projects')` directly instead of the lifecycle's `handleBackToProjects`, so the `ship-studio-auto-open-dismissed-<window>` sessionStorage flag never got set.
- With that flag missing, the HMR-recovery effect in `useAppSetup.ts` saw the still-reserved dev-server port and snapped the user right back into the workspace. A second Home click finally landed because `autoOpenAttemptedRef` had been flipped by the first auto-restore.
- Wired `onGoHome` on both the workspace and project-loading sidebars to `handleBackToProjects`, which does the full teardown (clears `currentProject`, bumps nav version, saves terminal state, sets the dismissed flag).

## Test plan
- [x] Typecheck + Vitest suite (395 pass, 4 skipped) — ran via pre-push hook
- [ ] Manual: open a project, click Home once → lands on Home immediately (not workspace)
- [ ] Manual: re-open the same project → terminal tabs / dev server still restored as before (teardown preserves session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated navigation logic for returning to projects view by unifying callback handlers across different UI states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->