### PR TITLE
Assets panel: configurable per-project assets folder

### DIFF
--- a/src-tauri/src/commands/assets.rs
+++ b/src-tauri/src/commands/assets.rs
@@ -1,7 +1,10 @@
 //! # Assets Commands
 //!
-//! Commands for managing files in the /public folder of projects.
+//! Commands for managing asset files in a project. The managed folder defaults
+//! to `/public` but can be re-pointed per project (e.g. `src/assets` for Astro
+//! image pipelines) via `assets_root` in `.shipstudio/project.json`.
 
+use crate::commands::git::{load_project_metadata, save_project_metadata};
 use crate::errors::CommandError;
 use crate::types::Asset;
 use crate::utils::{resolve_workspace_path, validate_project_path};
@@ -9,23 +12,54 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-/// Validates that an asset path is within the /public directory of the project.
+/// Folder the Assets panel manages when no per-project override is set.
+const DEFAULT_ASSETS_ROOT: &str = "public";
+
+/// Sanitize a configured assets root: a non-empty relative path with no
+/// traversal, no backslashes, and no empty/`.`/`..` segments. Returns `None`
+/// when invalid so callers fall back to the default instead of trusting a
+/// hand-edited project.json.
+fn sanitize_assets_root(root: &str) -> Option<String> {
+    let trimmed = root.trim().trim_matches('/');
+    if trimmed.is_empty()
+        || trimmed.contains('\\')
+        || Path::new(trimmed).is_absolute()
+        || trimmed
+            .split('/')
+            .any(|seg| seg.is_empty() || seg == "." || seg == "..")
+    {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+/// The folder the Assets panel manages for this project. `repo_root` locates
+/// `.shipstudio/project.json`; the returned dir lives under `workspace`
+/// (monorepo-aware), matching the rest of the asset commands.
+fn assets_root_dir(repo_root: &Path, workspace: &Path) -> PathBuf {
+    let configured = load_project_metadata(repo_root)
+        .assets_root
+        .as_deref()
+        .and_then(sanitize_assets_root);
+    workspace.join(configured.as_deref().unwrap_or(DEFAULT_ASSETS_ROOT))
+}
+
+/// Validates that an asset path is within the project's assets folder.
 /// Prevents path traversal attacks.
-fn validate_asset_path(project_path: &Path, asset_path: &str) -> Result<PathBuf, String> {
+fn validate_asset_path(root_dir: &Path, asset_path: &str) -> Result<PathBuf, String> {
     // Check for obvious path traversal attempts
     if asset_path.contains("..") {
         return Err("Invalid path: path traversal not allowed".to_string());
     }
 
-    let public_dir = project_path.join("public");
-    let full_path = public_dir.join(asset_path);
+    let full_path = root_dir.join(asset_path);
 
-    // Canonicalize to resolve any symlinks and ensure it's within public
+    // Canonicalize to resolve any symlinks and ensure it's within the root.
     // For new files that don't exist yet, we need to check the parent
     let check_path = if full_path.exists() {
         dunce::canonicalize(&full_path).map_err(|e| format!("Invalid path: {e}"))?
     } else {
-        // For non-existent paths, verify parent exists and is within public
+        // For non-existent paths, verify parent exists and is within the root
         let parent = full_path
             .parent()
             .ok_or("Invalid path: no parent directory")?;
@@ -34,33 +68,32 @@ fn validate_asset_path(project_path: &Path, asset_path: &str) -> Result<PathBuf,
         }
         let canonical_parent =
             dunce::canonicalize(parent).map_err(|e| format!("Invalid path: {e}"))?;
-        let canonical_public = if public_dir.exists() {
-            dunce::canonicalize(&public_dir).map_err(|e| format!("Invalid path: {e}"))?
+        let canonical_root = if root_dir.exists() {
+            dunce::canonicalize(root_dir).map_err(|e| format!("Invalid path: {e}"))?
         } else {
-            return Err("Public directory does not exist".to_string());
+            return Err("Assets folder does not exist".to_string());
         };
-        if !canonical_parent.starts_with(&canonical_public) {
-            return Err("Security error: path is outside public directory".to_string());
+        if !canonical_parent.starts_with(&canonical_root) {
+            return Err("Security error: path is outside the assets folder".to_string());
         }
         return Ok(full_path);
     };
 
-    let canonical_public =
-        dunce::canonicalize(&public_dir).map_err(|e| format!("Invalid path: {e}"))?;
+    let canonical_root = dunce::canonicalize(root_dir).map_err(|e| format!("Invalid path: {e}"))?;
 
-    if !check_path.starts_with(&canonical_public) {
-        return Err("Security error: path is outside public directory".to_string());
+    if !check_path.starts_with(&canonical_root) {
+        return Err("Security error: path is outside the assets folder".to_string());
     }
 
     Ok(check_path)
 }
 
 /// Helper to convert a file path to Asset struct
-fn path_to_asset(path: &PathBuf, public_dir: &PathBuf) -> Result<Asset, String> {
+fn path_to_asset(path: &PathBuf, root_dir: &PathBuf) -> Result<Asset, String> {
     let metadata = fs::metadata(path).map_err(|e| format!("Failed to read metadata: {e}"))?;
 
     let relative_path = path
-        .strip_prefix(public_dir)
+        .strip_prefix(root_dir)
         .map_err(|_| "Failed to get relative path")?
         .to_string_lossy()
         .to_string();
@@ -88,7 +121,7 @@ fn path_to_asset(path: &PathBuf, public_dir: &PathBuf) -> Result<Asset, String> 
 /// Recursively list all files in a directory
 fn list_files_recursive(
     dir: &PathBuf,
-    public_dir: &PathBuf,
+    root_dir: &PathBuf,
     assets: &mut Vec<Asset>,
 ) -> Result<(), String> {
     if !dir.exists() {
@@ -107,33 +140,83 @@ fn list_files_recursive(
             }
         }
 
-        if let Ok(asset) = path_to_asset(&path, public_dir) {
+        if let Ok(asset) = path_to_asset(&path, root_dir) {
             assets.push(asset);
         }
 
         // Recurse into subdirectories
         if path.is_dir() {
-            list_files_recursive(&path, public_dir, assets)?;
+            list_files_recursive(&path, root_dir, assets)?;
         }
     }
 
     Ok(())
 }
 
-/// List all assets in the /public folder (recursive)
+/// Get the folder (relative to the project workspace) the Assets panel manages.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn get_assets_root(project_path: String) -> Result<String, CommandError> {
+    let repo_root = validate_project_path(&project_path)?;
+    let configured = load_project_metadata(&repo_root)
+        .assets_root
+        .as_deref()
+        .and_then(sanitize_assets_root);
+    Ok(configured.unwrap_or_else(|| DEFAULT_ASSETS_ROOT.to_string()))
+}
+
+/// Point the Assets panel at a different folder (e.g. `src/assets`), persisted
+/// per project in `.shipstudio/project.json`. Creates the folder if missing.
+/// Returns the normalized root that was saved.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn set_assets_root(project_path: String, root: String) -> Result<String, CommandError> {
+    let repo_root = validate_project_path(&project_path)?;
+    let workspace = resolve_workspace_path(&repo_root);
+
+    let sanitized = sanitize_assets_root(&root)
+        .ok_or("Enter a folder inside the project, like public or src/assets")?;
+
+    let dir = workspace.join(&sanitized);
+    if !dir.exists() {
+        fs::create_dir_all(&dir).map_err(|e| format!("Failed to create folder: {e}"))?;
+    }
+
+    // Canonical containment check — the sanitizer blocks traversal lexically,
+    // but symlinked folders could still escape the project.
+    let canonical_dir = dunce::canonicalize(&dir).map_err(|e| format!("Invalid path: {e}"))?;
+    let canonical_workspace =
+        dunce::canonicalize(&workspace).map_err(|e| format!("Invalid path: {e}"))?;
+    if !canonical_dir.starts_with(&canonical_workspace) {
+        return Err(("Security error: folder is outside the project".to_string()).into());
+    }
+
+    let mut metadata = load_project_metadata(&repo_root);
+    // Store None for the default so untouched projects keep a clean project.json.
+    metadata.assets_root = if sanitized == DEFAULT_ASSETS_ROOT {
+        None
+    } else {
+        Some(sanitized.clone())
+    };
+    save_project_metadata(&repo_root, &metadata)?;
+
+    Ok(sanitized)
+}
+
+/// List all assets in the project's assets folder (recursive)
 #[tauri::command]
 #[tracing::instrument(fields(project = %project_path))]
 pub async fn list_assets(project_path: String) -> Result<Vec<Asset>, CommandError> {
     let repo_root = validate_project_path(&project_path)?;
     let project = resolve_workspace_path(&repo_root);
-    let public_dir = project.join("public");
+    let root_dir = assets_root_dir(&repo_root, &project);
 
-    if !public_dir.exists() {
+    if !root_dir.exists() {
         return Ok(Vec::new());
     }
 
     let mut assets = Vec::new();
-    list_files_recursive(&public_dir, &public_dir, &mut assets)?;
+    list_files_recursive(&root_dir, &root_dir, &mut assets)?;
 
     // Sort by path for consistent ordering
     assets.sort_by(|a, b| a.path.cmp(&b.path));
@@ -141,7 +224,7 @@ pub async fn list_assets(project_path: String) -> Result<Vec<Asset>, CommandErro
     Ok(assets)
 }
 
-/// Upload a file to /public (or subfolder)
+/// Upload a file to the assets folder (or subfolder)
 #[tauri::command]
 #[tracing::instrument(fields(project = %project_path))]
 pub async fn upload_asset(
@@ -152,12 +235,12 @@ pub async fn upload_asset(
 ) -> Result<Asset, CommandError> {
     let repo_root = validate_project_path(&project_path)?;
     let project = resolve_workspace_path(&repo_root);
-    let public_dir = project.join("public");
+    let root_dir = assets_root_dir(&repo_root, &project);
 
-    // Create public directory if it doesn't exist
-    if !public_dir.exists() {
-        fs::create_dir_all(&public_dir)
-            .map_err(|e| format!("Failed to create public directory: {e}"))?;
+    // Create the assets folder if it doesn't exist
+    if !root_dir.exists() {
+        fs::create_dir_all(&root_dir)
+            .map_err(|e| format!("Failed to create assets folder: {e}"))?;
     }
 
     // Validate filename
@@ -167,14 +250,14 @@ pub async fn upload_asset(
 
     // Build destination path
     let dest_dir = if destination.is_empty() || destination == "/" {
-        public_dir.clone()
+        root_dir.clone()
     } else {
         // Validate and resolve destination path
         let dest = destination.trim_start_matches('/');
         if dest.contains("..") {
             return Err(("Invalid destination: path traversal not allowed".to_string()).into());
         }
-        let dest_path = public_dir.join(dest);
+        let dest_path = root_dir.join(dest);
         if !dest_path.exists() {
             fs::create_dir_all(&dest_path)
                 .map_err(|e| format!("Failed to create destination directory: {e}"))?;
@@ -184,19 +267,21 @@ pub async fn upload_asset(
 
     let file_path = dest_dir.join(&file_name);
 
-    // Ensure final path is within public directory
-    let canonical_public =
-        dunce::canonicalize(&public_dir).map_err(|e| format!("Invalid path: {e}"))?;
+    // Ensure final path is within the assets folder
+    let canonical_root =
+        dunce::canonicalize(&root_dir).map_err(|e| format!("Invalid path: {e}"))?;
     let canonical_dest =
         dunce::canonicalize(&dest_dir).map_err(|e| format!("Invalid path: {e}"))?;
-    if !canonical_dest.starts_with(&canonical_public) {
-        return Err(("Security error: destination is outside public directory".to_string()).into());
+    if !canonical_dest.starts_with(&canonical_root) {
+        return Err(
+            ("Security error: destination is outside the assets folder".to_string()).into(),
+        );
     }
 
     // Write file
     fs::write(&file_path, file_data).map_err(|e| format!("Failed to write file: {e}"))?;
 
-    path_to_asset(&file_path, &public_dir).map_err(CommandError::from)
+    path_to_asset(&file_path, &root_dir).map_err(CommandError::from)
 }
 
 /// Delete an asset
@@ -205,16 +290,16 @@ pub async fn upload_asset(
 pub async fn delete_asset(project_path: String, asset_path: String) -> Result<(), CommandError> {
     let repo_root = validate_project_path(&project_path)?;
     let project = resolve_workspace_path(&repo_root);
-    let public_dir = project.join("public");
-    let full_path = validate_asset_path(&project, &asset_path)?;
+    let root_dir = assets_root_dir(&repo_root, &project);
+    let full_path = validate_asset_path(&root_dir, &asset_path)?;
 
-    // Double-check it's within public
-    let canonical_public =
-        dunce::canonicalize(&public_dir).map_err(|e| format!("Invalid path: {e}"))?;
+    // Double-check it's within the assets folder
+    let canonical_root =
+        dunce::canonicalize(&root_dir).map_err(|e| format!("Invalid path: {e}"))?;
     let canonical_path =
         dunce::canonicalize(&full_path).map_err(|e| format!("Invalid path: {e}"))?;
-    if !canonical_path.starts_with(&canonical_public) {
-        return Err(("Security error: path is outside public directory".to_string()).into());
+    if !canonical_path.starts_with(&canonical_root) {
+        return Err(("Security error: path is outside the assets folder".to_string()).into());
     }
 
     if full_path.is_dir() {
@@ -236,8 +321,8 @@ pub async fn rename_asset(
 ) -> Result<Asset, CommandError> {
     let repo_root = validate_project_path(&project_path)?;
     let project = resolve_workspace_path(&repo_root);
-    let public_dir = project.join("public");
-    let old_path = validate_asset_path(&project, &asset_path)?;
+    let root_dir = assets_root_dir(&repo_root, &project);
+    let old_path = validate_asset_path(&root_dir, &asset_path)?;
 
     // Validate new name
     if new_name.contains('/') || new_name.contains('\\') || new_name.contains("..") {
@@ -254,12 +339,12 @@ pub async fn rename_asset(
         .ok_or("Invalid path: no parent directory")?;
     let new_path = parent.join(&new_name);
 
-    // Check new path is still within public
-    let canonical_public =
-        dunce::canonicalize(&public_dir).map_err(|e| format!("Invalid path: {e}"))?;
+    // Check new path is still within the assets folder
+    let canonical_root =
+        dunce::canonicalize(&root_dir).map_err(|e| format!("Invalid path: {e}"))?;
     let canonical_parent = dunce::canonicalize(parent).map_err(|e| format!("Invalid path: {e}"))?;
-    if !canonical_parent.starts_with(&canonical_public) {
-        return Err(("Security error: path is outside public directory".to_string()).into());
+    if !canonical_parent.starts_with(&canonical_root) {
+        return Err(("Security error: path is outside the assets folder".to_string()).into());
     }
 
     // Check if target already exists
@@ -270,10 +355,10 @@ pub async fn rename_asset(
     // Rename
     fs::rename(&old_path, &new_path).map_err(|e| format!("Failed to rename: {e}"))?;
 
-    path_to_asset(&new_path, &public_dir).map_err(CommandError::from)
+    path_to_asset(&new_path, &root_dir).map_err(CommandError::from)
 }
 
-/// Create a folder in /public
+/// Create a folder in the assets folder
 #[tauri::command]
 #[tracing::instrument(fields(project = %project_path))]
 pub async fn create_asset_folder(
@@ -282,12 +367,12 @@ pub async fn create_asset_folder(
 ) -> Result<(), CommandError> {
     let repo_root = validate_project_path(&project_path)?;
     let project = resolve_workspace_path(&repo_root);
-    let public_dir = project.join("public");
+    let root_dir = assets_root_dir(&repo_root, &project);
 
-    // Create public directory if it doesn't exist
-    if !public_dir.exists() {
-        fs::create_dir_all(&public_dir)
-            .map_err(|e| format!("Failed to create public directory: {e}"))?;
+    // Create the assets folder if it doesn't exist
+    if !root_dir.exists() {
+        fs::create_dir_all(&root_dir)
+            .map_err(|e| format!("Failed to create assets folder: {e}"))?;
     }
 
     // Validate folder path
@@ -300,20 +385,20 @@ pub async fn create_asset_folder(
         return Err(("Folder name cannot be empty".to_string()).into());
     }
 
-    let full_path = public_dir.join(folder_name);
+    let full_path = root_dir.join(folder_name);
 
-    // Ensure it's within public
-    let canonical_public =
-        dunce::canonicalize(&public_dir).map_err(|e| format!("Invalid path: {e}"))?;
+    // Ensure it's within the assets folder
+    let canonical_root =
+        dunce::canonicalize(&root_dir).map_err(|e| format!("Invalid path: {e}"))?;
 
-    // For the new folder, check parent is within public
+    // For the new folder, check parent is within the assets folder
     if let Some(parent) = full_path.parent() {
         if parent.exists() {
             let canonical_parent =
                 dunce::canonicalize(parent).map_err(|e| format!("Invalid path: {e}"))?;
-            if !canonical_parent.starts_with(&canonical_public) {
+            if !canonical_parent.starts_with(&canonical_root) {
                 return Err(
-                    ("Security error: path is outside public directory".to_string()).into(),
+                    ("Security error: path is outside the assets folder".to_string()).into(),
                 );
             }
         }
@@ -326,4 +411,77 @@ pub async fn create_asset_folder(
     fs::create_dir_all(&full_path).map_err(|e| format!("Failed to create folder: {e}"))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_accepts_simple_and_nested_roots() {
+        assert_eq!(sanitize_assets_root("public"), Some("public".to_string()));
+        assert_eq!(
+            sanitize_assets_root("src/assets"),
+            Some("src/assets".to_string())
+        );
+        assert_eq!(
+            sanitize_assets_root(" /src/assets/ "),
+            Some("src/assets".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_rejects_traversal_and_absolute_paths() {
+        assert_eq!(sanitize_assets_root(""), None);
+        assert_eq!(sanitize_assets_root("   "), None);
+        assert_eq!(sanitize_assets_root(".."), None);
+        assert_eq!(sanitize_assets_root("../outside"), None);
+        assert_eq!(sanitize_assets_root("src/../../etc"), None);
+        assert_eq!(sanitize_assets_root("src/./assets"), None);
+        assert_eq!(sanitize_assets_root("src//assets"), None);
+        assert_eq!(sanitize_assets_root("/"), None);
+        assert_eq!(sanitize_assets_root("src\\assets"), None);
+    }
+
+    #[test]
+    fn assets_root_dir_falls_back_to_public() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No .shipstudio/project.json → default root.
+        let dir = assets_root_dir(tmp.path(), tmp.path());
+        assert_eq!(dir, tmp.path().join("public"));
+    }
+
+    #[test]
+    fn assets_root_dir_reads_configured_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shipstudio = tmp.path().join(".shipstudio");
+        std::fs::create_dir_all(&shipstudio).unwrap();
+        let mut metadata = crate::types::ProjectMetadata::default();
+        metadata.assets_root = Some("src/assets".to_string());
+        std::fs::write(
+            shipstudio.join("project.json"),
+            serde_json::to_string(&metadata).unwrap(),
+        )
+        .unwrap();
+
+        let dir = assets_root_dir(tmp.path(), tmp.path());
+        assert_eq!(dir, tmp.path().join("src/assets"));
+    }
+
+    #[test]
+    fn assets_root_dir_ignores_invalid_configured_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shipstudio = tmp.path().join(".shipstudio");
+        std::fs::create_dir_all(&shipstudio).unwrap();
+        let mut metadata = crate::types::ProjectMetadata::default();
+        metadata.assets_root = Some("../escape".to_string());
+        std::fs::write(
+            shipstudio.join("project.json"),
+            serde_json::to_string(&metadata).unwrap(),
+        )
+        .unwrap();
+
+        let dir = assets_root_dir(tmp.path(), tmp.path());
+        assert_eq!(dir, tmp.path().join("public"));
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -575,6 +575,8 @@ pub fn run() {
             commands::code::list_project_files,
             commands::code::read_project_file,
             // Assets
+            commands::assets::get_assets_root,
+            commands::assets::set_assets_root,
             commands::assets::list_assets,
             commands::assets::upload_asset,
             commands::assets::delete_asset,

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -210,6 +210,11 @@ pub struct ProjectMetadata {
     /// operations stay at the repo root.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_subpath: Option<String>,
+    /// Folder (relative to the project workspace) the Assets panel manages.
+    /// `None` means the default `public`. Set to e.g. `src/assets` for Astro
+    /// projects that use the built-in image pipeline.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assets_root: Option<String>,
 }
 
 fn default_schema_version() -> u32 {
@@ -233,6 +238,7 @@ impl Default for ProjectMetadata {
             terminal_state: None,
             custom_thumbnail: None,
             workspace_subpath: None,
+            assets_root: None,
         }
     }
 }

--- a/src/components/AssetsPanel.tsx
+++ b/src/components/AssetsPanel.tsx
@@ -11,9 +11,11 @@
  * @module components/AssetsPanel
  */
 
+import { useRef, useState } from 'react';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { formatFileSize, isImageFile, type Asset } from '../lib/assets';
 import { useAssetManagement } from '../hooks/useAssetManagement';
+import { useClickOutside } from '../hooks/useClickOutside';
 import { useOptionalToast } from '../contexts/ToastContext';
 import { useModal } from '../contexts/ModalContext';
 import {
@@ -25,11 +27,15 @@ import {
   FolderIcon,
   FileIcon,
   ImageIcon,
+  ChevronIcon,
   ChevronRightIcon,
   FolderPlusIcon,
   CheckIcon,
   SearchIcon,
 } from './icons';
+
+/** Common asset folders offered in the root picker. */
+const ASSETS_ROOT_SUGGESTIONS = ['public', 'src/assets', 'assets', 'static'];
 
 // Grid and List icons for view toggle
 function GridIcon({ size = 14 }: { size?: number }) {
@@ -104,6 +110,8 @@ export function AssetsPanel({ projectPath }: AssetsPanelProps) {
     setSearchQuery,
     clearSearchQuery,
     deleteTarget,
+    assetsRoot,
+    changeAssetsRoot,
     fileInputRef,
     dropZoneRef,
     sortedAssets,
@@ -120,6 +128,30 @@ export function AssetsPanel({ projectPath }: AssetsPanelProps) {
     handleDragOver,
     handleDrop,
   } = useAssetManagement({ projectPath, isOpen, onToast });
+
+  // --- Assets root picker state ---
+  const [rootMenuOpen, setRootMenuOpen] = useState(false);
+  // null = not editing; string = custom folder input value
+  const [customRoot, setCustomRoot] = useState<string | null>(null);
+  const rootMenuRef = useRef<HTMLDivElement>(null);
+  useClickOutside(
+    rootMenuRef,
+    () => {
+      setRootMenuOpen(false);
+      setCustomRoot(null);
+    },
+    rootMenuOpen
+  );
+
+  const selectRoot = (root: string) => {
+    setRootMenuOpen(false);
+    setCustomRoot(null);
+    if (root.trim() && root !== assetsRoot) void changeAssetsRoot(root);
+  };
+
+  const rootSuggestions = ASSETS_ROOT_SUGGESTIONS.includes(assetsRoot)
+    ? ASSETS_ROOT_SUGGESTIONS
+    : [assetsRoot, ...ASSETS_ROOT_SUGGESTIONS];
 
   // Render asset preview (thumbnail for images, icon for others)
   const renderAssetPreview = (asset: Asset) => {
@@ -220,15 +252,76 @@ export function AssetsPanel({ projectPath }: AssetsPanelProps) {
             )}
           </div>
 
-          {/* Breadcrumb navigation */}
+          {/* Breadcrumb navigation. The root crumb navigates home; the chevron
+              beside it re-points the panel at a different folder. */}
           {!searchQuery && (
             <div className="assets-breadcrumb">
-              {breadcrumbs.map((crumb, index) => (
+              <div className="assets-root-picker" ref={rootMenuRef}>
+                <button
+                  className={`assets-breadcrumb-btn ${breadcrumbs.length === 1 ? 'active' : ''}`}
+                  onClick={() => setCurrentPath('')}
+                >
+                  {assetsRoot}
+                </button>
+                <button
+                  className="assets-root-toggle"
+                  title="Change assets folder"
+                  onClick={() => setRootMenuOpen((o) => !o)}
+                >
+                  <ChevronIcon size={12} />
+                </button>
+                {rootMenuOpen && (
+                  <div className="assets-root-menu">
+                    {rootSuggestions.map((root) => (
+                      <button
+                        key={root}
+                        className={`assets-root-item ${root === assetsRoot ? 'active' : ''}`}
+                        onClick={() => selectRoot(root)}
+                      >
+                        <FolderIcon size={13} />
+                        <span>{root}</span>
+                        {root === assetsRoot && <CheckIcon size={12} />}
+                      </button>
+                    ))}
+                    {customRoot === null ? (
+                      <button className="assets-root-item" onClick={() => setCustomRoot('')}>
+                        <EditIcon size={13} />
+                        <span>Custom folder…</span>
+                      </button>
+                    ) : (
+                      <div className="assets-root-custom">
+                        <input
+                          type="text"
+                          value={customRoot}
+                          onChange={(e) => setCustomRoot(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') selectRoot(customRoot);
+                            if (e.key === 'Escape') setCustomRoot(null);
+                          }}
+                          placeholder="e.g. src/images"
+                          autoFocus
+                          autoComplete="off"
+                          autoCorrect="off"
+                          autoCapitalize="off"
+                          spellCheck={false}
+                        />
+                        <button
+                          className="assets-new-folder-confirm"
+                          onClick={() => selectRoot(customRoot)}
+                        >
+                          <CheckIcon size={14} />
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+              {breadcrumbs.slice(1).map((crumb, index) => (
                 <span key={crumb.path} className="assets-breadcrumb-item">
-                  {index > 0 && <ChevronRightIcon size={12} />}
+                  <ChevronRightIcon size={12} />
                   <button
                     className={`assets-breadcrumb-btn ${
-                      index === breadcrumbs.length - 1 ? 'active' : ''
+                      index === breadcrumbs.length - 2 ? 'active' : ''
                     }`}
                     onClick={() => setCurrentPath(crumb.path)}
                   >

--- a/src/hooks/useAssetManagement.ts
+++ b/src/hooks/useAssetManagement.ts
@@ -14,6 +14,9 @@ import {
   deleteAsset,
   renameAsset,
   createAssetFolder,
+  getAssetsRoot,
+  setAssetsRoot,
+  DEFAULT_ASSETS_ROOT,
   type Asset,
 } from '../lib/assets';
 import { trackEvent, trackError, trackSearch } from '../lib/analytics';
@@ -49,6 +52,7 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
   const [viewMode, setViewMode] = useState<'list' | 'grid'>('grid');
   const [searchQuery, setSearchQuery] = useState('');
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [assetsRoot, setAssetsRootState] = useState(DEFAULT_ASSETS_ROOT);
 
   // --- Refs ---
   const deleteTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -76,8 +80,33 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
       void loadAssets();
       setCurrentPath('');
       setSearchQuery('');
+      getAssetsRoot(projectPath)
+        .then(setAssetsRootState)
+        .catch((e) =>
+          logger.warn('Failed to load assets root', {
+            error: e instanceof Error ? e.message : String(e),
+          })
+        );
     }
-  }, [isOpen, loadAssets]);
+  }, [isOpen, loadAssets, projectPath]);
+
+  // Re-point the panel at a different folder (persisted per project).
+  const changeAssetsRoot = async (root: string) => {
+    try {
+      const saved = await setAssetsRoot(projectPath, root);
+      setAssetsRootState(saved);
+      setCurrentPath('');
+      setSearchQuery('');
+      await loadAssets();
+      void trackEvent('assets_root_changed', { $screen_name: 'Workspace' });
+      onToast?.(`Assets folder set to ${saved}`, 'success');
+    } catch (e) {
+      trackError('assets_root_change', e, 'Workspace');
+      const msg = e instanceof Error ? e.message : 'Failed to change assets folder';
+      setError(msg);
+      onToast?.(msg, 'error');
+    }
+  };
 
   // --- Computed values ---
 
@@ -110,7 +139,7 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
   // Breadcrumb navigation
   const pathParts = currentPath ? currentPath.split('/') : [];
   const breadcrumbs: Breadcrumb[] = [
-    { name: 'public', path: '' },
+    { name: assetsRoot, path: '' },
     ...pathParts.map((part, index) => ({
       name: part,
       path: pathParts.slice(0, index + 1).join('/'),
@@ -248,9 +277,12 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
     }
   };
 
-  // Handle copy path
+  // Handle copy path. Files under /public are served from the site root, so
+  // copy a web path; for any other root copy a project-relative path (useful
+  // for imports, e.g. src/assets/logo.png).
   const handleCopyPath = async (asset: Asset) => {
-    const webPath = `/${asset.path}`;
+    const webPath =
+      assetsRoot === DEFAULT_ASSETS_ROOT ? `/${asset.path}` : `${assetsRoot}/${asset.path}`;
     try {
       await navigator.clipboard.writeText(webPath);
       setCopiedPath(asset.path);
@@ -335,6 +367,8 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
     setSearchQuery: handleSearchChange,
     clearSearchQuery: () => setSearchQuery(''),
     deleteTarget,
+    assetsRoot,
+    changeAssetsRoot,
 
     // Refs
     fileInputRef,

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -1,13 +1,34 @@
 /**
- * Asset management functions for the /public folder.
+ * Asset management functions for the project's assets folder.
  *
  * These functions wrap Tauri commands for managing files in a project's
- * public directory - listing, uploading, deleting, renaming assets.
+ * assets folder — listing, uploading, deleting, renaming assets. The folder
+ * defaults to `/public` but can be re-pointed per project (e.g. `src/assets`
+ * for Astro image pipelines) via get/setAssetsRoot.
  *
  * @module lib/assets
  */
 
 import { invoke } from '@tauri-apps/api/core';
+
+/** Folder the Assets panel manages when no per-project override is set. */
+export const DEFAULT_ASSETS_ROOT = 'public';
+
+/**
+ * Get the folder (relative to the project) the Assets panel manages.
+ * Returns "public" unless the project overrides it.
+ */
+export async function getAssetsRoot(projectPath: string): Promise<string> {
+  return invoke<string>('get_assets_root', { projectPath });
+}
+
+/**
+ * Point the Assets panel at a different folder (persisted per project).
+ * Creates the folder if it doesn't exist; returns the normalized root.
+ */
+export async function setAssetsRoot(projectPath: string, root: string): Promise<string> {
+  return invoke<string>('set_assets_root', { projectPath, root });
+}
 
 /**
  * Represents a file or folder in the /public directory

--- a/src/styles/features/assets-panel.css
+++ b/src/styles/features/assets-panel.css
@@ -99,11 +99,13 @@
 .assets-breadcrumb {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 2px;
   padding: 8px 12px;
   background: var(--bg-tertiary);
   border-radius: var(--radius);
-  overflow-x: auto;
+  /* Must stay visible so the assets-root dropdown isn't clipped. */
+  overflow: visible;
 }
 
 .assets-breadcrumb-item {
@@ -135,6 +137,101 @@
 .assets-breadcrumb-btn.active {
   color: var(--text-primary);
   font-weight: 500;
+}
+
+/* Assets root picker — re-point the panel at a different folder */
+.assets-root-picker {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.assets-root-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-xs);
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition:
+    background-color var(--transition),
+    color var(--transition);
+}
+
+.assets-root-toggle:hover {
+  background: var(--border);
+  color: var(--text-primary);
+}
+
+.assets-root-menu {
+  position: absolute;
+  top: calc(100% + var(--spacing-xs));
+  left: 0;
+  min-width: 180px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  padding: var(--spacing-xs);
+  z-index: var(--z-dropdown);
+}
+
+.assets-root-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition:
+    background-color var(--transition),
+    color var(--transition);
+}
+
+.assets-root-item span {
+  flex: 1;
+}
+
+.assets-root-item:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.assets-root-item.active {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.assets-root-custom {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs);
+}
+
+.assets-root-custom input {
+  flex: 1;
+  min-width: 0;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.assets-root-custom input:focus {
+  outline: none;
+  border-color: var(--accent);
 }
 
 /* Toolbar */


### PR DESCRIPTION
## Summary
- The Assets panel root (previously hardcoded to `/public`) is now configurable per project — requested by Sam for Astro's `src/assets` image pipeline
- New root picker in the breadcrumb bar: common roots (public, src/assets, assets, static) + custom folder input; persisted as `assets_root` in `.shipstudio/project.json`
- All asset commands resolve the configured root with the same traversal/canonicalization checks, plus a symlink-escape check on the root; invalid hand-edited values fall back to `public`
- Copy path: web path (`/foo.png`) for public, project-relative (`src/assets/foo.png`) for other roots
- Monorepo-aware (root resolves under the active workspace subdir)

## Test plan
- [x] 5 new Rust unit tests (sanitization, resolution, invalid-config fallback) — 349 backend tests pass
- [x] 580 frontend tests, typecheck, lint, prettier, check:all green
- [x] Manual review in dev app: switch roots, upload, copy path semantics, persistence across reopen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Customize your assets directory per project—configure which folder stores assets instead of using the default `/public`
  * New asset root picker UI with suggested folders for quick selection
  * Asset paths automatically adjust based on your selected root directory

<!-- end of auto-generated comment: release notes by coderabbit.ai -->