### PR TITLE
Release CI: carry installers forward across the "latest" alias flip

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -158,16 +158,31 @@ jobs:
 
           python3 -c "import json; json.load(open('latest-windows.json'))" && echo "JSON is valid"
 
-      # Carry forward macOS manifest so macOS auto-update keeps working
-      # when this Windows release flips the "latest" alias
-      - name: Carry forward macOS manifest file
+      # Carry forward macOS manifest AND installers so neither macOS
+      # auto-update nor the site's download links break when this Windows
+      # release flips the "latest" alias. The marketing site links to
+      # releases/latest/download/ShipStudio_darwin-*.dmg — publishing
+      # v0.6.8-win without the DMGs 404'd the Mac download buttons.
+      # Resolve the newest macOS (non -win) release explicitly: it is
+      # guaranteed to have both the manifest and the DMGs. Strict (no
+      # continue-on-error): publishing without these assets breaks macOS
+      # users, so failing the Windows release is the lesser evil.
+      - name: Carry forward macOS manifest and installers
         env:
           GH_TOKEN: ${{ secrets.RELEASES_PAT }}
         run: |
           mkdir -p carry-forward
-          gh release download \
+          MAC_TAG=$(gh release list --repo ship-studio/releases --limit 50 \
+            --json tagName --jq '[.[] | select(.tagName | endswith("-win") | not)][0].tagName // empty')
+          if [ -z "$MAC_TAG" ]; then
+            echo "No macOS release found to carry forward" >&2
+            exit 1
+          fi
+          echo "Carrying forward macOS assets from $MAC_TAG"
+          gh release download "$MAC_TAG" \
             --repo ship-studio/releases \
             --pattern "latest.json" \
+            --pattern "ShipStudio_darwin-*.dmg" \
             --dir carry-forward
           ls -la carry-forward/
 
@@ -186,8 +201,9 @@ jobs:
       # has no --draft). The old --draft "manual publish gate" meant every
       # Windows build silently stopped at a draft and no download ever went
       # live — the CI windows-check job now provides the verification that
-      # gate stood in for. Includes the carry-forward macOS manifest so this
-      # release flipping the "latest" alias doesn't drop macOS auto-update.
+      # gate stood in for. Includes the carry-forward macOS manifest and DMG
+      # installers so this release flipping the "latest" alias doesn't drop
+      # macOS auto-update or the site's Mac download links.
       - name: Create release in public ship-studio/releases repo
         env:
           GH_TOKEN: ${{ secrets.RELEASES_PAT }}
@@ -203,4 +219,6 @@ jobs:
             artifacts/ShipStudio_windows-x86_64-setup.exe \
             artifacts/ShipStudio_windows-x86_64-setup.exe.sig \
             latest-windows.json \
-            carry-forward/latest.json
+            carry-forward/latest.json \
+            carry-forward/ShipStudio_darwin-aarch64.dmg \
+            carry-forward/ShipStudio_darwin-x86_64.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,16 +243,17 @@ jobs:
           # Validate JSON
           python3 -c "import json; json.load(open('latest.json'))" && echo "JSON is valid"
 
-      # Carry forward Windows manifest so Windows auto-update keeps working
-      # when this macOS release flips the "latest" alias.
+      # Carry forward Windows manifest AND installer so Windows auto-update
+      # and the site's /latest/download Windows link keep working when this
+      # macOS release flips the "latest" alias.
       #
-      # NOTE: latest-windows.json only lives on the most recent *-win release,
-      # NOT on the implicit "latest" release (which is a macOS release without
-      # it). Always resolve the newest -win tag explicitly. This step is
-      # best-effort: a missing/unavailable Windows manifest must never block
-      # the macOS release from publishing (that regression shipped a broken
-      # auto-update chain in v0.6.4).
-      - name: Carry forward Windows manifest file
+      # NOTE: latest-windows.json and the .exe only live on the most recent
+      # *-win release, NOT on the implicit "latest" release (which is a macOS
+      # release without them). Always resolve the newest -win tag explicitly.
+      # This step is best-effort: a missing/unavailable Windows asset must
+      # never block the macOS release from publishing (that regression shipped
+      # a broken auto-update chain in v0.6.4).
+      - name: Carry forward Windows manifest and installer
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.RELEASES_PAT }}
@@ -261,15 +262,16 @@ jobs:
           WIN_TAG=$(gh release list --repo ship-studio/releases --limit 50 \
             --json tagName --jq '[.[] | select(.tagName | endswith("-win"))][0].tagName // empty')
           if [ -z "$WIN_TAG" ]; then
-            echo "::warning::No -win release found; skipping Windows manifest carry-forward"
+            echo "::warning::No -win release found; skipping Windows carry-forward"
             exit 0
           fi
-          echo "Carrying forward Windows manifest from $WIN_TAG"
+          echo "Carrying forward Windows assets from $WIN_TAG"
           gh release download "$WIN_TAG" \
             --repo ship-studio/releases \
             --pattern "latest-windows.json" \
+            --pattern "ShipStudio_windows-x86_64-setup.exe" \
             --dir carry-forward \
-            || echo "::warning::No latest-windows.json on $WIN_TAG; skipping carry-forward"
+            || echo "::warning::Could not download Windows assets from $WIN_TAG; skipping carry-forward"
           ls -la carry-forward/ || true
 
       # Upload to the PRIVATE main repo (for reference/backup)
