### PR TITLE
Release v0.5.1: fix garbled terminal output on some macOS betas

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,11 @@ These notes appear in the update dialog that users see when a new version is ava
 Write clear, user-friendly notes about what changed in this version.
 -->
 
+## What's New in v0.5.1
+
+- **Fixed garbled terminal output on some macOS betas** — new "Terminal GPU acceleration" toggle in Settings → Preferences lets you fall back to the canvas renderer if agent output looks fragmented or corrupted
+
+
 ## What's New in v0.5.0
 
 - **Multi-project multitasking** — Run multiple projects at once with live Claude Code / Codex / Opencode sessions and dev servers in each. Switching projects is instant — nothing tears down until you explicitly close it.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ship-studio",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Ship Studio - Launch Claude Code for marketing sites",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4417,7 +4417,7 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "ship-studio"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64 0.22.1",
  "block2 0.5.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ship-studio"
-version = "0.5.0"
+version = "0.5.1"
 description = "Ship Studio - Launch Claude Code for marketing sites"
 authors = ["Julian Galluzzo"]
 edition = "2021"

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -38,3 +38,20 @@ pub fn set_slack_cta_hidden(hidden: bool) -> Result<(), CommandError> {
     state.slack_cta_hidden = Some(hidden);
     write_app_state(&state).map_err(CommandError::from)
 }
