### PR TITLE
Sidebar: move agent-picker caret to the right

### DIFF
--- a/src/components/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar.tsx
@@ -992,6 +992,19 @@ function SidebarSection({
                 className={`sidebar-section-add-footer-group ${hasMultipleOptions ? 'has-caret' : ''}`}
                 ref={footerWrapRef}
               >
+                <button
+                  type="button"
+                  className="toolbar-icon-btn sidebar-section-add-footer"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setFooterPickerOpen(false);
+                    onAdd();
+                  }}
+                  aria-label={addFooterLabel}
+                >
+                  <span>{addFooterLabel}</span>
+                  {addShortcut && <span className="capture-shortcut">{addShortcut}</span>}
+                </button>
                 {hasMultipleOptions && (
                   <button
                     type="button"
@@ -1007,19 +1020,6 @@ function SidebarSection({
                     <ChevronIcon size={12} />
                   </button>
                 )}
-                <button
-                  type="button"
-                  className="toolbar-icon-btn sidebar-section-add-footer"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setFooterPickerOpen(false);
-                    onAdd();
-                  }}
-                  aria-label={addFooterLabel}
-                >
-                  <span>{addFooterLabel}</span>
-                  {addShortcut && <span className="capture-shortcut">{addShortcut}</span>}
-                </button>
               </div>
               {footerPickerOpen &&
                 addOptions &&

--- a/src/styles/features/workspace/sidebar.css
+++ b/src/styles/features/workspace/sidebar.css
@@ -581,18 +581,18 @@
   border-radius: var(--radius);
 }
 
-/* When the group includes the caret (rendered to the *left* of the main
-   button), the main button gives up its left border + corners so the
-   two segments read as one pill. The right corners pick up the base
+/* When the group includes the caret (rendered to the *right* of the main
+   button), the main button gives up its right border + corners so the
+   two segments read as one pill. The left corners pick up the base
    --radius from .toolbar-icon-btn. */
 .sidebar-section-add-footer-group.has-caret button.sidebar-section-add-footer {
   flex: 1;
   width: auto;
-  border-top-right-radius: var(--radius);
-  border-bottom-right-radius: var(--radius);
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  border-left: none;
+  border-top-left-radius: var(--radius);
+  border-bottom-left-radius: var(--radius);
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: none;
 }
 
 /* Corners are set explicitly because the sidebar-wide
@@ -602,18 +602,18 @@
   width: 28px;
   padding: 0;
   flex: 0 0 auto;
-  border-top-left-radius: var(--radius);
-  border-bottom-left-radius: var(--radius);
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
+  border-top-right-radius: var(--radius);
+  border-bottom-right-radius: var(--radius);
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
-/* The visible seam between the two segments is the caret's right border
-   (the main button's left border was removed so the pill reads as one).
+/* The visible seam between the two segments is the caret's left border
+   (the main button's right border was removed so the pill reads as one).
    Brighten that seam whenever either half is hovered, otherwise hovering
-   "Add new agent" leaves a stale dim line on its left edge. */
+   "Add new agent" leaves a stale dim line on its right edge. */
 .sidebar-section-add-footer-group.has-caret:hover button.sidebar-section-add-footer-caret {
-  border-right-color: var(--text-muted);
+  border-left-color: var(--text-muted);
 }
 
 .workspace-sidebar button.sidebar-section-add-footer-caret.is-open svg {


### PR DESCRIPTION
Carets sit on the right by convention; having it on the left of the "Add new agent" pill read backwards. JSX source-order swap plus mirrored border-radius / seam-border rules.

Before: `[v] Add new agent ⌘T`
After: `Add new agent ⌘T [v]`

## Test plan

- [ ] Picker opens from the right caret and lists Claude Code / Codex / Opencode
- [ ] Hover state on either half brightens the seam between them
- [ ] Single-agent install still renders as a flat pill (no caret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dropdown picker for multiple add-options in the sidebar's add button
  * The add action now features a caret control to toggle additional options
  * Improved visual design with refined button styling for the multi-option interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->