### PR TITLE
Add rename project feature (real folder rename)

### DIFF
--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -55,6 +55,28 @@ fn save_folder_config(config: &FolderConfig) -> Result<(), String> {
     Ok(())
 }
 
+/// Rekey a project's path from `old_path` to `new_path` across all folders
+/// after a folder rename, preserving folder membership. No-op (and no write)
+/// if the project isn't filed in any folder. Not a Tauri command — called
+/// internally by `rename_project`.
+pub fn rename_project_path(old_path: &str, new_path: &str) -> Result<(), CommandError> {
+    let mut config = load_folder_config()?;
+    let mut changed = false;
+    for folder in &mut config.folders {
+        for p in &mut folder.project_paths {
+            if p == old_path {
+                *p = new_path.to_string();
+                folder.updated_at = now_ms();
+                changed = true;
+            }
+        }
+    }
+    if changed {
+        save_folder_config(&config)?;
+    }
+    Ok(())
+}
+
 /// Get current timestamp in milliseconds
 fn now_ms() -> u64 {
     std::time::SystemTime::now()

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -540,3 +540,150 @@ pub async fn delete_project(path: String) -> Result<(), CommandError> {
     std::fs::remove_dir_all(project_path).map_err(|e| e.to_string())?;
     Ok(())
 }
+
+/// Validate a proposed new project folder name, returning the trimmed value.
+///
+/// A project name becomes a directory name, so it must be a single path
+/// component: no separators, no `.`/`..`, no leading dot (hidden dirs), not
+/// empty, not absurdly long.
+fn validate_project_name(name: &str) -> Result<String, CommandError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(CommandError::Validation {
+            field: "new_name".into(),
+            reason: "Project name cannot be empty".into(),
+        });
+    }
+    if trimmed.len() > 255 {
+        return Err(CommandError::Validation {
+            field: "new_name".into(),
+            reason: "Project name is too long".into(),
+        });
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(CommandError::Validation {
+            field: "new_name".into(),
+            reason: "Project name cannot contain slashes".into(),
+        });
+    }
+    if trimmed == "." || trimmed == ".." {
+        return Err(CommandError::Validation {
+            field: "new_name".into(),
+            reason: "Invalid project name".into(),
+        });
+    }
+    if trimmed.starts_with('.') {
+        return Err(CommandError::Validation {
+            field: "new_name".into(),
+            reason: "Project name cannot start with a dot".into(),
+        });
+    }
+    Ok(trimmed.to_string())
+}
+
+/// Renames a project's directory on disk and rekeys all path-keyed stores.
+///
+/// Only ~/ShipStudio projects can be renamed (external projects are rejected,
+/// matching `delete_project`). Refuses to rename while the project is open in a
+/// window or has an active background session, to avoid racing live PTYs and
+/// reserved ports. Everything inside the directory — git remotes, `.vercel`,
+/// `.shipstudio` metadata — travels with the move untouched. Returns the new
+/// absolute path.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn rename_project(old_path: String, new_name: String) -> Result<String, CommandError> {
+    let project_path = std::path::Path::new(&old_path);
+
+    // Reject external projects (their folders live outside ~/ShipStudio).
+    if let Ok(canonical) = dunce::canonicalize(project_path) {
+        if crate::commands::external_projects::is_registered_external_path(&canonical)? {
+            return Err(
+                "Renaming external projects isn't supported yet. Remove it from the list and re-add it under a new folder name."
+                    .to_string()
+                    .into(),
+            );
+        }
+    }
+
+    // Must live inside ~/ShipStudio and exist.
+    let home = dirs::home_dir().ok_or("Could not find home directory")?;
+    let shipstudio_dir = home.join("ShipStudio");
+    if !project_path.starts_with(&shipstudio_dir) {
+        return Err(("Can only rename projects in the ShipStudio directory".to_string()).into());
+    }
+    if !project_path.exists() {
+        return Err(("Project not found".to_string()).into());
+    }
+
+    // Validate + normalize the requested name.
+    let new_name = validate_project_name(&new_name)?;
+
+    // Refuse to rename a project that's currently open or actively running —
+    // moving the directory out from under live PTYs / reserved ports is a
+    // recipe for corruption. Suspended pinned sessions are fine (rekeyed below).
+    if crate::state::get_window_for_project(&old_path).is_some() {
+        return Err(("Close this project before renaming it.".to_string()).into());
+    }
+    if let Some(session) = crate::state::get_session(&old_path) {
+        if session.status == crate::state::SessionStatus::Active {
+            return Err(("Close this project before renaming it.".to_string()).into());
+        }
+    }
+
+    // Destination is a sibling directory with the new name.
+    let parent = project_path
+        .parent()
+        .ok_or("Invalid project path (no parent)")?;
+    let new_path = parent.join(&new_name);
+
+    // No-op if the name didn't actually change.
+    if new_path.as_path() == project_path {
+        return Ok(old_path);
+    }
+    if new_path.exists() {
+        return Err((format!("A project named \"{new_name}\" already exists.")).into());
+    }
+
+    std::fs::rename(project_path, &new_path)
+        .map_err(|e| format!("Failed to rename project: {e}"))?;
+
+    let new_path_str = new_path.to_string_lossy().to_string();
+
+    // Rekey path-keyed stores. Best-effort: the rename already succeeded, so a
+    // store hiccup must not surface as a hard failure — log and continue.
+    if let Err(e) = pins::rename_pinned_path(&old_path, &new_path_str) {
+        tracing::warn!(error = %e, "Failed to rekey pins after project rename");
+    }
+    if let Err(e) = crate::commands::folders::rename_project_path(&old_path, &new_path_str) {
+        tracing::warn!(error = %e, "Failed to rekey folder membership after project rename");
+    }
+    crate::state::rename_session_path(&old_path, &new_path_str);
+
+    tracing::info!("Renamed project: {} -> {}", old_path, new_path_str);
+    Ok(new_path_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_project_name_accepts_normal_names() {
+        assert_eq!(validate_project_name("my-app").unwrap(), "my-app");
+        assert_eq!(validate_project_name("My App 2").unwrap(), "My App 2");
+        // Surrounding whitespace is trimmed.
+        assert_eq!(validate_project_name("  spaced  ").unwrap(), "spaced");
+    }
+
+    #[test]
+    fn validate_project_name_rejects_invalid_names() {
+        assert!(validate_project_name("").is_err());
+        assert!(validate_project_name("   ").is_err());
+        assert!(validate_project_name("a/b").is_err());
+        assert!(validate_project_name("a\\b").is_err());
+        assert!(validate_project_name(".").is_err());
+        assert!(validate_project_name("..").is_err());
+        assert!(validate_project_name(".hidden").is_err());
+        assert!(validate_project_name(&"x".repeat(256)).is_err());
+    }
+}

