### PR TITLE
Improvements: red-X quit fix + resizable Inspect panel

### DIFF
--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -168,6 +168,24 @@ export interface PreviewHandle {
   isServerReady: () => boolean;
 }
 
+/** Smallest the Inspect panel can be dragged to. Below this the tab bar
+ *  dominates the panel and the user is better off closing it. */
+const INSPECT_PANEL_MIN_HEIGHT_PX = 120;
+
+/** Vertical space reserved above the Inspect panel when computing its
+ *  max height — covers the preview toolbar (~40px) plus a usable
+ *  viewport floor (~160px) so the iframe never collapses to nothing. */
+const INSPECT_VIEWPORT_RESERVE_PX = 200;
+
+/** Floor for the computed max height; ensures the panel stays resizable
+ *  in containers small enough that `clientHeight - reserve` would be
+ *  negative or absurdly small. */
+const INSPECT_PANEL_MAX_FALLBACK_PX = 160;
+
+/** Keyboard arrow-key step. Shift+arrow uses the larger step. */
+const INSPECT_PANEL_KEY_STEP_PX = 12;
+const INSPECT_PANEL_KEY_STEP_LARGE_PX = 60;
+
 export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
   {
     port = 3000,
@@ -221,6 +239,101 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
   const resize = usePreviewResize({
     iframeWrapperRef: capture.iframeWrapperRef,
   });
+
+  // Inspect-panel vertical resize. Null = use the default 1fr split from CSS;
+  // a number = explicit panel height in px (overrides via inline grid-template-rows).
+  const [inspectPanelHeight, setInspectPanelHeight] = useState<number | null>(null);
+  const [isInspectResizing, setIsInspectResizing] = useState(false);
+  const inspectPanelRef = useRef<HTMLDivElement | null>(null);
+
+  const computeMaxPanelHeight = useCallback((containerHeight: number) => {
+    return Math.max(INSPECT_PANEL_MAX_FALLBACK_PX, containerHeight - INSPECT_VIEWPORT_RESERVE_PX);
+  }, []);
+
+  const handleInspectResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const panel = inspectPanelRef.current;
+      const container = panel?.parentElement;
+      if (!panel || !container) return;
+
+      setIsInspectResizing(true);
+      document.body.style.cursor = 'ns-resize';
+      document.body.style.userSelect = 'none';
+
+      const startY = e.clientY;
+      const startHeight = panel.offsetHeight;
+      const maxPanelHeight = computeMaxPanelHeight(container.clientHeight);
+
+      let rafId: number | null = null;
+      const onMove = (ev: MouseEvent) => {
+        if (rafId !== null) return;
+        rafId = requestAnimationFrame(() => {
+          rafId = null;
+          const deltaY = startY - ev.clientY; // up = grow panel
+          const next = startHeight + deltaY;
+          setInspectPanelHeight(
+            Math.max(INSPECT_PANEL_MIN_HEIGHT_PX, Math.min(next, maxPanelHeight))
+          );
+        });
+      };
+      const onUp = () => {
+        if (rafId !== null) cancelAnimationFrame(rafId);
+        setIsInspectResizing(false);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+      };
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    },
+    [computeMaxPanelHeight]
+  );
+
+  // Keyboard support for the resize separator: arrow keys nudge, Home/End
+  // jump to the bounds. Required for users who can't drag with a pointer.
+  const handleInspectResizeKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown' && e.key !== 'Home' && e.key !== 'End') {
+        return;
+      }
+      const panel = inspectPanelRef.current;
+      const container = panel?.parentElement;
+      if (!panel || !container) return;
+      e.preventDefault();
+
+      const max = computeMaxPanelHeight(container.clientHeight);
+      const current = inspectPanelHeight ?? panel.offsetHeight;
+      const step = e.shiftKey ? INSPECT_PANEL_KEY_STEP_LARGE_PX : INSPECT_PANEL_KEY_STEP_PX;
+
+      if (e.key === 'ArrowUp') {
+        setInspectPanelHeight(Math.min(current + step, max));
+      } else if (e.key === 'ArrowDown') {
+        setInspectPanelHeight(Math.max(current - step, INSPECT_PANEL_MIN_HEIGHT_PX));
+      } else if (e.key === 'Home') {
+        setInspectPanelHeight(INSPECT_PANEL_MIN_HEIGHT_PX);
+      } else if (e.key === 'End') {
+        setInspectPanelHeight(max);
+      }
+    },
+    [inspectPanelHeight, computeMaxPanelHeight]
+  );
+
+  // Reclamp the panel height when the container resizes — without this, a
+  // user-set absolute pixel height can outgrow a shrunken window and push
+  // the viewport row to zero.
+  useEffect(() => {
+    if (!showLogs) return;
+    const container = inspectPanelRef.current?.parentElement;
+    if (!container) return;
+    const ro = new ResizeObserver(() => {
+      const max = computeMaxPanelHeight(container.clientHeight);
+      setInspectPanelHeight((prev) => (prev === null || prev <= max ? prev : max));
+    });
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, [showLogs, computeMaxPanelHeight]);
 
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [iframeSize, setIframeSize] = useState<{ w: number; h: number } | null>(null);
@@ -325,7 +438,17 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
   }
 
   return (
-    <div className="preview-container" data-logs={showLogs ? 'open' : 'closed'}>
+    <div
+      className="preview-container"
+      data-logs={showLogs ? 'open' : 'closed'}
+      style={
+        showLogs && inspectPanelHeight !== null
+          ? {
+              gridTemplateRows: `auto minmax(0, 1fr) var(--handle-size) ${inspectPanelHeight}px`,
+            }
+          : undefined
+      }
+    >
       <div className="preview-toolbar">
         {onToggleLogs && (
           <button
@@ -492,8 +615,14 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
                 ? 'calc(100% - 4px)'
                 : `${resize.customWidth + RESIZE_HANDLE_PX}px`,
             maxWidth: 'calc(100% - 4px)',
+            // While Inspect is open the bottom resize handle is hidden, so
+            // we ignore (but preserve) the user's customHeight to avoid an
+            // unreachable floating-iframe state. The value comes back when
+            // Inspect closes and the handle returns.
             height:
-              resize.customHeight === null ? '100%' : `${resize.customHeight + RESIZE_HANDLE_PX}px`,
+              resize.customHeight === null || showLogs
+                ? '100%'
+                : `${resize.customHeight + RESIZE_HANDLE_PX}px`,
             maxHeight: '100%',
           }}
         >
@@ -569,7 +698,22 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
           </div>
         </div>
       </div>
+      {showLogs && (
+        <div
+          className="inspect-resize-handle"
+          onMouseDown={handleInspectResizeStart}
+          onKeyDown={handleInspectResizeKey}
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label="Resize inspect panel"
+          tabIndex={0}
+        >
+          <div className="inspect-resize-handle-bar" />
+        </div>
+      )}
+      {isInspectResizing && <div className="inspect-resize-overlay" />}
       <InspectPanel
+        ref={inspectPanelRef}
         hidden={!showLogs}
         devServerOutput={devServerOutput}
         devServerOutputVersion={devServerOutputVersion}
@@ -595,21 +739,24 @@ interface InspectPanelProps {
   onActiveTabChange?: (tab: InspectTab) => void;
 }
 
-function InspectPanel({
-  hidden,
-  devServerOutput,
-  devServerOutputVersion,
-  onClose,
-  onSendToAgent,
-  activeTab: activeTabProp,
-  onActiveTabChange,
-}: InspectPanelProps) {
+const InspectPanel = forwardRef<HTMLDivElement, InspectPanelProps>(function InspectPanel(
+  {
+    hidden,
+    devServerOutput,
+    devServerOutputVersion,
+    onClose,
+    onSendToAgent,
+    activeTab: activeTabProp,
+    onActiveTabChange,
+  },
+  ref
+) {
   const [activeTabLocal, setActiveTabLocal] = useState<InspectTab>('logs');
   const activeTab = activeTabProp ?? activeTabLocal;
   const setActiveTab = onActiveTabChange ?? setActiveTabLocal;
 
   return (
-    <div className="preview-logs-panel" aria-hidden={hidden}>
+    <div ref={ref} className="preview-logs-panel" aria-hidden={hidden}>
       <div className="preview-logs-header">
         <div className="preview-logs-tabs" role="tablist">
           <button
@@ -676,4 +823,4 @@ function InspectPanel({
       </div>
     </div>
   );
-}
+});

--- a/src/lib/appLifecycle.ts
+++ b/src/lib/appLifecycle.ts
@@ -78,8 +78,8 @@ export function installAppLifecycleTracking(): () => void {
 
   // Tauri-level: OS-initiated close (cmd+Q, red traffic light, alt+f4).
   // We preventDefault, fire events, wait briefly for the IPC + HTTP send
-  // to leave the box, then destroy() — destroy bypasses onCloseRequested
-  // so we don't re-enter this handler.
+  // to leave the box, then exit(0) — destroy() is blocked by ACL and
+  // we want to terminate the whole process anyway.
   let unlistenClose: (() => void) | null = null;
   // Cleanup may run before the listener-registration promise resolves
   // (StrictMode mount→unmount→remount). Track a cancellation flag so a
@@ -95,9 +95,9 @@ export function installAppLifecycleTracking(): () => void {
         fireAppQuit('os_close');
         await new Promise((resolve) => setTimeout(resolve, QUIT_FLUSH_DELAY_MS));
         try {
-          await getCurrentWindow().destroy();
+          await exit(0);
         } catch (err) {
-          logger.warn('[appLifecycle] window.destroy failed', { error: String(err) });
+          logger.warn('[appLifecycle] exit failed', { error: String(err) });
         }
       })();
     })

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -11,15 +11,82 @@
    style state inside doesn't get torn down on toggle. JS sets
    `data-logs="open"` on the container when showLogs is true. */
 .preview-container {
+  /* Resize-handle thickness for both the inspect-panel handle (defined
+     here) and the inner `.preview-frame-grid` handles. MUST match
+     `RESIZE_HANDLE_PX` in `src/hooks/usePreviewResize.ts` — the
+     component reads RESIZE_HANDLE_PX when it writes an inline
+     `grid-template-rows` override on this element. */
+  --handle-size: 8px;
   flex: 1;
   display: grid;
   grid-template-rows: auto 1fr 0;
   min-height: 0;
   overflow: hidden;
+  position: relative;
 }
 
+/* When inspect is open, insert a handle-sized row for the resize handle
+   between the viewport (row 2) and the panel (row 4). The default 1fr
+   split keeps the previous 50/50 layout; an inline `gridTemplateRows`
+   override from the component supplies an explicit panel height once
+   the user drags. */
 .preview-container[data-logs='open'] {
-  grid-template-rows: auto 1fr 1fr;
+  grid-template-rows: auto minmax(0, 1fr) var(--handle-size) minmax(0, 1fr);
+}
+
+/* When the inspect panel is open, the preview's own bottom-edge vertical
+   handle would sit directly above our new inspect handle and look like a
+   doubled bar. Hide it and collapse its grid row so the iframe area
+   reaches the inspect handle cleanly. */
+.preview-container[data-logs='open'] .preview-resize-handle--vertical {
+  display: none;
+}
+
+.preview-container[data-logs='open'] .preview-frame-grid {
+  grid-template-rows: minmax(0, 1fr);
+  grid-template-areas: 'iframe right';
+}
+
+/* Inspect-panel resize handle. Mirrors the visual language of the
+   preview's vertical resize handle, but lives in the outer
+   .preview-container grid (not the .preview-frame-grid). */
+.inspect-resize-handle {
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  cursor: ns-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background var(--transition),
+    border-color var(--transition);
+}
+
+.inspect-resize-handle:hover {
+  background: var(--bg-tertiary);
+  border-color: var(--accent);
+}
+
+.inspect-resize-handle-bar {
+  width: 40px;
+  height: 2px;
+  background: var(--text-muted);
+  border-radius: 1px;
+  transition: background var(--transition);
+}
+
+.inspect-resize-handle:hover .inspect-resize-handle-bar {
+  background: var(--accent);
+}
+
+/* Full-container overlay during drag — prevents iframes inside the
+   viewport or the inspect panel from swallowing mouse events. */
+.inspect-resize-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: var(--z-dropdown);
+  cursor: ns-resize;
 }
 
 .preview-toolbar {


### PR DESCRIPTION
## Summary

- **Red traffic-light quit was silently broken.** `appLifecycle` called `getCurrentWindow().destroy()`, which is blocked by Tauri's ACL (no `core:window:allow-destroy` permission). The `preventDefault` ran but `destroy` was rejected, leaving the window stranded. Logs from prior sessions showed `"Command plugin:window|destroy not allowed by ACL"`. Switched to `exit(0)` from `plugin-process` (already permitted).
- **Inspect panel had no way to be resized.** Its grid row was hard-coded to `1fr`, so when open it always took 50% of the preview area. Added a vertical drag handle between the viewport and the panel, mirroring the look/feel of the preview's existing bottom handle (2px bar, `ns-resize` cursor, accent on hover).

### Inspect resize details

- Pointer drag with rAF-throttled mousemove and a full-container overlay during drag (so iframes inside the viewport / Browser Tools tab can't swallow events).
- Keyboard-accessible: `tabIndex={0}` on the separator + ArrowUp/ArrowDown nudge, Shift+arrow for larger steps, Home/End jump to bounds.
- `ResizeObserver` reclamps panel height when the window shrinks so an absolute-px value can't push the viewport row to zero.
- While Inspect is open the preview's bottom-edge vertical handle is hidden (it would visually double up with the new one) and the user's `customHeight` is suppressed-but-preserved — comes back when Inspect closes so a previously-floating iframe isn't lost.
- Handle thickness lives in a single CSS custom property (`--handle-size`) read by both the static rule and the JS-supplied inline grid template.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 407 passed
- [x] Red X closes the app (no more `window.destroy failed` warnings in `~/Library/Logs/ShipStudio/`)
- [x] Inspect handle drags, hover state lights up, overlay prevents iframe interception
- [ ] Keyboard: Tab to handle, ArrowUp/Down/Home/End all behave
- [ ] Shrink window after dragging panel taller — verify it reclamps instead of overflowing
- [ ] Close Inspect with `customHeight` previously set — iframe goes full-height; reopen Inspect — height suppressed; close again — iframe restores prior `customHeight`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inspect/logs panel is now vertically resizable via mouse dragging and keyboard controls (Arrow Up/Down, Home/End keys).
  * Panel height automatically adjusts to respect container boundaries.

* **Bug Fixes**
  * Improved application termination handling for OS shutdown requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->