### PR TITLE
PostHog visibility: end-to-end event coverage

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -124,10 +124,14 @@ Fired from `useIntegrationStatus` once GitHub auth resolves with a username.
 
 Centralized in [`src/contexts/ModalContext.tsx`](../src/contexts/ModalContext.tsx) — every `open(id)` and `close(id)` fires automatically. `commandPalette` is excluded (Phase 3 tracks it richer).
 
-| Event | Properties |
-|---|---|
-| `modal_opened` | `modal_id` |
-| `modal_closed` | `modal_id`, `duration_ms`, optional `reason` (`'provider_unmount'` on app teardown) |
+The modal id is baked into the event name (`modal_<id>_opened` / `modal_<id>_closed`) so PostHog's default events list is self-describing. `modal_id` is also in the payload for cross-modal filters.
+
+| Event pattern | Properties | Examples |
+|---|---|---|
+| `modal_<id>_opened` | `modal_id` | `modal_envEditor_opened`, `modal_skills_opened`, `modal_pluginManager_opened` |
+| `modal_<id>_closed` | `modal_id`, `duration_ms`, optional `reason` (`'provider_unmount'` on app teardown) | `modal_envEditor_closed`, etc. |
+
+To get an aggregate "any modal opened" count in PostHog, use a regex match on event name (`modal_.*_opened`) or a property filter on `modal_id`.
 
 ### Plugins / Skills / MCP
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,192 @@
+# Analytics Reference
+
+Single source of truth for every PostHog event Ship Studio emits, what
+properties it carries, and the question the event answers.
+
+The pipeline: TypeScript [`src/lib/analytics.ts`](../src/lib/analytics.ts) →
+Tauri `track_event` IPC → Rust [`src-tauri/src/commands/analytics.rs`](../src-tauri/src/commands/analytics.rs)
+→ PostHog HTTP capture API. The API key never leaves the Rust backend.
+
+## Standard properties (auto-attached)
+
+`enrichProperties()` in `lib/analytics.ts` adds these to every event so no
+callsite has to remember:
+
+| Property | Source | Notes |
+|---|---|---|
+| `$session_id` | App session UUID, generated at module load | PostHog standard — groups all events from one launch |
+| `$screen_name` | `setActiveScreen()` | Set by view transitions; explicit per-event values override |
+| `project_id` | `getProjectId(path)` (FNV-1a hash, 8 chars) | Privacy-safe, stable across launches |
+| `project_name` | Folder name | Human-readable; only emitted when in a project context |
+| `project_session_id` | UUID per project session | Spans open → close/switch |
+| `app_version` | Backend (`CARGO_PKG_VERSION`) | Added in Rust |
+| `$os` | Backend (`#cfg!(target_os)`) | Added in Rust |
+
+## User identification (`$identify`)
+
+Fired from `useIntegrationStatus` once GitHub auth resolves with a username.
+
+| Action | Properties |
+|---|---|
+| `$set` (overwrites every identify) | `github_username`, `latest_app_version`, `last_identified_at` |
+| `$set_once` (first identify only) | `first_identified_at`, `first_app_version` |
+
+## Events by domain
+
+### Lifecycle (`app_*`, `project_*`)
+
+| Event | Fired when | Key properties | Question it answers |
+|---|---|---|---|
+| `app_launched` | App boot | — | DAU/MAU baseline |
+| `app_window_focused` | Window gains focus | — | When users return to the app |
+| `app_window_blurred` | Window loses focus | `focus_duration_ms` | How long users stay in-app per focus session |
+| `app_idle_detected` | 5 min of no input | `threshold_ms` | True engaged time |
+| `app_idle_resumed` | Activity after idle | — | Pair with idle for engagement deltas |
+| `app_quit` | Quit confirmed (user_action) or OS close | `reason` | Quit reason; pair with session length |
+| `project_opened` | Project enters workspace | inherited project context | Per-project engagement |
+| `project_session_started` | Project becomes active | inherited project context | Session funnel start |
+| `project_session_ended` | Switch / back / close / quit | `duration_seconds`, `reason` | Session length and how it ended |
+
+### Screens (`$pageview`)
+
+`trackPageview(name)` ships `$pageview` with `$current_url: app://ship-studio/<slug>` and `$pathname: /<slug>`. Screens currently emitted:
+
+- `Dashboard`
+- `Onboarding - <Step Title>` (per wizard step)
+- `Workspace - Preview | Code | Branches | Pull Requests`
+
+### Navigation
+
+| Event | Properties | Notes |
+|---|---|---|
+| `workspace_tab_switched` | `from_tab`, `to_tab` | Click-tracked; pageview fires on the projected (gate-applied) tab via effect |
+| `inspect_subtab_switched` | `from_tab`, `to_tab` | Console / Network / Elements |
+| `inspect_panel_toggled` | `is_open` | The dev-logs / browser-tools panel |
+| `sidebar_toggled` | `is_hidden` | Workspace sidebar collapse |
+| `project_pinned` | `project_id`, `project_name`, `pin_count` | |
+| `project_unpinned` | same | |
+| `pins_reordered` | `pin_count` | Drop event only — not mid-drag |
+| `project_picker_button_clicked` | — | Dedicated picker button only; Cmd+K opens are tracked separately |
+
+### Cmd+K palette
+
+| Event | Properties |
+|---|---|
+| `palette_opened` | `context`, `initial_tab` |
+| `palette_closed` | `context`, `dismissed_with` (`command_run`/`manual`), `duration_ms` |
+| `palette_command_run` | `command_id`, `category`, `position`, `total_results`, `query`, `query_length`, `had_query`, `tab`, `context` |
+| `palette_tab_switched` | `from_tab`, `to_tab`, `cause` (`click`/`keyboard`), `context` |
+| `search_performed` (with `search_type: 'palette'`) | Debounced 1s; cancelled on close |
+
+### Workspace deep features
+
+| Event | Properties |
+|---|---|
+| `screenshot_captured` | `mode` (`viewport`/`fullpage`), `success`, `fell_back` |
+| `preview_refreshed` | `trigger: 'user'` |
+| `preview_page_selected` | `route_pattern` (id segments → `:id`, capped 200), `depth` |
+| `logs_sent_to_agent` | `source` (`full_buffer`/`selection`), `char_count`, `line_count`, `had_question` |
+| `browser_tools_subtab_switched` | `from_tab`, `to_tab` |
+| `browser_tools_cleared` | `tab` |
+| `browser_tools_dom_refreshed` | — |
+| `browser_tools_sent_to_agent` | `tab`, `entry_count` (null for elements), `had_data`, `char_count` |
+| `code_file_opened` | `file_extension` |
+| `code_tree_refreshed` | — |
+| `code_snippet_sent_to_agent` | `file_extension`, `language`, `line_count`, `char_count`, `had_question` |
+| `code_snippet_copied` | `file_extension`, `line_count` |
+| `search_performed` (`code_files`) | Debounced |
+
+### Branches & PRs
+
+| Event | Properties |
+|---|---|
+| `branch_created` | `from_branch` |
+| `branch_switched` | — |
+| `branch_deleted` | — |
+| `branch_published` | `is_main`, `branch`, `time_since_last_publish_seconds` |
+| `pr_created` | `base_branch`, `used_ai`, `title_length`, `description_length` |
+| `pr_merged` | `head_ref`, `base_ref` |
+| `pr_closed` | — |
+| `pr_checked_out` | `head_ref` |
+| `post_merge_cleanup` | `deleted_branch` |
+| `submit_review_opened` | `branch` |
+| `ai_pr_description_generated` | optional `committed_first` |
+
+### Conflicts
+
+| Event | Properties |
+|---|---|
+| `conflict_resolved` | per-file count |
+| `merge_completed` | — |
+| `merge_aborted` | — |
+
+### Modals
+
+Centralized in [`src/contexts/ModalContext.tsx`](../src/contexts/ModalContext.tsx) — every `open(id)` and `close(id)` fires automatically. `commandPalette` is excluded (Phase 3 tracks it richer).
+
+| Event | Properties |
+|---|---|
+| `modal_opened` | `modal_id` |
+| `modal_closed` | `modal_id`, `duration_ms`, optional `reason` (`'provider_unmount'` on app teardown) |
+
+### Plugins / Skills / MCP
+
+| Event | Properties |
+|---|---|
+| `plugin_installed` / `plugin_uninstalled` / `plugin_updated` | `plugin_id` |
+| `plugin_toggled` | `plugin_id`, enabled state |
+| `plugin_dev_linked` / `plugin_dev_unlinked` | `plugin_id` |
+| `skill_installed` / `skill_removed` | skill ID |
+| `skills_searched` | search query |
+| `mcp_server_added` / `mcp_server_removed` | `scope` |
+
+### Onboarding funnel
+
+| Event | Properties |
+|---|---|
+| `setup_started` | `entry_path` (`wizard`/`fast_path`), `entry_step` |
+| `setup_step_entered` | `step_id`, `step_index` |
+| `setup_step_completed` | `step_id`, `step_index`, `duration_ms`, `is_final` |
+| `setup_step_skipped` | `step_id`, `step_index`, `reason: 'already_complete'` |
+| `setup_step_navigated_back` | `from_step`, `to_step` |
+| `setup_action_clicked` | `item_id`, `action` (`install`/`connect`), `step_id` |
+| `onboarding_completed` | `agents`, `entry_path` |
+| `default_agent_selected` | `agent_id`, `agent_count` |
+
+### Errors & misc
+
+| Event | Properties |
+|---|---|
+| `error_occurred` | `action`, `error_message` (capped 500), `error_type` |
+| `update_started` / `update_downloaded` / `update_restarted` / `update_deferred` | version info |
+| `version_rewind_started` / `version_rewind_completed` | — |
+| `support_*` | various — see `src/components/support/` |
+| `analytics_enabled` / `analytics_opted_in` | — |
+
+## Suggested PostHog dashboards
+
+Create these in the PostHog UI and link them here when set up:
+
+1. **North-star** — DAU/MAU/WAU, projects per user, agent messages per session, publish success rate, Cmd+K usage.
+2. **Onboarding funnel** — `app_launched → setup_started → setup_step_completed (per step) → onboarding_completed → first project_opened`. Break down by `entry_path`.
+3. **Publish funnel** — `branch_created → branch_published → pr_created → pr_merged`. Conversion at each step.
+4. **Feature adoption** — % of users who used Cmd+K, Inspect panel, Focus mode, Server Logs → Agent, plugins, skills, MCP, screenshots.
+5. **Retention** — cohort by `first_app_version` (set_once), retained by `project_session_started`.
+6. **Error frequency** — `error_occurred` grouped by `action`. Watch for spikes across release boundaries (cohort by `latest_app_version`).
+7. **Engagement** — `app_window_focused` durations, `app_idle_detected` rate, `project_session_ended` `duration_seconds` distribution.
+
+## Adding a new event
+
+1. Pick a name from the existing taxonomy: `domain_action` (snake_case).
+2. Call `trackEvent(name, props)` from the relevant component or hook.
+3. If the action is a screen change, prefer `trackPageview('Display Name')` instead — it sets the active screen *and* fires `$pageview`.
+4. If the action is a search, use `trackSearch(searchType, query)` — debounced 1s, free of empty-query spam.
+5. Add a row to the table above so the next reader doesn't have to grep.
+
+## Privacy
+
+- Project paths are never sent — only the 8-char `project_id` hash.
+- `error_message` is capped at 500 chars.
+- Search queries are sent but capped (palette: 100 chars).
+- Person properties on `$set_once` (first_seen, first_version) never overwrite — even on re-identify.
+- Users can disable analytics via Settings; the Rust backend short-circuits all sends when disabled.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -186,7 +186,8 @@ Create these in the PostHog UI and link them here when set up:
 ## Privacy
 
 - Project paths are never sent — only the 8-char `project_id` hash.
+- Branch names are never sent (they routinely contain customer/codename data); the `is_main` boolean carries the meaningful signal.
 - `error_message` is capped at 500 chars.
-- Search queries are sent but capped (palette: 100 chars).
+- Search queries are capped at 100 chars by `trackSearch`; the original length lands in `query_length`.
 - Person properties on `$set_once` (first_seen, first_version) never overwrite — even on re-identify.
 - Users can disable analytics via Settings; the Rust backend short-circuits all sends when disabled.

