### PR TITLE
Improvements: side-by-side agents + multiple fixes

### DIFF
--- a/scripts/check-loc-limits.sh
+++ b/scripts/check-loc-limits.sh
@@ -31,13 +31,15 @@ echo
 echo "Components (.tsx limit 1200):"
 # WorkspaceView + App.tsx got denser with the multi-project multitasking
 # work (per-project tab state, per-project dev servers, attach-based PTY
-# sessions). Raised deliberately — splitting further is on the roadmap but
+# sessions) and again with the side-by-side agents feature (per-pane
+# state, split rendering, drag handles). Raised deliberately — extracting
+# a TerminalPanes sub-component from WorkspaceView is on the roadmap but
 # doesn't belong in the same PR as the feature itself.
-check_file src/components/WorkspaceView.tsx 1400
+check_file src/components/WorkspaceView.tsx 1500
 check_file src/components/ProjectList.tsx 800
 check_file src/components/PluginManager.tsx 700
 check_file src/components/ImportProject.tsx 500
-check_file src/App.tsx 1200
+check_file src/App.tsx 1250
 echo
 echo "CSS (limit 1200 per file):"
 while IFS= read -r f; do

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,6 +164,14 @@ function AppContents({ initialProjectPath }: AppProps) {
     getActiveTabAgent,
     restoreTerminalTabs,
     ensureProjectSeeded,
+    splitPaneTabIds,
+    splitPaneSizes,
+    enableSplitView,
+    disableSplitView,
+    setSplitPaneTab,
+    addSplitPane,
+    removeSplitPane,
+    setSplitPaneSizes,
   } = useTerminalManagement(currentProject?.path ?? null);
 
   // Mirror EVERY active session's tabs into the session registry so the
@@ -640,6 +648,14 @@ function AppContents({ initialProjectPath }: AppProps) {
       focusActiveTerminal,
       switchTabAgent,
       getActiveTabAgent,
+      splitPaneTabIds,
+      splitPaneSizes,
+      enableSplitView,
+      disableSplitView,
+      setSplitPaneTab,
+      addSplitPane,
+      removeSplitPane,
+      setSplitPaneSizes,
     }),
     [
       terminalTabs,
@@ -654,6 +670,14 @@ function AppContents({ initialProjectPath }: AppProps) {
       focusActiveTerminal,
       switchTabAgent,
       getActiveTabAgent,
+      splitPaneTabIds,
+      splitPaneSizes,
+      enableSplitView,
+      disableSplitView,
+      setSplitPaneTab,
+      addSplitPane,
+      removeSplitPane,
+      setSplitPaneSizes,
     ]
   );
 

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -606,7 +606,7 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
           })}
         </div>
 
-        {conn.serverReady && conn.currentUrl && <BrowserDropdown url={conn.currentUrl} />}
+        {conn.serverReady && conn.externalUrl && <BrowserDropdown url={conn.externalUrl} />}
       </div>
       <div
         className="preview-viewport"

