### PR TITLE
Code cleanup: pattern debt, panic path, observability + folder button height

### DIFF
--- a/src-tauri/src/commands/claude.rs
+++ b/src-tauri/src/commands/claude.rs
@@ -23,6 +23,7 @@ use crate::utils::{create_command, get_extended_path};
 /// pruned it), resume exits code 1 and we fall back to a fresh session.
 /// The fallback works but wastes ~1s and produces noisy logs.
 #[tauri::command]
+#[tracing::instrument(skip(project_path, session_id), fields(project = %project_path, session_id = %session_id))]
 pub fn claude_session_exists(project_path: String, session_id: String) -> bool {
     let Some(home) = dirs::home_dir() else {
         return false;

--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -330,6 +330,7 @@ pub async fn get_project_folder(project_path: String) -> Result<Option<String>, 
 
 /// Get all project paths that are in folders (used to filter unfiled projects)
 #[tauri::command]
+#[tracing::instrument]
 pub async fn get_filed_project_paths() -> Result<Vec<String>, CommandError> {
     let config = load_folder_config()?;
 
@@ -343,6 +344,7 @@ pub async fn get_filed_project_paths() -> Result<Vec<String>, CommandError> {
 
 /// Get projects in a specific folder
 #[tauri::command]
+#[tracing::instrument(skip(folder_id), fields(folder_id = %folder_id))]
 pub async fn get_folder_projects(folder_id: String) -> Result<Vec<String>, CommandError> {
     let config = load_folder_config()?;
 
@@ -357,6 +359,7 @@ pub async fn get_folder_projects(folder_id: String) -> Result<Vec<String>, Comma
 
 /// Get folder details by ID
 #[tauri::command]
+#[tracing::instrument(skip(folder_id), fields(folder_id = %folder_id))]
 pub async fn get_folder(folder_id: String) -> Result<Option<Folder>, CommandError> {
     let config = load_folder_config()?;
 

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -364,7 +364,7 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
     }
 
     // Ensure git identity is configured (required for commits)
-    ensure_git_identity(&validated_path).map_err(CommandError::from)?;
+    ensure_git_identity(&validated_path)?;
 
     // Stage and commit any files
     let _ = git_stage_and_commit(

--- a/src-tauri/src/commands/mobile.rs
+++ b/src-tauri/src/commands/mobile.rs
@@ -513,11 +513,11 @@ async fn ensure_emulator(preferred: Option<String>) -> Result<(AndroidDevice, bo
     // while one is running — `expo run:android` / `react-native run-android`
     // target "the" device and would be ambiguous with two attached.
     let running = list_android_devices().await?;
-    if !running.is_empty() {
-        let dev = preferred
-            .as_deref()
-            .and_then(|p| running.iter().find(|d| d.serial == p).cloned())
-            .unwrap_or_else(|| running.into_iter().next().expect("non-empty"));
+    let already_up = preferred
+        .as_deref()
+        .and_then(|p| running.iter().find(|d| d.serial == p).cloned())
+        .or_else(|| running.into_iter().next());
+    if let Some(dev) = already_up {
         return Ok((dev, false));
     }
 
@@ -1550,7 +1550,7 @@ async fn handle_bridge_client(
             } = sess;
             *current_scid.lock().unwrap_or_else(|e| e.into_inner()) = Some(scid);
             if sink
-                .send(Message::Text(bridge_hello("scrcpy").into()))
+                .send(Message::Text(bridge_hello("scrcpy")))
                 .await
                 .is_ok()
             {
@@ -1568,11 +1568,7 @@ async fn handle_bridge_client(
         }
         None => {
             tracing::info!(%serial, "scrcpy unavailable — using screenrecord mirror");
-            if sink
-                .send(Message::Text(bridge_hello("adb").into()))
-                .await
-                .is_err()
-            {
+            if sink.send(Message::Text(bridge_hello("adb"))).await.is_err() {
                 return;
             }
             tokio::select! {

--- a/src-tauri/src/commands/projects/detection.rs
+++ b/src-tauri/src/commands/projects/detection.rs
@@ -362,9 +362,9 @@ pub(crate) fn scan_nextjs_pages(
                         if let std::path::Component::Normal(s) = c {
                             let segment = s.to_string_lossy();
                             // Skip route groups: directories starting with '(' and ending with ')'
-                            if segment.starts_with('(') && segment.ends_with(')') {
-                                None
-                            } else if segment == "[locale]" {
+                            if (segment.starts_with('(') && segment.ends_with(')'))
+                                || segment == "[locale]"
+                            {
                                 None
                             } else {
                                 Some(segment.to_string())

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -103,7 +103,7 @@ pub async fn set_always_on_top(window: Window, enabled: bool) -> Result<(), Comm
 #[tauri::command]
 #[tracing::instrument]
 pub async fn save_compact_position(x: i32, y: i32) -> Result<(), CommandError> {
-    save_compact_position_internal(x, y).map_err(CommandError::from)
+    save_compact_position_internal(x, y)
 }
 
 /// Internal helper to save position (used by both command and exit_compact_mode)

--- a/src/components/ClientEditorButton.tsx
+++ b/src/components/ClientEditorButton.tsx
@@ -3,6 +3,7 @@ import { openUrl } from '@tauri-apps/plugin-opener';
 import { detectClientEditor } from '../lib/client-editor';
 import { UsersIcon } from './icons';
 import { Button } from './primitives/Button';
+import { ModalFrame } from './primitives/ModalFrame';
 
 const DASHBOARD_URL = 'https://www.ship.studio/dashboard/projects';
 
@@ -51,93 +52,92 @@ export function ClientEditorButton({ projectPath }: ClientEditorButtonProps) {
         <span>Add Clients</span>
       </button>
 
-      {showModal && (
-        <div className="modal-overlay" onClick={() => setShowModal(false)}>
-          <div className="modal client-editor-modal" onClick={(e) => e.stopPropagation()}>
-            {step === 0 && (
-              <>
-                <div className="client-editor-modal-icon">
-                  <UsersIcon size={24} />
-                </div>
-                <h3>
-                  Client Editor <span style={{ fontWeight: 400, opacity: 0.5 }}>Beta</span>
-                </h3>
-                <p>
-                  Let your clients update text, images, and metadata directly on their live site —
-                  no code, no CMS, no training required.
-                </p>
-                <p>
-                  Works with any stack. You add one script tag, and they get an inline editing
-                  experience that commits changes straight to your repo.
-                </p>
-                <p className="client-editor-pricing">
-                  <strong>$10/month per client seat.</strong> Your developer seat is free for now,
-                  but this may change in the future.
-                </p>
-                <div className="modal-actions">
-                  <Button variant="secondary" onClick={() => setShowModal(false)}>
-                    Close
-                  </Button>
-                  <Button variant="primary" onClick={() => setStep(1)}>
-                    Continue
-                  </Button>
-                </div>
-              </>
-            )}
+      <ModalFrame
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+        className="client-editor-modal"
+        ariaLabel="Client Editor"
+      >
+        {step === 0 && (
+          <>
+            <div className="client-editor-modal-icon">
+              <UsersIcon size={24} />
+            </div>
+            <h3>
+              Client Editor <span style={{ fontWeight: 400, opacity: 0.5 }}>Beta</span>
+            </h3>
+            <p>
+              Let your clients update text, images, and metadata directly on their live site — no
+              code, no CMS, no training required.
+            </p>
+            <p>
+              Works with any stack. You add one script tag, and they get an inline editing
+              experience that commits changes straight to your repo.
+            </p>
+            <p className="client-editor-pricing">
+              <strong>$10/month per client seat.</strong> Your developer seat is free for now, but
+              this may change in the future.
+            </p>
+            <div className="modal-actions">
+              <Button variant="secondary" onClick={() => setShowModal(false)}>
+                Close
+              </Button>
+              <Button variant="primary" onClick={() => setStep(1)}>
+                Continue
+              </Button>
+            </div>
+          </>
+        )}
 
-            {step === 1 && (
-              <>
-                <h3>How it works</h3>
-                <div className="client-editor-steps">
-                  <div className="client-editor-step">
-                    <span className="client-editor-step-num">1</span>
-                    <div>
-                      <strong>Enable the editor</strong>
-                      <p>
-                        Connect your project and enter your site URL on the Ship Studio dashboard.
-                      </p>
-                    </div>
-                  </div>
-                  <div className="client-editor-step">
-                    <span className="client-editor-step-num">2</span>
-                    <div>
-                      <strong>Add the script tag</strong>
-                      <p>
-                        Drop a single {'<script>'} tag into your layout. It's invisible to visitors
-                        — only activates when your client opens the editor.
-                      </p>
-                    </div>
-                  </div>
-                  <div className="client-editor-step">
-                    <span className="client-editor-step-num">3</span>
-                    <div>
-                      <strong>Invite your client</strong>
-                      <p>
-                        They'll get a branded email with a link to start editing. Edits become PRs
-                        in your repo automatically.
-                      </p>
-                    </div>
-                  </div>
+        {step === 1 && (
+          <>
+            <h3>How it works</h3>
+            <div className="client-editor-steps">
+              <div className="client-editor-step">
+                <span className="client-editor-step-num">1</span>
+                <div>
+                  <strong>Enable the editor</strong>
+                  <p>Connect your project and enter your site URL on the Ship Studio dashboard.</p>
                 </div>
-                <div className="modal-actions">
-                  <Button variant="secondary" onClick={() => setStep(0)}>
-                    Back
-                  </Button>
-                  <Button
-                    variant="primary"
-                    onClick={() => {
-                      setShowModal(false);
-                      void openUrl(DASHBOARD_URL);
-                    }}
-                  >
-                    Get Started
-                  </Button>
+              </div>
+              <div className="client-editor-step">
+                <span className="client-editor-step-num">2</span>
+                <div>
+                  <strong>Add the script tag</strong>
+                  <p>
+                    Drop a single {'<script>'} tag into your layout. It's invisible to visitors —
+                    only activates when your client opens the editor.
+                  </p>
                 </div>
-              </>
-            )}
-          </div>
-        </div>
-      )}
+              </div>
+              <div className="client-editor-step">
+                <span className="client-editor-step-num">3</span>
+                <div>
+                  <strong>Invite your client</strong>
+                  <p>
+                    They'll get a branded email with a link to start editing. Edits become PRs in
+                    your repo automatically.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="modal-actions">
+              <Button variant="secondary" onClick={() => setStep(0)}>
+                Back
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => {
+                  setShowModal(false);
+                  void openUrl(DASHBOARD_URL);
+                }}
+              >
+                Get Started
+              </Button>
+            </div>
+          </>
+        )}
+      </ModalFrame>
     </>
   );
 }

--- a/src/components/ScreenshotPreview.tsx
+++ b/src/components/ScreenshotPreview.tsx
@@ -11,6 +11,7 @@
 import { useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { CameraIcon, CloseIcon } from './icons';
+import { ModalFrame } from './primitives/ModalFrame';
 import { logger } from '../lib/logger';
 
 /** Duration to show the toast before auto-dismiss (ms) */
@@ -121,37 +122,23 @@ export function ScreenshotPreviewModal({ filePath, onClose }: ScreenshotPreviewM
       );
   }, [filePath]);
 
-  // Close on escape key
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
-
   return (
-    <div className="modal-overlay screenshot-preview-overlay" onClick={onClose}>
-      <div className="screenshot-preview-modal" onClick={(e) => e.stopPropagation()}>
-        <div className="screenshot-preview-header">
-          <span className="screenshot-preview-title">Screenshot Preview</span>
-          <button className="screenshot-preview-close" onClick={onClose}>
-            <CloseIcon size={20} />
-          </button>
-        </div>
-        <div className="screenshot-preview-content">
-          {imageSrc ? (
-            <img src={imageSrc} alt="Full screenshot" />
-          ) : (
-            <div className="screenshot-modal-loading">Loading...</div>
-          )}
-        </div>
-        <div className="screenshot-preview-footer">
-          <span className="screenshot-preview-path">{filePath.split('/').pop()}</span>
-        </div>
+    <ModalFrame
+      isOpen
+      onClose={onClose}
+      title="Screenshot Preview"
+      className="screenshot-preview-modal"
+    >
+      <div className="screenshot-preview-content">
+        {imageSrc ? (
+          <img src={imageSrc} alt="Full screenshot" />
+        ) : (
+          <div className="screenshot-modal-loading">Loading...</div>
+        )}
       </div>
-    </div>
+      <div className="screenshot-preview-footer">
+        <span className="screenshot-preview-path">{filePath.split('/').pop()}</span>
+      </div>
+    </ModalFrame>
   );
 }

--- a/src/components/SearchAndSort.tsx
+++ b/src/components/SearchAndSort.tsx
@@ -77,6 +77,7 @@ export function SearchAndSort({
         <Button
           variant="secondary"
           size="sm"
+          className="new-folder-btn"
           data-education-id="new-folder-button"
           onClick={() => {
             void trackEvent('new_folder_clicked', { $screen_name: 'Dashboard' });

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -803,7 +803,11 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           if (event.key === 'c' && event.ctrlKey && !event.shiftKey && !event.altKey) {
             const selection = term.getSelection();
             if (selection) {
-              void navigator.clipboard.writeText(selection);
+              navigator.clipboard.writeText(selection).catch((err: unknown) => {
+                logger.warn('[Terminal] Failed to copy selection to clipboard', {
+                  error: String(err),
+                });
+              });
               term.clearSelection();
               return false;
             }

--- a/src/components/setup/OnboardingTerminal.tsx
+++ b/src/components/setup/OnboardingTerminal.tsx
@@ -271,7 +271,11 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
           if (event.key === 'c' && event.ctrlKey && !event.shiftKey && !event.altKey) {
             const selection = term.getSelection();
             if (selection) {
-              void navigator.clipboard.writeText(selection);
+              navigator.clipboard.writeText(selection).catch((err: unknown) => {
+                logger.warn('[OnboardingTerminal] Failed to copy selection to clipboard', {
+                  error: String(err),
+                });
+              });
               term.clearSelection();
               return false; // Prevent sending to PTY
             }

--- a/src/styles/components/modal.css
+++ b/src/styles/components/modal.css
@@ -204,9 +204,13 @@
   animation: spin 0.8s linear infinite;
 }
 
-/* Client Editor Modal */
+/* Client Editor Modal — rendered via ModalFrame, so it restores the legacy
+   .modal sizing/padding that .modal-frame-content doesn't provide. */
 .client-editor-modal {
+  display: block;
+  width: 90%;
   max-width: 420px;
+  padding: var(--spacing-xl);
   animation: plugin-suggestion-in 0.25s ease-out;
 }
 
@@ -224,7 +228,14 @@
 }
 
 .client-editor-modal h3 {
+  font-size: 18px;
+  margin-bottom: var(--spacing-md);
   text-align: center;
+}
+
+.client-editor-modal p {
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-sm);
 }
 
 .client-editor-modal > p {

--- a/src/styles/features/dashboard/projects.css
+++ b/src/styles/features/dashboard/projects.css
@@ -18,6 +18,11 @@
   gap: 8px;
 }
 
+/* Match the new-folder button's height to the sort dropdown beside it. */
+.dashboard-section-controls .new-folder-btn {
+  align-self: stretch;
+}
+
 .dashboard-section-controls .btn-icon {
   padding: 6px 7px;
   background: transparent;

--- a/src/styles/features/publish/toasts.css
+++ b/src/styles/features/publish/toasts.css
@@ -176,53 +176,11 @@
   }
 }
 
-/* Screenshot Preview Modal */
-.screenshot-preview-overlay {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 40px;
-}
-
+/* Screenshot Preview Modal — rendered via ModalFrame; the modal should size
+   to the image, so undo .modal-frame-content's fixed 480px width. */
 .screenshot-preview-modal {
-  display: flex;
-  flex-direction: column;
-  max-width: 90vw;
-  max-height: 90vh;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  width: auto;
   overflow: hidden;
-  box-shadow: 0 16px 64px rgba(0, 0, 0, 0.5);
-}
-
-.screenshot-preview-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-tertiary);
-}
-
-.screenshot-preview-title {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.screenshot-preview-close {
-  padding: 4px;
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-}
-
-.screenshot-preview-close:hover {
-  background: var(--bg-secondary);
-  color: var(--text-primary);
 }
 
 .screenshot-preview-content {


### PR DESCRIPTION
## Summary

Non-breaking cleanup pass over the codebase, fully verified against a green baseline (580 frontend + 344 Rust tests, `check:all`, `lint:strict`).

### Backend (Rust)
- Add missing `#[tracing::instrument]` to 4 commands (`claude_session_exists`, `get_filed_project_paths`, `get_folder_projects`, `get_folder`)
- Remove `.expect("non-empty")` panic path in `ensure_emulator` — the device pick now carries the non-empty guarantee in the value
- Drop 4 useless `CommandError`/`String` conversions; merge identical filter branches in `scan_nextjs_pages`

### Frontend
- Handle clipboard write rejection in Terminal/OnboardingTerminal Ctrl+C copy handlers (was an unhandled rejection)
- Convert `ClientEditorButton` modal to `ModalFrame` — gains ESC dismissal + dialog role it lacked (component currently behind `SHOW_CLIENT_EDITOR = false`)
- Convert `ScreenshotPreviewModal` to `ModalFrame` — removes duplicated ESC/overlay logic and ~45 lines of dead header CSS
- Match the dashboard new-folder button height to the sort dropdown (`align-self: stretch`)

## Test plan
- [x] `pnpm check:all` clean (tsc, eslint, prettier, rustfmt, clippy, patterns, LOC)
- [x] `pnpm lint:strict` zero warnings
- [x] 580 frontend tests pass, 344 Rust tests pass
- [x] Manual: screenshot preview modal, terminal Ctrl+C copy, dashboard folders + button height verified in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for clipboard operations in terminal components when copying selected text, with detailed logging of failures.

* **Refactor**
  * Updated modal dialog component architecture to use a shared framework for improved consistency and maintainability across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->