### PR TITLE
Preview: vertical resize handle + floating panel framing

### DIFF
--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -15,7 +15,12 @@
 import { useRef, forwardRef, useImperativeHandle, useCallback, useState } from 'react';
 import { usePreviewConnection, SERVER_MAX_RETRIES } from '../hooks/usePreviewConnection';
 import { usePreviewCapture } from '../hooks/usePreviewCapture';
-import { usePreviewResize, BREAKPOINTS, type Breakpoint } from '../hooks/usePreviewResize';
+import {
+  usePreviewResize,
+  BREAKPOINTS,
+  RESIZE_HANDLE_PX,
+  type Breakpoint,
+} from '../hooks/usePreviewResize';
 import { useOptionalToast } from '../contexts/ToastContext';
 import { DevServerLogs } from './DevServerLogs';
 import { BrowserTools } from './BrowserTools';
@@ -411,76 +416,100 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
         data-education-id="preview-viewport"
       >
         {/* Overlay to capture mouse events during resize */}
-        {resize.isResizing && <div className="preview-resize-overlay" />}
+        {(resize.isResizing || resize.isVerticalResizing) && (
+          <div
+            className={`preview-resize-overlay${
+              resize.isVerticalResizing ? ' preview-resize-overlay--vertical' : ''
+            }`}
+          />
+        )}
         <div
-          ref={capture.iframeWrapperRef}
-          className="preview-iframe-wrapper"
+          className={`preview-frame-grid${
+            resize.customWidth !== null && resize.customHeight !== null
+              ? ' preview-frame-grid--floating'
+              : ''
+          }`}
           style={{
-            width: resize.customWidth === null ? 'calc(100% - 12px)' : `${resize.customWidth}px`,
-            maxWidth: 'calc(100% - 12px)',
+            width:
+              resize.customWidth === null
+                ? 'calc(100% - 4px)'
+                : `${resize.customWidth + RESIZE_HANDLE_PX}px`,
+            maxWidth: 'calc(100% - 4px)',
+            height:
+              resize.customHeight === null ? '100%' : `${resize.customHeight + RESIZE_HANDLE_PX}px`,
+            maxHeight: '100%',
           }}
         >