@@ -284,7 +286,8 @@ jobs:
           draft: true
 
       # Upload to public repo for auto-updater. Includes carry-forward
-      # Windows manifest so "latest" alias flip doesn't drop Windows.
+      # Windows manifest + installer so "latest" alias flip doesn't drop
+      # Windows auto-update or the site's Windows download link.
       - name: Create release in public releases repo
         env:
           GH_TOKEN: ${{ secrets.RELEASES_PAT }}
@@ -292,9 +295,9 @@ jobs:
           TAG="${{ github.ref_name }}"
           VERSION="${{ steps.version.outputs.version }}"
 
-          # Required macOS assets + manifest. The Windows manifest is appended
-          # only if the carry-forward step actually produced it, so a missing
-          # Windows manifest can never block the macOS auto-update release.
+          # Required macOS assets + manifest. The Windows assets are appended
+          # only if the carry-forward step actually produced them, so missing
+          # Windows assets can never block the macOS auto-update release.
           ASSETS=(
             artifacts/updater-darwin-aarch64/ShipStudio_darwin-aarch64.app.tar.gz
             artifacts/updater-darwin-x86_64/ShipStudio_darwin-x86_64.app.tar.gz
@@ -306,6 +309,11 @@ jobs:
             ASSETS+=(carry-forward/latest-windows.json)
           else
             echo "::warning::latest-windows.json missing; publishing macOS release without it. Windows auto-update may need a manual re-publish of the latest -win manifest."
+          fi
+          if [ -f carry-forward/ShipStudio_windows-x86_64-setup.exe ]; then
+            ASSETS+=(carry-forward/ShipStudio_windows-x86_64-setup.exe)
+          else
+            echo "::warning::Windows installer missing; the site's /latest/download Windows link will 404 until the next -win release or a manual upload."
           fi
 
           # Create the release in the public repo (auto-published, no draft)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -113,7 +113,7 @@ The version a `-win` build ships comes from the source files (`package.json` etc
 
 After the workflow completes (~15–25 min for the Windows build):
 
-- [ ] A **published** (not draft) release exists in `ship-studio/releases` with 2 Windows artifacts (`-setup.exe`, `-setup.exe.sig`) and 2 manifests (`latest-windows.json`, carried-forward `latest.json`)
+- [ ] A **published** (not draft) release exists in `ship-studio/releases` with 2 Windows artifacts (`-setup.exe`, `-setup.exe.sig`), 2 manifests (`latest-windows.json`, carried-forward `latest.json`), and 2 carried-forward macOS DMGs (`ShipStudio_darwin-aarch64.dmg`, `ShipStudio_darwin-x86_64.dmg`)
 - [ ] `latest-windows.json` is valid and has a `windows-x86_64` platform entry:
   ```bash
   curl -sL https://github.com/ship-studio/releases/releases/latest/download/latest-windows.json | jq
@@ -121,6 +121,13 @@ After the workflow completes (~15–25 min for the Windows build):
 - [ ] `latest.json` still resolves at the public latest URL and still points at the most recent macOS bundle (the carry-forward keeps macOS auto-update alive when this release flips the "latest" alias):
   ```bash
   curl -sL https://github.com/ship-studio/releases/releases/latest/download/latest.json | jq '.version'
+  ```
+- [ ] The site's static download links all still resolve (every release must carry the other platform's installers forward, or flipping the "latest" alias 404s them — this bit us when v0.6.8-win shipped without the DMGs):
+  ```bash
+  for f in ShipStudio_darwin-aarch64.dmg ShipStudio_darwin-x86_64.dmg ShipStudio_windows-x86_64-setup.exe; do
+    curl -s -o /dev/null -w "$f -> %{http_code}\n" -L -r 0-0 \
+      "https://github.com/ship-studio/releases/releases/latest/download/$f"
+  done   # all three should print 206
   ```
 - [ ] A draft release also lands in the main repo (the build-artifact dump); publishing it is optional — the public repo is what users and the updater read.
 


### PR DESCRIPTION
## Why

Publishing `v0.6.8-win` flipped the "latest" release pointer to a release with no DMGs, which 404'd the marketing site's Mac download buttons (`releases/latest/download/ShipStudio_darwin-*.dmg`) until the DMGs were manually uploaded onto `v0.6.8-win`. The same thing would happen in reverse to the Windows link on the next macOS release.

## What

- **release-windows.yml** — carry forward the newest macOS release's `latest.json` **and both DMGs** (resolved by explicit non-`-win` tag). Strict: failing the Windows release beats silently breaking Mac downloads.
- **release.yml** — carry forward the newest `-win` release's `latest-windows.json` **and the `.exe`**. Best-effort, so a missing Windows build never blocks a macOS release (same philosophy as the existing manifest guard).
- **RELEASING.md** — updated asset list + new checklist item: all three `/latest/download/` installer links must return 206 after any release.

After this, every published release carries all installers, so the "latest" alias always serves macOS + Windows downloads regardless of which platform shipped last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to ensure Windows and macOS installer assets are properly coordinated and made available in public releases.
  * Updated release verification documentation to validate that all platform download URLs resolve correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->