--- a/src/components/ProjectSettingsModal.tsx
+++ b/src/components/ProjectSettingsModal.tsx
@@ -57,7 +57,7 @@ export function ProjectSettingsModal({
       <>
         <p
           style={{
-            padding: '0 var(--spacing-xl) var(--spacing-md)',
+            padding: 'var(--spacing-lg) var(--spacing-xl) var(--spacing-md)',
             color: 'var(--text-secondary)',
             fontSize: 13,
           }}

--- a/src/components/PublishBranchDropdown.tsx
+++ b/src/components/PublishBranchDropdown.tsx
@@ -120,6 +120,20 @@ export function PublishBranchDropdown({
   }, [onModalClose]);
   useClickOutside(dropdownRef, closeDropdown, isOpen, excludeClickOutsideSelector);
 
+  // Drop a stale `success` state when the dropdown closes by any path —
+  // click-outside, toggle, controlled-mode close, etc. Without this, the
+  // user dismissing the "Changes synced — Done" view without clicking
+  // Done would see the same stale view next time they opened the
+  // dropdown, even after making new changes. Resetting only `success`
+  // (not `error` or `publishing`) keeps useful state around: errors
+  // remain visible on reopen so the user can retry, and an in-flight
+  // publish keeps reporting its progress.
+  useEffect(() => {
+    if (!isOpen && publishState.status === 'success') {
+      setPublishState({ status: 'idle' });
+    }
+  }, [isOpen, publishState.status]);
+
   const handlePublish = async () => {
     logger.info('Starting publish', { branch: currentBranch, isMainBranch, projectPath });
     setIsPublishing(true);

--- a/src/components/TerminalSplitDividers.tsx
+++ b/src/components/TerminalSplitDividers.tsx
@@ -1,0 +1,95 @@
+/**
+ * Vertical drag handles between split panes. Renders N-1 dividers at the
+ * cumulative boundaries between adjacent panes. Dragging adjusts the two
+ * neighbouring panes' percentages without affecting the rest.
+ *
+ * Mirrors `SplitPane.tsx`'s drag pattern: mousedown captures starting
+ * percentages and pointer X, mousemove diffs against container width and
+ * pushes the new percentages via `onResize`, mouseup ends the drag and
+ * fires a window resize so xterm refits.
+ *
+ * @module components/TerminalSplitDividers
+ */
+
+import { useCallback } from 'react';
+
+/** Minimum pane width as a percentage. Must match the hook's clamp. */
+const MIN_PANE_PERCENT = 12;
+
+interface TerminalSplitDividersProps {
+  /** Current pane sizes (percent, sum to 100). */
+  sizes: number[];
+  /** Called with new sizes when the user drags. */
+  onResize: (sizes: number[]) => void;
+}
+
+export function TerminalSplitDividers({ sizes, onResize }: TerminalSplitDividersProps) {
+  // Both move + up handlers are created inside mousedown so they share a
+  // closure over the starting state and can reference each other for
+  // teardown — avoids a useCallback cycle.
+  const handleMouseDown = useCallback(
+    (boundaryIndex: number) => (e: React.MouseEvent) => {
+      e.preventDefault();
+      const container = (e.currentTarget as HTMLElement).parentElement;
+      const containerWidth = container?.clientWidth ?? 0;
+      if (containerWidth === 0) return;
+      const startX = e.clientX;
+      const startSizes = [...sizes];
+
+      const onMove = (ev: MouseEvent) => {
+        const deltaPx = ev.clientX - startX;
+        const deltaPct = (deltaPx / containerWidth) * 100;
+        const a = startSizes[boundaryIndex] + deltaPct;
+        const b = startSizes[boundaryIndex + 1] - deltaPct;
+        if (a < MIN_PANE_PERCENT || b < MIN_PANE_PERCENT) return;
+        const next = [...startSizes];
+        next[boundaryIndex] = a;
+        next[boundaryIndex + 1] = b;
+        onResize(next);
+      };
+
+      const onUp = () => {
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        // Refit xterm to the final widths.
+        setTimeout(() => window.dispatchEvent(new Event('resize')), 50);
+      };
+
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
+    },
+    [sizes, onResize]
+  );
+
+  // Cumulative boundary positions: between pane i and i+1, boundary is at
+  // sum(sizes[0..i]). The 8px-wide handle is centered on the boundary, so
+  // its left edge sits at `boundary% - 4px`.
+  const boundaries: number[] = [];
+  let cum = 0;
+  for (let i = 0; i < sizes.length - 1; i++) {
+    cum += sizes[i];
+    boundaries.push(cum);
+  }
+
+  return (
+    <>
+      {boundaries.map((pct, i) => (
+        <div
+          key={i}
+          className="terminal-split-handle"
+          style={{ left: `calc(${pct}% - 4px)` }}
+          onMouseDown={handleMouseDown(i)}
+          role="separator"
+          aria-orientation="vertical"
+          aria-label={`Resize between pane ${i + 1} and pane ${i + 2}`}
+        >
+          <div className="terminal-split-handle-bar" />
+        </div>
+      ))}
+    </>
+  );
+}

--- a/src/components/TerminalSplitHeaders.tsx
+++ b/src/components/TerminalSplitHeaders.tsx
@@ -1,0 +1,217 @@
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useClickOutside } from '../hooks/useClickOutside';
+import { getAgentById } from '../lib/agent';
+import { ChevronIcon, CloseIcon } from './icons/common';
+import { PlusIcon } from './icons/utility';
+import type { TerminalTab } from '../hooks/useTerminalManagement';
+
+interface TerminalSplitHeadersProps {
+  panes: number[];
+  /** Width of each pane as a percentage of container; sums to 100. */
+  sizes: number[];
+  tabs: TerminalTab[];
+  tabTitles: Map<number, string>;
+  onSelectTab: (paneIndex: number, tabId: number) => void;
+  onRemovePane: (paneIndex: number) => void;
+  onAddPane: () => void;
+  canAddPane: boolean;
+}
+
+export function TerminalSplitHeaders({
+  panes,
+  sizes,
+  tabs,
+  tabTitles,
+  onSelectTab,
+  onRemovePane,
+  onAddPane,
+  canAddPane,
+}: TerminalSplitHeadersProps) {
+  const labelFor = (tabId: number): string => {
+    const tab = tabs.find((t) => t.id === tabId);
+    if (!tab) return 'Unknown';
+    return tabTitles.get(tab.id) || getAgentById(tab.agentId).displayName;
+  };
+
+  // Pre-compute cumulative left+right percentages for each pane so the
+  // last pane's right edge lands at exactly 100% (no rounding drift).
+  // Carry whether each side abuts a drag handle so the consumer can leave
+  // a 4px gutter exactly where the 8px handle sits centered.
+  const n = panes.length;
+  const positions = panes.map((_, i) => ({
+    leftPct: sizes.slice(0, i).reduce((a, b) => a + b, 0),
+    rightPct: sizes.slice(i + 1).reduce((a, b) => a + b, 0),
+    leftAbutsHandle: i > 0,
+    rightAbutsHandle: i < n - 1,
+  }));
+
+  return (
+    <div className="terminal-split-headers">
+      {panes.map((tabId, paneIdx) => (
+        <PaneHeader
+          key={paneIdx}
+          paneIndex={paneIdx}
+          leftPct={positions[paneIdx].leftPct}
+          rightPct={positions[paneIdx].rightPct}
+          leftAbutsHandle={positions[paneIdx].leftAbutsHandle}
+          rightAbutsHandle={positions[paneIdx].rightAbutsHandle}
+          tabId={tabId}
+          label={labelFor(tabId)}
+          tabs={tabs}
+          tabTitles={tabTitles}
+          assignedTabIds={panes}
+          onSelectTab={onSelectTab}
+          onRemovePane={onRemovePane}
+          showAddButton={canAddPane && paneIdx === panes.length - 1}
+          onAddPane={onAddPane}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface PaneHeaderProps {
+  paneIndex: number;
+  leftPct: number;
+  rightPct: number;
+  leftAbutsHandle: boolean;
+  rightAbutsHandle: boolean;
+  tabId: number;
+  label: string;
+  tabs: TerminalTab[];
+  tabTitles: Map<number, string>;
+  assignedTabIds: number[];
+  onSelectTab: (paneIndex: number, tabId: number) => void;
+  onRemovePane: (paneIndex: number) => void;
+  showAddButton: boolean;
+  onAddPane: () => void;
+}
+
+function PaneHeader({
+  paneIndex,
+  leftPct,
+  rightPct,
+  leftAbutsHandle,
+  rightAbutsHandle,
+  tabId,
+  label,
+  tabs,
+  tabTitles,
+  assignedTabIds,
+  onSelectTab,
+  onRemovePane,
+  showAddButton,
+  onAddPane,
+}: PaneHeaderProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [menuPosition, setMenuPosition] = useState<{ top: number; left: number } | null>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const closeMenu = useCallback(() => setIsOpen(false), []);
+  useClickOutside(rootRef, closeMenu, isOpen, '.toolbar-dropdown-menu');
+
+  // Anchor the portaled menu under the trigger. Anchor by LEFT edge —
+  // pane labels are left-aligned within each pane column, so left anchor
+  // keeps the menu under the label rather than drifting right.
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+    const anchor = () => {
+      const btn = buttonRef.current;
+      if (!btn) return;
+      const rect = btn.getBoundingClientRect();
+      setMenuPosition({ top: rect.bottom + 6, left: rect.left });
+    };
+    anchor();
+    window.addEventListener('scroll', anchor, true);
+    window.addEventListener('resize', anchor);
+    return () => {
+      window.removeEventListener('scroll', anchor, true);
+      window.removeEventListener('resize', anchor);
+    };
+  }, [isOpen]);
+
+  // Reserve a 4px gutter on any side that abuts a drag handle so the
+  // 8px-wide handle (centered on the boundary) sits in clean space rather
+  // than overlapping the header chrome.
+  const style = {
+    left: leftAbutsHandle ? `calc(${leftPct}% + 4px)` : `${leftPct}%`,
+    right: rightAbutsHandle ? `calc(${rightPct}% + 4px)` : `${rightPct}%`,
+  };
+
+  return (
+    <div
+      className="terminal-split-pane-header"
+      style={style}
+      ref={rootRef}
+      data-pane-idx={paneIndex}
+    >
+      <button
+        ref={buttonRef}
+        type="button"
+        className={`toolbar-icon-btn terminal-split-pane-trigger ${isOpen ? 'is-open' : ''}`}
+        onClick={() => setIsOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+      >
+        <span className="terminal-split-pane-name">{label}</span>
+        <ChevronIcon size={10} className={isOpen ? 'chevron-flipped' : undefined} />
+      </button>
+      <div className="terminal-split-pane-actions">
+        {showAddButton && (
+          <button
+            type="button"
+            className="toolbar-icon-btn terminal-split-pane-iconbtn"
+            onClick={onAddPane}
+            title="Add another agent pane"
+            aria-label="Add agent pane"
+          >
+            <PlusIcon size={12} />
+          </button>
+        )}
+        <button
+          type="button"
+          className="toolbar-icon-btn terminal-split-pane-iconbtn"
+          onClick={() => onRemovePane(paneIndex)}
+          title="Remove this pane"
+          aria-label="Remove pane"
+        >
+          <CloseIcon size={12} />
+        </button>
+      </div>
+      {isOpen &&
+        menuPosition &&
+        createPortal(
+          <div
+            className="toolbar-dropdown-menu toolbar-dropdown-menu-floating"
+            style={{ top: menuPosition.top, left: menuPosition.left }}
+            role="menu"
+          >
+            {tabs.map((t) => {
+              const isCurrent = t.id === tabId;
+              const inOtherPane = !isCurrent && assignedTabIds.includes(t.id);
+              const itemLabel = tabTitles.get(t.id) || getAgentById(t.agentId).displayName;
+              return (
+                <button
+                  key={t.id}
+                  type="button"
+                  role="menuitem"
+                  className="toolbar-dropdown-item"
+                  onClick={() => {
+                    onSelectTab(paneIndex, t.id);
+                    setIsOpen(false);
+                  }}
+                >
+                  <span>{itemLabel}</span>
+                  {inOtherPane && <span className="toggle-indicator off">SWAP</span>}
+                  {isCurrent && <span className="toggle-indicator on">ON</span>}
+                </button>
+              );
+            })}
+          </div>,
+          document.body
+        )}
+    </div>
+  );
+}

--- a/src/components/ToolbarDropdown.tsx
+++ b/src/components/ToolbarDropdown.tsx
@@ -56,7 +56,7 @@ export function ToolbarDropdown({
   pluginTheme,
 }: ToolbarDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [menuPosition, setMenuPosition] = useState<{ top: number; left: number } | null>(null);
+  const [menuPosition, setMenuPosition] = useState<{ top: number; right: number } | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -78,7 +78,11 @@ export function ToolbarDropdown({
       const btn = buttonRef.current;
       if (!btn) return;
       const rect = btn.getBoundingClientRect();
-      setMenuPosition({ top: rect.bottom + 6, left: rect.left });
+      // Anchor by the button's RIGHT edge so the menu expands leftward.
+      // The Agent Settings button sits at the right end of the terminal
+      // toolbar — in focus mode (and on narrow windows) anchoring by the
+      // left edge pushed the menu off-screen.
+      setMenuPosition({ top: rect.bottom + 6, right: window.innerWidth - rect.right });
     };
     anchor();
     window.addEventListener('scroll', anchor, true);
@@ -111,7 +115,7 @@ export function ToolbarDropdown({
           <div
             ref={menuRef}
             className="toolbar-dropdown-menu toolbar-dropdown-menu-floating"
-            style={{ top: menuPosition.top, left: menuPosition.left }}
+            style={{ top: menuPosition.top, right: menuPosition.right }}
           >
             <button
               className="toolbar-dropdown-item"

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -54,6 +54,8 @@ import {
 } from './icons';
 import { useSnapshots } from '../hooks/useSnapshots';
 import { ToolbarDropdown } from './ToolbarDropdown';
+import { TerminalSplitHeaders } from './TerminalSplitHeaders';
+import { TerminalSplitDividers } from './TerminalSplitDividers';
 import { PluginsDropdown } from './PluginsDropdown';
 import { getAgentById } from '../lib/agent';
 import type { AgentConfig } from '../lib/agent';
@@ -100,6 +102,16 @@ interface TerminalProps {
   focusActiveTerminal: () => void;
   switchTabAgent: (tabId: number, agentId: string) => void;
   getActiveTabAgent: () => AgentConfig;
+  /** Side-by-side view: tab ids visible in panes, or null when off. */
+  splitPaneTabIds: number[] | null;
+  /** Width of each pane as a percentage (sums to 100). Null when split off. */
+  splitPaneSizes: number[] | null;
+  enableSplitView: () => void;
+  disableSplitView: () => void;
+  setSplitPaneTab: (paneIndex: number, tabId: number) => void;
+  addSplitPane: (tabId?: number) => void;
+  removeSplitPane: (paneIndex: number) => void;
+  setSplitPaneSizes: (sizes: number[]) => void;
 }
 
 interface DevServerProps {
@@ -360,6 +372,14 @@ export const WorkspaceView = memo(function WorkspaceView({
     closeTerminalTab,
     focusActiveTerminal,
     getActiveTabAgent,
+    splitPaneTabIds,
+    splitPaneSizes,
+    enableSplitView,
+    disableSplitView,
+    setSplitPaneTab,
+    addSplitPane,
+    removeSplitPane,
+    setSplitPaneSizes,
   } = terminal;
 
   // Modal context (Block 6 migration). Modals self-read open state via useModal('id');
@@ -446,6 +466,20 @@ export const WorkspaceView = memo(function WorkspaceView({
     workspaceTab,
     setWorkspaceTab,
   } = layout;
+
+  // Split view is only meaningful when focus mode is on AND the current
+  // project has ≥2 tabs AND the user has opted in (splitPaneTabIds set).
+  const canSplit = isPreviewHidden && terminalTabs.length >= 2;
+  const isSplitActive = canSplit && !!splitPaneTabIds && splitPaneTabIds.length >= 2;
+
+  // Auto-disable split when preconditions break (focus exited, tab count
+  // dropped, project changed). User opted into "disable entirely" — they
+  // re-enable manually next time. `disableSplitView` no-ops if already off.
+  useEffect(() => {
+    if (splitPaneTabIds && !canSplit) {
+      disableSplitView();
+    }
+  }, [canSplit, splitPaneTabIds, disableSplitView]);
 
   const {
     pluginTerminal,
@@ -1032,27 +1066,123 @@ export const WorkspaceView = memo(function WorkspaceView({
                             </button>
                           </div>
                           <div style={{ flex: 1 }} />
-                          <ToolbarDropdown
-                            agent={getActiveTabAgent()}
-                            autoAcceptMode={autoAcceptMode}
-                            onNotificationSettings={() => setShowNotificationSettings(true)}
-                            onSkills={skillsModal.open}
-                            onMcp={mcpModal.open}
-                            onAutoAcceptToggle={handleToolbarAutoAcceptToggle}
-                            onHelp={helpModal.open}
-                            terminalPlugins={getSlotPlugins('terminal')}
-                            pluginProject={pluginProject}
-                            pluginActions={pluginActions}
-                            pluginTheme={pluginTheme}
-                          />
+                          <div className="terminal-tabs-bar-right">
+                            {canSplit && (
+                              <button
+                                type="button"
+                                className="toggle-pill-btn"
+                                onClick={() =>
+                                  isSplitActive ? disableSplitView() : enableSplitView()
+                                }
+                                title={
+                                  isSplitActive
+                                    ? 'Exit side-by-side view'
+                                    : 'View agents side by side'
+                                }
+                                aria-label="Toggle side-by-side view"
+                                aria-pressed={isSplitActive}
+                              >
+                                <svg
+                                  width="14"
+                                  height="14"
+                                  viewBox="0 0 16 16"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  strokeWidth="1.6"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  aria-hidden="true"
+                                >
+                                  <rect x="2" y="3" width="12" height="10" rx="1.2" />
+                                  <line x1="8" y1="3" x2="8" y2="13" />
+                                </svg>
+                                <span>Split</span>
+                                <span
+                                  className={`toggle-pill-switch ${isSplitActive ? 'is-on' : ''}`}
+                                  aria-hidden
+                                />
+                              </button>
+                            )}
+                            <ToolbarDropdown
+                              agent={getActiveTabAgent()}
+                              autoAcceptMode={autoAcceptMode}
+                              onNotificationSettings={() => setShowNotificationSettings(true)}
+                              onSkills={skillsModal.open}
+                              onMcp={mcpModal.open}
+                              onAutoAcceptToggle={handleToolbarAutoAcceptToggle}
+                              onHelp={helpModal.open}
+                              terminalPlugins={getSlotPlugins('terminal')}
+                              pluginProject={pluginProject}
+                              pluginActions={pluginActions}
+                              pluginTheme={pluginTheme}
+                            />
+                          </div>
                         </div>
-                        <div className="terminal-content" data-education-id="claude-terminal">
+                        <div
+                          className={`terminal-content${isSplitActive ? ' split' : ''}`}
+                          data-education-id="claude-terminal"
+                        >
+                          {isSplitActive && currentProject && splitPaneTabIds && splitPaneSizes && (
+                            <>
+                              <TerminalSplitHeaders
+                                panes={splitPaneTabIds}
+                                sizes={splitPaneSizes}
+                                tabs={terminalTabs}
+                                tabTitles={tabTitles}
+                                onSelectTab={setSplitPaneTab}
+                                onRemovePane={removeSplitPane}
+                                onAddPane={() => addSplitPane()}
+                                canAddPane={splitPaneTabIds.length < terminalTabs.length}
+                              />
+                              <TerminalSplitDividers
+                                sizes={splitPaneSizes}
+                                onResize={setSplitPaneSizes}
+                              />
+                            </>
+                          )}
                           {allSessions.flatMap((session) =>
                             session.tabs.map((tab) => {
                               const isCurrentProject = session.projectPath === currentProject.path;
+                              const paneIdx =
+                                isSplitActive && isCurrentProject && splitPaneTabIds
+                                  ? splitPaneTabIds.indexOf(tab.id)
+                                  : -1;
+                              const inSplitPane = paneIdx >= 0;
                               const isVisible =
-                                isCurrentProject && !showHealthLogs && activeTerminalTab === tab.id;
+                                isCurrentProject &&
+                                !showHealthLogs &&
+                                (isSplitActive ? inSplitPane : activeTerminalTab === tab.id);
                               const refKey = `${session.projectPath}::${tab.id}`;
+                              // Anchor both edges to percentages computed from
+                              // splitPaneSizes — guarantees the last pane's
+                              // right edge hits exactly 100% (no rounding
+                              // drift). Reserve 4px next to each drag handle
+                              // so the 8px handle sits in clean space. Then
+                              // add a 12px content gutter on every edge so
+                              // xterm has the same breathing room from the
+                              // pane chrome that single-pane mode gives it
+                              // from the sidebar. Opencode is full-bleed by
+                              // design (its TUI fills the viewport) — skip
+                              // the content gutter for it.
+                              let paneStyle: React.CSSProperties | undefined;
+                              if (inSplitPane && splitPaneSizes) {
+                                const leftPct = splitPaneSizes
+                                  .slice(0, paneIdx)
+                                  .reduce((a, b) => a + b, 0);
+                                const rightPct = splitPaneSizes
+                                  .slice(paneIdx + 1)
+                                  .reduce((a, b) => a + b, 0);
+                                const leftAbutsHandle = paneIdx > 0;
+                                const rightAbutsHandle = paneIdx < splitPaneSizes.length - 1;
+                                const gutter = tab.agentId === 'opencode' ? 0 : 12;
+                                const leftOffset = (leftAbutsHandle ? 4 : 0) + gutter;
+                                const rightOffset = (rightAbutsHandle ? 4 : 0) + gutter;
+                                paneStyle = {
+                                  left: `calc(${leftPct}% + ${leftOffset}px)`,
+                                  right: `calc(${rightPct}% + ${rightOffset}px)`,
+                                  top: 'var(--split-pane-header-height)',
+                                };
+                              }
                               // Background projects use the same `.terminal-tab-content`
                               // visibility-based hide (position: absolute + visibility: hidden).
                               // `display: none` would zero out xterm's container dims and leave
@@ -1060,8 +1190,17 @@ export const WorkspaceView = memo(function WorkspaceView({
                               return (
                                 <div
                                   key={`session-${session.sessionEpoch}-${refKey}`}
-                                  className={`terminal-tab-content ${isVisible ? 'active' : ''}`}
+                                  className={`terminal-tab-content ${isVisible ? 'active' : ''}${
+                                    inSplitPane ? ' in-pane' : ''
+                                  }`}
                                   data-agent-id={tab.agentId}
+                                  data-pane-idx={inSplitPane ? paneIdx : undefined}
+                                  style={paneStyle}
+                                  onMouseDownCapture={
+                                    inSplitPane && tab.id !== activeTerminalTab
+                                      ? () => setActiveTerminalTab(tab.id)
+                                      : undefined
+                                  }
                                 >
                                   <Terminal
                                     ref={(ref) => {

--- a/src/hooks/usePreviewConnection.ts
+++ b/src/hooks/usePreviewConnection.ts
@@ -66,6 +66,11 @@ export function usePreviewConnection({
   const devServerUrl = `http://localhost:${port}`;
   const baseUrl = proxyPort ? `http://localhost:${proxyPort}` : devServerUrl;
   const currentUrl = `${baseUrl}${iframePath === '/' ? '' : iframePath}?_cb=${cacheBuster}&shipstudio=1`;
+  // URL safe to hand to the user's default browser: real dev server,
+  // current iframe path, no proxy and no Ship Studio query params. The
+  // iframe needs the proxy URL (for navigation tracking + cache busting)
+  // but external browsers should land on the dev server directly.
+  const externalUrl = `${devServerUrl}${iframePath === '/' ? '' : iframePath}`;
 
   const wasRestartingRef = useRef(false);
   const healthCheckFailuresRef = useRef(0);
@@ -417,6 +422,7 @@ export function usePreviewConnection({
     // URL state
     baseUrl,
     currentUrl,
+    externalUrl,
 
     // Page navigation
     currentPage,

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -264,6 +264,18 @@ export function useProjectLifecycle({
       });
     }
 
+    // Fetch auto-accept BEFORE the workspace renders. The Terminal
+    // reads `autoAcceptMode` at spawn time to decide whether to pass
+    // `--dangerously-skip-permissions`; if we let the workspace render
+    // first and fetch after, the resumed PTY launches with the previous
+    // state (typically `false`) and never gets the flag, even though
+    // the toolbar toggle shows it as on. ~3ms disk read.
+    try {
+      setAutoAcceptMode(await getAutoAcceptMode(project.path));
+    } catch {
+      setAutoAcceptMode(false);
+    }
+
     // ─── IMMEDIATE: Show workspace right away ───
     // We always land in the workspace view so WorkspaceView stays mounted
     // continuously — unmounting it would take every Terminal child (and
@@ -503,17 +515,9 @@ export function useProjectLifecycle({
     );
     setDevServerPort(port, project.path);
 
-    // Fetch auto-accept mode preference for this project
-    stepStart = performance.now();
-    try {
-      const autoAccept = await getAutoAcceptMode(project.path);
-      setAutoAcceptMode(autoAccept);
-    } catch {
-      setAutoAcceptMode(false);
-    }
-    logger.info(
-      `[OpenProject] Step 5: Fetch auto-accept mode - ${Math.round(performance.now() - stepStart)}ms`
-    );
+    // Step 5 (fetch auto-accept) used to live here, but the value was
+    // already applied synchronously from `project.auto_accept_mode`
+    // before the workspace rendered — see the seed above.
 
     // Check if navigation was superseded
     if (navigationVersionRef.current !== navVersion) {

--- a/src/hooks/useTerminalManagement.ts
+++ b/src/hooks/useTerminalManagement.ts
@@ -40,6 +40,24 @@ interface ProjectTerminalState {
   counter: number;
   /** Bumps on resetTerminalsForProject — used to force xterm remount */
   sessionEpoch: number;
+  /** Tab ids visible side-by-side in split view, one per pane.
+   *  `null` = split view disabled (single-pane, default). Only meaningful
+   *  in focus mode with >=2 tabs; UI enforces those preconditions. */
+  splitPaneTabIds: number[] | null;
+  /** Width of each split pane as a percentage of the container, one per
+   *  pane. Sums to 100. `null` when split is off. */
+  splitPaneSizes: number[] | null;
+}
+
+/** Minimum pane width as a percentage of the container. Below this the
+ *  agent name + chevron starts truncating uncomfortably. */
+const MIN_SPLIT_PANE_PERCENT = 12;
+
+/** Dispatch a window resize event so xterm's FitAddon refits to the new
+ *  pane width. Matches the 50ms delay `SplitPane` uses on collapse, so
+ *  the DOM has committed the new layout before refit runs. */
+function dispatchTerminalResize(): void {
+  setTimeout(() => window.dispatchEvent(new Event('resize')), 50);
 }
 
 /** A session (project) that should have its terminal components rendered. */
@@ -48,6 +66,8 @@ export interface TerminalSessionView {
   tabs: TerminalTab[];
   activeTabId: number;
   sessionEpoch: number;
+  splitPaneTabIds: number[] | null;
+  splitPaneSizes: number[] | null;
 }
 
 export interface UseTerminalManagementReturn {
@@ -88,6 +108,24 @@ export interface UseTerminalManagementReturn {
   /** Ensure there's a default tab list for a freshly-opened project
    *  that has no persisted state. */
   ensureProjectSeeded: (projectPath: string) => void;
+  /** Current project's split-pane assignment, or null when split is off. */
+  splitPaneTabIds: number[] | null;
+  /** Width of each split pane as percentage of container, sums to 100. */
+  splitPaneSizes: number[] | null;
+  /** Turn on side-by-side view; initializes with the current active tab
+   *  plus the next available tab. No-op if fewer than 2 tabs exist. */
+  enableSplitView: () => void;
+  /** Turn off side-by-side view and return to single-pane. */
+  disableSplitView: () => void;
+  /** Replace the tab assigned to a given pane index. */
+  setSplitPaneTab: (paneIndex: number, tabId: number) => void;
+  /** Append a new pane showing `tabId` (or the first unused tab). */
+  addSplitPane: (tabId?: number) => void;
+  /** Remove the pane at `paneIndex`. If only one pane remains, disable split. */
+  removeSplitPane: (paneIndex: number) => void;
+  /** Replace the pane width percentages. Caller must ensure they sum to
+   *  100 and each is >= MIN_SPLIT_PANE_PERCENT. */
+  setSplitPaneSizes: (sizes: number[]) => void;
 }
 
 function makeDefaultState(): ProjectTerminalState {
@@ -96,6 +134,8 @@ function makeDefaultState(): ProjectTerminalState {
     activeTabId: 1,
     counter: 1,
     sessionEpoch: 1,
+    splitPaneTabIds: null,
+    splitPaneSizes: null,
   };
 }
 
@@ -146,6 +186,8 @@ export function useTerminalManagement(
   const terminalTabs = currentState?.tabs ?? [];
   const activeTerminalTab = currentState?.activeTabId ?? 1;
   const terminalSessionId = currentState?.sessionEpoch ?? 1;
+  const splitPaneTabIds = currentState?.splitPaneTabIds ?? null;
+  const splitPaneSizes = currentState?.splitPaneSizes ?? null;
 
   const allSessions = useMemo<TerminalSessionView[]>(() => {
     void epoch;
@@ -156,6 +198,8 @@ export function useTerminalManagement(
         tabs: s.tabs,
         activeTabId: s.activeTabId,
         sessionEpoch: s.sessionEpoch,
+        splitPaneTabIds: s.splitPaneTabIds,
+        splitPaneSizes: s.splitPaneSizes,
       });
     }
     return out;
@@ -176,6 +220,7 @@ export function useTerminalManagement(
     (tabId: number) => {
       const s = getCurrent();
       if (!s) return;
+      if (s.activeTabId === tabId) return; // no-op when already active
       s.activeTabId = tabId;
       bump();
     },
@@ -223,6 +268,25 @@ export function useTerminalManagement(
       if (tabId === s.activeTabId) {
         const newActiveIdx = Math.max(0, closedIdx - 1);
         s.activeTabId = s.tabs[newActiveIdx].id;
+      }
+      // Drop the closed tab from split panes; disable split if the
+      // remaining pane count would fall below 2 (or no tabs left to show).
+      // Sizes shrink with the panes — redistribute the closed pane's
+      // share equally across survivors so widths still sum to 100.
+      if (s.splitPaneTabIds && s.splitPaneSizes) {
+        const removedIdx = s.splitPaneTabIds.indexOf(tabId);
+        const remainingIds = s.splitPaneTabIds.filter((id) => id !== tabId);
+        if (remainingIds.length >= 2 && removedIdx >= 0) {
+          const removedShare = s.splitPaneSizes[removedIdx] ?? 0;
+          const remainingSizes = s.splitPaneSizes.filter((_, i) => i !== removedIdx);
+          const bonus = removedShare / remainingSizes.length;
+          s.splitPaneTabIds = remainingIds;
+          s.splitPaneSizes = remainingSizes.map((sz) => sz + bonus);
+        } else {
+          s.splitPaneTabIds = null;
+          s.splitPaneSizes = null;
+        }
+        dispatchTerminalResize();
       }
       bump();
       void trackEvent('terminal_tab_closed', { $screen_name: 'Workspace' });
@@ -324,6 +388,8 @@ export function useTerminalManagement(
         activeTabId: activeId,
         counter: restoredTabs.length,
         sessionEpoch: 1,
+        splitPaneTabIds: null,
+        splitPaneSizes: null,
       });
       bump();
       logger.info('[TerminalMgmt] Restored tabs from saved state', {
@@ -342,6 +408,130 @@ export function useTerminalManagement(
       bump();
     },
     [bump]
+  );
+
+  const enableSplitView = useCallback(() => {
+    const s = getCurrent();
+    if (!s || s.tabs.length < 2) return;
+    const active = s.tabs.find((t) => t.id === s.activeTabId) ?? s.tabs[0];
+    const other = s.tabs.find((t) => t.id !== active.id);
+    if (!other) return;
+    s.splitPaneTabIds = [active.id, other.id];
+    s.splitPaneSizes = [50, 50];
+    bump();
+    dispatchTerminalResize();
+    void trackEvent('split_view_enabled', {
+      pane_count: 2,
+      $screen_name: 'Workspace',
+    });
+  }, [bump, getCurrent]);
+
+  const disableSplitView = useCallback(() => {
+    const s = getCurrent();
+    if (!s || s.splitPaneTabIds === null) return;
+    s.splitPaneTabIds = null;
+    s.splitPaneSizes = null;
+    bump();
+    dispatchTerminalResize();
+    void trackEvent('split_view_disabled', { $screen_name: 'Workspace' });
+  }, [bump, getCurrent]);
+
+  const setSplitPaneTab = useCallback(
+    (paneIndex: number, tabId: number) => {
+      const s = getCurrent();
+      if (!s || !s.splitPaneTabIds) return;
+      if (paneIndex < 0 || paneIndex >= s.splitPaneTabIds.length) return;
+      if (!s.tabs.some((t) => t.id === tabId)) return;
+      // No-op when the pane already shows this tab — saves a render and
+      // makes the menu-click case ergonomic.
+      if (s.splitPaneTabIds[paneIndex] === tabId) return;
+      // Avoid duplicate panes — if this tab is already in another pane,
+      // swap them so each agent appears at most once.
+      const existingIdx = s.splitPaneTabIds.indexOf(tabId);
+      const next = [...s.splitPaneTabIds];
+      if (existingIdx >= 0) {
+        next[existingIdx] = next[paneIndex];
+      }
+      next[paneIndex] = tabId;
+      s.splitPaneTabIds = next;
+      bump();
+    },
+    [bump, getCurrent]
+  );
+
+  const addSplitPane = useCallback(
+    (tabId?: number) => {
+      const s = getCurrent();
+      if (!s) return;
+      const currentIds = s.splitPaneTabIds ?? [];
+      if (currentIds.length >= s.tabs.length) return; // no more agents to show
+      let target = tabId;
+      if (target === undefined || currentIds.includes(target)) {
+        const unused = s.tabs.find((t) => !currentIds.includes(t.id));
+        target = unused?.id;
+      }
+      if (target === undefined) return;
+      const nextIds = [...currentIds, target];
+      // Carve the new pane's share off the existing panes proportionally.
+      // `each = 100/nextLen` keeps panes equal-width after a manual add;
+      // this matches user intuition ("I added a pane, they're all equal
+      // again") and avoids drift from many adds/removes.
+      const equalShare = 100 / nextIds.length;
+      s.splitPaneTabIds = nextIds;
+      s.splitPaneSizes = nextIds.map(() => equalShare);
+      bump();
+      dispatchTerminalResize();
+    },
+    [bump, getCurrent]
+  );
+
+  const removeSplitPane = useCallback(
+    (paneIndex: number) => {
+      const s = getCurrent();
+      if (!s || !s.splitPaneTabIds || !s.splitPaneSizes) return;
+      if (paneIndex < 0 || paneIndex >= s.splitPaneTabIds.length) return;
+      const removedTabId = s.splitPaneTabIds[paneIndex];
+      const removedShare = s.splitPaneSizes[paneIndex];
+      const nextIds = s.splitPaneTabIds.filter((_, i) => i !== paneIndex);
+      const nextSizes = s.splitPaneSizes.filter((_, i) => i !== paneIndex);
+      if (nextIds.length >= 2) {
+        // Redistribute the removed share equally so widths still sum to 100.
+        const bonus = removedShare / nextSizes.length;
+        s.splitPaneTabIds = nextIds;
+        s.splitPaneSizes = nextSizes.map((sz) => sz + bonus);
+      } else {
+        s.splitPaneTabIds = null;
+        s.splitPaneSizes = null;
+      }
+      // If the removed pane held the active tab, hand focus to a surviving
+      // pane's tab. Without this, the single-pane fallback re-renders
+      // showing the agent the user just dismissed.
+      if (removedTabId === s.activeTabId) {
+        const survivor = nextIds[0] ?? s.tabs[0]?.id;
+        if (survivor !== undefined) s.activeTabId = survivor;
+      }
+      bump();
+      dispatchTerminalResize();
+    },
+    [bump, getCurrent]
+  );
+
+  const setSplitPaneSizes = useCallback(
+    (sizes: number[]) => {
+      const s = getCurrent();
+      if (!s || !s.splitPaneTabIds) return;
+      if (sizes.length !== s.splitPaneTabIds.length) return;
+      // Caller is responsible for clamping; defend anyway so a buggy
+      // caller can't push a pane to 0% (would freeze its xterm).
+      const clamped = sizes.map((sz) => Math.max(MIN_SPLIT_PANE_PERCENT, sz));
+      const total = clamped.reduce((a, b) => a + b, 0);
+      // Renormalize to 100 in case clamping changed the sum.
+      s.splitPaneSizes = clamped.map((sz) => (sz * 100) / total);
+      bump();
+      // Frequent drag updates — skip the resize dispatch here; the
+      // caller (drag handler) emits it on mouseup.
+    },
+    [bump, getCurrent]
   );
 
   return {
@@ -364,5 +554,13 @@ export function useTerminalManagement(
     getActiveTabAgent,
     restoreTerminalTabs,
     ensureProjectSeeded,
+    splitPaneTabIds,
+    splitPaneSizes,
+    enableSplitView,
+    disableSplitView,
+    setSplitPaneTab,
+    addSplitPane,
+    removeSplitPane,
+    setSplitPaneSizes,
   };
 }

--- a/src/styles/features/help-modal.css
+++ b/src/styles/features/help-modal.css
@@ -45,7 +45,7 @@
 }
 
 .help-modal-body {
-  padding: 0 24px 24px;
+  padding: 16px 24px 24px;
   overflow-y: auto;
   flex: 1;
   scrollbar-width: thin;

--- a/src/styles/features/mcp-modal.css
+++ b/src/styles/features/mcp-modal.css
@@ -48,7 +48,7 @@
 .mcp-tabs {
   display: flex;
   gap: 6px;
-  padding: 0 24px 12px;
+  padding: 16px 24px 12px;
 }
 
 .mcp-tab {

--- a/src/styles/features/skills-modal.css
+++ b/src/styles/features/skills-modal.css
@@ -48,7 +48,7 @@
 .skills-tabs {
   display: flex;
   gap: 6px;
-  padding: 0 24px 12px;
+  padding: 16px 24px 12px;
 }
 
 .skills-tab {

--- a/src/styles/features/workspace/terminal.css
+++ b/src/styles/features/workspace/terminal.css
@@ -11,6 +11,15 @@
   flex-shrink: 0;
 }
 
+/* Right-side cluster — groups feature toggles + the Agent Settings
+   dropdown so they sit together with a consistent gap. Mirrors the
+   left-side undo/redo cluster's `gap: 6` rhythm. */
+.terminal-tabs-bar-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .terminal-tabs {
   display: flex;
   align-items: center;
@@ -258,6 +267,111 @@
 
 .terminal-tab-content.active {
   visibility: visible;
+}
+
+/* ===== Side-by-side split view ===== */
+/* When `.terminal-content.split` is on, each pane gets its column via
+   inline `left/width` on `.terminal-tab-content.in-pane`. Reserve vertical
+   space at the top for the pane header strip. */
+.terminal-content.split {
+  /* Match `.terminal-tabs-bar`'s `min-height: 48px` so the pane header
+     visually reads as a continuation of the terminal toolbar above. */
+  --split-pane-header-height: 48px;
+}
+
+.terminal-split-headers {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--split-pane-header-height);
+  z-index: 2;
+  pointer-events: none;
+}
+
+.terminal-split-pane-header {
+  position: absolute;
+  top: 0;
+  height: var(--split-pane-header-height);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  /* Match `.terminal-tabs-bar`'s 10px horizontal padding so the pane
+     label trigger sits flush with the Undo/Redo and Branch indicator
+     above. */
+  padding: 0 10px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  pointer-events: auto;
+}
+
+/* Pane label trigger reuses .toolbar-icon-btn for consistency with the
+   Agent Settings dropdown. Natural size — the action cluster's
+   `margin-left: auto` handles right-alignment; no max-width math needed.
+   `min-width: 0` lets the label ellipsize if a pane gets very narrow. */
+.terminal-split-pane-trigger {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.terminal-split-pane-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.terminal-split-pane-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+}
+
+/* The per-pane add/remove buttons reuse `.toolbar-icon-btn` directly —
+   same height (28px) and padding as the dropdown trigger next to them,
+   so the row reads as one consistent control cluster. No size override
+   needed beyond the base class. */
+
+/* Drag handle between adjacent split panes. Mirrors the visual language
+   of `.split-pane-handle` used by the workspace's preview SplitPane — 8px
+   wide track with a centered vertical bar, accent-on-hover. The pane
+   columns leave a matching 4px gutter on each side of the boundary so
+   the handle sits between panes rather than overlapping their content. */
+.terminal-split-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-secondary);
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+  cursor: col-resize;
+  z-index: 4;
+  transition:
+    background var(--transition),
+    border-color var(--transition);
+}
+
+.terminal-split-handle:hover,
+.terminal-split-handle:active {
+  background: var(--bg-tertiary);
+  border-color: var(--accent);
+}
+
+.terminal-split-handle-bar {
+  width: 2px;
+  height: 40px;
+  background: var(--text-muted);
+  border-radius: 1px;
+  transition: background var(--transition);
+}
+
+.terminal-split-handle:hover .terminal-split-handle-bar,
+.terminal-split-handle:active .terminal-split-handle-bar {
+  background: var(--accent);
 }
 
 .terminal-logs-tabs {

--- a/src/styles/global/base.css
+++ b/src/styles/global/base.css
@@ -316,6 +316,70 @@ button:hover {
   color: var(--text-secondary);
 }
 
+/* Toggle pill button — label + iOS-style switch pill on the right.
+   Use for boolean feature toggles (Inspect, Split, etc.). Pair the
+   button with a child `.toggle-pill-switch` span that gets `.is-on`
+   when the feature is active. */
+.toggle-pill-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: 6px 10px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background var(--transition),
+    color var(--transition),
+    border-color var(--transition);
+}
+
+.toggle-pill-btn:hover {
+  color: var(--text-primary);
+}
+
+.toggle-pill-switch {
+  position: relative;
+  display: inline-block;
+  width: 22px;
+  height: 12px;
+  margin-left: 2px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  transition:
+    background var(--transition),
+    border-color var(--transition);
+}
+
+.toggle-pill-switch::after {
+  content: '';
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  width: 8px;
+  height: 8px;
+  background: var(--text-muted);
+  border-radius: 50%;
+  transition:
+    transform var(--transition),
+    background var(--transition);
+}
+
+.toggle-pill-switch.is-on {
+  background: var(--success-light);
+  border-color: var(--success-light);
+}
+
+.toggle-pill-switch.is-on::after {
+  transform: translateX(10px);
+  background: #ffffff;
+}
+
 /* Rotate the chevron 180° when its parent dropdown is open. */
 .toolbar-icon-btn .chevron-flipped {
   transform: rotate(180deg);


### PR DESCRIPTION
## Summary

One new feature plus five bug fixes that surfaced from real usage.

### New: side-by-side agents view

Opt-in split view that lets you see multiple agents at once when working in focus mode on a project with ≥2 tabs.

- Toggle pill in the terminal toolbar — visible only when focus mode is on and the project has ≥2 agents. Disables itself when either precondition breaks.
- Per-pane header with an agent dropdown (matches Agent Settings conventions), a `+` to add another pane, and an `×` to remove this one.
- Drag handles between panes — same visual language as the workspace preview SplitPane (8px track with centered bar, accent on hover). 12% min-pane clamp keeps any pane from being pushed to zero.
- 12px content gutter on every pane edge so xterm doesn't crowd the chrome (matches single-pane mode's left-side breathing room from the sidebar).
- Click-to-focus: clicking a pane sets it as the active tab so the Agent Settings dropdown and auto-accept toggle target the agent you're actually using.
- New reusable `.toggle-pill-btn` primitive in `base.css` extracted from the Inspect-panel toggle's pattern.

### Fixes

- **Modal padding** — Skills, MCP, Help, and Project Settings modals each had their first child rendered with `padding-top: 0`, so the content sat flush against `ModalFrame`'s bottom-bordered header.
- **Agent Settings dropdown cut off in focus mode** — anchored to the button's left edge so it expanded right-and-off-screen. Now anchored to the right edge so it expands leftward and stays in view on any window width.
- **Publish dropdown remembered stale success state** — dismissing the "All changes synced — Done" view by clicking outside (not clicking Done) left `publishState` as `'success'`. Next time the user opened the dropdown for a new sync, the stale view reappeared and blocked the action. Reset `'success' → 'idle'` on any close path. `'error'` and `'publishing'` are preserved on purpose.
- **"Open in Browser" loaded the proxy URL** — the Preview iframe runs against an internal HTTP proxy on a random high port (for navigation tracking and cache busting). The toolbar's "Open in Browser" was passing that proxy URL — including `?_cb=…&shipstudio=1` — to the user's default browser. Now opens the real dev server URL plus the current iframe path. The sidebar's "Open in Browser" already did the right thing; only the Preview toolbar was affected.
- **Auto-accept lost on resumed sessions** — the previous flow rendered the workspace immediately, which mounted the Terminal and spawned the PTY in parallel with the async fetch of the project's auto-accept setting. On a slow disk read the PTY won the race, started without `--dangerously-skip-permissions`, and Claude would prompt for permission on a resumed session even though the toolbar toggle correctly showed auto-accept as on. Now fetches the setting before `setCurrentProject` so the state is settled before the Terminal mounts. ~3ms on the synchronous path.

## Test plan

- [ ] Open a project, spawn a second agent, enter focus mode → "Split" toggle appears in the terminal toolbar
- [ ] Click Split → two panes appear side-by-side with the active tab in pane 1 and another tab in pane 2
- [ ] Drag the handle between panes → both resize; can't push either below ~12%
- [ ] Click pane 2's terminal → Agent Settings dropdown reflects pane 2's agent
- [ ] Click the `+` button → third pane appears with the next unused agent
- [ ] Click a pane's `×` → that pane is removed; if it held the active tab, focus hands off to a survivor
- [ ] Exit focus mode → split disables entirely
- [ ] Skills / MCP / Help / Project Settings modals → first child has visible breathing room from the header border
- [ ] Open Agent Settings in focus mode → menu expands leftward and is fully visible
- [ ] Sync a branch, click outside the dropdown (not Done), reopen → see the current sync state, not the stale "All changes synced" view
- [ ] Click "Open in Browser" in the Preview toolbar → opens the real dev server URL (e.g. `localhost:3000`), no proxy port, no `_cb`/`shipstudio` query params
- [ ] Enable auto-accept on a project, close Ship Studio, reopen → resumed session runs with auto-accept actually applied (no permission prompts on resume)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Side-by-side split terminal with pane headers, add/remove controls, and a “Split” toggle.
  * Draggable dividers to resize terminal panes; split-aware tab behavior and pane sizing.
  * New toggle-pill UI and a right-side header cluster for workspace controls.
  * Preview now offers a direct external preview URL.

* **Bug Fixes**
  * Publish dropdown no longer preserves the prior “success” view when reopened.

* **Style**
  * Adjusted modal and tabs padding and terminal header/layout spacing; dropdown positioning improved.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ship-studio/ship-studio/pull/63)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->