### PR TITLE
UX polish: branch name truncation, preview dimensions, CI lint fix

### DIFF
--- a/src/components/BranchesTab.tsx
+++ b/src/components/BranchesTab.tsx
@@ -228,7 +228,9 @@ export function BranchesTab({
             <div className="branch-card-info">
               <div className="branch-card-name">
                 <BranchIcon size={14} />
-                {currentBranchInfo.name}
+                <span className="branch-card-name-text" title={currentBranchInfo.name}>
+                  {currentBranchInfo.name}
+                </span>
                 {currentBranchInfo.isDefault && <span className="branch-live-badge">Live</span>}
                 <span className="branch-card-current-label">you are here</span>
               </div>
@@ -517,7 +519,9 @@ function BranchCard({
       <div className="branch-card-info">
         <div className="branch-card-name">
           <BranchIcon size={14} />
-          {branch.name}
+          <span className="branch-card-name-text" title={branch.name}>
+            {branch.name}
+          </span>
           {branch.isDefault && <span className="branch-live-badge">Live</span>}
           {isCurrent && <span className="branch-card-current-label">you are here</span>}
         </div>

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -12,7 +12,7 @@
  * @module components/Preview
  */
 
-import { useRef, forwardRef, useImperativeHandle, useCallback, useState } from 'react';
+import { useRef, forwardRef, useImperativeHandle, useCallback, useState, useEffect } from 'react';
 import { usePreviewConnection, SERVER_MAX_RETRIES } from '../hooks/usePreviewConnection';
 import { usePreviewCapture } from '../hooks/usePreviewCapture';
 import {
@@ -223,6 +223,43 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
   });
 
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [iframeSize, setIframeSize] = useState<{ w: number; h: number } | null>(null);
+  const iframeSizeObserverRef = useRef<ResizeObserver | null>(null);
+
+  // Callback ref that observes the iframe wrapper's size and forwards the
+  // element to the capture hook's ref (used for screenshots and crop math).
+  const setIframeWrapperEl = useCallback(
+    (el: HTMLDivElement | null) => {
+      capture.iframeWrapperRef.current = el;
+
+      if (iframeSizeObserverRef.current) {
+        iframeSizeObserverRef.current.disconnect();
+        iframeSizeObserverRef.current = null;
+      }
+
+      if (el) {
+        const ro = new ResizeObserver((entries) => {
+          const entry = entries[0];
+          if (!entry) return;
+          setIframeSize({
+            w: Math.round(entry.contentRect.width),
+            h: Math.round(entry.contentRect.height),
+          });
+        });
+        ro.observe(el);
+        iframeSizeObserverRef.current = ro;
+      } else {
+        setIframeSize(null);
+      }
+    },
+    [capture.iframeWrapperRef]
+  );
+
+  useEffect(() => {
+    return () => {
+      iframeSizeObserverRef.current?.disconnect();
+    };
+  }, []);
 
   // Force refresh the preview iframe with cache busting
   // Uses currentPage (tracked via proxy) so it refreshes the actual visible page,
@@ -387,6 +424,16 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
 
         {previewPlugins}
 
+        {iframeSize && iframeSize.w > 0 && iframeSize.h > 0 && (
+          <span
+            className="preview-dimensions"
+            title="Preview dimensions"
+            aria-label={`Preview dimensions ${iframeSize.w} by ${iframeSize.h}`}
+          >
+            {iframeSize.w} × {iframeSize.h}
+          </span>
+        )}
+
         <div className="preview-breakpoints" data-education-id="breakpoints">
           {(Object.keys(BREAKPOINTS) as Breakpoint[]).map((bp) => {
             // Always show 'full' - it adapts to any size
@@ -440,7 +487,7 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
             maxHeight: '100%',
           }}
         >
-          <div ref={capture.iframeWrapperRef} className="preview-iframe-wrapper">
+          <div ref={setIframeWrapperEl} className="preview-iframe-wrapper">
             <iframe
               key={projectPath}
               ref={iframeRef}

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -425,13 +425,23 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
         {previewPlugins}
 
         {iframeSize && iframeSize.w > 0 && iframeSize.h > 0 && (
-          <span
+          <button
+            type="button"
             className="preview-dimensions"
-            title="Preview dimensions"
-            aria-label={`Preview dimensions ${iframeSize.w} by ${iframeSize.h}`}
+            title={onSendToClaude ? 'Click to send to agent' : undefined}
+            disabled={!onSendToClaude}
+            aria-label={`Preview dimensions ${iframeSize.w} by ${iframeSize.h}${
+              onSendToClaude ? ', click to send to agent' : ''
+            }`}
+            onClick={() => {
+              if (!onSendToClaude) return;
+              onSendToClaude(
+                `The preview viewport is currently ${iframeSize.w} × ${iframeSize.h} (width × height in CSS pixels).`
+              );
+            }}
           >
             {iframeSize.w} × {iframeSize.h}
-          </span>
+          </button>
         )}
 
         <div className="preview-breakpoints" data-education-id="breakpoints">

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -119,10 +119,15 @@ export function ModalProvider({ children }: ProviderProps) {
   // unmounts (app quit, hard reload). Without this, the open event has no
   // close partner and duration is lost.
   useEffect(() => {
+    // Snapshot the Map ref at mount-time so the cleanup doesn't read
+    // `openedAtRef.current` directly (lint flags ref reads in cleanup).
+    // The Map is mutated in place — never reassigned — so the captured
+    // reference stays current through the provider's lifetime.
+    const openedAtMap = openedAtRef.current;
     return () => {
       for (const id of openSetRef.current) {
         if (MODAL_TRACKING_EXCLUDED.has(id)) continue;
-        const openedAt = openedAtRef.current.get(id);
+        const openedAt = openedAtMap.get(id);
         void trackEvent(`modal_${id}_closed`, {
           modal_id: id,
           duration_ms: openedAt !== undefined ? Math.round(performance.now() - openedAt) : null,

--- a/src/hooks/usePreviewCapture.ts
+++ b/src/hooks/usePreviewCapture.ts
@@ -46,7 +46,7 @@ export function usePreviewCapture({
   const [selectionEnd, setSelectionEnd] = useState<{ x: number; y: number } | null>(null);
   const [isSelecting, setIsSelecting] = useState(false);
 
-  const iframeWrapperRef = useRef<HTMLDivElement>(null);
+  const iframeWrapperRef = useRef<HTMLDivElement | null>(null);
   const cropOverlayRef = useRef<HTMLDivElement>(null);
 
   // Shared helper: capture the current window and return the temp file path

--- a/src/styles/features/branches/main.css
+++ b/src/styles/features/branches/main.css
@@ -52,7 +52,7 @@
 }
 
 .branch-name {
-  max-width: 150px;
+  max-width: 280px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/styles/features/branches/pr-list.css
+++ b/src/styles/features/branches/pr-list.css
@@ -129,6 +129,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
+  gap: 12px;
   padding: 14px 16px;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
@@ -154,10 +155,24 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
   font-size: 14px;
   font-weight: 500;
   color: var(--text-primary);
   margin-bottom: 4px;
+}
+
+.branch-card-name > svg,
+.branch-card-name > .branch-live-badge,
+.branch-card-name > .branch-card-current-label {
+  flex-shrink: 0;
+}
+
+.branch-card-name-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .branch-card-current-label {
@@ -199,6 +214,7 @@
 .branch-card-actions {
   display: flex;
   gap: 8px;
+  flex-shrink: 0;
 }
 
 .branch-card-action {

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -186,6 +186,15 @@
   animation: spin 0.8s linear infinite;
 }
 
+.preview-dimensions {
+  margin-left: auto;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+  user-select: none;
+  white-space: nowrap;
+}
+
 .preview-breakpoints {
   display: flex;
   align-self: stretch;
@@ -198,6 +207,12 @@
   margin-bottom: -9px;
   margin-left: auto;
   margin-right: 0;
+}
+
+/* When the dimensions readout precedes the breakpoints, it owns the
+   auto-margin push so the two sit together on the right edge. */
+.preview-dimensions + .preview-breakpoints {
+  margin-left: var(--spacing-xs);
 }
 
 .breakpoint-btn {

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -188,11 +188,35 @@
 
 .preview-dimensions {
   margin-left: auto;
+  padding: 2px 6px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  font: inherit;
   font-size: 11px;
   font-variant-numeric: tabular-nums;
   color: var(--text-muted);
   user-select: none;
   white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 0.15s,
+    color 0.15s,
+    border-color 0.15s;
+}
+
+.preview-dimensions:hover:not(:disabled) {
+  background: var(--bg-tertiary);
+  border-color: var(--border);
+  color: var(--text-primary);
+}
+
+.preview-dimensions:active:not(:disabled) {
+  background: var(--border);
+}
+
+.preview-dimensions:disabled {
+  cursor: default;
 }
 
 .preview-breakpoints {


### PR DESCRIPTION
## Summary
- **Branch indicator:** bumped `.branch-name` `max-width` 150px → 280px so typical `username/branch-name` strings fit before ellipsing.
- **Branch card layout:** wrapped the branch name in a flex-shrinkable text element with ellipsis + `title` tooltip; pinned the icon, badges, and "you are here" label; locked `.branch-card-actions` against shrinkage. Long branch names no longer overlap the action buttons.
- **Preview toolbar:** new live `W × H` readout (observed via `ResizeObserver` on the iframe wrapper) sits just left of the breakpoints group. Hovering says "Click to send to agent"; clicking pipes the current viewport size into the active terminal via `onSendToClaude`.
- **CI fix:** snapshotted `openedAtRef.current` at effect-mount time in `ModalContext.tsx` so the cleanup function doesn't read the ref directly. The Map is mutated in place (never reassigned), so the captured reference stays current — same semantics, but `react-hooks/exhaustive-deps` is happy. This unblocks `lint:strict --max-warnings 0` which has been failing on main since #54.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint:strict`
- [x] `pnpm test:run` (407 pass, 4 skipped)
- [ ] Manually verify long branch name no longer overlaps Submit/Revert buttons
- [ ] Manually verify preview dimensions update on resize and that clicking sends the readout to the agent terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview toolbar now displays viewport dimensions and includes a button to send them when available

* **Bug Fixes**
  * Enhanced branch name display with improved text truncation and layout handling
  * Refined modal cleanup event tracking for proper duration calculation

* **Style**
  * Updated branch card layout with improved spacing and text constraints
  * Added styling for the dimensions display button with hover and active states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->