-          <iframe
-            key={projectPath}
-            ref={iframeRef}
-            src={conn.serverReady ? conn.currentUrl : 'about:blank'}
-            className="preview-iframe"
-            title="Preview"
-          />
-          {/* Branch switching overlay */}
-          {isBranchSwitching && (
-            <div className="preview-branch-switching-overlay">
-              <div className="preview-branch-switching-spinner" />
-              <span>Switching branch...</span>
-            </div>
-          )}
-          {/* Dev server restarting overlay */}
-          {isDevServerRestarting && (
-            <div className="preview-branch-switching-overlay">
-              <div className="preview-branch-switching-spinner" />
-              <span>Restarting dev server...</span>
-            </div>
-          )}
-          {/* Crop selection overlay */}
-          {isCropMode && (
-            <div
-              ref={capture.cropOverlayRef}
-              className="crop-overlay"
-              onMouseDown={capture.handleCropMouseDown}
-              onMouseMove={capture.handleCropMouseMove}
-              onMouseUp={() => void capture.handleCropMouseUp()}
-              onMouseLeave={() => {
-                if (capture.isSelecting) {
-                  void capture.handleCropMouseUp();
-                }
-              }}
-            >
-              {/* Selection rectangle */}
-              {/* Selection box with box-shadow creating the dark overlay */}
-              {capture.selectionStart && capture.selectionEnd && (
-                <div
-                  className="crop-selection"
-                  style={{
-                    left: Math.min(capture.selectionStart.x, capture.selectionEnd.x),
-                    top: Math.min(capture.selectionStart.y, capture.selectionEnd.y),
-                    width: Math.abs(capture.selectionEnd.x - capture.selectionStart.x),
-                    height: Math.abs(capture.selectionEnd.y - capture.selectionStart.y),
-                  }}
-                />
-              )}
-              {/* Instructions */}
-              {!capture.selectionStart && (
-                <div className="crop-instructions">
-                  Click and drag to select area
-                  <span className="crop-hint">Press Esc to cancel</span>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-        {/* Resize handle */}
-        <div className="preview-resize-handle" onMouseDown={resize.handleResizeStart}>
-          <div className="preview-resize-handle-bar" />
+          <div ref={capture.iframeWrapperRef} className="preview-iframe-wrapper">
+            <iframe
+              key={projectPath}
+              ref={iframeRef}
+              src={conn.serverReady ? conn.currentUrl : 'about:blank'}
+              className="preview-iframe"
+              title="Preview"
+            />
+            {/* Branch switching overlay */}
+            {isBranchSwitching && (
+              <div className="preview-branch-switching-overlay">
+                <div className="preview-branch-switching-spinner" />
+                <span>Switching branch...</span>
+              </div>
+            )}
+            {/* Dev server restarting overlay */}
+            {isDevServerRestarting && (
+              <div className="preview-branch-switching-overlay">
+                <div className="preview-branch-switching-spinner" />
+                <span>Restarting dev server...</span>
+              </div>
+            )}
+            {/* Crop selection overlay */}
+            {isCropMode && (
+              <div
+                ref={capture.cropOverlayRef}
+                className="crop-overlay"
+                onMouseDown={capture.handleCropMouseDown}
+                onMouseMove={capture.handleCropMouseMove}
+                onMouseUp={() => void capture.handleCropMouseUp()}
+                onMouseLeave={() => {
+                  if (capture.isSelecting) {
+                    void capture.handleCropMouseUp();
+                  }
+                }}
+              >
+                {/* Selection rectangle */}
+                {/* Selection box with box-shadow creating the dark overlay */}
+                {capture.selectionStart && capture.selectionEnd && (
+                  <div
+                    className="crop-selection"
+                    style={{
+                      left: Math.min(capture.selectionStart.x, capture.selectionEnd.x),
+                      top: Math.min(capture.selectionStart.y, capture.selectionEnd.y),
+                      width: Math.abs(capture.selectionEnd.x - capture.selectionStart.x),
+                      height: Math.abs(capture.selectionEnd.y - capture.selectionStart.y),
+                    }}
+                  />
+                )}
+                {/* Instructions */}
+                {!capture.selectionStart && (
+                  <div className="crop-instructions">
+                    Click and drag to select area
+                    <span className="crop-hint">Press Esc to cancel</span>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+          {/* Right (horizontal) resize handle — height tracks iframe via grid */}
+          <div className="preview-resize-handle" onMouseDown={resize.handleResizeStart}>
+            <div className="preview-resize-handle-bar" />
+          </div>
+          {/* Bottom (vertical) resize handle — width tracks iframe via grid */}
+          <div
+            className="preview-resize-handle preview-resize-handle--vertical"
+            onMouseDown={resize.handleVerticalResizeStart}
+          >
+            <div className="preview-resize-handle-bar preview-resize-handle-bar--vertical" />
+          </div>
         </div>
       </div>
       <InspectPanel

--- a/src/hooks/usePreviewResize.ts
+++ b/src/hooks/usePreviewResize.ts
@@ -28,6 +28,11 @@ const BREAKPOINT_WIDTHS: number[] = [1440, 1024, 768, 375];
 /** Space reserved for the resize handle on the right side of the viewport */
 const VIEWPORT_PADDING_PX = 12;
 
+/** Resize handle thickness in pixels. MUST stay in sync with the
+ *  `--handle-size` custom property in `src/styles/features/preview.css`
+ *  — JS uses it for drag math, CSS uses it for grid track sizing. */
+export const RESIZE_HANDLE_PX = 8;
+
 interface UsePreviewResizeParams {
   /** Ref to the iframe wrapper element, used to read its offsetWidth during resize drag */
   iframeWrapperRef: React.RefObject<HTMLDivElement | null>;
@@ -35,6 +40,7 @@ interface UsePreviewResizeParams {
 
 export function usePreviewResize({ iframeWrapperRef }: UsePreviewResizeParams) {
   const [customWidth, setCustomWidth] = useState<number | null>(null); // null = 100% (desktop)
+  const [customHeight, setCustomHeight] = useState<number | null>(null); // null = full available height
 
   const viewportRef = useRef<HTMLDivElement | null>(null);
 
@@ -56,6 +62,7 @@ export function usePreviewResize({ iframeWrapperRef }: UsePreviewResizeParams) {
 
   // Resize state
   const [isResizing, setIsResizing] = useState(false);
+  const [isVerticalResizing, setIsVerticalResizing] = useState(false);
 
   // Track viewport width to hide breakpoints that won't fit
   // ResizeObserver fires efficiently (not on every frame) so no debouncing needed
@@ -142,10 +149,62 @@ export function usePreviewResize({ iframeWrapperRef }: UsePreviewResizeParams) {
     [iframeWrapperRef]
   );
 
+  // Handle vertical (height) resize drag. The `* 2` is required because
+  // `.preview-viewport` uses `align-items: center` (preview.css) — the iframe
+  // grows centered, so the bottom handle's screen-Y only shifts by half the
+  // height delta. If the CSS centering changes, this math changes too.
+  // Min height is lower than the horizontal min (320) because portrait mobile
+  // viewports are taller than they are wide, so 200 is a fair small-screen floor.
+  const handleVerticalResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      setIsVerticalResizing(true);
+      document.body.style.cursor = 'ns-resize';
+      document.body.style.userSelect = 'none';
+
+      const startY = e.clientY;
+      const startHeight = iframeWrapperRef.current?.offsetHeight || 0;
+
+      let rafId: number | null = null;
+      const handleMouseMove = (e: MouseEvent) => {
+        if (!viewportRef.current) return;
+        if (rafId !== null) return;
+        rafId = requestAnimationFrame(() => {
+          rafId = null;
+          if (!viewportRef.current) return;
+
+          const deltaY = e.clientY - startY;
+          const newHeight = startHeight + deltaY * 2;
+          const maxHeight = viewportRef.current.offsetHeight - RESIZE_HANDLE_PX;
+
+          if (newHeight >= maxHeight - 10) {
+            setCustomHeight(null);
+          } else {
+            setCustomHeight(Math.max(200, Math.min(newHeight, maxHeight)));
+          }
+        });
+      };
+
+      const handleMouseUp = () => {
+        if (rafId !== null) cancelAnimationFrame(rafId);
+        setIsVerticalResizing(false);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+      };
+
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+    },
+    [iframeWrapperRef]
+  );
+
   // Handle breakpoint button click
   const handleBreakpointClick = useCallback((bp: Breakpoint) => {
     if (bp === 'full') {
       setCustomWidth(null);
+      setCustomHeight(null);
     } else if (bp === 'desktop') {
       setCustomWidth(1440);
     } else if (bp === 'laptop') {
@@ -160,11 +219,14 @@ export function usePreviewResize({ iframeWrapperRef }: UsePreviewResizeParams) {
 
   return {
     customWidth,
+    customHeight,
     isResizing,
+    isVerticalResizing,
     viewportWidth,
     getActiveBreakpoint,
     setViewportRefs,
     handleResizeStart,
+    handleVerticalResizeStart,
     handleBreakpointClick,
   };
 }

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -322,16 +322,56 @@
   flex: 1;
   display: flex;
   justify-content: center;
+  align-items: center;
   background: var(--bg-tertiary);
   overflow: hidden;
   padding: 0;
   position: relative;
 }
 
+/* Grid layout that pairs the iframe with its right + bottom resize handles.
+   The 1fr cell auto-sizes to whatever space remains after the 8px handles,
+   so dragging either handle resizes the iframe AND the perpendicular handle
+   together (right handle's height tracks iframe height, etc.). */
+.preview-frame-grid {
+  /* Handle thickness — must match `RESIZE_HANDLE_PX` in usePreviewResize.ts.
+     JS uses it for drag math, CSS uses it for grid track sizing. */
+  --handle-size: 8px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--handle-size);
+  grid-template-rows: minmax(0, 1fr) var(--handle-size);
+  grid-template-areas:
+    'iframe right'
+    'bottom .';
+  min-width: 0;
+  min-height: 0;
+}
+
+/* When the iframe is shrunk in BOTH dimensions, frame the whole grid as a
+   floating panel: outer border, rounded corners, shared bg fills the empty
+   bottom-right cell. The handles drop their own outer borders so the grid's
+   border is the single outer line. */
+.preview-frame-grid--floating {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--bg-secondary);
+}
+
+.preview-frame-grid--floating .preview-resize-handle {
+  border-right: none;
+}
+
+.preview-frame-grid--floating .preview-resize-handle--vertical {
+  border-bottom: none;
+}
+
 .preview-iframe-wrapper {
-  height: 100%;
+  grid-area: iframe;
   overflow: hidden;
   position: relative;
+  min-width: 0;
+  min-height: 0;
 }
 
 .preview-iframe {
@@ -352,10 +392,13 @@
   cursor: ew-resize;
 }
 
-/* Preview resize handle */
+.preview-resize-overlay--vertical {
+  cursor: ns-resize;
+}
+
+/* Preview resize handle (right edge by default; placed by grid). */
 .preview-resize-handle {
-  width: 8px;
-  height: 100%;
+  grid-area: right;
   background: var(--bg-secondary);
   border-left: 1px solid var(--border);
   border-right: 1px solid var(--border);
@@ -363,7 +406,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-shrink: 0;
   transition:
     background 0.15s,
     border-color 0.15s;
@@ -383,6 +425,21 @@
 
 .preview-resize-handle:hover .preview-resize-handle-bar {
   background: var(--accent);
+}
+
+/* Vertical (bottom) resize handle — flips the right-handle layout */
+.preview-resize-handle--vertical {
+  grid-area: bottom;
+  border-left: none;
+  border-right: none;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  cursor: ns-resize;
+}
+
+.preview-resize-handle-bar--vertical {
+  width: 40px;
+  height: 2px;
 }
 
 /* Dev server logs toggle (toolbar button) */


### PR DESCRIPTION
## Summary

- Adds a **vertical (bottom) resize handle** to the preview iframe so it's resizable in both dimensions. The right + bottom handles live in a 2x2 CSS grid, so dragging either resizes the iframe AND the perpendicular handle together (right handle's height tracks iframe height, etc.).
- The viewport now uses `align-items: center` so the iframe sits vertically centered when shrunk (instead of hugging the top), and the resize handle bars now visually center on the iframe's actual height.
- When **both** width AND height are custom, the whole grid frames itself as a floating panel: outer border, rounded corners (`--radius-md`), shared bg fills the empty bottom-right cell.
- The 'full' breakpoint button (the expand icon) now resets height as well as width.
- Handle thickness is exported as `RESIZE_HANDLE_PX` from `usePreviewResize.ts` so the JS drag math, the inline grid sizing in `Preview.tsx`, and the CSS custom property `--handle-size` all read from the same value (no more bare `8` scattered across files).
- Cross-file coupling between the `* 2` vertical drag math and `align-items: center` is documented inline.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` — all 392 tests pass
- [x] `pnpm build` clean
- [ ] Manual: drag right handle — iframe widens, handle stays right-side
- [ ] Manual: drag bottom handle — iframe shortens, handle stays bottom; iframe re-centers vertically
- [ ] Manual: shrink both dimensions — outer border + rounded corners appear; corners blend into handle gray
- [ ] Manual: click 'full' breakpoint button — iframe returns to full width AND full height
- [ ] Manual: shrink iframe height in mobile breakpoint — right handle's bar stays vertically centered on the iframe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview component now supports vertical resizing via a new bottom resize handle, enabling independent adjustment of both preview width and height
  * Enhanced preview container layout with improved structure and floating styling support for better visual control
  * Preview content is now vertically centered within the viewport for enhanced visual presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->