--- a/src-tauri/src/commands/projects/pins.rs
+++ b/src-tauri/src/commands/projects/pins.rs
@@ -158,6 +158,24 @@ pub async fn unpin_project(project_path: String) -> Result<Vec<String>, CommandE
     })
 }
 
+/// Rekey a pinned project from `old_path` to `new_path` after a folder rename.
+///
+/// Preserves pin order and any `last_sessions` metadata (Claude/Codex resume
+/// IDs, tab layout). No-op if `old_path` isn't pinned. Not a Tauri command —
+/// called internally by `rename_project`.
+pub fn rename_pinned_path(old_path: &str, new_path: &str) -> Result<(), CommandError> {
+    with_pins_locked(|pins| {
+        for p in &mut pins.pinned_paths {
+            if p == old_path {
+                *p = new_path.to_string();
+            }
+        }
+        if let Some(session) = pins.last_sessions.remove(old_path) {
+            pins.last_sessions.insert(new_path.to_string(), session);
+        }
+    })
+}
+
 /// Return the current ordered list of pinned project paths.
 #[tauri::command]
 #[tracing::instrument]
@@ -410,6 +428,47 @@ mod tests {
         assert_eq!(session.active_tab_index, 1);
         assert_eq!(session.last_agent.as_deref(), Some("codex"));
         assert_eq!(session.suspended_at, Some(999));
+    }
+
+    #[tokio::test]
+    async fn rename_pinned_path_rekeys_and_preserves_session() {
+        let _g = TEST_LOCK.lock().unwrap();
+        let _snap = PinsSnapshot::capture();
+
+        let old = "/tmp/test-project-old".to_string();
+        let new = "/tmp/test-project-new".to_string();
+        pin_project(old.clone()).await.unwrap();
+        save_pin_session(
+            old.clone(),
+            LastSession {
+                tab_session_ids: vec!["s1".into()],
+                active_tab_index: 0,
+                last_agent: Some("claude-code".into()),
+                suspended_at: Some(7),
+            },
+        )
+        .await
+        .unwrap();
+
+        rename_pinned_path(&old, &new).unwrap();
+
+        // Pin order entry moved to the new path...
+        assert_eq!(list_pinned_projects().await.unwrap(), vec![new.clone()]);
+        // ...old session key is gone, new key carries the same metadata.
+        assert!(get_pin_session(old).await.unwrap().is_none());
+        let session = get_pin_session(new).await.unwrap().unwrap();
+        assert_eq!(session.tab_session_ids, vec!["s1"]);
+        assert_eq!(session.last_agent.as_deref(), Some("claude-code"));
+    }
+
+    #[tokio::test]
+    async fn rename_pinned_path_is_noop_for_unpinned() {
+        let _g = TEST_LOCK.lock().unwrap();
+        let _snap = PinsSnapshot::capture();
+
+        // Renaming a path that was never pinned must not create an entry.
+        rename_pinned_path("/tmp/never-pinned", "/tmp/whatever").unwrap();
+        assert!(list_pinned_projects().await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -323,6 +323,7 @@ pub fn run() {
             commands::projects::create_blank_project,
             commands::projects::remove_git_history,
             commands::projects::delete_project,
+            commands::projects::rename_project,
             commands::projects::clear_project_cache,
             commands::projects::get_auto_accept_mode,
             commands::projects::set_auto_accept_mode,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -365,6 +365,23 @@ pub fn unregister_session(project_path: &str) {
     }
 }
 
+/// Rekey an in-memory session from `old_path` to `new_path` after a folder
+/// rename. Idempotent and safe when no session exists for `old_path`. Active
+/// sessions are blocked from renaming upstream, so in practice this migrates
+/// suspended entries that still display on the rail.
+pub fn rename_session_path(old_path: &str, new_path: &str) {
+    if let Ok(mut sessions) = PROJECT_SESSIONS.lock() {
+        if let Some(session) = sessions.remove(old_path) {
+            sessions.insert(new_path.to_string(), session);
+            tracing::info!(
+                "Rekeyed session: {} -> {} (project rename)",
+                old_path,
+                new_path
+            );
+        }
+    }
+}
+
 /// Snapshot of all current sessions. Used by the rail UI and debugging.
 pub fn list_sessions() -> Vec<(String, ProjectSessionBackend)> {
     PROJECT_SESSIONS

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -25,6 +25,8 @@ interface ProjectCardProps {
   onDelete: () => void;
   /** Callback when main branch warning is toggled */
   onToggleMainBranchWarning: (hidden: boolean) => void;
+  /** Callback to rename the project (non-external projects only) */
+  onRename?: () => void;
   /** Callback to move project to a folder */
   onMoveToFolder?: () => void;
   /** Callback to export project as a template zip */
@@ -47,6 +49,7 @@ export const ProjectCard = memo(function ProjectCard({
   onSelect,
   onDelete,
   onToggleMainBranchWarning,
+  onRename,
   onMoveToFolder,
   onExportAsTemplate,
   onUploadThumbnail,
@@ -106,6 +109,7 @@ export const ProjectCard = memo(function ProjectCard({
         <ProjectCardMenu
           hideMainBranchWarning={hideMainBranchWarning}
           onToggleMainBranchWarning={onToggleMainBranchWarning}
+          onRename={onRename}
           onMoveToFolder={onMoveToFolder}
           onExportAsTemplate={onExportAsTemplate}
           onUploadThumbnail={onUploadThumbnail}

--- a/src/components/ProjectCardMenu.tsx
+++ b/src/components/ProjectCardMenu.tsx
@@ -10,7 +10,15 @@
  */
 
 import { useState, useRef, useCallback } from 'react';
-import { TrashIcon, FolderIcon, WarningIcon, DownloadIcon, CloseIcon, ImageIcon } from './icons';
+import {
+  TrashIcon,
+  FolderIcon,
+  WarningIcon,
+  DownloadIcon,
+  CloseIcon,
+  ImageIcon,
+  EditIcon,
+} from './icons';
 import { useClickOutside } from '../hooks/useClickOutside';
 
 interface ProjectCardMenuProps {
@@ -18,6 +26,9 @@ interface ProjectCardMenuProps {
   hideMainBranchWarning: boolean;
   /** Callback when main branch warning toggle is clicked */
   onToggleMainBranchWarning: (hidden: boolean) => void;
+  /** Callback to rename the project (non-external projects only). When omitted,
+   *  the "Rename project" item is hidden. */
+  onRename?: () => void;
   /** Callback to move project to a folder */
   onMoveToFolder?: () => void;
   /** Callback to export project as a template zip */
@@ -41,6 +52,7 @@ interface ProjectCardMenuProps {
 export function ProjectCardMenu({
   hideMainBranchWarning,
   onToggleMainBranchWarning,
+  onRename,
   onMoveToFolder,
   onExportAsTemplate,
   onUploadThumbnail,
@@ -66,6 +78,12 @@ export function ProjectCardMenu({
     e.stopPropagation();
     setIsOpen(false);
     onRemove?.();
+  };
+
+  const handleRenameClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsOpen(false);
+    onRename?.();
   };
 
   const handleMoveToFolderClick = (e: React.MouseEvent) => {
@@ -115,6 +133,12 @@ export function ProjectCardMenu({
               {!hideMainBranchWarning ? 'ON' : 'OFF'}
             </span>
           </button>
+          {onRename && !isExternal && (
+            <button className="project-card-dropdown-item" onClick={handleRenameClick}>
+              <EditIcon size={14} />
+              <span>Rename project</span>
+            </button>
+          )}
           {onMoveToFolder && (
             <button className="project-card-dropdown-item" onClick={handleMoveToFolderClick}>
               <FolderIcon size={14} />

--- a/src/components/ProjectGridView.tsx
+++ b/src/components/ProjectGridView.tsx
@@ -24,6 +24,7 @@ export interface ProjectGridViewProps {
 
   onSelectProject: (project: ProjectWithThumbnail) => void;
   onDeleteProject: (project: DashboardProject) => void;
+  onRenameProject: (project: DashboardProject) => void;
   onToggleMainBranchWarning: (projectPath: string, hidden: boolean) => void;
   onOpenMoveModal: (project: DashboardProject) => void;
   onExportAsTemplate: (projectPath: string) => void;
@@ -48,6 +49,7 @@ export function ProjectGridView({
   filteredProjects,
   onSelectProject,
   onDeleteProject,
+  onRenameProject,
   onToggleMainBranchWarning,
   onOpenMoveModal,
   onExportAsTemplate,
@@ -101,6 +103,7 @@ export function ProjectGridView({
           onSelect={() => onSelectProject(project)}
           onDelete={() => onDeleteProject(project)}
           onToggleMainBranchWarning={(hidden) => onToggleMainBranchWarning(project.path, hidden)}
+          onRename={project.is_external ? undefined : () => onRenameProject(project)}
           onMoveToFolder={() => onOpenMoveModal(project)}
           onExportAsTemplate={() => onExportAsTemplate(project.path)}
           onUploadThumbnail={() => onUploadThumbnail(project)}

--- a/src/components/ProjectList.tsx
+++ b/src/components/ProjectList.tsx
@@ -45,8 +45,7 @@ import { AgentsPanel } from './AgentsPanel';
 import { IntegrationBar } from './IntegrationBar';
 import { NewFolderModal } from './NewFolderModal';
 import { ProjectGridView } from './ProjectGridView';
-import { ModalFrame } from './primitives/ModalFrame';
-import { Button } from './primitives/Button';
+import { RenameProjectModal } from './RenameProjectModal';
 import { SearchAndSort } from './SearchAndSort';
 import { FolderBreadcrumb } from './FolderBreadcrumb';
 import { MoveFolderModal } from './MoveFolderModal';
@@ -131,8 +130,6 @@ export function ProjectList({
   const [deleteConfirm, setDeleteConfirm] = useState<DashboardProject | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [renameTarget, setRenameTarget] = useState<DashboardProject | null>(null);
-  const [renameValue, setRenameValue] = useState('');
-  const [renaming, setRenaming] = useState(false);
 
   // Folder navigation state
   const [currentFolderId, setCurrentFolderId] = useState<string | null>(null);
@@ -320,29 +317,21 @@ export function ProjectList({
     }
   };
 
-  const openRenameModal = (project: DashboardProject) => {
-    setRenameTarget(project);
-    setRenameValue(project.name);
-  };
-
-  const handleRename = async () => {
+  // Performs the rename and refreshes the dashboard. Throws on failure so the
+  // modal can render the backend's reason inline (e.g. "Close this project
+  // before renaming it.").
+  const handleRename = async (newName: string) => {
     if (!renameTarget) return;
-    const trimmed = renameValue.trim();
-    if (!trimmed || trimmed === renameTarget.name) return;
-    setRenaming(true);
     try {
-      await renameProject(renameTarget.path, trimmed);
+      await renameProject(renameTarget.path, newName);
       void trackEvent('project_renamed', { $screen_name: 'Dashboard' });
-      setRenameTarget(null);
       await loadAll();
     } catch (error) {
       trackError('project_rename', error, 'Dashboard');
       logger.error('Failed to rename project', {
         error: error instanceof Error ? error.message : String(error),
       });
-      alert('Failed to rename project: ' + String(error));
-    } finally {
-      setRenaming(false);
+      throw error;
     }
   };
 
@@ -600,7 +589,7 @@ export function ProjectList({
           filteredProjects={filteredProjects}
           onSelectProject={(project) => onSelectProject(project)}
           onDeleteProject={(project) => setDeleteConfirm(project)}
-          onRenameProject={(project) => openRenameModal(project)}
+          onRenameProject={(project) => setRenameTarget(project)}
           onToggleMainBranchWarning={(path, hidden) =>
             void handleToggleMainBranchWarning(path, hidden)
           }
@@ -717,60 +706,12 @@ export function ProjectList({
         />
 
         {/* Rename Project Modal */}
-        <ModalFrame
+        <RenameProjectModal
           isOpen={renameTarget !== null}
           onClose={() => setRenameTarget(null)}
-          title="Rename project"
-          dismissable={!renaming}
-        >
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              void handleRename();
-            }}
-            style={{ padding: 'var(--spacing-xl)' }}
-          >
-            <div className="form-group">
-              <label htmlFor="rename-project-name">Project name</label>
-              <input
-                id="rename-project-name"
-                type="text"
-                value={renameValue}
-                autoFocus
-                disabled={renaming}
-                onChange={(e) => setRenameValue(e.target.value)}
-                onFocus={(e) => e.currentTarget.select()}
-                autoComplete="off"
-                autoCorrect="off"
-                autoCapitalize="off"
-                spellCheck={false}
-              />
-            </div>
-            <p className="hint">
-              This renames the folder on disk. Git history, deployments, and project settings are
-              preserved.
-            </p>
-            <div className="modal-actions">
-              <Button
-                variant="secondary"
-                type="button"
-                onClick={() => setRenameTarget(null)}
-                disabled={renaming}
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="primary"
-                type="submit"
-                disabled={
-                  renaming || renameValue.trim() === '' || renameValue.trim() === renameTarget?.name
-                }
-              >
-                {renaming ? 'Renaming…' : 'Rename'}
-              </Button>
-            </div>
-          </form>
-        </ModalFrame>
+          currentName={renameTarget?.name ?? ''}
+          onRename={handleRename}
+        />
 
         {/* Delete Project Confirmation Modal */}
         {deleteConfirm && (

--- a/src/components/ProjectList.tsx
+++ b/src/components/ProjectList.tsx
@@ -22,6 +22,7 @@ import {
   getProjectThumbnail,
   uploadProjectThumbnail,
   deleteProject,
+  renameProject,
   exportProjectAsTemplate,
 } from '../lib/project';
 import { unregisterExternalProject } from '../lib/external-projects';
@@ -44,6 +45,8 @@ import { AgentsPanel } from './AgentsPanel';
 import { IntegrationBar } from './IntegrationBar';
 import { NewFolderModal } from './NewFolderModal';
 import { ProjectGridView } from './ProjectGridView';
+import { ModalFrame } from './primitives/ModalFrame';
+import { Button } from './primitives/Button';
 import { SearchAndSort } from './SearchAndSort';
 import { FolderBreadcrumb } from './FolderBreadcrumb';
 import { MoveFolderModal } from './MoveFolderModal';
@@ -127,6 +130,9 @@ export function ProjectList({
   const [loading, setLoading] = useState(true);
   const [deleteConfirm, setDeleteConfirm] = useState<DashboardProject | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [renameTarget, setRenameTarget] = useState<DashboardProject | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [renaming, setRenaming] = useState(false);
 
   // Folder navigation state
   const [currentFolderId, setCurrentFolderId] = useState<string | null>(null);
@@ -311,6 +317,32 @@ export function ProjectList({
       alert('Failed to delete project: ' + String(error));
     } finally {
       setDeleting(false);
+    }
+  };
+
+  const openRenameModal = (project: DashboardProject) => {
+    setRenameTarget(project);
+    setRenameValue(project.name);
+  };
+
+  const handleRename = async () => {
+    if (!renameTarget) return;
+    const trimmed = renameValue.trim();
+    if (!trimmed || trimmed === renameTarget.name) return;
+    setRenaming(true);
+    try {
+      await renameProject(renameTarget.path, trimmed);
+      void trackEvent('project_renamed', { $screen_name: 'Dashboard' });
+      setRenameTarget(null);
+      await loadAll();
+    } catch (error) {
+      trackError('project_rename', error, 'Dashboard');
+      logger.error('Failed to rename project', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      alert('Failed to rename project: ' + String(error));
+    } finally {
+      setRenaming(false);
     }
   };
 
@@ -568,6 +600,7 @@ export function ProjectList({
           filteredProjects={filteredProjects}
           onSelectProject={(project) => onSelectProject(project)}
           onDeleteProject={(project) => setDeleteConfirm(project)}
+          onRenameProject={(project) => openRenameModal(project)}
           onToggleMainBranchWarning={(path, hidden) =>
             void handleToggleMainBranchWarning(path, hidden)
           }
@@ -682,6 +715,62 @@ export function ProjectList({
           projectName={moveProject?.name || ''}
           currentFolderId={moveProjectFolderId}
         />
+
+        {/* Rename Project Modal */}
+        <ModalFrame
+          isOpen={renameTarget !== null}
+          onClose={() => setRenameTarget(null)}
+          title="Rename project"
+          dismissable={!renaming}
+        >
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              void handleRename();
+            }}
+            style={{ padding: 'var(--spacing-xl)' }}
+          >
+            <div className="form-group">
+              <label htmlFor="rename-project-name">Project name</label>
+              <input
+                id="rename-project-name"
+                type="text"
+                value={renameValue}
+                autoFocus
+                disabled={renaming}
+                onChange={(e) => setRenameValue(e.target.value)}
+                onFocus={(e) => e.currentTarget.select()}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
+              />
+            </div>
+            <p className="hint">
+              This renames the folder on disk. Git history, deployments, and project settings are
+              preserved.
+            </p>
+            <div className="modal-actions">
+              <Button
+                variant="secondary"
+                type="button"
+                onClick={() => setRenameTarget(null)}
+                disabled={renaming}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                type="submit"
+                disabled={
+                  renaming || renameValue.trim() === '' || renameValue.trim() === renameTarget?.name
+                }
+              >
+                {renaming ? 'Renaming…' : 'Rename'}
+              </Button>
+            </div>
+          </form>
+        </ModalFrame>
 
         {/* Delete Project Confirmation Modal */}
         {deleteConfirm && (

--- a/src/components/RenameProjectModal.tsx
+++ b/src/components/RenameProjectModal.tsx
@@ -1,0 +1,100 @@
+/**
+ * RenameProjectModal — rename a project's folder on disk.
+ *
+ * Mirrors NewFolderModal: self-contained input + loading + inline error.
+ * The actual backend call lives in the `onRename` callback supplied by the
+ * parent, which should throw on failure so the error renders inline.
+ *
+ * @module components/RenameProjectModal
+ */
+
+import { useState, useRef, useEffect } from 'react';
+import { ModalFrame } from './primitives/ModalFrame';
+import { Button } from './primitives/Button';
+
+interface RenameProjectModalProps {
+  /** Whether the modal is open */
+  isOpen: boolean;
+  /** Callback to close the modal */
+  onClose: () => void;
+  /** Current project (folder) name. Seeds the input and disables submit while
+   *  the value is unchanged. */
+  currentName: string;
+  /** Performs the rename. Should throw on failure so the error renders inline. */
+  onRename: (newName: string) => Promise<void>;
+}
+
+export function RenameProjectModal({
+  isOpen,
+  onClose,
+  currentName,
+  onRename,
+}: RenameProjectModalProps) {
+  const [name, setName] = useState(currentName);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reset to the current name and select it whenever the modal (re)opens.
+  useEffect(() => {
+    if (isOpen) {
+      setName(currentName);
+      setError(null);
+      setLoading(false);
+      setTimeout(() => inputRef.current?.select(), 50);
+    }
+  }, [isOpen, currentName]);
+
+  const trimmed = name.trim();
+  const unchanged = trimmed === currentName;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!trimmed || unchanged) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await onRename(trimmed);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ModalFrame isOpen={isOpen} onClose={onClose} title="Rename project" dismissable={!loading}>
+      <form onSubmit={(e) => void handleSubmit(e)} style={{ padding: 'var(--spacing-xl)' }}>
+        <div className="form-group">
+          <label htmlFor="rename-project-name">Project name</label>
+          <input
+            ref={inputRef}
+            id="rename-project-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={loading}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+          />
+        </div>
+        <p className="hint">
+          This renames the folder on disk. Git history, deployments, and project settings are
+          preserved.
+        </p>
+        {error && <p className="form-error">{error}</p>}
+        <div className="modal-actions">
+          <Button variant="secondary" type="button" onClick={onClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button variant="primary" type="submit" disabled={loading || !trimmed || unchanged}>
+            {loading ? 'Renaming…' : 'Rename'}
+          </Button>
+        </div>
+      </form>
+    </ModalFrame>
+  );
+}

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -138,6 +138,18 @@ export async function deleteProject(path: string): Promise<void> {
 }
 
 /**
+ * Rename a project's folder on disk and rekey path-keyed stores (pins, folders,
+ * sessions). Only works for ~/ShipStudio projects, and is rejected by the
+ * backend if the project is currently open or has an active session.
+ * @param oldPath - Current absolute path to the project directory
+ * @param newName - New folder name (single path component, no slashes)
+ * @returns The new absolute path
+ */
+export async function renameProject(oldPath: string, newName: string): Promise<string> {
+  return invoke<string>('rename_project', { oldPath, newName });
+}
+
+/**
  * Export a project as a reusable template.
  * Opens a save dialog and exports the project structure.
  * @param projectPath - Absolute path to the project directory


### PR DESCRIPTION
## What

Adds the ability to rename a project. A project's name is just its folder name on disk, so this does a **real folder rename** — `~/ShipStudio/old-name` → `~/ShipStudio/new-name` — keeping the app, Finder, and VS Code/Cursor all in sync.

Everything risky lives *inside* the project directory and rides along with the move untouched: git remotes (`.git/config`), the Vercel link (`.vercel/project.json`), and all `.shipstudio/project.json` metadata/publish records. Only the stores that key a project by its **absolute path** need rekeying, which this handles.

## Backend

- New `rename_project(old_path, new_name)` command:
  - Rejects external projects and paths outside `~/ShipStudio` (mirrors `delete_project`)
  - Validates the new name (no separators, no `.`/`..`, no leading dot, non-empty, length cap)
  - **Blocks the rename while the project is open in a window or has an active session** — so we never move a directory out from under live PTYs / reserved ports. Suspended pinned sessions are fine and get rekeyed.
- Rekey helpers: `pins::rename_pinned_path` (pin order + resume sessions), `folders::rename_project_path` (folder membership), `state::rename_session_path` (suspended in-memory sessions). Registered in `lib.rs`.

## Frontend

- `renameProject` wrapper in `lib/project.ts`
- "Rename project" item (`EditIcon`) in the card `···` menu, hidden for external projects
- Threaded `ProjectCard → ProjectGridView → ProjectList`
- `ModalFrame` + `Button` rename modal reusing the existing `form-group` pattern (no new CSS)

## Scope (v1)

- **ShipStudio projects only.** External projects keep "Remove from list" (no rename) — easy follow-up by updating `external-projects.json`.
- Not added to the Cmd+K palette — it's a per-row list action, which CLAUDE.md keeps out of the palette (same as per-row delete).

## Testing

- Rust: name-validation + pins-rekey unit tests
- Frontend: `pnpm typecheck` clean, full suite (427) green
- `cargo fmt` + full backend build clean
- Manually verified end-to-end in the running app: rename works, folder renamed on disk, settings preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add project rename flow with validation (rejects empty, hidden, relative, too-long, or path-containing names)
  * "Rename project" option in project menu for non-external projects; modal UI with loading/error states
  * Backend rename enforces safety (must be local, not open or running) and updates related records (pins, folders, sessions)
* **Tests**
  * Added unit tests covering accepted and rejected project names
<!-- end of auto-generated comment: release notes by coderabbit.ai -->