--- a/src-tauri/src/commands/analytics.rs
+++ b/src-tauri/src/commands/analytics.rs
@@ -238,9 +238,25 @@ pub async fn identify_user(
 
     let mut props = serde_json::Map::new();
     props.insert("$set".to_string(), serde_json::Value::Object(set_props));
-    if let Some(serde_json::Value::Object(once_map)) = set_once {
-        if !once_map.is_empty() {
+    match set_once {
+        Some(serde_json::Value::Object(once_map)) if !once_map.is_empty() => {
             props.insert("$set_once".to_string(), serde_json::Value::Object(once_map));
+        }
+        Some(serde_json::Value::Object(_)) | None => {
+            // Empty or absent — nothing to merge.
+        }
+        Some(other) => {
+            warn!(
+                "identify_user: set_once must be a non-empty object, got {} — ignoring",
+                match other {
+                    serde_json::Value::String(_) => "string",
+                    serde_json::Value::Number(_) => "number",
+                    serde_json::Value::Bool(_) => "bool",
+                    serde_json::Value::Array(_) => "array",
+                    serde_json::Value::Null => "null",
+                    serde_json::Value::Object(_) => unreachable!(),
+                }
+            );
         }
     }
     props.insert(

--- a/src-tauri/src/commands/analytics.rs
+++ b/src-tauri/src/commands/analytics.rs
@@ -296,15 +296,8 @@ pub fn set_analytics_enabled(enabled: bool) -> Result<(), CommandError> {
     app_state.analytics_enabled = Some(enabled);
     write_app_state(&app_state)?;
 
-    if enabled {
-        // Track that analytics were re-enabled
-        let device_id = get_device_id();
-        send_event(
-            "analytics_opted_in",
-            &device_id,
-            serde_json::Value::Object(serde_json::Map::new()),
-        );
-    }
+    // The frontend's SettingsModal fires `analytics_enabled` on the same
+    // user toggle, so we don't fire a second event here.
 
     debug!("Analytics enabled set to: {}", enabled);
     Ok(())

--- a/src-tauri/src/commands/analytics.rs
+++ b/src-tauri/src/commands/analytics.rs
@@ -204,11 +204,17 @@ pub async fn track_event(
 
 /// Identify a user by linking their distinct_id with person properties.
 /// Call this when the user authenticates (e.g., GitHub login).
+///
+/// `properties` becomes PostHog `$set` (always overwrites person props on
+/// every identify). `set_once` becomes `$set_once` (only written if the
+/// property doesn't already exist on the person — useful for first_seen_*
+/// fields that should never change after the first call).
 #[tauri::command]
 #[tracing::instrument]
 pub async fn identify_user(
     user_id: String,
     properties: Option<serde_json::Value>,
+    set_once: Option<serde_json::Value>,
 ) -> Result<(), CommandError> {
     // Cache the identified user ID so all future events use it
     if let Ok(mut guard) = ANALYTICS.lock() {
@@ -230,12 +236,19 @@ pub async fn identify_user(
         serde_json::Value::String(device_id.clone()),
     );
 
-    let props = serde_json::json!({
-        "$set": serde_json::Value::Object(set_props),
-        "$anon_distinct_id": device_id,
-    });
+    let mut props = serde_json::Map::new();
+    props.insert("$set".to_string(), serde_json::Value::Object(set_props));
+    if let Some(serde_json::Value::Object(once_map)) = set_once {
+        if !once_map.is_empty() {
+            props.insert("$set_once".to_string(), serde_json::Value::Object(once_map));
+        }
+    }
+    props.insert(
+        "$anon_distinct_id".to_string(),
+        serde_json::Value::String(device_id),
+    );
 
-    send_event("$identify", &user_id, props);
+    send_event("$identify", &user_id, serde_json::Value::Object(props));
     Ok(())
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -439,7 +439,9 @@ function AppContents({ initialProjectPath }: AppProps) {
 
   const openPalette = useOpenPalette();
   const openProjectPicker = useCallback(() => {
-    void trackEvent('project_picker_opened');
+    // Dedicated picker button only — Cmd+K palette opens are tracked by the
+    // palette itself in Phase 3, with `tab` as a property.
+    void trackEvent('project_picker_button_clicked');
     openPalette({ tab: 'project' });
   }, [openPalette]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,7 @@ import { useAppCommands } from './commands/useAppCommands';
 import { useProjectNumberShortcuts } from './hooks/useProjectNumberShortcuts';
 import { SuccessIcon, InfoIcon, CloseIcon } from './components/icons';
 import { logger } from './lib/logger';
-import { trackEvent, setActiveProject } from './lib/analytics';
+import { trackEvent, setActiveProject, trackPageview } from './lib/analytics';
 import { endProjectSession } from './lib/session';
 import type { AppView } from './lib/types';
 import './styles/index.css';
@@ -123,6 +123,15 @@ function AppContents({ initialProjectPath }: AppProps) {
       setPaletteContext({ kind: 'other', currentProjectName: null, currentProjectPath: null });
     }
   }, [view, currentProject, setPaletteContext]);
+
+  // Top-level pageviews. Workspace fires its own tab-specific pageviews from
+  // useWorkspaceLayout, so we skip it here to avoid double-firing.
+  useEffect(() => {
+    if (view === 'projects') trackPageview('Dashboard');
+    else if (view === 'onboarding') trackPageview('Onboarding');
+    // 'loading', 'project-loading', and 'workspace' are intentionally not
+    // tracked here — they're either transient or handled elsewhere.
+  }, [view]);
   const [cleanupStatus, setCleanupStatus] = useState<string | null>(null);
   const [showQuitConfirm, setShowQuitConfirm] = useState(false);
   const previewRef = useRef<import('./components/Preview').PreviewHandle | null>(null);
@@ -429,7 +438,10 @@ function AppContents({ initialProjectPath }: AppProps) {
   );
 
   const openPalette = useOpenPalette();
-  const openProjectPicker = useCallback(() => openPalette({ tab: 'project' }), [openPalette]);
+  const openProjectPicker = useCallback(() => {
+    void trackEvent('project_picker_opened');
+    openPalette({ tab: 'project' });
+  }, [openPalette]);
 
   // Cmd/Ctrl+1..9 → jump to Nth sidebar project (pinned first, then active).
   useProjectNumberShortcuts({ pinnedPaths, handleSelectProject });
@@ -488,6 +500,7 @@ function AppContents({ initialProjectPath }: AppProps) {
           setCurrentProject(null);
           currentProjectPathRef.current = null;
           setView('projects');
+          // The view-change effect above fires the Dashboard pageview.
         }
       })();
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,13 +124,14 @@ function AppContents({ initialProjectPath }: AppProps) {
     }
   }, [view, currentProject, setPaletteContext]);
 
-  // Top-level pageviews. Workspace fires its own tab-specific pageviews from
-  // useWorkspaceLayout, so we skip it here to avoid double-firing.
+  // Top-level pageviews. Per-step Onboarding pageviews are fired by
+  // OnboardingScreen so we don't double-up on entry. Workspace fires its
+  // own tab-specific pageviews from useWorkspaceLayout.
   useEffect(() => {
     if (view === 'projects') trackPageview('Dashboard');
-    else if (view === 'onboarding') trackPageview('Onboarding');
-    // 'loading', 'project-loading', and 'workspace' are intentionally not
-    // tracked here — they're either transient or handled elsewhere.
+    // 'loading', 'project-loading', 'onboarding', and 'workspace' are
+    // intentionally not tracked here — they're either transient or
+    // handled by the screen itself.
   }, [view]);
 
   // Install app-lifecycle tracking once (focus/blur, idle, OS close). The

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,6 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
-import { exit } from '@tauri-apps/plugin-process';
 import { useToasts } from './hooks/useToasts';
 import { useTerminalManagement } from './hooks/useTerminalManagement';
 import { usePlugins } from './hooks/usePlugins';
@@ -69,6 +68,7 @@ import { SuccessIcon, InfoIcon, CloseIcon } from './components/icons';
 import { logger } from './lib/logger';
 import { trackEvent, setActiveProject, trackPageview } from './lib/analytics';
 import { endProjectSession } from './lib/session';
+import { installAppLifecycleTracking, quitAppWithTracking } from './lib/appLifecycle';
 import type { AppView } from './lib/types';
 import './styles/index.css';
 
@@ -132,6 +132,13 @@ function AppContents({ initialProjectPath }: AppProps) {
     // 'loading', 'project-loading', and 'workspace' are intentionally not
     // tracked here — they're either transient or handled elsewhere.
   }, [view]);
+
+  // Install app-lifecycle tracking once (focus/blur, idle, OS close). The
+  // empty deps array is intentional — listeners are global and shouldn't
+  // re-bind on re-render.
+  useEffect(() => {
+    return installAppLifecycleTracking();
+  }, []);
   const [cleanupStatus, setCleanupStatus] = useState<string | null>(null);
   const [showQuitConfirm, setShowQuitConfirm] = useState(false);
   const previewRef = useRef<import('./components/Preview').PreviewHandle | null>(null);
@@ -953,7 +960,7 @@ function AppContents({ initialProjectPath }: AppProps) {
     >
       <div
         onKeyDown={(e) => {
-          if (e.key === 'Enter') void exit(0);
+          if (e.key === 'Enter') void quitAppWithTracking();
         }}
       >
         <p>Are you sure you want to quit Ship Studio?</p>
@@ -961,7 +968,7 @@ function AppContents({ initialProjectPath }: AppProps) {
           <Button variant="secondary" onClick={() => setShowQuitConfirm(false)}>
             Cancel
           </Button>
-          <Button variant="primary" onClick={() => void exit(0)} autoFocus>
+          <Button variant="primary" onClick={() => void quitAppWithTracking()} autoFocus>
             Quit
           </Button>
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,8 @@ import { useAppCommands } from './commands/useAppCommands';
 import { useProjectNumberShortcuts } from './hooks/useProjectNumberShortcuts';
 import { SuccessIcon, InfoIcon, CloseIcon } from './components/icons';
 import { logger } from './lib/logger';
-import { trackEvent } from './lib/analytics';
+import { trackEvent, setActiveProject } from './lib/analytics';
+import { endProjectSession } from './lib/session';
 import type { AppView } from './lib/types';
 import './styles/index.css';
 
@@ -472,6 +473,18 @@ function AppContents({ initialProjectPath }: AppProps) {
         }
         sessionRegistry.destroy(projectPath);
         if (currentProject?.path === projectPath) {
+          // Closing the current project ends its analytics session. Switching
+          // away to projects view also clears active project context so any
+          // home-screen events that follow aren't tagged with stale project_id.
+          const ended = endProjectSession();
+          if (ended) {
+            void trackEvent('project_session_ended', {
+              project_session_id: ended.session_id,
+              duration_seconds: ended.duration_seconds,
+              reason: 'project_closed',
+            });
+          }
+          setActiveProject(null);
           setCurrentProject(null);
           currentProjectPathRef.current = null;
           setView('projects');

--- a/src/components/BrowserTools.tsx
+++ b/src/components/BrowserTools.tsx
@@ -66,7 +66,10 @@ export function BrowserTools({ onSendToAgent }: BrowserToolsProps) {
   const handleSendToAgent = () => {
     if (!onSendToAgent) return;
     let prompt: string;
-    let entryCount = 0;
+    // entry_count only makes sense for the list-shaped tabs. For elements we
+    // emit it as null so PostHog doesn't average a fake "1 vs 0" boolean
+    // alongside real list lengths from console/network.
+    let entryCount: number | null = null;
     if (tab === 'console') {
       prompt = formatConsoleForAgent(consoleEntries);
       entryCount = consoleEntries.length;
@@ -75,11 +78,11 @@ export function BrowserTools({ onSendToAgent }: BrowserToolsProps) {
       entryCount = networkEntries.length;
     } else {
       prompt = formatElementsForAgent(domSnapshot);
-      entryCount = domSnapshot ? 1 : 0;
     }
     void trackEvent('browser_tools_sent_to_agent', {
       tab,
       entry_count: entryCount,
+      had_data: tab === 'elements' ? domSnapshot !== null : (entryCount ?? 0) > 0,
       char_count: prompt.length,
     });
     onSendToAgent(prompt);

--- a/src/components/BrowserTools.tsx
+++ b/src/components/BrowserTools.tsx
@@ -16,6 +16,7 @@ import {
   type DomNode,
   type DomSnapshot,
 } from '../lib/inspectStore';
+import { trackEvent } from '../lib/analytics';
 
 type InnerTab = 'console' | 'network' | 'elements';
 
@@ -25,7 +26,13 @@ interface BrowserToolsProps {
 }
 
 export function BrowserTools({ onSendToAgent }: BrowserToolsProps) {
-  const [tab, setTab] = useState<InnerTab>('console');
+  const [tab, setTabRaw] = useState<InnerTab>('console');
+  const setTab = (next: InnerTab) => {
+    if (next !== tab) {
+      void trackEvent('browser_tools_subtab_switched', { from_tab: tab, to_tab: next });
+    }
+    setTabRaw(next);
+  };
 
   const consoleEntries = useSyncExternalStore(
     inspectStore.subscribe,
@@ -44,21 +51,37 @@ export function BrowserTools({ onSendToAgent }: BrowserToolsProps) {
   }, [tab]);
 
   const handleClear = () => {
-    if (tab === 'console') inspectStore.clearConsole();
-    else if (tab === 'network') inspectStore.clearNetwork();
-    else if (tab === 'elements') inspectStore.refreshDom();
+    if (tab === 'console') {
+      void trackEvent('browser_tools_cleared', { tab: 'console' });
+      inspectStore.clearConsole();
+    } else if (tab === 'network') {
+      void trackEvent('browser_tools_cleared', { tab: 'network' });
+      inspectStore.clearNetwork();
+    } else if (tab === 'elements') {
+      void trackEvent('browser_tools_dom_refreshed');
+      inspectStore.refreshDom();
+    }
   };
 
   const handleSendToAgent = () => {
     if (!onSendToAgent) return;
     let prompt: string;
+    let entryCount = 0;
     if (tab === 'console') {
       prompt = formatConsoleForAgent(consoleEntries);
+      entryCount = consoleEntries.length;
     } else if (tab === 'network') {
       prompt = formatNetworkForAgent(networkEntries);
+      entryCount = networkEntries.length;
     } else {
       prompt = formatElementsForAgent(domSnapshot);
+      entryCount = domSnapshot ? 1 : 0;
     }
+    void trackEvent('browser_tools_sent_to_agent', {
+      tab,
+      entry_count: entryCount,
+      char_count: prompt.length,
+    });
     onSendToAgent(prompt);
   };
 

--- a/src/components/CodeTab.tsx
+++ b/src/components/CodeTab.tsx
@@ -10,7 +10,7 @@ import { useFileTree } from '../hooks/useFileTree';
 import { FileTree } from './FileTree';
 import { CodeViewer } from './CodeViewer';
 import { ResetIcon, SearchIcon } from './icons';
-import type { FileTreeNode } from '../lib/code';
+import { type FileTreeNode, fileExtensionForAnalytics } from '../lib/code';
 import { trackEvent, trackSearch } from '../lib/analytics';
 
 interface CodeTabProps {
@@ -35,10 +35,8 @@ export function CodeTab({ projectPath, onSendToAgent }: CodeTabProps) {
 
   const selectFile = useCallback(
     (path: string) => {
-      const ext = path.split('.').pop() ?? '';
       void trackEvent('code_file_opened', {
-        file_extension: ext,
-        path_depth: path.split('/').length,
+        file_extension: fileExtensionForAnalytics(path),
       });
       selectFileRaw(path);
     },

--- a/src/components/CodeTab.tsx
+++ b/src/components/CodeTab.tsx
@@ -11,6 +11,7 @@ import { FileTree } from './FileTree';
 import { CodeViewer } from './CodeViewer';
 import { ResetIcon, SearchIcon } from './icons';
 import type { FileTreeNode } from '../lib/code';
+import { trackEvent, trackSearch } from '../lib/analytics';
 
 interface CodeTabProps {
   projectPath: string;
@@ -28,9 +29,26 @@ export function CodeTab({ projectPath, onSendToAgent }: CodeTabProps) {
     treeError,
     fileError,
     toggleDirectory,
-    selectFile,
-    refreshTree,
+    selectFile: selectFileRaw,
+    refreshTree: refreshTreeRaw,
   } = useFileTree(projectPath);
+
+  const selectFile = useCallback(
+    (path: string) => {
+      const ext = path.split('.').pop() ?? '';
+      void trackEvent('code_file_opened', {
+        file_extension: ext,
+        path_depth: path.split('/').length,
+      });
+      selectFileRaw(path);
+    },
+    [selectFileRaw]
+  );
+
+  const refreshTree = useCallback(() => {
+    void trackEvent('code_tree_refreshed');
+    refreshTreeRaw();
+  }, [refreshTreeRaw]);
 
   const [sidebarWidth, setSidebarWidth] = useState(250);
   const [searchQuery, setSearchQuery] = useState('');
@@ -107,7 +125,10 @@ export function CodeTab({ projectPath, onSendToAgent }: CodeTabProps) {
             autoCapitalize="off"
             spellCheck={false}
             value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            onChange={(e) => {
+              setSearchQuery(e.target.value);
+              trackSearch('code_files', e.target.value);
+            }}
           />
         </div>
         <div className="code-tab-sidebar-content">

--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -14,6 +14,7 @@ import { useClickOutside } from '../hooks/useClickOutside';
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
 import { useOptionalToast } from '../contexts/ToastContext';
 import { ChevronIcon, CodeIcon, FileIcon, VSCodeIcon, CursorIcon, CopyIcon } from './icons';
+import { trackEvent } from '../lib/analytics';
 
 interface CodeViewerProps {
   projectPath: string;
@@ -253,9 +254,20 @@ export function CodeViewer({
     const formatted = parts.join('\n');
 
     if (onSendToAgent) {
+      void trackEvent('code_snippet_sent_to_agent', {
+        file_extension: filePath.split('.').pop() ?? '',
+        language: fileContent?.language ?? '',
+        line_count: selectionInfo.endLine - selectionInfo.startLine + 1,
+        char_count: formatted.length,
+        had_question: question.trim().length > 0,
+      });
       onSendToAgent(formatted);
       onToast?.('Sent to agent', 'success');
     } else {
+      void trackEvent('code_snippet_copied', {
+        file_extension: filePath.split('.').pop() ?? '',
+        line_count: selectionInfo.endLine - selectionInfo.startLine + 1,
+      });
       void copy(formatted);
     }
 

--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -15,6 +15,7 @@ import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
 import { useOptionalToast } from '../contexts/ToastContext';
 import { ChevronIcon, CodeIcon, FileIcon, VSCodeIcon, CursorIcon, CopyIcon } from './icons';
 import { trackEvent } from '../lib/analytics';
+import { fileExtensionForAnalytics } from '../lib/code';
 
 interface CodeViewerProps {
   projectPath: string;
@@ -253,11 +254,14 @@ export function CodeViewer({
 
     const formatted = parts.join('\n');
 
+    // Selections can be inverted (drag from line 10 → line 5); abs ensures the
+    // recorded count is always positive.
+    const lineCount = Math.abs(selectionInfo.endLine - selectionInfo.startLine) + 1;
     if (onSendToAgent) {
       void trackEvent('code_snippet_sent_to_agent', {
-        file_extension: filePath.split('.').pop() ?? '',
+        file_extension: fileExtensionForAnalytics(filePath),
         language: fileContent?.language ?? '',
-        line_count: selectionInfo.endLine - selectionInfo.startLine + 1,
+        line_count: lineCount,
         char_count: formatted.length,
         had_question: question.trim().length > 0,
       });
@@ -265,8 +269,8 @@ export function CodeViewer({
       onToast?.('Sent to agent', 'success');
     } else {
       void trackEvent('code_snippet_copied', {
-        file_extension: filePath.split('.').pop() ?? '',
-        line_count: selectionInfo.endLine - selectionInfo.startLine + 1,
+        file_extension: fileExtensionForAnalytics(filePath),
+        line_count: lineCount,
       });
       void copy(formatted);
     }

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -6,6 +6,9 @@ import { useRankedCommands, type RankedCommand } from '../../commands/useRankedC
 import { recordRun } from '../../commands/frecency';
 import type { CommandCategory } from '../../commands/types';
 import { logger } from '../../lib/logger';
+import { trackEvent, trackSearch } from '../../lib/analytics';
+
+type DismissReason = 'command_run' | 'manual';
 
 interface CommandPaletteProps {
   isOpen: boolean;
@@ -64,11 +67,17 @@ export function CommandPalette({
   currentProjectName,
 }: CommandPaletteProps) {
   const [query, setQuery] = useState('');
-  const [activeTab, setActiveTab] = useState<TabId>('all');
+  const [activeTab, setActiveTabRaw] = useState<TabId>('all');
   const [selectedIdx, setSelectedIdx] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const consumePendingTab = useConsumePendingTab();
+
+  // Analytics: track open duration and dismissal reason. The reason ref is set
+  // by runSelected before it calls onClose so the close-side effect knows the
+  // user invoked a command vs. dismissed via esc / click-outside.
+  const openedAtRef = useRef<number | null>(null);
+  const dismissReasonRef = useRef<DismissReason>('manual');
 
   const ranked = useRankedCommands({ kind: context, currentProjectName }, query);
 
@@ -95,14 +104,29 @@ export function CommandPalette({
   useEffect(() => {
     if (isOpen) {
       const pending = consumePendingTab();
-      setActiveTab(pending ?? 'all');
+      setActiveTabRaw(pending ?? 'all');
       inputRef.current?.focus();
+      openedAtRef.current = Date.now();
+      dismissReasonRef.current = 'manual';
+      void trackEvent('palette_opened', {
+        context,
+        initial_tab: pending ?? 'all',
+      });
     } else {
+      // Fire close event before resetting state so we have the active tab.
+      if (openedAtRef.current !== null) {
+        void trackEvent('palette_closed', {
+          context,
+          dismissed_with: dismissReasonRef.current,
+          duration_ms: Date.now() - openedAtRef.current,
+        });
+        openedAtRef.current = null;
+      }
       setQuery('');
-      setActiveTab('all');
+      setActiveTabRaw('all');
       setSelectedIdx(0);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- consumePendingTab is stable
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- consumePendingTab is stable, context is captured in handlers
   }, [isOpen]);
 
   // Clamp selection when the filtered list changes length.
@@ -121,7 +145,32 @@ export function CommandPalette({
 
   const tabs = context === 'project' ? PROJECT_TABS : HOME_TABS;
 
-  const runSelected = (cmd: RankedCommand) => {
+  // Tab-switch tracking. `cause` distinguishes between explicit clicks and
+  // keyboard navigation so we can tell whether power users prefer arrows.
+  const setActiveTab = (next: TabId, cause: 'click' | 'keyboard') => {
+    if (next !== activeTab) {
+      void trackEvent('palette_tab_switched', {
+        from_tab: activeTab,
+        to_tab: next,
+        cause,
+        context,
+      });
+    }
+    setActiveTabRaw(next);
+  };
+
+  const runSelected = (cmd: RankedCommand, position: number) => {
+    // Mark dismissal reason before close so the open/close effect tags the
+    // resulting palette_closed event correctly.
+    dismissReasonRef.current = 'command_run';
+    void trackEvent('palette_command_run', {
+      command_id: cmd.id,
+      category: cmd.category,
+      position,
+      query_length: query.length,
+      tab: activeTab,
+      context,
+    });
     // Close first so the UI doesn't block on long-running handlers.
     onClose();
     recordRun(cmd.id);
@@ -140,7 +189,7 @@ export function CommandPalette({
   const cycleTab = (direction: 1 | -1) => {
     const currentIdx = tabs.findIndex((t) => t.id === activeTab);
     const nextIdx = (currentIdx + direction + tabs.length) % tabs.length;
-    setActiveTab(tabs[nextIdx].id);
+    setActiveTab(tabs[nextIdx].id, 'keyboard');
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -159,7 +208,7 @@ export function CommandPalette({
     } else if (e.key === 'Enter') {
       e.preventDefault();
       const cmd = filtered[selectedIdx];
-      if (cmd) runSelected(cmd);
+      if (cmd) runSelected(cmd, selectedIdx);
     }
   };
 
@@ -182,7 +231,11 @@ export function CommandPalette({
           className="command-palette-input"
           placeholder={placeholderFor(context, currentProjectName)}
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            // Debounced (1s) — only the final query lands in PostHog.
+            trackSearch('palette', e.target.value);
+          }}
           onKeyDown={handleKeyDown}
           autoComplete="off"
           autoCorrect="off"
@@ -207,7 +260,7 @@ export function CommandPalette({
             role="tab"
             aria-selected={activeTab === tab.id}
             className={`command-palette-tab ${activeTab === tab.id ? 'is-active' : ''}`}
-            onClick={() => setActiveTab(tab.id)}
+            onClick={() => setActiveTab(tab.id, 'click')}
           >
             {tab.label}
           </button>
@@ -231,7 +284,7 @@ export function CommandPalette({
                     cmd={cmd}
                     selected={idx === selectedIdx}
                     onMouseEnter={() => setSelectedIdx(idx)}
-                    onClick={() => runSelected(cmd)}
+                    onClick={() => runSelected(cmd, idx)}
                   />
                 );
               })}
@@ -244,7 +297,7 @@ export function CommandPalette({
               cmd={cmd}
               selected={idx === selectedIdx}
               onMouseEnter={() => setSelectedIdx(idx)}
-              onClick={() => runSelected(cmd)}
+              onClick={() => runSelected(cmd, idx)}
             />
           ))
         )}

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -6,7 +6,7 @@ import { useRankedCommands, type RankedCommand } from '../../commands/useRankedC
 import { recordRun } from '../../commands/frecency';
 import type { CommandCategory } from '../../commands/types';
 import { logger } from '../../lib/logger';
-import { trackEvent, trackSearch } from '../../lib/analytics';
+import { trackEvent, trackSearch, cancelTrackedSearch } from '../../lib/analytics';
 
 type DismissReason = 'command_run' | 'manual';
 
@@ -113,6 +113,9 @@ export function CommandPalette({
         initial_tab: pending ?? 'all',
       });
     } else {
+      // Drop any pending debounced search — otherwise it fires *after* the
+      // palette is gone, attributing a search to a closed surface.
+      cancelTrackedSearch('palette');
       // Fire close event before resetting state so we have the active tab.
       if (openedAtRef.current !== null) {
         void trackEvent('palette_closed', {
@@ -163,11 +166,17 @@ export function CommandPalette({
     // Mark dismissal reason before close so the open/close effect tags the
     // resulting palette_closed event correctly.
     dismissReasonRef.current = 'command_run';
+    const trimmedQuery = query.trim();
     void trackEvent('palette_command_run', {
       command_id: cmd.id,
       category: cmd.category,
+      // `position` is the index in the *currently filtered* list; pair it
+      // with `total_results` so the metric is interpretable across queries.
       position,
-      query_length: query.length,
+      total_results: filtered.length,
+      query: trimmedQuery.slice(0, 100),
+      query_length: trimmedQuery.length,
+      had_query: trimmedQuery.length > 0,
       tab: activeTab,
       context,
     });

--- a/src/components/DevServerLogs.tsx
+++ b/src/components/DevServerLogs.tsx
@@ -20,6 +20,7 @@ import { loadNerdFonts } from '../lib/fonts';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { useOptionalToast } from '../contexts/ToastContext';
 import { CopyIcon } from './icons';
+import { trackEvent } from '../lib/analytics';
 import '@xterm/xterm/css/xterm.css';
 
 /* Tail-limit the full-buffer send so we don't fire 3k+ lines of HMR
@@ -233,12 +234,25 @@ export function DevServerLogs({ output, outputVersion, onSendToAgent }: DevServe
 
   const handleSendFullBuffer = useCallback(() => {
     if (!onSendToAgent) return;
-    onSendToAgent(formatServerLogsForAgent(output));
+    const text = formatServerLogsForAgent(output);
+    void trackEvent('logs_sent_to_agent', {
+      source: 'full_buffer',
+      char_count: text.length,
+      line_count: text.split('\n').length,
+    });
+    onSendToAgent(text);
   }, [onSendToAgent, output]);
 
   const handleSendSelection = useCallback(() => {
     if (!onSendToAgent || !selectionInfo) return;
-    onSendToAgent(formatSelectionForAgent(selectionInfo.text, question));
+    const text = formatSelectionForAgent(selectionInfo.text, question);
+    void trackEvent('logs_sent_to_agent', {
+      source: 'selection',
+      char_count: text.length,
+      line_count: selectionInfo.text.split('\n').length,
+      had_question: question.trim().length > 0,
+    });
+    onSendToAgent(text);
     showToast('Sent to agent', 'success');
     dismissPopover();
   }, [onSendToAgent, selectionInfo, question, showToast, dismissPopover]);

--- a/src/components/DevServerLogs.tsx
+++ b/src/components/DevServerLogs.tsx
@@ -238,7 +238,9 @@ export function DevServerLogs({ output, outputVersion, onSendToAgent }: DevServe
     void trackEvent('logs_sent_to_agent', {
       source: 'full_buffer',
       char_count: text.length,
-      line_count: text.split('\n').length,
+      // Count actual log lines (raw output), not the wrapped prompt — so
+      // the metric is comparable to the selection branch below.
+      line_count: output.split('\n').length,
     });
     onSendToAgent(text);
   }, [onSendToAgent, output]);

--- a/src/components/PublishBranchDropdown.tsx
+++ b/src/components/PublishBranchDropdown.tsx
@@ -14,11 +14,11 @@ import { ChevronIcon, BranchIcon, SuccessIcon, ErrorIcon, SpinnerIcon } from './
 import { useClickOutside } from '../hooks/useClickOutside';
 import { logger } from '../lib/logger';
 import { trackEvent, trackError } from '../lib/analytics';
+import { useOptionalToast } from '../contexts/ToastContext';
 
 // Module-scoped so the metric spans dropdown re-mounts. Per-project would be
 // better but cross-project publish cadence is also useful and far simpler.
 let lastPublishAt: number | null = null;
-import { useOptionalToast } from '../contexts/ToastContext';
 
 interface PublishBranchDropdownProps {
   /** Current branch name */

--- a/src/components/PublishBranchDropdown.tsx
+++ b/src/components/PublishBranchDropdown.tsx
@@ -14,6 +14,10 @@ import { ChevronIcon, BranchIcon, SuccessIcon, ErrorIcon, SpinnerIcon } from './
 import { useClickOutside } from '../hooks/useClickOutside';
 import { logger } from '../lib/logger';
 import { trackEvent, trackError } from '../lib/analytics';
+
+// Module-scoped so the metric spans dropdown re-mounts. Per-project would be
+// better but cross-project publish cadence is also useful and far simpler.
+let lastPublishAt: number | null = null;
 import { useOptionalToast } from '../contexts/ToastContext';
 
 interface PublishBranchDropdownProps {
@@ -130,11 +134,15 @@ export function PublishBranchDropdown({
       }
 
       logger.info('Publish succeeded', { branch: currentBranch });
+      const now = Date.now();
       void trackEvent('branch_published', {
         is_main: isMainBranch,
         branch: currentBranch,
+        time_since_last_publish_seconds:
+          lastPublishAt !== null ? Math.round((now - lastPublishAt) / 1000) : null,
         $screen_name: 'Workspace',
       });
+      lastPublishAt = now;
       onToast?.(isMainBranch ? 'Pushed to GitHub!' : 'Changes synced to GitHub!', 'success');
       onStatusChange();
       setPublishState({ status: 'success' });

--- a/src/components/PublishBranchDropdown.tsx
+++ b/src/components/PublishBranchDropdown.tsx
@@ -135,9 +135,11 @@ export function PublishBranchDropdown({
 
       logger.info('Publish succeeded', { branch: currentBranch });
       const now = Date.now();
+      // Don't ship the branch name — `feature/client-acme-flow` style names
+      // routinely contain customer/codename data that doesn't belong in
+      // PostHog. `is_main` carries the question we actually wanted to ask.
       void trackEvent('branch_published', {
         is_main: isMainBranch,
-        branch: currentBranch,
         time_since_last_publish_seconds:
           lastPublishAt !== null ? Math.round((now - lastPublishAt) / 1000) : null,
         $screen_name: 'Workspace',

--- a/src/components/SubmitReviewModal.tsx
+++ b/src/components/SubmitReviewModal.tsx
@@ -52,7 +52,8 @@ export function SubmitReviewModal({
 
   // Track modal open
   useEffect(() => {
-    void trackEvent('submit_review_opened', { branch: branchName, $screen_name: 'Workspace' });
+    // Branch name omitted on purpose — see PublishBranchDropdown for rationale.
+    void trackEvent('submit_review_opened', { $screen_name: 'Workspace' });
   }, [branchName]);
 
   const handleGenerate = async () => {

--- a/src/components/SubmitReviewModal.tsx
+++ b/src/components/SubmitReviewModal.tsx
@@ -127,9 +127,14 @@ export function SubmitReviewModal({
         description.trim() || null,
         baseBranch
       );
+      const trimmedTitle = title.trim();
+      const trimmedDescription = description.trim();
       void trackEvent('pr_created', {
         base_branch: baseBranch,
         used_ai: usedAiGeneration,
+        title_length: trimmedTitle.length,
+        description_length: trimmedDescription.length,
+        had_description: trimmedDescription.length > 0,
         $screen_name: 'Workspace',
       });
       onSuccess(prUrl);

--- a/src/components/SubmitReviewModal.tsx
+++ b/src/components/SubmitReviewModal.tsx
@@ -120,21 +120,21 @@ export function SubmitReviewModal({
     setIsSubmitting(true);
     setError(null);
 
+    const trimmedTitle = title.trim();
+    const trimmedDescription = description.trim();
+
     try {
       const prUrl = await createPullRequest(
         projectPath,
-        title.trim(),
-        description.trim() || null,
+        trimmedTitle,
+        trimmedDescription || null,
         baseBranch
       );
-      const trimmedTitle = title.trim();
-      const trimmedDescription = description.trim();
       void trackEvent('pr_created', {
         base_branch: baseBranch,
         used_ai: usedAiGeneration,
         title_length: trimmedTitle.length,
         description_length: trimmedDescription.length,
-        had_description: trimmedDescription.length > 0,
         $screen_name: 'Workspace',
       });
       onSuccess(prUrl);

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -38,6 +38,7 @@ import { WorkspaceHeader, HOSTING_PLUGIN_IDS } from './WorkspaceHeader';
 import { WorkspaceSidebar } from './WorkspaceSidebar';
 import { PluginSlot } from './PluginSlot';
 import { UpdateBanner } from './UpdateBanner';
+import { trackEvent } from '../lib/analytics';
 import { useWorkspaceCommands } from '../commands/useWorkspaceCommands';
 import {
   CameraIcon,
@@ -570,7 +571,22 @@ export const WorkspaceView = memo(function WorkspaceView({
   const [isSidebarHidden, setIsSidebarHidden] = useState(false);
   const effectiveSidebarHidden = isSidebarHidden;
   const [showPreviewLogs, setShowPreviewLogs] = useState(false);
-  const [inspectTab, setInspectTab] = useState<InspectTab>('logs');
+  const [inspectTab, setInspectTabRaw] = useState<InspectTab>('logs');
+  // Wrap setter so we don't have to remember to track at every call site.
+  const setInspectTab = useCallback((tab: InspectTab) => {
+    setInspectTabRaw((prev) => {
+      if (prev !== tab) {
+        void trackEvent('inspect_subtab_switched', { from_tab: prev, to_tab: tab });
+      }
+      return tab;
+    });
+  }, []);
+  const togglePreviewLogs = useCallback(() => {
+    setShowPreviewLogs((prev) => {
+      void trackEvent('inspect_panel_toggled', { is_open: !prev });
+      return !prev;
+    });
+  }, []);
 
   // Workspace-scoped palette commands (branch + PR flows).
   useWorkspaceCommands({
@@ -690,7 +706,11 @@ export const WorkspaceView = memo(function WorkspaceView({
       />
     ),
     isSidebarHidden: effectiveSidebarHidden,
-    onToggleSidebar: () => setIsSidebarHidden((v) => !v),
+    onToggleSidebar: () =>
+      setIsSidebarHidden((v) => {
+        void trackEvent('sidebar_toggled', { is_hidden: !v });
+        return !v;
+      }),
     integrations,
     onGitHubStatusChange: handleGitHubStatusChange,
     onGitHubConnect: handleGitHubConnect,
@@ -1087,9 +1107,7 @@ export const WorkspaceView = memo(function WorkspaceView({
                             isDevServerRestarting={isRestartingDevServer}
                             onSendToClaude={sendToClaude}
                             showLogs={showPreviewLogs}
-                            onToggleLogs={
-                              hasDevServer ? () => setShowPreviewLogs((s) => !s) : undefined
-                            }
+                            onToggleLogs={hasDevServer ? togglePreviewLogs : undefined}
                             devServerOutput={devServerOutput}
                             devServerOutputVersion={devServerOutputVersion}
                             inspectTab={inspectTab}

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -570,23 +570,27 @@ export const WorkspaceView = memo(function WorkspaceView({
   // layout owns its own chrome (see `CompactWorkspace`).
   const [isSidebarHidden, setIsSidebarHidden] = useState(false);
   const effectiveSidebarHidden = isSidebarHidden;
+  // Naming note: `showPreviewLogs` is the legacy state for the inspect panel
+  // (which hosts dev-server logs + browser tools). The event keeps the
+  // generic name so future inspect-only telemetry doesn't have to migrate.
   const [showPreviewLogs, setShowPreviewLogs] = useState(false);
   const [inspectTab, setInspectTabRaw] = useState<InspectTab>('logs');
-  // Wrap setter so we don't have to remember to track at every call site.
-  const setInspectTab = useCallback((tab: InspectTab) => {
-    setInspectTabRaw((prev) => {
-      if (prev !== tab) {
-        void trackEvent('inspect_subtab_switched', { from_tab: prev, to_tab: tab });
+
+  // Wrap setters with click tracking. We read previous state from the closure
+  // (not a functional updater) to avoid double-firing under React StrictMode.
+  const setInspectTab = useCallback(
+    (tab: InspectTab) => {
+      if (inspectTab !== tab) {
+        void trackEvent('inspect_subtab_switched', { from_tab: inspectTab, to_tab: tab });
       }
-      return tab;
-    });
-  }, []);
+      setInspectTabRaw(tab);
+    },
+    [inspectTab]
+  );
   const togglePreviewLogs = useCallback(() => {
-    setShowPreviewLogs((prev) => {
-      void trackEvent('inspect_panel_toggled', { is_open: !prev });
-      return !prev;
-    });
-  }, []);
+    void trackEvent('inspect_panel_toggled', { is_open: !showPreviewLogs });
+    setShowPreviewLogs(!showPreviewLogs);
+  }, [showPreviewLogs]);
 
   // Workspace-scoped palette commands (branch + PR flows).
   useWorkspaceCommands({
@@ -706,11 +710,10 @@ export const WorkspaceView = memo(function WorkspaceView({
       />
     ),
     isSidebarHidden: effectiveSidebarHidden,
-    onToggleSidebar: () =>
-      setIsSidebarHidden((v) => {
-        void trackEvent('sidebar_toggled', { is_hidden: !v });
-        return !v;
-      }),
+    onToggleSidebar: () => {
+      void trackEvent('sidebar_toggled', { is_hidden: !isSidebarHidden });
+      setIsSidebarHidden(!isSidebarHidden);
+    },
     integrations,
     onGitHubStatusChange: handleGitHubStatusChange,
     onGitHubConnect: handleGitHubConnect,

--- a/src/components/setup/OnboardingScreen.tsx
+++ b/src/components/setup/OnboardingScreen.tsx
@@ -18,7 +18,7 @@ import { AgentStep } from './steps/AgentStep';
 import { HostingStep } from './steps/HostingStep';
 import { CelebrationScreen } from './CelebrationScreen';
 import { OnboardingTerminal } from './OnboardingTerminal';
-import { trackEvent } from '../../lib/analytics';
+import { trackEvent, trackPageview } from '../../lib/analytics';
 import { Button } from '../primitives/Button';
 import { logger } from '../../lib/logger';
 import {
@@ -69,6 +69,27 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
 
   const unlistenRef = useRef<UnlistenFn | null>(null);
+  const setupStartedRef = useRef(false);
+  const stepEnteredAtRef = useRef<Map<WizardStepId, number>>(new Map());
+
+  // Track each step entry: pageview, setup_step_entered, and remember when
+  // we entered so the completion event can carry duration_ms.
+  useEffect(() => {
+    if (state !== 'wizard') return;
+    const stepIndex = WIZARD_STEPS.findIndex((s) => s.id === currentStep);
+    const stepDef = WIZARD_STEPS[stepIndex];
+    if (!stepDef) return;
+    if (!setupStartedRef.current) {
+      setupStartedRef.current = true;
+      void trackEvent('setup_started', { entry_step: currentStep });
+    }
+    trackPageview(`Onboarding - ${stepDef.title}`);
+    void trackEvent('setup_step_entered', {
+      step_id: currentStep,
+      step_index: stepIndex,
+    });
+    stepEnteredAtRef.current.set(currentStep, performance.now());
+  }, [state, currentStep]);
 
   // Compute completed steps: only show as completed if before the current step
   const completedSteps = useMemo(() => {
@@ -245,6 +266,14 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
     async (itemId: string) => {
       if (activeItemId || terminalConfig) return;
 
+      // Auth items are "connect"; everything else is "install".
+      const isAuth = itemId === 'gh_auth' || itemId === 'claude_auth' || itemId === 'vercel_auth';
+      void trackEvent('setup_action_clicked', {
+        item_id: itemId,
+        action: isAuth ? 'connect' : 'install',
+        step_id: currentStep,
+      });
+
       setActiveItemId(itemId);
       updateItemStatus(itemId, { status: 'in_progress', errorMessage: undefined });
 
@@ -329,8 +358,21 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
         setActiveItemId(null);
       }
     },
-    [activeItemId, terminalConfig, updateItemStatus, fetchStatus, items]
+    [activeItemId, terminalConfig, updateItemStatus, fetchStatus, items, currentStep]
   );
+
+  // Emit setup_step_completed for the step we're leaving. Called from both
+  // handleNext (after we know the advance is happening) and from
+  // handleAllComplete (the auto-skip-to-celebration path).
+  const fireStepCompleted = useCallback((stepId: WizardStepId, isFinal: boolean) => {
+    const enteredAt = stepEnteredAtRef.current.get(stepId);
+    void trackEvent('setup_step_completed', {
+      step_id: stepId,
+      step_index: WIZARD_STEPS.findIndex((s) => s.id === stepId),
+      duration_ms: enteredAt !== undefined ? Math.round(performance.now() - enteredAt) : null,
+      is_final: isFinal,
+    });
+  }, []);
 
   // Navigate to the next incomplete step
   const handleNext = useCallback(async () => {
@@ -364,20 +406,27 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
     for (let i = currentIndex + 1; i < WIZARD_STEPS.length; i++) {
       const step = WIZARD_STEPS[i];
       if (!isWizardStepComplete(step.id, items)) {
+        fireStepCompleted(currentStep, false);
         setCurrentStep(step.id);
         return;
       }
     }
 
     // All steps after current are complete → celebration
+    fireStepCompleted(currentStep, true);
     setState('complete');
-  }, [currentStep, items, selectedAgentId]);
+  }, [currentStep, items, selectedAgentId, fireStepCompleted]);
 
   // Navigate to the previous step
   const handleBack = useCallback(() => {
     const currentIndex = WIZARD_STEPS.findIndex((s) => s.id === currentStep);
     if (currentIndex > 0) {
-      setCurrentStep(WIZARD_STEPS[currentIndex - 1].id);
+      const prevStep = WIZARD_STEPS[currentIndex - 1].id;
+      void trackEvent('setup_step_navigated_back', {
+        from_step: currentStep,
+        to_step: prevStep,
+      });
+      setCurrentStep(prevStep);
     }
   }, [currentStep]);
 

--- a/src/components/setup/OnboardingScreen.tsx
+++ b/src/components/setup/OnboardingScreen.tsx
@@ -46,6 +46,16 @@ import { SlackIcon } from '../icons';
 
 type OnboardingState = 'loading' | 'wizard' | 'complete';
 
+// Module-scoped so React 18 StrictMode's mount→unmount→remount in dev doesn't
+// re-fire `setup_started` after the first launch of this app session. Each
+// app process gets a fresh module load, so this is naturally session-scoped.
+let setupStartedFiredThisSession = false;
+function fireSetupStartedOnce(entryPath: 'wizard' | 'fast_path', entryStep: WizardStepId | null) {
+  if (setupStartedFiredThisSession) return;
+  setupStartedFiredThisSession = true;
+  void trackEvent('setup_started', { entry_path: entryPath, entry_step: entryStep });
+}
+
 /** Configuration for the active terminal command */
 interface TerminalConfig {
   itemId: string;
@@ -69,7 +79,6 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
 
   const unlistenRef = useRef<UnlistenFn | null>(null);
-  const setupStartedRef = useRef(false);
   const stepEnteredAtRef = useRef<Map<WizardStepId, number>>(new Map());
 
   // Track each step entry: pageview, setup_step_entered, and remember when
@@ -79,10 +88,7 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
     const stepIndex = WIZARD_STEPS.findIndex((s) => s.id === currentStep);
     const stepDef = WIZARD_STEPS[stepIndex];
     if (!stepDef) return;
-    if (!setupStartedRef.current) {
-      setupStartedRef.current = true;
-      void trackEvent('setup_started', { entry_step: currentStep });
-    }
+    fireSetupStartedOnce('wizard', currentStep);
     trackPageview(`Onboarding - ${stepDef.title}`);
     void trackEvent('setup_step_entered', {
       step_id: currentStep,
@@ -175,9 +181,12 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
       await setDefaultAgentId(agentId);
       initDefaultAgent(agentId);
     }
+    // Fast-path users still need a setup_started for funnel completeness.
+    fireSetupStartedOnce('fast_path', null);
     // If multiple agents, they'll be asked to pick in the agent step
     void trackEvent('onboarding_completed', {
       agents: status.detectedAgents,
+      entry_path: 'fast_path',
       $screen_name: 'Onboarding',
     });
     setState('complete');
@@ -266,8 +275,10 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
     async (itemId: string) => {
       if (activeItemId || terminalConfig) return;
 
-      // Auth items are "connect"; everything else is "install".
-      const isAuth = itemId === 'gh_auth' || itemId === 'claude_auth' || itemId === 'vercel_auth';
+      // Auth items are "connect"; everything else is "install". Derive from
+      // the convention (`*_auth` suffix) so adding a new auth flow doesn't
+      // require remembering to update this list.
+      const isAuth = itemId.endsWith('_auth');
       void trackEvent('setup_action_clicked', {
         item_id: itemId,
         action: isAuth ? 'connect' : 'install',
@@ -361,9 +372,10 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
     [activeItemId, terminalConfig, updateItemStatus, fetchStatus, items, currentStep]
   );
 
-  // Emit setup_step_completed for the step we're leaving. Called from both
-  // handleNext (after we know the advance is happening) and from
-  // handleAllComplete (the auto-skip-to-celebration path).
+  // Emit setup_step_completed for the step the user just clicked Next on.
+  // Only fires from handleNext — the all-complete fast path skips the wizard
+  // entirely and never enters any step, so a per-step completion event there
+  // would be a fabrication.
   const fireStepCompleted = useCallback((stepId: WizardStepId, isFinal: boolean) => {
     const enteredAt = stepEnteredAtRef.current.get(stepId);
     void trackEvent('setup_step_completed', {
@@ -402,18 +414,38 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
       }
     }
 
-    // Find next incomplete step after current
+    // Find next incomplete step after current. Anything between current and
+    // the target is auto-skipped because it's already complete; emit a
+    // setup_step_skipped event for each so the funnel shows where the user
+    // breezed through vs. where they actually stopped.
     for (let i = currentIndex + 1; i < WIZARD_STEPS.length; i++) {
       const step = WIZARD_STEPS[i];
       if (!isWizardStepComplete(step.id, items)) {
         fireStepCompleted(currentStep, false);
+        for (let j = currentIndex + 1; j < i; j++) {
+          const skipped = WIZARD_STEPS[j];
+          void trackEvent('setup_step_skipped', {
+            step_id: skipped.id,
+            step_index: j,
+            reason: 'already_complete',
+          });
+        }
         setCurrentStep(step.id);
         return;
       }
     }
 
-    // All steps after current are complete → celebration
+    // All steps after current are complete → celebration. Emit skipped
+    // events for each intermediate so the funnel terminates cleanly.
     fireStepCompleted(currentStep, true);
+    for (let j = currentIndex + 1; j < WIZARD_STEPS.length; j++) {
+      const skipped = WIZARD_STEPS[j];
+      void trackEvent('setup_step_skipped', {
+        step_id: skipped.id,
+        step_index: j,
+        reason: 'already_complete',
+      });
+    }
     setState('complete');
   }, [currentStep, items, selectedAgentId, fireStepCompleted]);
 

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -86,7 +86,10 @@ export function ModalProvider({ children }: ProviderProps) {
     setOpenSet(next);
     if (!MODAL_TRACKING_EXCLUDED.has(id)) {
       openedAtRef.current.set(id, performance.now());
-      void trackEvent('modal_opened', { modal_id: id });
+      // Modal id is baked into the event name so PostHog's default events
+      // list is self-describing — no column add required to know which
+      // modal opened. `modal_id` stays in the payload too for filters.
+      void trackEvent(`modal_${id}_opened`, { modal_id: id });
     }
   }, []);
 
@@ -102,7 +105,7 @@ export function ModalProvider({ children }: ProviderProps) {
     if (!MODAL_TRACKING_EXCLUDED.has(id)) {
       const openedAt = openedAtRef.current.get(id);
       openedAtRef.current.delete(id);
-      void trackEvent('modal_closed', {
+      void trackEvent(`modal_${id}_closed`, {
         modal_id: id,
         // Explicit `undefined` check so a value of 0 (impossible in
         // practice with performance.now()) wouldn't be treated as missing.
@@ -120,7 +123,7 @@ export function ModalProvider({ children }: ProviderProps) {
       for (const id of openSetRef.current) {
         if (MODAL_TRACKING_EXCLUDED.has(id)) continue;
         const openedAt = openedAtRef.current.get(id);
-        void trackEvent('modal_closed', {
+        void trackEvent(`modal_${id}_closed`, {
           modal_id: id,
           duration_ms: openedAt !== undefined ? Math.round(performance.now() - openedAt) : null,
           reason: 'provider_unmount',

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import { trackEvent } from '../lib/analytics';
 
 /**
  * Registered modal IDs. Add a string here when introducing a new modal so
@@ -52,29 +53,56 @@ interface ProviderProps {
   children: ReactNode;
 }
 
+/**
+ * Modal IDs whose open/close events are *not* fired centrally. The command
+ * palette has its own `palette_opened`/`palette_closed` with richer payload
+ * (context, dismissal reason, search query) — duplicating it here would
+ * inflate counts.
+ */
+const MODAL_TRACKING_EXCLUDED: ReadonlySet<ModalId> = new Set(['commandPalette']);
+
 export function ModalProvider({ children }: ProviderProps) {
   const [openSet, setOpenSet] = useState<Set<ModalId>>(() => new Set());
   const callbacksRef = useRef(new Map<ModalId, Set<() => void>>());
+  // Open-timestamps so `modal_closed` can carry a duration. Keyed by ID;
+  // overwriting on re-open is fine since open and close are paired.
+  const openedAtRef = useRef(new Map<ModalId, number>());
 
   const isOpen = useCallback((id: ModalId) => openSet.has(id), [openSet]);
 
   const open = useCallback((id: ModalId) => {
+    let wasNew = false;
     setOpenSet((prev) => {
       if (prev.has(id)) return prev;
+      wasNew = true;
       const next = new Set(prev);
       next.add(id);
       return next;
     });
+    if (wasNew && !MODAL_TRACKING_EXCLUDED.has(id)) {
+      openedAtRef.current.set(id, Date.now());
+      void trackEvent('modal_opened', { modal_id: id });
+    }
   }, []);
 
   const close = useCallback((id: ModalId) => {
+    let wasOpen = false;
     setOpenSet((prev) => {
       if (!prev.has(id)) return prev;
+      wasOpen = true;
       const next = new Set(prev);
       next.delete(id);
       return next;
     });
     callbacksRef.current.get(id)?.forEach((fn) => fn());
+    if (wasOpen && !MODAL_TRACKING_EXCLUDED.has(id)) {
+      const openedAt = openedAtRef.current.get(id);
+      openedAtRef.current.delete(id);
+      void trackEvent('modal_closed', {
+        modal_id: id,
+        duration_ms: openedAt ? Date.now() - openedAt : null,
+      });
+    }
   }, []);
 
   const toggle = useCallback(

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -2,6 +2,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -64,45 +65,68 @@ const MODAL_TRACKING_EXCLUDED: ReadonlySet<ModalId> = new Set(['commandPalette']
 export function ModalProvider({ children }: ProviderProps) {
   const [openSet, setOpenSet] = useState<Set<ModalId>>(() => new Set());
   const callbacksRef = useRef(new Map<ModalId, Set<() => void>>());
-  // Open-timestamps so `modal_closed` can carry a duration. Keyed by ID;
-  // overwriting on re-open is fine since open and close are paired.
+  // Mirror of `openSet` for synchronous transition detection. We can't read
+  // `openSet` directly from the useCallback below (closure would be stale)
+  // and we don't want to rely on functional-updater side effects (timing
+  // depends on React 18 internals). Mutating both this ref *and* the state
+  // setter keeps the source of truth consistent.
+  const openSetRef = useRef<Set<ModalId>>(new Set());
+  // Open-timestamps so `modal_closed` can carry a duration. Uses
+  // `performance.now()` because it's monotonic — wall-clock changes (NTP,
+  // DST) won't yield negative durations.
   const openedAtRef = useRef(new Map<ModalId, number>());
 
   const isOpen = useCallback((id: ModalId) => openSet.has(id), [openSet]);
 
   const open = useCallback((id: ModalId) => {
-    let wasNew = false;
-    setOpenSet((prev) => {
-      if (prev.has(id)) return prev;
-      wasNew = true;
-      const next = new Set(prev);
-      next.add(id);
-      return next;
-    });
-    if (wasNew && !MODAL_TRACKING_EXCLUDED.has(id)) {
-      openedAtRef.current.set(id, Date.now());
+    if (openSetRef.current.has(id)) return;
+    const next = new Set(openSetRef.current);
+    next.add(id);
+    openSetRef.current = next;
+    setOpenSet(next);
+    if (!MODAL_TRACKING_EXCLUDED.has(id)) {
+      openedAtRef.current.set(id, performance.now());
       void trackEvent('modal_opened', { modal_id: id });
     }
   }, []);
 
   const close = useCallback((id: ModalId) => {
-    let wasOpen = false;
-    setOpenSet((prev) => {
-      if (!prev.has(id)) return prev;
-      wasOpen = true;
-      const next = new Set(prev);
-      next.delete(id);
-      return next;
-    });
-    callbacksRef.current.get(id)?.forEach((fn) => fn());
-    if (wasOpen && !MODAL_TRACKING_EXCLUDED.has(id)) {
+    if (!openSetRef.current.has(id)) return;
+    const next = new Set(openSetRef.current);
+    next.delete(id);
+    openSetRef.current = next;
+    setOpenSet(next);
+    // Fire the analytics event *before* user-supplied close callbacks so
+    // a slow/throwing callback doesn't inflate `duration_ms` or skip the
+    // event entirely.
+    if (!MODAL_TRACKING_EXCLUDED.has(id)) {
       const openedAt = openedAtRef.current.get(id);
       openedAtRef.current.delete(id);
       void trackEvent('modal_closed', {
         modal_id: id,
-        duration_ms: openedAt ? Date.now() - openedAt : null,
+        // Explicit `undefined` check so a value of 0 (impossible in
+        // practice with performance.now()) wouldn't be treated as missing.
+        duration_ms: openedAt !== undefined ? Math.round(performance.now() - openedAt) : null,
       });
     }
+    callbacksRef.current.get(id)?.forEach((fn) => fn());
+  }, []);
+
+  // Flush a `modal_closed` for any modals still open when the provider
+  // unmounts (app quit, hard reload). Without this, the open event has no
+  // close partner and duration is lost.
+  useEffect(() => {
+    return () => {
+      for (const id of openSetRef.current) {
+        if (MODAL_TRACKING_EXCLUDED.has(id)) continue;
+        const openedAt = openedAtRef.current.get(id);
+        void trackEvent('modal_closed', {
+          modal_id: id,
+          duration_ms: openedAt !== undefined ? Math.round(performance.now() - openedAt) : null,
+          reason: 'provider_unmount',
+        });
+      }
+    };
   }, []);
 
   const toggle = useCallback(

--- a/src/hooks/useIntegrationStatus.test.ts
+++ b/src/hooks/useIntegrationStatus.test.ts
@@ -184,9 +184,9 @@ describe('useIntegrationStatus', () => {
         github_username: 'myuser',
         latest_app_version: '9.9.9',
       });
-      expect(typeof setProps?.last_seen_at).toBe('string');
+      expect(typeof setProps?.last_identified_at).toBe('string');
       expect(setOnceProps).toMatchObject({ first_app_version: '9.9.9' });
-      expect(typeof setOnceProps?.first_seen_at).toBe('string');
+      expect(typeof setOnceProps?.first_identified_at).toBe('string');
     });
   });
 

--- a/src/hooks/useIntegrationStatus.test.ts
+++ b/src/hooks/useIntegrationStatus.test.ts
@@ -19,16 +19,22 @@ vi.mock('../lib/analytics', () => ({
   identifyUser: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('@tauri-apps/api/app', () => ({
+  getVersion: vi.fn().mockResolvedValue('9.9.9'),
+}));
+
 describe('useIntegrationStatus', () => {
   let github: typeof import('../lib/github');
   let claude: typeof import('../lib/claude');
   let analytics: typeof import('../lib/analytics');
+  let app: typeof import('@tauri-apps/api/app');
 
   beforeEach(async () => {
     vi.clearAllMocks();
     github = await import('../lib/github');
     claude = await import('../lib/claude');
     analytics = await import('../lib/analytics');
+    app = await import('@tauri-apps/api/app');
 
     vi.mocked(github.checkGitHubCliStatus).mockResolvedValue({
       installed: false,
@@ -38,6 +44,9 @@ describe('useIntegrationStatus', () => {
     vi.mocked(github.getGitHubUsername).mockResolvedValue('');
     vi.mocked(github.getProjectGitHubStatus).mockResolvedValue(GITHUB_STATUS_FALLBACK);
     vi.mocked(analytics.identifyUser).mockResolvedValue(undefined);
+    // Re-establish each test — global afterEach calls restoreAllMocks which
+    // strips the implementation from the top-of-file `vi.mock`.
+    vi.mocked(app.getVersion).mockResolvedValue('9.9.9');
   });
 
   it('initializes with default state', () => {
@@ -167,9 +176,17 @@ describe('useIntegrationStatus', () => {
         await result.current.refreshAllCliStatuses();
       });
 
-      expect(vi.mocked(analytics.identifyUser)).toHaveBeenCalledWith('myuser', {
+      const identifyMock = vi.mocked(analytics.identifyUser);
+      expect(identifyMock).toHaveBeenCalledTimes(1);
+      const [userId, setProps, setOnceProps] = identifyMock.mock.calls[0];
+      expect(userId).toBe('myuser');
+      expect(setProps).toMatchObject({
         github_username: 'myuser',
+        latest_app_version: '9.9.9',
       });
+      expect(typeof setProps?.last_seen_at).toBe('string');
+      expect(setOnceProps).toMatchObject({ first_app_version: '9.9.9' });
+      expect(typeof setOnceProps?.first_seen_at).toBe('string');
     });
   });
 

--- a/src/hooks/useIntegrationStatus.ts
+++ b/src/hooks/useIntegrationStatus.ts
@@ -14,6 +14,7 @@
  */
 
 import { useReducer, useCallback, useState } from 'react';
+import { getVersion } from '@tauri-apps/api/app';
 import {
   checkGitHubCliStatus,
   getGitHubUsername,
@@ -189,7 +190,25 @@ export function useIntegrationStatus(): UseIntegrationStatusReturn {
       try {
         ghUsername = await getGitHubUsername();
         if (ghUsername) {
-          void identifyUser(ghUsername, { github_username: ghUsername });
+          // Person props ($set) overwrite on every identify; person props
+          // ($set_once) only land the first time we see this user.
+          let appVersion: string | null = null;
+          try {
+            appVersion = await getVersion();
+          } catch {
+            // Optional — backend already attaches app_version to events
+          }
+          const nowIso = new Date().toISOString();
+          const setProps: Record<string, unknown> = {
+            github_username: ghUsername,
+            last_seen_at: nowIso,
+          };
+          if (appVersion) setProps.latest_app_version = appVersion;
+          const setOnce: Record<string, unknown> = {
+            first_seen_at: nowIso,
+          };
+          if (appVersion) setOnce.first_app_version = appVersion;
+          void identifyUser(ghUsername, setProps, setOnce);
         }
       } catch {
         // Ignore - username is optional

--- a/src/hooks/useIntegrationStatus.ts
+++ b/src/hooks/useIntegrationStatus.ts
@@ -25,6 +25,19 @@ import {
 import { checkAgentCliStatus, AgentCliStatus } from '../lib/claude';
 import { identifyUser } from '../lib/analytics';
 
+// `getVersion` reads a baked-in compile-time constant; cache it so the
+// repeated identify path doesn't pay the Tauri IPC cost on every refresh.
+let cachedAppVersion: string | null | undefined;
+async function getCachedAppVersion(): Promise<string | null> {
+  if (cachedAppVersion !== undefined) return cachedAppVersion;
+  try {
+    cachedAppVersion = await getVersion();
+  } catch {
+    cachedAppVersion = null;
+  }
+  return cachedAppVersion;
+}
+
 /** Global GitHub CLI and authentication state */
 export interface GitHubState {
   /** CLI installation and auth status */
@@ -192,20 +205,15 @@ export function useIntegrationStatus(): UseIntegrationStatusReturn {
         if (ghUsername) {
           // Person props ($set) overwrite on every identify; person props
           // ($set_once) only land the first time we see this user.
-          let appVersion: string | null = null;
-          try {
-            appVersion = await getVersion();
-          } catch {
-            // Optional — backend already attaches app_version to events
-          }
+          const appVersion = await getCachedAppVersion();
           const nowIso = new Date().toISOString();
           const setProps: Record<string, unknown> = {
             github_username: ghUsername,
-            last_seen_at: nowIso,
+            last_identified_at: nowIso,
           };
           if (appVersion) setProps.latest_app_version = appVersion;
           const setOnce: Record<string, unknown> = {
-            first_seen_at: nowIso,
+            first_identified_at: nowIso,
           };
           if (appVersion) setOnce.first_app_version = appVersion;
           void identifyUser(ghUsername, setProps, setOnce);

--- a/src/hooks/usePinnedProjects.ts
+++ b/src/hooks/usePinnedProjects.ts
@@ -34,6 +34,7 @@ import {
 } from '../lib/sessionRegistry';
 import { logger } from '../lib/logger';
 import { trackEvent } from '../lib/analytics';
+import { getProjectId } from '../lib/projectIdentity';
 
 /** A pinned project as the rail wants to render it. */
 export interface PinnedProjectRow {
@@ -153,7 +154,11 @@ export function usePinnedProjects(currentProjectPath: string | null): UsePinnedP
     try {
       const updated = await pinProjectApi(projectPath);
       setPinnedPaths(updated);
-      void trackEvent('project_pinned', { pin_count: updated.length });
+      void trackEvent('project_pinned', {
+        project_id: getProjectId(projectPath),
+        project_name: projectPath.split('/').pop() ?? projectPath,
+        pin_count: updated.length,
+      });
     } catch (err) {
       logger.error('[usePinnedProjects] Failed to pin project', {
         projectPath,
@@ -167,7 +172,11 @@ export function usePinnedProjects(currentProjectPath: string | null): UsePinnedP
     try {
       const updated = await unpinProjectApi(projectPath);
       setPinnedPaths(updated);
-      void trackEvent('project_unpinned', { pin_count: updated.length });
+      void trackEvent('project_unpinned', {
+        project_id: getProjectId(projectPath),
+        project_name: projectPath.split('/').pop() ?? projectPath,
+        pin_count: updated.length,
+      });
     } catch (err) {
       logger.error('[usePinnedProjects] Failed to unpin project', {
         projectPath,

--- a/src/hooks/usePinnedProjects.ts
+++ b/src/hooks/usePinnedProjects.ts
@@ -33,6 +33,7 @@ import {
   type AgentActivityStatus,
 } from '../lib/sessionRegistry';
 import { logger } from '../lib/logger';
+import { trackEvent } from '../lib/analytics';
 
 /** A pinned project as the rail wants to render it. */
 export interface PinnedProjectRow {
@@ -152,6 +153,7 @@ export function usePinnedProjects(currentProjectPath: string | null): UsePinnedP
     try {
       const updated = await pinProjectApi(projectPath);
       setPinnedPaths(updated);
+      void trackEvent('project_pinned', { pin_count: updated.length });
     } catch (err) {
       logger.error('[usePinnedProjects] Failed to pin project', {
         projectPath,
@@ -165,6 +167,7 @@ export function usePinnedProjects(currentProjectPath: string | null): UsePinnedP
     try {
       const updated = await unpinProjectApi(projectPath);
       setPinnedPaths(updated);
+      void trackEvent('project_unpinned', { pin_count: updated.length });
     } catch (err) {
       logger.error('[usePinnedProjects] Failed to unpin project', {
         projectPath,
@@ -178,6 +181,7 @@ export function usePinnedProjects(currentProjectPath: string | null): UsePinnedP
     try {
       const updated = await reorderPinsApi(orderedPaths);
       setPinnedPaths(updated);
+      void trackEvent('pins_reordered', { pin_count: updated.length });
     } catch (err) {
       logger.error('[usePinnedProjects] Failed to reorder pins', { error: String(err) });
       throw err;

--- a/src/hooks/usePreviewCapture.ts
+++ b/src/hooks/usePreviewCapture.ts
@@ -11,6 +11,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { logger } from '../lib/logger';
+import { trackEvent } from '../lib/analytics';
 
 interface UsePreviewCaptureParams {
   /** Absolute path to the project directory */
@@ -93,11 +94,13 @@ export function usePreviewCapture({
         width: Math.round(rect.width * dpr),
         height: Math.round(rect.height * dpr),
       });
+      void trackEvent('screenshot_captured', { mode: 'viewport', success: true });
       return finalPath;
     } catch (error) {
       logger.error('[Preview] Viewport capture failed', {
         error: error instanceof Error ? error.message : String(error),
       });
+      void trackEvent('screenshot_captured', { mode: 'viewport', success: false });
       return null;
     } finally {
       setIsCapturing(false);
@@ -117,11 +120,13 @@ export function usePreviewCapture({
         projectPath,
         url: captureUrl,
       });
+      void trackEvent('screenshot_captured', { mode: 'fullpage', success: true });
       return filePath;
     } catch (error) {
       logger.error('[Preview] Full page capture failed', {
         error: error instanceof Error ? error.message : String(error),
       });
+      void trackEvent('screenshot_captured', { mode: 'fullpage', success: false, fell_back: true });
       // Fall back to viewport capture if Playwright fails
       return captureForClaude();
     } finally {

--- a/src/hooks/usePreviewCapture.ts
+++ b/src/hooks/usePreviewCapture.ts
@@ -69,43 +69,61 @@ export function usePreviewCapture({
 
   // Capture viewport screenshot by capturing the window and cropping to iframe bounds
   // This captures what's actually visible on screen (including any navigation the user did in the iframe)
-  const captureForClaude = useCallback(async (): Promise<string | null> => {
-    if (isCapturing) {
-      return null;
-    }
+  const captureForClaude = useCallback(
+    // `silent` suppresses tracking when this is called from `captureFullPage`
+    // as a fallback — the user's intent was a fullpage capture, the
+    // `screenshot_captured` event for that intent already fired.
+    async (opts?: { silent?: boolean }): Promise<string | null> => {
+      if (isCapturing) {
+        return null;
+      }
 
-    setIsCapturing(true);
-    try {
-      if (!iframeWrapperRef.current) return null;
+      setIsCapturing(true);
+      try {
+        if (!iframeWrapperRef.current) return null;
 
-      const tempPath = await captureWindowScreenshot();
-      if (!tempPath) return null;
+        const tempPath = await captureWindowScreenshot();
+        if (!tempPath) return null;
 
-      const rect = iframeWrapperRef.current.getBoundingClientRect();
-      const dpr = window.devicePixelRatio || 1;
-      // Account for macOS title bar in window screenshot
-      const TITLE_BAR_HEIGHT = 31;
+        const rect = iframeWrapperRef.current.getBoundingClientRect();
+        const dpr = window.devicePixelRatio || 1;
+        // Account for macOS title bar in window screenshot
+        const TITLE_BAR_HEIGHT = 31;
 
-      const finalPath = await invoke<string>('crop_and_save_screenshot', {
-        projectPath,
-        sourcePath: tempPath,
-        x: Math.round(rect.left * dpr),
-        y: Math.round((rect.top + TITLE_BAR_HEIGHT) * dpr),
-        width: Math.round(rect.width * dpr),
-        height: Math.round(rect.height * dpr),
-      });
-      void trackEvent('screenshot_captured', { mode: 'viewport', success: true });
-      return finalPath;
-    } catch (error) {
-      logger.error('[Preview] Viewport capture failed', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      void trackEvent('screenshot_captured', { mode: 'viewport', success: false });
-      return null;
-    } finally {
-      setIsCapturing(false);
-    }
-  }, [projectPath, captureWindowScreenshot, isCapturing]);
+        const finalPath = await invoke<string>('crop_and_save_screenshot', {
+          projectPath,
+          sourcePath: tempPath,
+          x: Math.round(rect.left * dpr),
+          y: Math.round((rect.top + TITLE_BAR_HEIGHT) * dpr),
+          width: Math.round(rect.width * dpr),
+          height: Math.round(rect.height * dpr),
+        });
+        if (!opts?.silent) {
+          void trackEvent('screenshot_captured', {
+            mode: 'viewport',
+            success: true,
+            fell_back: false,
+          });
+        }
+        return finalPath;
+      } catch (error) {
+        logger.error('[Preview] Viewport capture failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        if (!opts?.silent) {
+          void trackEvent('screenshot_captured', {
+            mode: 'viewport',
+            success: false,
+            fell_back: false,
+          });
+        }
+        return null;
+      } finally {
+        setIsCapturing(false);
+      }
+    },
+    [projectPath, captureWindowScreenshot, isCapturing]
+  );
 
   // Full-page capture using Playwright (scrolls page to trigger lazy content, then captures)
   // Uses currentPage (tracked via proxy) so it captures the actual visible page,
@@ -120,15 +138,23 @@ export function usePreviewCapture({
         projectPath,
         url: captureUrl,
       });
-      void trackEvent('screenshot_captured', { mode: 'fullpage', success: true });
+      void trackEvent('screenshot_captured', {
+        mode: 'fullpage',
+        success: true,
+        fell_back: false,
+      });
       return filePath;
     } catch (error) {
       logger.error('[Preview] Full page capture failed', {
         error: error instanceof Error ? error.message : String(error),
       });
-      void trackEvent('screenshot_captured', { mode: 'fullpage', success: false, fell_back: true });
-      // Fall back to viewport capture if Playwright fails
-      return captureForClaude();
+      void trackEvent('screenshot_captured', {
+        mode: 'fullpage',
+        success: false,
+        fell_back: true,
+      });
+      // Fall back to viewport capture; suppress its own tracking event.
+      return captureForClaude({ silent: true });
     } finally {
       setIsCapturing(false);
     }

--- a/src/hooks/usePreviewConnection.ts
+++ b/src/hooks/usePreviewConnection.ts
@@ -11,6 +11,7 @@ import { listen } from '@tauri-apps/api/event';
 import { useClickOutside } from './useClickOutside';
 import { logger } from '../lib/logger';
 import { getWindowLabel } from '../lib/window';
+import { trackEvent } from '../lib/analytics';
 
 /** How often to refresh the page list (ms) */
 const PAGE_REFRESH_INTERVAL_MS = 5000;
@@ -375,11 +376,13 @@ export function usePreviewConnection({
 
   // Handlers
   const handleRefresh = useCallback(() => {
+    void trackEvent('preview_refreshed', { trigger: 'user' });
     setIframePath(currentPage);
     setCacheBuster(Date.now());
   }, [currentPage]);
 
   const handlePageSelect = useCallback((route: string) => {
+    void trackEvent('preview_page_selected');
     setCurrentPage(route);
     setIframePath(route);
     setShowPageDropdown(false);

--- a/src/hooks/usePreviewConnection.ts
+++ b/src/hooks/usePreviewConnection.ts
@@ -382,7 +382,12 @@ export function usePreviewConnection({
   }, [currentPage]);
 
   const handlePageSelect = useCallback((route: string) => {
-    void trackEvent('preview_page_selected');
+    void trackEvent('preview_page_selected', {
+      // Strip dynamic-looking segments (numeric ids, uuids) so the cardinality
+      // doesn't explode while still keeping the route shape useful.
+      route_pattern: route.replace(/\/(\d+|[0-9a-f-]{8,})/g, '/:id').slice(0, 200),
+      depth: route.split('/').filter(Boolean).length,
+    });
     setCurrentPage(route);
     setIframePath(route);
     setShowPageDropdown(false);

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -28,7 +28,7 @@ import {
 } from '../lib/window';
 import { invoke } from '@tauri-apps/api/core';
 import { logger } from '../lib/logger';
-import { trackEvent, trackError, setActiveProject } from '../lib/analytics';
+import { trackEvent, trackError, setActiveProject, trackPageview } from '../lib/analytics';
 import { getProjectId } from '../lib/projectIdentity';
 import { startProjectSession, endProjectSession } from '../lib/session';
 
@@ -222,6 +222,10 @@ export function useProjectLifecycle({
 
     void trackEvent('project_opened', { $screen_name: 'Workspace' });
     void trackEvent('project_session_started', { $screen_name: 'Workspace' });
+    // Initial workspace lands on Preview by default (web projects) or Code
+    // (generic projects). useWorkspaceLayout fires its own pageview on tab
+    // change; this seeds the first one.
+    trackPageview('Workspace - Preview');
 
     // Every active session is hot: once a project has a dev server, it
     // stays alive until the user explicitly closes it via the sidebar (or
@@ -672,6 +676,7 @@ export function useProjectLifecycle({
       });
     }
     setActiveProject(null);
+    // App.tsx fires the Dashboard pageview when view becomes 'projects'.
 
     // New model: back-to-projects is a *view switch*, not a teardown. The
     // leaving project's dev server, PTYs, and session registry entry all

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -28,7 +28,9 @@ import {
 } from '../lib/window';
 import { invoke } from '@tauri-apps/api/core';
 import { logger } from '../lib/logger';
-import { trackEvent, trackError } from '../lib/analytics';
+import { trackEvent, trackError, setActiveProject } from '../lib/analytics';
+import { getProjectId } from '../lib/projectIdentity';
+import { startProjectSession, endProjectSession } from '../lib/session';
 
 import type { AppView } from '../lib/types';
 
@@ -190,11 +192,27 @@ export function useProjectLifecycle({
     const navVersion = ++navigationVersionRef.current;
 
     logger.info(`[OpenProject] Starting: ${project.name}`, { windowLabel });
-    void trackEvent('project_opened', {
-      project_name: project.name,
-      project_path: project.path,
-      $screen_name: 'Workspace',
-    });
+
+    // Warm the project_id cache and set the active project so every subsequent
+    // event in this session auto-tags project context. We intentionally do NOT
+    // emit the raw project_path — it leaks user filesystem layout to PostHog.
+    const projectId = await getProjectId(project.path);
+    setActiveProject({ id: projectId, name: project.name });
+
+    // End any prior project session before starting a new one. Switching A→B
+    // should record A's session before opening B.
+    const priorSession = endProjectSession();
+    if (priorSession) {
+      void trackEvent('project_session_ended', {
+        project_session_id: priorSession.session_id,
+        duration_seconds: priorSession.duration_seconds,
+        reason: 'project_switched',
+      });
+    }
+    startProjectSession();
+
+    void trackEvent('project_opened', { $screen_name: 'Workspace' });
+    void trackEvent('project_session_started', { $screen_name: 'Workspace' });
 
     // Guard against concurrent opens for the same project (race condition prevention)
     if (openingProjectPathRef.current === project.path) {
@@ -639,6 +657,19 @@ export function useProjectLifecycle({
     ++navigationVersionRef.current;
 
     logger.info('[BackToProjects] Leaving session alive', { leavingProjectPath });
+
+    // End the project session. The dev server / PTYs stay alive (see comment
+    // below), but for analytics we treat returning to the dashboard as the
+    // end of the engaged session.
+    const ended = endProjectSession();
+    if (ended) {
+      void trackEvent('project_session_ended', {
+        project_session_id: ended.session_id,
+        duration_seconds: ended.duration_seconds,
+        reason: 'back_to_projects',
+      });
+    }
+    setActiveProject(null);
 
     // New model: back-to-projects is a *view switch*, not a teardown. The
     // leaving project's dev server, PTYs, and session registry entry all

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -193,11 +193,20 @@ export function useProjectLifecycle({
 
     logger.info(`[OpenProject] Starting: ${project.name}`, { windowLabel });
 
-    // Warm the project_id cache and set the active project so every subsequent
-    // event in this session auto-tags project context. We intentionally do NOT
-    // emit the raw project_path — it leaks user filesystem layout to PostHog.
-    const projectId = await getProjectId(project.path);
-    setActiveProject({ id: projectId, name: project.name });
+    // Guard against concurrent opens for the same project (race condition
+    // prevention). Must run before any tracking — otherwise a double-click
+    // emits project_opened twice.
+    if (openingProjectPathRef.current === project.path) {
+      logger.info(`[OpenProject] Already opening ${project.name}, skipping duplicate call`);
+      return;
+    }
+    openingProjectPathRef.current = project.path;
+
+    // Set the active project so every subsequent event in this session
+    // auto-tags project context. The hash is sync (FNV-1a) so this never
+    // blocks the render path. We intentionally do NOT emit the raw
+    // project_path — it leaks user filesystem layout to PostHog.
+    setActiveProject({ id: getProjectId(project.path), name: project.name });
 
     // End any prior project session before starting a new one. Switching A→B
     // should record A's session before opening B.
@@ -213,13 +222,6 @@ export function useProjectLifecycle({
 
     void trackEvent('project_opened', { $screen_name: 'Workspace' });
     void trackEvent('project_session_started', { $screen_name: 'Workspace' });
-
-    // Guard against concurrent opens for the same project (race condition prevention)
-    if (openingProjectPathRef.current === project.path) {
-      logger.info(`[OpenProject] Already opening ${project.name}, skipping duplicate call`);
-      return;
-    }
-    openingProjectPathRef.current = project.path;
 
     // Every active session is hot: once a project has a dev server, it
     // stays alive until the user explicitly closes it via the sidebar (or

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -28,7 +28,7 @@ import {
 } from '../lib/window';
 import { invoke } from '@tauri-apps/api/core';
 import { logger } from '../lib/logger';
-import { trackEvent, trackError, setActiveProject, trackPageview } from '../lib/analytics';
+import { trackEvent, trackError, setActiveProject } from '../lib/analytics';
 import { getProjectId } from '../lib/projectIdentity';
 import { startProjectSession, endProjectSession } from '../lib/session';
 
@@ -222,10 +222,8 @@ export function useProjectLifecycle({
 
     void trackEvent('project_opened', { $screen_name: 'Workspace' });
     void trackEvent('project_session_started', { $screen_name: 'Workspace' });
-    // Initial workspace lands on Preview by default (web projects) or Code
-    // (generic projects). useWorkspaceLayout fires its own pageview on tab
-    // change; this seeds the first one.
-    trackPageview('Workspace - Preview');
+    // The initial Workspace pageview is fired by useWorkspaceLayout's
+    // workspaceTab effect once the resolved tab is known.
 
     // Every active session is hot: once a project has a dev server, it
     // stays alive until the user explicitly closes it via the sidebar (or

--- a/src/hooks/useWorkspaceLayout.ts
+++ b/src/hooks/useWorkspaceLayout.ts
@@ -7,7 +7,7 @@
  * not here.
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { trackEvent, trackPageview } from '../lib/analytics';
 
 interface UseWorkspaceLayoutParams {
@@ -38,22 +38,33 @@ export function useWorkspaceLayout({ isGitHubConnected }: UseWorkspaceLayoutPara
   // keep the raw value so the user's last selection comes back on reconnect.
   const [workspaceTabRaw, setWorkspaceTabRaw] = useState<WorkspaceTab>('preview');
 
-  // Wrap the raw setter with analytics. Functional update lets us see the
-  // previous tab without re-rendering this hook on every workspaceTabRaw change.
-  const setWorkspaceTab = useCallback((tab: WorkspaceTab) => {
-    setWorkspaceTabRaw((prev) => {
-      if (prev !== tab) {
-        void trackEvent('workspace_tab_switched', { from_tab: prev, to_tab: tab });
-        trackPageview(TAB_SCREEN[tab]);
+  // Wrap the raw setter with `workspace_tab_switched` so click tracking is
+  // automatic. Capture `workspaceTabRaw` from the closure rather than from
+  // a functional updater — functional updaters fire twice under React 18
+  // StrictMode and would double-count clicks in dev/tests. The closure is
+  // refreshed on every state change anyway.
+  const setWorkspaceTab = useCallback(
+    (tab: WorkspaceTab) => {
+      if (workspaceTabRaw !== tab) {
+        void trackEvent('workspace_tab_switched', { from_tab: workspaceTabRaw, to_tab: tab });
       }
-      return tab;
-    });
-  }, []);
+      setWorkspaceTabRaw(tab);
+    },
+    [workspaceTabRaw]
+  );
 
   const workspaceTab: WorkspaceTab =
     !isGitHubConnected && (workspaceTabRaw === 'branches' || workspaceTabRaw === 'prs')
       ? 'preview'
       : workspaceTabRaw;
+
+  // Pageview tracks the *projected* tab (after the GitHub-connected gate),
+  // so a forced fallback when GitHub disconnects is recorded as a screen
+  // change. Also fires once on mount with the initial resolved tab — replaces
+  // the seed previously fired from useProjectLifecycle.
+  useEffect(() => {
+    trackPageview(TAB_SCREEN[workspaceTab]);
+  }, [workspaceTab]);
 
   // Reset layout state (when going back to projects)
   const resetLayout = useCallback(() => {

--- a/src/hooks/useWorkspaceLayout.ts
+++ b/src/hooks/useWorkspaceLayout.ts
@@ -8,11 +8,21 @@
  */
 
 import { useState, useCallback } from 'react';
+import { trackEvent, trackPageview } from '../lib/analytics';
 
 interface UseWorkspaceLayoutParams {
   /** Whether GitHub is connected for the current project */
   isGitHubConnected: boolean;
 }
+
+type WorkspaceTab = 'preview' | 'code' | 'branches' | 'prs';
+
+const TAB_SCREEN: Record<WorkspaceTab, string> = {
+  preview: 'Workspace - Preview',
+  code: 'Workspace - Code',
+  branches: 'Workspace - Branches',
+  prs: 'Workspace - Pull Requests',
+};
 
 export function useWorkspaceLayout({ isGitHubConnected }: UseWorkspaceLayoutParams) {
   // Health-logs panel visibility (takes over the terminal pane when the user
@@ -26,10 +36,21 @@ export function useWorkspaceLayout({ isGitHubConnected }: UseWorkspaceLayoutPara
   // user selected; `workspaceTab` below projects it through the GitHub-connected
   // gate so branches/prs fall back to preview when GitHub isn't available. We
   // keep the raw value so the user's last selection comes back on reconnect.
-  const [workspaceTabRaw, setWorkspaceTab] = useState<'preview' | 'code' | 'branches' | 'prs'>(
-    'preview'
-  );
-  const workspaceTab: 'preview' | 'code' | 'branches' | 'prs' =
+  const [workspaceTabRaw, setWorkspaceTabRaw] = useState<WorkspaceTab>('preview');
+
+  // Wrap the raw setter with analytics. Functional update lets us see the
+  // previous tab without re-rendering this hook on every workspaceTabRaw change.
+  const setWorkspaceTab = useCallback((tab: WorkspaceTab) => {
+    setWorkspaceTabRaw((prev) => {
+      if (prev !== tab) {
+        void trackEvent('workspace_tab_switched', { from_tab: prev, to_tab: tab });
+        trackPageview(TAB_SCREEN[tab]);
+      }
+      return tab;
+    });
+  }, []);
+
+  const workspaceTab: WorkspaceTab =
     !isGitHubConnected && (workspaceTabRaw === 'branches' || workspaceTabRaw === 'prs')
       ? 'preview'
       : workspaceTabRaw;

--- a/src/hooks/useWorkspaceLayout.ts
+++ b/src/hooks/useWorkspaceLayout.ts
@@ -43,10 +43,21 @@ export function useWorkspaceLayout({ isGitHubConnected }: UseWorkspaceLayoutPara
   // a functional updater — functional updaters fire twice under React 18
   // StrictMode and would double-count clicks in dev/tests. The closure is
   // refreshed on every state change anyway.
+  //
+  // Tag the click with the *destination* screen so this event and the
+  // `$pageview` that follows agree on what screen the user is on. Without
+  // the explicit override, enrichProperties would attach the active screen
+  // (the *origin* tab), which makes "modal_opened on Workspace - Preview"
+  // look adjacent to "Pageview /workspace-code" in the timeline and
+  // confuses everyone reading the dashboard.
   const setWorkspaceTab = useCallback(
     (tab: WorkspaceTab) => {
       if (workspaceTabRaw !== tab) {
-        void trackEvent('workspace_tab_switched', { from_tab: workspaceTabRaw, to_tab: tab });
+        void trackEvent('workspace_tab_switched', {
+          from_tab: workspaceTabRaw,
+          to_tab: tab,
+          $screen_name: TAB_SCREEN[tab],
+        });
       }
       setWorkspaceTabRaw(tab);
     },

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  trackEvent,
+  trackPageview,
+  setActiveScreen,
+  setActiveProject,
+  trackError,
+  trackSearch,
+  cancelTrackedSearch,
+} from './analytics';
+import { invoke } from '@tauri-apps/api/core';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('analytics', () => {
+  const invokeMock = vi.mocked(invoke);
+
+  beforeEach(() => {
+    invokeMock.mockClear();
+    setActiveScreen(null);
+    setActiveProject(null);
+  });
+
+  afterEach(() => {
+    setActiveScreen(null);
+    setActiveProject(null);
+  });
+
+  /** Pull the props bag the most recent track_event invocation shipped. */
+  function lastEventProps(): Record<string, unknown> {
+    const calls = invokeMock.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall?.[0]).toBe('track_event');
+    const args = lastCall?.[1] as { properties: Record<string, unknown> };
+    return args.properties;
+  }
+
+  describe('enrichProperties (via trackEvent)', () => {
+    it('attaches $session_id to every event', async () => {
+      await trackEvent('test_event');
+      const props = lastEventProps();
+      expect(typeof props.$session_id).toBe('string');
+      expect((props.$session_id as string).length).toBeGreaterThan(0);
+    });
+
+    it('attaches the active screen when one is set', async () => {
+      setActiveScreen('Dashboard');
+      await trackEvent('test_event');
+      expect(lastEventProps().$screen_name).toBe('Dashboard');
+    });
+
+    it('does not overwrite an explicit $screen_name', async () => {
+      setActiveScreen('Dashboard');
+      await trackEvent('test_event', { $screen_name: 'Override' });
+      expect(lastEventProps().$screen_name).toBe('Override');
+    });
+
+    it('omits $screen_name when no screen is active', async () => {
+      await trackEvent('test_event');
+      expect(lastEventProps().$screen_name).toBeUndefined();
+    });
+
+    it('attaches project context when set', async () => {
+      setActiveProject({ id: 'abc12345', name: 'demo', type: 'next', ageDays: 7 });
+      await trackEvent('test_event');
+      const props = lastEventProps();
+      expect(props.project_id).toBe('abc12345');
+      expect(props.project_name).toBe('demo');
+      expect(props.project_type).toBe('next');
+      expect(props.project_age_days).toBe(7);
+    });
+
+    it('omits project fields after setActiveProject(null)', async () => {
+      setActiveProject({ id: 'abc12345', name: 'demo' });
+      setActiveProject(null);
+      await trackEvent('test_event');
+      const props = lastEventProps();
+      expect(props.project_id).toBeUndefined();
+      expect(props.project_name).toBeUndefined();
+    });
+
+    it('preserves caller properties verbatim', async () => {
+      await trackEvent('test_event', { custom_prop: 'value', count: 42 });
+      const props = lastEventProps();
+      expect(props.custom_prop).toBe('value');
+      expect(props.count).toBe(42);
+    });
+  });
+
+  describe('trackPageview', () => {
+    it('emits $pageview with synthetic URL and pathname', async () => {
+      trackPageview('Workspace - Code');
+      // trackPageview internally awaits invoke; small tick to settle.
+      await Promise.resolve();
+      const props = lastEventProps();
+      expect(props.$current_url).toBe('app://ship-studio/workspace-code');
+      expect(props.$pathname).toBe('/workspace-code');
+      expect(props.$screen_name).toBe('Workspace - Code');
+    });
+
+    it('collapses runs of non-alphanumerics into a single hyphen', async () => {
+      trackPageview('Onboarding - Package Manager & Node.js');
+      await Promise.resolve();
+      const props = lastEventProps();
+      expect(props.$pathname).toBe('/onboarding-package-manager-node-js');
+    });
+  });
+
+  describe('trackError', () => {
+    it('caps error_message at 500 chars', () => {
+      const huge = 'x'.repeat(2000);
+      trackError('cmd', new Error(huge));
+      const props = lastEventProps();
+      expect((props.error_message as string).length).toBe(500);
+    });
+
+    it('records error_type from the Error name', () => {
+      trackError('cmd', new TypeError('bad'));
+      expect(lastEventProps().error_type).toBe('TypeError');
+    });
+  });
+
+  describe('trackSearch', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('debounces and fires the trimmed query after 1s', () => {
+      trackSearch('palette', 'gi');
+      trackSearch('palette', 'git');
+      vi.advanceTimersByTime(1000);
+      const props = lastEventProps();
+      expect(props.search_type).toBe('palette');
+      expect(props.query).toBe('git');
+      expect(props.query_length).toBe(3);
+    });
+
+    it('caps the query at 100 chars', () => {
+      const huge = 'a'.repeat(500);
+      trackSearch('palette', huge);
+      vi.advanceTimersByTime(1000);
+      const props = lastEventProps();
+      expect((props.query as string).length).toBe(100);
+      expect(props.query_length).toBe(500);
+    });
+
+    it('cancelTrackedSearch drops a pending fire', () => {
+      trackSearch('palette', 'foo');
+      cancelTrackedSearch('palette');
+      vi.advanceTimersByTime(2000);
+      // No track_event call should have happened.
+      expect(invokeMock).not.toHaveBeenCalled();
+    });
+
+    it('skips empty queries', () => {
+      trackSearch('palette', '   ');
+      vi.advanceTimersByTime(2000);
+      expect(invokeMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -5,10 +5,90 @@
  * All events are sent through the Tauri IPC bridge to the Rust backend,
  * which forwards them to PostHog. The API key never touches the frontend.
  *
+ * Every event flows through `enrichProperties` which auto-attaches:
+ * - `$session_id` — current app session (PostHog standard)
+ * - `$screen_name` — current screen, if a callsite hasn't set one explicitly
+ * - `project_id` / `project_name` / `project_type` / `project_age_days` — when in a project
+ * - `project_session_id` — current project session, when one is active
+ *
+ * Call `setActiveScreen()` and `setActiveProject()` from view-switching code
+ * so every event picks up correct context without per-call boilerplate.
+ *
  * @module lib/analytics
  */
 
 import { invoke } from '@tauri-apps/api/core';
+import { getAppSessionId, getProjectSessionId } from './session';
+
+// ============ Active Context ============
+
+interface ProjectContext {
+  /** 12-char hashed path (privacy-safe, stable across launches) */
+  id: string;
+  /** Human-readable folder name */
+  name: string;
+  /** Detected framework: next, vite, astro, etc. */
+  type?: string;
+  /** Days since the project folder was created */
+  ageDays?: number;
+}
+
+let activeScreen: string | null = null;
+let activeProject: ProjectContext | null = null;
+
+/**
+ * Set the current screen. Future events that don't pass `$screen_name`
+ * explicitly will be tagged with this value. Pass null to clear.
+ */
+export function setActiveScreen(screen: string | null): void {
+  activeScreen = screen;
+}
+
+/**
+ * Set the current project context. Pass null when leaving a project (e.g.
+ * back to dashboard). Future events will auto-include project_id, name,
+ * type, and age.
+ */
+export function setActiveProject(ctx: ProjectContext | null): void {
+  activeProject = ctx;
+}
+
+/**
+ * Build the property bag we ship to PostHog. Pulls in standard context
+ * (screen, app session, project) without overwriting anything the caller
+ * passed explicitly.
+ */
+function enrichProperties(properties?: Record<string, unknown> | null): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...(properties ?? {}) };
+
+  if (!('$screen_name' in out) && activeScreen) {
+    out.$screen_name = activeScreen;
+  }
+
+  if (!('$session_id' in out)) {
+    out.$session_id = getAppSessionId();
+  }
+
+  const projSession = getProjectSessionId();
+  if (projSession && !('project_session_id' in out)) {
+    out.project_session_id = projSession;
+  }
+
+  if (activeProject) {
+    if (!('project_id' in out)) out.project_id = activeProject.id;
+    if (!('project_name' in out)) out.project_name = activeProject.name;
+    if (activeProject.type && !('project_type' in out)) {
+      out.project_type = activeProject.type;
+    }
+    if (typeof activeProject.ageDays === 'number' && !('project_age_days' in out)) {
+      out.project_age_days = activeProject.ageDays;
+    }
+  }
+
+  return out;
+}
+
+// ============ Core Tracking ============
 
 /**
  * Track an analytics event. Fire-and-forget — never throws.
@@ -23,7 +103,7 @@ export async function trackEvent(
   try {
     await invoke('track_event', {
       eventName,
-      properties: properties ?? null,
+      properties: enrichProperties(properties),
       distinctId: null,
     });
   } catch {
@@ -32,20 +112,34 @@ export async function trackEvent(
 }
 
 /**
+ * Track a screen view. Sets the active screen *and* sends a `$pageview`
+ * event so PostHog's path/screen analytics light up. Use this whenever
+ * the user navigates between top-level views (dashboard, workspace tabs,
+ * onboarding steps).
+ */
+export function trackPageview(screen: string): void {
+  setActiveScreen(screen);
+  void trackEvent('$pageview', { $screen_name: screen });
+}
+
+/**
  * Identify a user by linking their device to a known user ID.
  * Call this when the user authenticates (e.g., GitHub login).
  *
  * @param userId - Unique user identifier (e.g., GitHub username)
- * @param properties - Optional person properties ($set)
+ * @param properties - Person properties merged via PostHog `$set` (always overwrite)
+ * @param setOnce - Person properties merged via `$set_once` (preserved on later identifies)
  */
 export async function identifyUser(
   userId: string,
-  properties?: Record<string, unknown>
+  properties?: Record<string, unknown>,
+  setOnce?: Record<string, unknown>
 ): Promise<void> {
   try {
     await invoke('identify_user', {
       userId,
       properties: properties ?? null,
+      setOnce: setOnce ?? null,
     });
   } catch {
     // Never let analytics break the app
@@ -82,7 +176,7 @@ export async function setAnalyticsEnabled(enabled: boolean): Promise<void> {
  *
  * @param action - What the user was trying to do (e.g., "git_push", "plugin_install")
  * @param error - The caught error (string, Error, or unknown)
- * @param screenName - Screen where the error occurred
+ * @param screenName - Screen where the error occurred (overrides active screen)
  */
 export function trackError(action: string, error: unknown, screenName?: string): void {
   let message = 'Unknown error';
@@ -91,7 +185,6 @@ export function trackError(action: string, error: unknown, screenName?: string):
   if (error instanceof Error) {
     message = error.message;
     errorType = error.name || 'Error';
-    // Include cause if available
     const cause = (error as Error & { cause?: unknown }).cause;
     if (cause instanceof Error) {
       message += ` (${cause.message})`;
@@ -106,12 +199,14 @@ export function trackError(action: string, error: unknown, screenName?: string):
     errorType = 'object';
   }
 
-  void trackEvent('error_occurred', {
+  const props: Record<string, unknown> = {
     action,
     error_message: message.slice(0, 500), // Cap length for PostHog
     error_type: errorType,
-    $screen_name: screenName ?? 'Ship Studio',
-  });
+  };
+  if (screenName) props.$screen_name = screenName;
+
+  void trackEvent('error_occurred', props);
 }
 
 // ============ Debounced Search Tracking ============
@@ -125,7 +220,7 @@ const searchTimers: Record<string, ReturnType<typeof setTimeout>> = {};
  *
  * @param searchType - Category of search (e.g., "project_search", "skills_search")
  * @param query - The raw search string
- * @param screenName - Screen name for PostHog (e.g., "Dashboard")
+ * @param screenName - Screen name override (defaults to active screen)
  */
 export function trackSearch(searchType: string, query: string, screenName?: string): void {
   if (searchTimers[searchType]) clearTimeout(searchTimers[searchType]);
@@ -133,10 +228,11 @@ export function trackSearch(searchType: string, query: string, screenName?: stri
   if (!query.trim()) return;
 
   searchTimers[searchType] = setTimeout(() => {
-    void trackEvent('search_performed', {
+    const props: Record<string, unknown> = {
       search_type: searchType,
       query: query.trim(),
-      $screen_name: screenName ?? 'Ship Studio',
-    });
+    };
+    if (screenName) props.$screen_name = screenName;
+    void trackEvent('search_performed', props);
   }, 1000);
 }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -246,3 +246,15 @@ export function trackSearch(searchType: string, query: string, screenName?: stri
     void trackEvent('search_performed', props);
   }, 1000);
 }
+
+/**
+ * Cancel any pending debounced search for the given type. Call when the
+ * surface that owns the search closes — otherwise a search event can fire
+ * after its parent (e.g. a closed palette) is gone, polluting analytics.
+ */
+export function cancelTrackedSearch(searchType: string): void {
+  if (searchTimers[searchType]) {
+    clearTimeout(searchTimers[searchType]);
+    delete searchTimers[searchType];
+  }
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -112,14 +112,22 @@ export async function trackEvent(
 }
 
 /**
- * Track a screen view. Sets the active screen *and* sends a `$pageview`
- * event so PostHog's path/screen analytics light up. Use this whenever
- * the user navigates between top-level views (dashboard, workspace tabs,
- * onboarding steps).
+ * Track a screen view. Sets the active screen and sends a `$pageview` event
+ * with a synthetic `app://ship-studio/<slug>` URL so PostHog's URL-keyed
+ * dashboards (Paths, Web Analytics) work. Call on every top-level view
+ * change (dashboard, workspace tabs, onboarding steps).
  */
 export function trackPageview(screen: string): void {
   setActiveScreen(screen);
-  void trackEvent('$pageview', { $screen_name: screen });
+  const slug = screen
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9/-]/g, '');
+  void trackEvent('$pageview', {
+    $screen_name: screen,
+    $current_url: `app://ship-studio/${slug}`,
+    $pathname: `/${slug}`,
+  });
 }
 
 /**

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -119,10 +119,12 @@ export async function trackEvent(
  */
 export function trackPageview(screen: string): void {
   setActiveScreen(screen);
+  // Collapse non-alphanumerics (spaces, dashes, etc.) into a single hyphen so
+  // "Workspace - Preview" becomes "workspace-preview", not "workspace---preview".
   const slug = screen
     .toLowerCase()
-    .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9/-]/g, '');
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
   void trackEvent('$pageview', {
     $screen_name: screen,
     $current_url: `app://ship-studio/${slug}`,

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -223,10 +223,15 @@ export function trackError(action: string, error: unknown, screenName?: string):
 
 const searchTimers: Record<string, ReturnType<typeof setTimeout>> = {};
 
+/** Cap on every query that lands in PostHog, regardless of search type. */
+const SEARCH_QUERY_CAP = 100;
+
 /**
  * Track a search query with 1-second debounce.
  * Call this on every keystroke — it only fires after the user stops typing.
- * Empty queries are ignored.
+ * Empty queries are ignored. The query is capped at SEARCH_QUERY_CAP chars
+ * so a paste of an arbitrary string into a search box can't dump unbounded
+ * user content to analytics.
  *
  * @param searchType - Category of search (e.g., "project_search", "skills_search")
  * @param query - The raw search string
@@ -235,12 +240,14 @@ const searchTimers: Record<string, ReturnType<typeof setTimeout>> = {};
 export function trackSearch(searchType: string, query: string, screenName?: string): void {
   if (searchTimers[searchType]) clearTimeout(searchTimers[searchType]);
 
-  if (!query.trim()) return;
+  const trimmed = query.trim();
+  if (!trimmed) return;
 
   searchTimers[searchType] = setTimeout(() => {
     const props: Record<string, unknown> = {
       search_type: searchType,
-      query: query.trim(),
+      query: trimmed.slice(0, SEARCH_QUERY_CAP),
+      query_length: trimmed.length,
     };
     if (screenName) props.$screen_name = screenName;
     void trackEvent('search_performed', props);

--- a/src/lib/appLifecycle.ts
+++ b/src/lib/appLifecycle.ts
@@ -17,12 +17,22 @@ import { logger } from './logger';
 /** Fire `app_idle_detected` after this many ms of no user input. */
 const IDLE_THRESHOLD_MS = 5 * 60 * 1000;
 
+/**
+ * Window we hold the close open for so the analytics IPC + Rust HTTP
+ * request can leave the box. There's no flush handle from PostHog's
+ * fire-and-forget send, so this is empirical.
+ */
+const QUIT_FLUSH_DELAY_MS = 200;
+
 let installed = false;
 let idleTimer: ReturnType<typeof setTimeout> | null = null;
 let isIdle = false;
-let isFocused = true;
+// Use document.hasFocus() — the app may have launched backgrounded, in which
+// case the first blur would otherwise record focus_duration since module load.
+let isFocused = typeof document !== 'undefined' ? document.hasFocus() : true;
 let lastFocusedAt = Date.now();
 let appQuitFired = false;
+let quitInProgress = false;
 
 /**
  * Install lifecycle listeners. Idempotent — calling more than once is a
@@ -67,13 +77,36 @@ export function installAppLifecycleTracking(): () => void {
   window.addEventListener('touchstart', onActivity, { passive: true });
 
   // Tauri-level: OS-initiated close (cmd+Q, red traffic light, alt+f4).
-  // Event payload is ignored; we just want to flush before the window dies.
+  // We preventDefault, fire events, wait briefly for the IPC + HTTP send
+  // to leave the box, then destroy() — destroy bypasses onCloseRequested
+  // so we don't re-enter this handler.
   let unlistenClose: (() => void) | null = null;
+  // Cleanup may run before the listener-registration promise resolves
+  // (StrictMode mount→unmount→remount). Track a cancellation flag so a
+  // late-resolving promise unregisters itself rather than leaking the
+  // listener past the cleanup boundary.
+  let cleanupRan = false;
   void getCurrentWindow()
-    .onCloseRequested(() => {
-      fireAppQuit('os_close');
+    .onCloseRequested((event) => {
+      if (quitInProgress) return;
+      quitInProgress = true;
+      event.preventDefault();
+      void (async () => {
+        fireAppQuit('os_close');
+        await new Promise((resolve) => setTimeout(resolve, QUIT_FLUSH_DELAY_MS));
+        try {
+          await getCurrentWindow().destroy();
+        } catch (err) {
+          logger.warn('[appLifecycle] window.destroy failed', { error: String(err) });
+        }
+      })();
     })
     .then((fn) => {
+      if (cleanupRan) {
+        // Provider already torn down; immediately unregister.
+        fn();
+        return;
+      }
       unlistenClose = fn;
     })
     .catch((err) =>
@@ -83,6 +116,7 @@ export function installAppLifecycleTracking(): () => void {
   resetIdleTimer();
 
   return () => {
+    cleanupRan = true;
     window.removeEventListener('focus', onFocus);
     window.removeEventListener('blur', onBlur);
     window.removeEventListener('mousemove', onActivity);
@@ -134,9 +168,10 @@ function fireAppQuit(reason: 'os_close' | 'user_action'): void {
  * quit reason is recorded.
  */
 export async function quitAppWithTracking(): Promise<void> {
+  if (quitInProgress) return;
+  quitInProgress = true;
   fireAppQuit('user_action');
-  // Give the fire-and-forget HTTP requests on the Rust side a small window
-  // to leave the box. They're async and we don't have a flush handle.
-  await new Promise((resolve) => setTimeout(resolve, 200));
+  // Same flush window the OS-close path uses.
+  await new Promise((resolve) => setTimeout(resolve, QUIT_FLUSH_DELAY_MS));
   await exit(0);
 }

--- a/src/lib/appLifecycle.ts
+++ b/src/lib/appLifecycle.ts
@@ -1,0 +1,142 @@
+/**
+ * App-level lifecycle analytics: window focus/blur, idle detection, quit.
+ *
+ * Wires into Tauri's window events and DOM activity events so PostHog has a
+ * clean picture of when users are *actively* using the app vs. having it
+ * sitting in the background.
+ *
+ * @module lib/appLifecycle
+ */
+
+import { exit } from '@tauri-apps/plugin-process';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import { trackEvent } from './analytics';
+import { endProjectSession } from './session';
+import { logger } from './logger';
+
+/** Fire `app_idle_detected` after this many ms of no user input. */
+const IDLE_THRESHOLD_MS = 5 * 60 * 1000;
+
+let installed = false;
+let idleTimer: ReturnType<typeof setTimeout> | null = null;
+let isIdle = false;
+let isFocused = true;
+let lastFocusedAt = Date.now();
+let appQuitFired = false;
+
+/**
+ * Install lifecycle listeners. Idempotent — calling more than once is a
+ * no-op. Returns a cleanup function for tests/HMR.
+ */
+export function installAppLifecycleTracking(): () => void {
+  if (installed) return () => {};
+  installed = true;
+
+  const onActivity = () => {
+    if (isIdle) {
+      isIdle = false;
+      void trackEvent('app_idle_resumed');
+    }
+    resetIdleTimer();
+  };
+
+  const onFocus = () => {
+    if (!isFocused) {
+      isFocused = true;
+      lastFocusedAt = Date.now();
+      void trackEvent('app_window_focused');
+      onActivity();
+    }
+  };
+
+  const onBlur = () => {
+    if (isFocused) {
+      isFocused = false;
+      void trackEvent('app_window_blurred', {
+        focus_duration_ms: Date.now() - lastFocusedAt,
+      });
+    }
+  };
+
+  // DOM-level signals — covers in-app activity and tab switches.
+  window.addEventListener('focus', onFocus);
+  window.addEventListener('blur', onBlur);
+  window.addEventListener('mousemove', onActivity, { passive: true });
+  window.addEventListener('keydown', onActivity);
+  window.addEventListener('scroll', onActivity, { passive: true });
+  window.addEventListener('touchstart', onActivity, { passive: true });
+
+  // Tauri-level: OS-initiated close (cmd+Q, red traffic light, alt+f4).
+  // Event payload is ignored; we just want to flush before the window dies.
+  let unlistenClose: (() => void) | null = null;
+  void getCurrentWindow()
+    .onCloseRequested(() => {
+      fireAppQuit('os_close');
+    })
+    .then((fn) => {
+      unlistenClose = fn;
+    })
+    .catch((err) =>
+      logger.warn('[appLifecycle] onCloseRequested listener failed', { error: String(err) })
+    );
+
+  resetIdleTimer();
+
+  return () => {
+    window.removeEventListener('focus', onFocus);
+    window.removeEventListener('blur', onBlur);
+    window.removeEventListener('mousemove', onActivity);
+    window.removeEventListener('keydown', onActivity);
+    window.removeEventListener('scroll', onActivity);
+    window.removeEventListener('touchstart', onActivity);
+    if (unlistenClose) unlistenClose();
+    if (idleTimer) clearTimeout(idleTimer);
+    installed = false;
+  };
+}
+
+function resetIdleTimer(): void {
+  if (idleTimer) clearTimeout(idleTimer);
+  idleTimer = setTimeout(() => {
+    isIdle = true;
+    void trackEvent('app_idle_detected', { threshold_ms: IDLE_THRESHOLD_MS });
+  }, IDLE_THRESHOLD_MS);
+}
+
+/**
+ * Fire `app_quit` plus any pending project_session_ended exactly once.
+ * The Tauri close-requested handler and the explicit quit-button paths
+ * both call this — the `appQuitFired` guard makes a duplicate call
+ * (e.g. user confirms quit, then OS sends close-requested) safe.
+ */
+function fireAppQuit(reason: 'os_close' | 'user_action'): void {
+  if (appQuitFired) return;
+  appQuitFired = true;
+
+  // Flush any open project session so the duration lands.
+  const ended = endProjectSession();
+  if (ended) {
+    void trackEvent('project_session_ended', {
+      project_session_id: ended.session_id,
+      duration_seconds: ended.duration_seconds,
+      reason: 'app_quit',
+    });
+  }
+
+  void trackEvent('app_quit', { reason });
+}
+
+/**
+ * Programmatic quit. Fires app_quit, gives the analytics request a moment
+ * to flush, then terminates the process.
+ *
+ * Use this instead of calling `exit(0)` directly from UI code so the
+ * quit reason is recorded.
+ */
+export async function quitAppWithTracking(): Promise<void> {
+  fireAppQuit('user_action');
+  // Give the fire-and-forget HTTP requests on the Rust side a small window
+  // to leave the box. They're async and we don't have a flush handle.
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  await exit(0);
+}

--- a/src/lib/code.ts
+++ b/src/lib/code.ts
@@ -9,6 +9,19 @@
 
 import { invoke } from '@tauri-apps/api/core';
 
+/**
+ * Extract a file extension for analytics. Returns the trailing extension
+ * (lowercase, no dot) when the basename contains a dot AFTER the first
+ * character, otherwise an empty string. Avoids classifying `Dockerfile` as
+ * extension `Dockerfile` and `.gitignore` as `gitignore`.
+ */
+export function fileExtensionForAnalytics(path: string): string {
+  const base = path.split('/').pop() ?? '';
+  const dot = base.lastIndexOf('.');
+  if (dot <= 0) return ''; // no dot, or only a leading dot (`.gitignore`)
+  return base.slice(dot + 1).toLowerCase();
+}
+
 /** A file or directory entry from the backend. */
 export interface FileEntry {
   name: string;

--- a/src/lib/projectIdentity.ts
+++ b/src/lib/projectIdentity.ts
@@ -1,0 +1,49 @@
+/**
+ * Stable, privacy-safe project identity for analytics.
+ *
+ * Project paths can leak user data (client names, repo names on disk). We
+ * derive a 12-char hash of the path that's stable across launches and use
+ * that as `project_id` in PostHog events. Project names are still emitted
+ * as `project_name` for human readability in the PostHog UI.
+ *
+ * @module lib/projectIdentity
+ */
+
+import { logger } from './logger';
+
+const idCache = new Map<string, string>();
+
+/**
+ * Async: compute and cache the 12-char project_id for a path. Call this on
+ * project open so the sync getter is hot for `enrichProperties`.
+ */
+export async function getProjectId(path: string): Promise<string> {
+  const cached = idCache.get(path);
+  if (cached) return cached;
+
+  try {
+    const data = new TextEncoder().encode(path);
+    const buf = await crypto.subtle.digest('SHA-256', data);
+    const hex = Array.from(new Uint8Array(buf))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+    const id = hex.slice(0, 12);
+    idCache.set(path, id);
+    return id;
+  } catch (e) {
+    logger.warn('[projectIdentity] sha256 failed, falling back to fnv1a', { error: String(e) });
+    let h = 2166136261;
+    for (let i = 0; i < path.length; i++) {
+      h ^= path.charCodeAt(i);
+      h = Math.imul(h, 16777619);
+    }
+    const id = (h >>> 0).toString(16).padStart(8, '0');
+    idCache.set(path, id);
+    return id;
+  }
+}
+
+/** Sync read of the cached project_id. Returns undefined if not yet warmed. */
+export function getCachedProjectId(path: string): string | undefined {
+  return idCache.get(path);
+}

--- a/src/lib/projectIdentity.ts
+++ b/src/lib/projectIdentity.ts
@@ -2,48 +2,35 @@
  * Stable, privacy-safe project identity for analytics.
  *
  * Project paths can leak user data (client names, repo names on disk). We
- * derive a 12-char hash of the path that's stable across launches and use
- * that as `project_id` in PostHog events. Project names are still emitted
- * as `project_name` for human readability in the PostHog UI.
+ * derive an 8-char hex hash of the path that's stable across launches and
+ * use that as `project_id` in PostHog events. Project names are still
+ * emitted as `project_name` for human readability in the PostHog UI.
+ *
+ * The hash is non-cryptographic (FNV-1a). We don't need to resist preimage
+ * attacks — we just need a stable, short, sync identifier that doesn't ship
+ * the literal path. Sync matters: enrichment and project-open run on the
+ * render path and cannot await.
  *
  * @module lib/projectIdentity
  */
 
-import { logger } from './logger';
-
 const idCache = new Map<string, string>();
 
 /**
- * Async: compute and cache the 12-char project_id for a path. Call this on
- * project open so the sync getter is hot for `enrichProperties`.
+ * Compute (and cache) the 8-char project_id for a path. Sync — safe to call
+ * inline from render-path code.
  */
-export async function getProjectId(path: string): Promise<string> {
+export function getProjectId(path: string): string {
   const cached = idCache.get(path);
   if (cached) return cached;
 
-  try {
-    const data = new TextEncoder().encode(path);
-    const buf = await crypto.subtle.digest('SHA-256', data);
-    const hex = Array.from(new Uint8Array(buf))
-      .map((b) => b.toString(16).padStart(2, '0'))
-      .join('');
-    const id = hex.slice(0, 12);
-    idCache.set(path, id);
-    return id;
-  } catch (e) {
-    logger.warn('[projectIdentity] sha256 failed, falling back to fnv1a', { error: String(e) });
-    let h = 2166136261;
-    for (let i = 0; i < path.length; i++) {
-      h ^= path.charCodeAt(i);
-      h = Math.imul(h, 16777619);
-    }
-    const id = (h >>> 0).toString(16).padStart(8, '0');
-    idCache.set(path, id);
-    return id;
+  // FNV-1a 32-bit. Stable, fast, no crypto.
+  let h = 2166136261;
+  for (let i = 0; i < path.length; i++) {
+    h ^= path.charCodeAt(i);
+    h = Math.imul(h, 16777619);
   }
-}
-
-/** Sync read of the cached project_id. Returns undefined if not yet warmed. */
-export function getCachedProjectId(path: string): string | undefined {
-  return idCache.get(path);
+  const id = (h >>> 0).toString(16).padStart(8, '0');
+  idCache.set(path, id);
+  return id;
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -16,7 +16,6 @@
  */
 
 const APP_SESSION_ID = crypto.randomUUID();
-const APP_SESSION_START = Date.now();
 
 let projectSessionId: string | null = null;
 let projectSessionStart: number | null = null;
@@ -24,11 +23,6 @@ let projectSessionStart: number | null = null;
 /** Stable for the lifetime of this app process. */
 export function getAppSessionId(): string {
   return APP_SESSION_ID;
-}
-
-/** Seconds since app boot. */
-export function getAppSessionDuration(): number {
-  return Math.round((Date.now() - APP_SESSION_START) / 1000);
 }
 
 /** Current project session ID, or null if no project is open. */

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -35,10 +35,9 @@ export function getProjectSessionId(): string | null {
  * ended (caller is responsible for firing `project_session_ended` first
  * if they want the previous session's metadata).
  */
-export function startProjectSession(): string {
+export function startProjectSession(): void {
   projectSessionId = crypto.randomUUID();
   projectSessionStart = Date.now();
-  return projectSessionId;
 }
 
 /**

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,62 @@
+/**
+ * Session tracking for analytics.
+ *
+ * Two session scopes:
+ * - **App session** — lives for the entire app process. ID generated at
+ *   module load. Used as PostHog's `$session_id` so all events from one
+ *   launch group together.
+ * - **Project session** — starts when a user opens a project, ends when
+ *   they close it or switch to another. Used to compute session length
+ *   and per-project engagement.
+ *
+ * Sessions are stored in memory only — no persistence. Quitting the app
+ * ends both implicitly.
+ *
+ * @module lib/session
+ */
+
+const APP_SESSION_ID = crypto.randomUUID();
+const APP_SESSION_START = Date.now();
+
+let projectSessionId: string | null = null;
+let projectSessionStart: number | null = null;
+
+/** Stable for the lifetime of this app process. */
+export function getAppSessionId(): string {
+  return APP_SESSION_ID;
+}
+
+/** Seconds since app boot. */
+export function getAppSessionDuration(): number {
+  return Math.round((Date.now() - APP_SESSION_START) / 1000);
+}
+
+/** Current project session ID, or null if no project is open. */
+export function getProjectSessionId(): string | null {
+  return projectSessionId;
+}
+
+/**
+ * Start a fresh project session. If one is already active it is silently
+ * ended (caller is responsible for firing `project_session_ended` first
+ * if they want the previous session's metadata).
+ */
+export function startProjectSession(): string {
+  projectSessionId = crypto.randomUUID();
+  projectSessionStart = Date.now();
+  return projectSessionId;
+}
+
+/**
+ * End the current project session. Returns metadata for the caller to
+ * include in the `project_session_ended` event, or null if no session
+ * was active.
+ */
+export function endProjectSession(): { session_id: string; duration_seconds: number } | null {
+  if (!projectSessionId || projectSessionStart === null) return null;
+  const duration_seconds = Math.round((Date.now() - projectSessionStart) / 1000);
+  const session_id = projectSessionId;
+  projectSessionId = null;
+  projectSessionStart = null;
+  return { session_id, duration_seconds };
+}


### PR DESCRIPTION
## Summary

Rebuilds PostHog event coverage from the ground up so we can answer "what do users actually do in Ship Studio" without guessing. Adds ~50 new events across 19 commits / 9 phases, with each phase reviewed by Marko (the grumpy code-review skill) and the gripes addressed before moving on.

The full event taxonomy is in [`docs/analytics.md`](./docs/analytics.md). Key additions:

- **Foundations** — `enrichProperties()` auto-attaches `$session_id`, `$screen_name`, `project_id` (sha-hashed path), `project_name`, `project_session_id` to every event. Removes the raw `project_path` leak.
- **Sessions** — app-session UUID at boot; project-session UUID per project, ended on switch / back / close / app-quit with `duration_seconds`.
- **Screens** — `$pageview` with synthetic `app://ship-studio/<slug>` URLs on every workspace tab change, dashboard, onboarding step.
- **Cmd+K palette** — `palette_opened`/`closed` with dismissal reason, `palette_command_run` with command_id, position, query, total_results, `palette_tab_switched` with cause (click vs keyboard).
- **Workspace deep features** — `screenshot_captured`, `preview_refreshed`, `preview_page_selected`, `logs_sent_to_agent` (full_buffer | selection), `browser_tools_*`, `code_file_opened`, `code_snippet_sent_to_agent`.
- **Modal lifecycle** — centralized in `ModalContext`: `modal_opened`/`modal_closed` with `duration_ms` for every registered modal, plus a provider-unmount flush so app-quit doesn't drop closes.
- **Onboarding funnel** — `setup_started` with entry_path (`wizard`|`fast_path`), `setup_step_entered`/`completed`/`skipped`/`navigated_back`, `setup_action_clicked` (install vs connect derived from `*_auth` suffix).
- **Publish/PR enrichment** — `branch_published` carries `time_since_last_publish_seconds`; `pr_created` carries `title_length`, `description_length`, `used_ai`.
- **App lifecycle** — `app_window_focused`/`blurred` (with focus_duration_ms), `app_idle_detected`/`resumed` (5-min threshold), `app_quit` with reason. OS-close path preventDefaults the close, fires events, waits 200ms for IPC flush, then destroys the window — without this, OS-initiated quits dropped final events.

### Privacy

- Project paths are never sent — only an 8-char FNV-1a `project_id` hash.
- Branch names are never sent (they routinely contain customer/codename data); `is_main` carries the meaningful signal.
- Search queries are capped at 100 chars by `trackSearch`; the original length lands in `query_length`.
- `error_message` is capped at 500 chars.
- Users can disable analytics via Settings; the Rust backend short-circuits all sends when disabled.

## Test plan

- [ ] `npx tsc --noEmit` — green
- [ ] `npx vitest run` — 407 tests pass (15 new in `src/lib/analytics.test.ts`)
- [ ] `cd src-tauri && cargo test --lib` — 194 tests pass
- [ ] `npm run check:patterns` and `npm run check:loc` — green
- [ ] Run `pnpm tauri dev` and walk through:
  - First launch → onboarding flows through every step → celebration → dashboard pageview lands in PostHog
  - Open a project → workspace pageview fires per tab as you switch (preview/code/branches/prs)
  - Cmd+K → palette_opened, type → debounced search_performed, click a row → palette_command_run with position
  - Open and close every modal → modal_opened/closed pairs, durations look right
  - Resize preview, pick a page from the dropdown, refresh → events fire
  - Send server logs / browser console / code snippet to agent → respective `*_sent_to_agent` events
  - Toggle Settings → Analytics off → no further events fire; toggle on → `analytics_enabled` fires once
  - Quit via Cmd+Q (OS close) → `app_quit { reason: 'os_close' }` + final `project_session_ended` lands in PostHog before the process dies
  - Quit via the in-app confirm modal → `app_quit { reason: 'user_action' }` lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Analytics Reference documenting events, properties, pageview/screen rules, dashboard guidance, event checklist, and privacy constraints.

* **New Features**
  * Expanded analytics across the app: lifecycle, pageviews, project sessions, UI actions, sends-to-agent, captures, and onboarding flows.
  * Added stable app and project session identifiers and lifecycle tracking (focus/quit/idle) for improved event attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->