### PR TITLE
Preview toolbar: Open in Browser button + dropdown

### DIFF
--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -33,6 +33,7 @@ import { useOptionalToast } from '../contexts/ToastContext';
 import { DevServerLogs } from './DevServerLogs';
 import { BrowserTools } from './BrowserTools';
 import { HealthTabPanel, type HealthTabPanelRef } from './HealthTabPanel';
+import { BrowserDropdown } from './BrowserDropdown';
 
 // SVG icons for breakpoints
 const BreakpointIcon = ({ type }: { type: Breakpoint }) => {
@@ -604,6 +605,8 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
             );
           })}
         </div>
+
+        {conn.serverReady && conn.currentUrl && <BrowserDropdown url={conn.currentUrl} />}
       </div>
       <div
         className="preview-viewport"


### PR DESCRIPTION
## Summary

- Adds the existing `BrowserDropdown` to the preview toolbar, right of the breakpoint buttons.
- Click opens the default browser; hover reveals the picker (Safari, Chrome, Firefox, Arc, Brave, Edge).
- Same component already used by the sidebar Dev server row — no new CSS, no new behavior, just a new render site.
- Conditionally rendered on `serverReady && currentUrl` so it doesn't show before the iframe has a target.

## Test plan

- [ ] Open a project, wait for the dev server.
- [ ] Verify the new button sits to the right of the breakpoint buttons in the preview toolbar.
- [ ] Click → default browser opens to the dev server URL.
- [ ] Hover → dropdown lists all detected browsers; each option opens that browser.
- [ ] Restart dev server → button hides during restart, reappears once ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)