### PR TITLE
Release v0.6.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,16 @@ These notes appear in the update dialog that users see when a new version is ava
 Write clear, user-friendly notes about what changed in this version.
 -->
 
+## What's New in v0.6.3
+
+- **Side-by-side agents** — in focus mode with two or more agents on a project, toggle "Split" in the terminal toolbar to view them side by side. Drag the handle between panes to resize. Click a pane to make it the active one.
+- **Open in Browser** now opens your real dev server URL (e.g. `localhost:3000`) instead of Ship Studio's internal proxy port.
+- **Auto-accept on resume** — resumed sessions now apply auto-accept mode correctly on startup; a race could previously cause it to silently turn off.
+- **Sync dropdown polish** — no longer shows the stale "All changes synced — Done" view after dismissing it without clicking Done.
+- **Agent Settings dropdown** stays on-screen in focus mode (previously cut off on the right).
+- **Modal headers** — Skills, MCP, Help, and Project Settings modals no longer have their first row of content touching the header border.
+
+
 ## What's New in v0.6.2
 
 - **Undo/Redo (⌘Z / ⌘⇧Z)** — every burst of edits gets snapshotted as a git stash so you can roll the working tree back, even on changes the agent never committed. Toast confirms "Undid 3 files: App.tsx, Preview.tsx +1 more". Buttons grey out at the edge of history. Native character-undo still wins inside text inputs.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ship-studio",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Ship Studio - Launch Claude Code for marketing sites",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4417,7 +4417,7 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "ship-studio"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "base64 0.22.1",
  "block2 0.5.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ship-studio"
-version = "0.6.2"
+version = "0.6.3"
 description = "Ship Studio - Launch Claude Code for marketing sites"
 authors = ["Julian Galluzzo"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ship Studio",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "identifier": "com.memberstack.shipstudio",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -25,6 +25,17 @@ interface ChangelogEntry {
 // Keep ~15 most recent versions for the sidebar
 const CHANGELOG: ChangelogEntry[] = [
   {
+    version: '0.6.3', // v0.6.3
+    items: [
+      'Side-by-side agents — in focus mode with two or more agents on a project, toggle "Split" in the terminal toolbar to view them side by side. Drag the handle between panes to resize. Click a pane to make it the active one',
+      'Open in Browser fix — Preview toolbar\'s "Open in Browser" now opens your real dev server URL (e.g. `localhost:3000`) instead of Ship Studio\'s internal proxy port',
+      'Auto-accept on resume — resumed sessions now apply auto-accept mode correctly on startup; a race could previously cause it to silently turn off',
+      'Sync dropdown polish — no longer shows the stale "All changes synced — Done" view after dismissing it without clicking Done',
+      'Agent Settings dropdown stays on-screen in focus mode — previously the menu could be cut off on the right',
+      'Modal header padding — Skills, MCP, Help, and Project Settings modals no longer have their first row of content touching the header border',
+    ],
+  },
+  {
     version: '0.6.2', // v0.6.2
     items: [
       'Undo/Redo (⌘Z / ⌘⇧Z) — every burst of edits gets snapshotted as a git stash so you can roll the working tree back, even on work the agent never committed. Toast confirms "Undid 3 files: App.tsx, Preview.tsx +1 more". Buttons grey out at the edge of history. Native character-undo still wins inside text inputs',


### PR DESCRIPTION
Mechanical release commits for v0.6.3:

1. `Add v0.6.3 entry to Changelog.tsx` — drives the dashboard "What's New" sidebar
2. `Release v0.6.3` — version bump in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `Cargo.lock`, plus the entry appended to `RELEASE_NOTES.md`

Tag `v0.6.3` is already pushed and the macOS release workflow is running off it independently. This PR is just to bring `main` in line with the tag so subsequent releases continue from the right base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Side-by-side agents now display in focus mode
  * Auto-accept functionality added on resume

* **Bug Fixes**
  * "Open in Browser" now uses the actual dev-server URL
  * Improved sync dropdown interface
  * Enhanced agent settings dropdown visibility
  * Refined modal header spacing

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ship-studio/ship-studio/pull/64)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->