### PR TITLE
Add Expo, React Native, and Flutter starter templates

### DIFF
--- a/src/components/DeviceMirror.tsx
+++ b/src/components/DeviceMirror.tsx
@@ -614,7 +614,14 @@ export function DeviceMirror({ projectName, projectPath, onSendToAgent }: Device
             <ResetIcon size={14} /> Restart
           </Button>
         </div>
-        <div className="device-mirror-stage">
+        <div
+          className="device-mirror-stage"
+          // A double-click would start a native text/image selection that
+          // floods the pane blue — clicks here are touches, never selections.
+          onMouseDown={(e) => {
+            if (e.detail > 1) e.preventDefault();
+          }}
+        >
           {activePlatform === 'android' ? (
             // Key by attempt so a heal/Restart remounts the decoder even when the
             // backend hands back the same bridge port (wsUrl alone wouldn't change).

--- a/src/hooks/useProjectCreation.ts
+++ b/src/hooks/useProjectCreation.ts
@@ -29,6 +29,8 @@ export interface Template {
   description: string;
   /** GitHub repository URL to clone */
   repo: string;
+  /** Skip the npm install step (templates with no package.json, e.g. HTML/Flutter) */
+  skipInstall?: boolean;
 }
 
 const DEFAULT_TEMPLATE_KEY = 'defaultTemplateId';
@@ -73,6 +75,26 @@ export const TEMPLATES: Template[] = [
     name: 'HTML/CSS/JS',
     description: 'A plain HTML starter — no framework, no build step',
     repo: 'https://github.com/ship-studio/html-starter',
+    skipInstall: true,
+  },
+  {
+    id: 'expo-mobile',
+    name: 'Expo',
+    description: 'An iOS & Android app powered by Expo — the easiest mobile path',
+    repo: 'https://github.com/ship-studio/expo-starter',
+  },
+  {
+    id: 'react-native-mobile',
+    name: 'React Native',
+    description: 'An iOS & Android app with bare React Native — full native control',
+    repo: 'https://github.com/ship-studio/react-native-starter',
+  },
+  {
+    id: 'flutter-mobile',
+    name: 'Flutter',
+    description: 'An iOS & Android app built with Flutter and Material 3',
+    repo: 'https://github.com/ship-studio/flutter-starter',
+    skipInstall: true,
   },
   {
     id: 'blank',
@@ -368,9 +390,9 @@ export function useProjectCreation({ onComplete, onCancel }: UseProjectCreationP
         // Pre-install Vercel plugin (fire-and-forget, don't block creation)
         installPlugin(projectPath, VERCEL_PLUGIN_REPO).catch(() => {});
 
-        // Install dependencies (skip for HTML-only templates with no package.json)
+        // Install dependencies (skip for templates with no package.json)
         setCreatedProjectPath(projectPath);
-        if (selectedTemplate.id === 'html-basic') {
+        if (selectedTemplate.skipInstall) {
           setCurrentStep('done');
         } else {
           setCurrentStep('install');

--- a/src/hooks/useProjectCreation.ts
+++ b/src/hooks/useProjectCreation.ts
@@ -80,13 +80,13 @@ export const TEMPLATES: Template[] = [
   {
     id: 'expo-mobile',
     name: 'Expo',
-    description: 'An iOS & Android app powered by Expo — the easiest mobile path',
+    description: 'An iOS & Android app — the easiest mobile path',
     repo: 'https://github.com/ship-studio/expo-starter',
   },
   {
     id: 'react-native-mobile',
     name: 'React Native',
-    description: 'An iOS & Android app with bare React Native — full native control',
+    description: 'An iOS & Android app with full native control',
     repo: 'https://github.com/ship-studio/react-native-starter',
   },
   {

--- a/src/styles/features/device-mirror.css
+++ b/src/styles/features/device-mirror.css
@@ -66,6 +66,8 @@
   min-height: 0;
   padding: var(--spacing-md);
   overflow: hidden;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 /* The streamed simulator framebuffer. Constrain to the stage, preserve aspect,


### PR DESCRIPTION
## Summary
- Three new mobile starter templates in the create-project picker, backed by new ship-studio org repos: [expo-starter](https://github.com/ship-studio/expo-starter) (SDK 55), [react-native-starter](https://github.com/ship-studio/react-native-starter) (bare RN 0.86, CocoaPods via postinstall), [flutter-starter](https://github.com/ship-studio/flutter-starter) (Material 3)
- `skipInstall` flag on templates with no package.json (HTML, Flutter) replaces the hardcoded html-basic check
- Mirror fix: double-click no longer starts a native selection over the device preview

## Test plan
- [x] Each starter built + launched on iPhone 17 Pro simulator with the exact DeviceMirror launch commands; Expo screenshot-verified
- [x] Fresh GitHub clones re-verified (npm install/pods/tsc/lint/jest/flutter analyze+test)
- [x] Detection markers match detection.rs rules for RN/Expo/Flutter
- [x] 580 frontend tests, typecheck, lint, prettier all green
- [x] Manual review in dev app: template cards, create flow, RN app live in mirror with working taps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Optimized project creation: select templates now skip dependency installation automatically for faster project setup.

* **Bug Fixes**
  * Fixed double-click interference in iOS device preview to improve touch interaction stability.
  * Prevented unwanted text selection within the device preview stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->