+
+/// Get whether the terminal uses WebGL (GPU-accelerated) rendering. Defaults to true.
+#[tauri::command]
+#[tracing::instrument]
+pub fn get_terminal_gpu_enabled() -> Result<bool, CommandError> {
+    let state = read_app_state();
+    Ok(state.terminal_gpu_enabled.unwrap_or(true))
+}
+
+/// Set whether the terminal uses WebGL rendering (persisted to app state).
+#[tauri::command]
+#[tracing::instrument]
+pub fn set_terminal_gpu_enabled(enabled: bool) -> Result<(), CommandError> {
+    let mut state = read_app_state();
+    state.terminal_gpu_enabled = Some(enabled);
+    write_app_state(&state).map_err(CommandError::from)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -351,6 +351,8 @@ pub fn run() {
             commands::settings::set_calendar_hidden,
             commands::settings::get_slack_cta_hidden,
             commands::settings::set_slack_cta_hidden,
+            commands::settings::get_terminal_gpu_enabled,
+            commands::settings::set_terminal_gpu_enabled,
             // AI generation
             commands::ai::generate_pr_description,
             // Claude integration

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -694,6 +694,11 @@ pub struct AppState {
     /// Whether the Slack community CTA banner is hidden on the dashboard
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slack_cta_hidden: Option<bool>,
+    /// Whether the terminal uses WebGL (GPU-accelerated) rendering. Defaults to true.
+    /// Disable if the terminal renders corrupted/fragmented characters (known issue on some
+    /// macOS beta / GPU-driver combinations).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_gpu_enabled: Option<bool>,
 }
 
 // ============ Compact Mode ============

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ship Studio",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "com.memberstack.shipstudio",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -25,6 +25,12 @@ interface ChangelogEntry {
 // Keep ~15 most recent versions for the sidebar
 const CHANGELOG: ChangelogEntry[] = [
   {
+    version: '0.5.1', // v0.5.1
+    items: [
+      'Fix terminal rendering corruption on some macOS betas — new "Terminal GPU acceleration" toggle in Settings → Preferences lets you fall back to the canvas renderer if agent output looks garbled or fragmented',
+    ],
+  },
+  {
     version: '0.5.0', // v0.5.0
     items: [
       'Multi-project multitasking — run multiple projects at once with live agents and dev servers in each',

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -15,6 +15,8 @@ import {
   setCalendarHidden,
   getSlackCtaHidden,
   setSlackCtaHidden,
+  getTerminalGpuEnabled,
+  setTerminalGpuEnabled,
 } from '../lib/settings';
 
 interface SettingsModalProps {
@@ -33,21 +35,24 @@ export function SettingsModal({
   const [analyticsEnabled, setLocalAnalyticsEnabled] = useState(true);
   const [calendarVisible, setLocalCalendarVisible] = useState(true);
   const [slackCtaVisible, setLocalSlackCtaVisible] = useState(true);
+  const [terminalGpuEnabled, setLocalTerminalGpuEnabled] = useState(true);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (!isOpen) return;
     let cancelled = false;
     void (async () => {
-      const [enabled, calHidden, slackHidden] = await Promise.all([
+      const [enabled, calHidden, slackHidden, gpuEnabled] = await Promise.all([
         getAnalyticsEnabled(),
         getCalendarHidden(),
         getSlackCtaHidden(),
+        getTerminalGpuEnabled(),
       ]);
       if (!cancelled) {
         setLocalAnalyticsEnabled(enabled);
         setLocalCalendarVisible(!calHidden);
         setLocalSlackCtaVisible(!slackHidden);
+        setLocalTerminalGpuEnabled(gpuEnabled);
         setLoading(false);
       }
     })();
@@ -83,6 +88,16 @@ export function SettingsModal({
     void setSlackCtaHidden(!newVisible);
     onSlackCtaHiddenChange?.(!newVisible);
   }, [slackCtaVisible, onSlackCtaHiddenChange]);
+
+  const handleTerminalGpuToggle = useCallback(() => {
+    const newEnabled = !terminalGpuEnabled;
+    setLocalTerminalGpuEnabled(newEnabled);
+    void setTerminalGpuEnabled(newEnabled);
+    void trackEvent('terminal_gpu_toggled', {
+      enabled: newEnabled,
+      $screen_name: 'Settings',
+    });
+  }, [terminalGpuEnabled]);
 
   return (
     <ModalFrame isOpen={isOpen} onClose={onClose} title="Settings" className="settings-modal">
@@ -120,6 +135,27 @@ export function SettingsModal({
               disabled={loading}
               role="switch"
               aria-checked={slackCtaVisible}
+            >
+              <span className="settings-toggle-track">
+                <span className="settings-toggle-thumb" />
+              </span>
+            </button>
+          </div>
+          <div className="settings-row">
+            <div className="settings-row-info">
+              <span className="settings-row-label">Terminal GPU acceleration</span>
+              <span className="settings-row-description">
+                Use GPU rendering for faster, smoother terminals. Turn off if agent output looks
+                garbled or fragmented (a known issue on some macOS beta builds). Applies to newly
+                opened terminals.
+              </span>
+            </div>
+            <button
+              className={`settings-toggle ${terminalGpuEnabled ? 'on' : 'off'}`}
+              onClick={handleTerminalGpuToggle}
+              disabled={loading}
+              role="switch"
+              aria-checked={terminalGpuEnabled}
             >
               <span className="settings-toggle-track">
                 <span className="settings-toggle-thumb" />

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -43,6 +43,7 @@ import { homeDir } from '@tauri-apps/api/path';
 import { loadNerdFonts } from '../lib/fonts';
 import { isWindows } from '../lib/setup';
 import { logger } from '../lib/logger';
+import { getTerminalGpuEnabled } from '../lib/settings';
 import type { AgentConfig } from '../lib/agent';
 import '@xterm/xterm/css/xterm.css';
 
@@ -342,16 +343,25 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     // Open terminal in container
     term.open(container);
 
-    // Use WebGL renderer for GPU-accelerated rendering (reduces flickering)
-    try {
-      const webglAddon = new WebglAddon();
-      webglAddon.onContextLoss(() => {
-        webglAddon.dispose();
-      });
-      term.loadAddon(webglAddon);
-    } catch {
-      logger.warn('[Terminal] WebGL not available, using canvas renderer');
-    }
+    // Use WebGL renderer for GPU-accelerated rendering (reduces flickering).
+    // Gated by a user setting — some macOS beta / GPU-driver combinations render corrupted
+    // glyphs through WebGL, so users can opt out via Settings → Preferences.
+    void (async () => {
+      const gpuEnabled = await getTerminalGpuEnabled();
+      if (!gpuEnabled) {
+        logger.info('[Terminal] GPU rendering disabled by user, using canvas renderer');
+        return;
+      }
+      try {
+        const webglAddon = new WebglAddon();
+        webglAddon.onContextLoss(() => {
+          webglAddon.dispose();
+        });
+        term.loadAddon(webglAddon);
+      } catch {
+        logger.warn('[Terminal] WebGL not available, using canvas renderer');
+      }
+    })();
 
     // Initial fit
     setTimeout(() => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -51,3 +51,28 @@ export async function setSlackCtaHidden(hidden: boolean): Promise<void> {
     // Silently fail
   }
 }
+
+/**
+ * Check whether the terminal uses WebGL (GPU-accelerated) rendering. Defaults to true.
+ * Users on macOS beta builds or certain GPU drivers may see corrupted glyphs with WebGL
+ * and should disable this.
+ */
+export async function getTerminalGpuEnabled(): Promise<boolean> {
+  try {
+    return await invoke<boolean>('get_terminal_gpu_enabled');
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Set whether the terminal uses WebGL rendering (persisted across sessions).
+ * Takes effect for newly opened terminals.
+ */
+export async function setTerminalGpuEnabled(enabled: boolean): Promise<void> {
+  try {
+    await invoke('set_terminal_gpu_enabled', { enabled });
+  } catch {
+    // Silently fail
+  }
+}


### PR DESCRIPTION
## Summary

- **Root cause:** v0.4.11's `@xterm/addon-webgl` (commit 6798656) uses a GPU glyph atlas that renders corrupted/fragmented characters on some macOS Tahoe 26.5 beta + GPU-driver combinations. A user confirmed the bisect — downgrading to v0.4.10 (pre-WebGL) fixes the rendering for them.
- **Fix:** new persisted setting `terminal_gpu_enabled` (default **true**, so no regression) at `Settings → Preferences → "Terminal GPU acceleration"`. When off, `Terminal.tsx` skips loading `WebglAddon` and falls back to the canvas renderer.
- Pattern is a copy of existing `calendar_hidden` / `slack_cta_hidden` settings.
- Includes v0.5.1 version bump, `RELEASE_NOTES.md`, and `Changelog.tsx` entry.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `cd src-tauri && cargo check` clean
- [x] `pnpm build` clean
- [x] All 395 existing tests pass
- [ ] **Post-merge user verification:** affected user on macOS Tahoe 26.5 beta installs v0.5.1, toggles Settings → Preferences → "Terminal GPU acceleration" OFF, reopens terminals, confirms agent output renders cleanly

## Notes

- Not verified by boot-click: the feature is a direct copy of existing working settings and default=true means zero risk for users who don't flip it. Only the affected user can confirm the actual fix resolves their symptom.
- **Merge strategy note:** the tag `v0.5.1` currently exists only locally. After this PR merges, I'll re-point and push the tag so CI picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Terminal GPU acceleration" toggle in Settings → Preferences to control terminal rendering.

* **Bug Fixes**
  * Fixed terminal output corruption on certain macOS systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->