### PR TITLE
Preview fullscreen, pinned visual editor, clickable terminal URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@tauri-apps/plugin-updater": "^2.9.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-unicode11": "^0.9.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "culori": "^4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@xterm/addon-unicode11':
         specifier: ^0.9.0
         version: 0.9.0
+      '@xterm/addon-web-links':
+        specifier: ^0.12.0
+        version: 0.12.0
       '@xterm/addon-webgl':
         specifier: ^0.19.0
         version: 0.19.0
@@ -1008,6 +1011,9 @@ packages:
 
   '@xterm/addon-unicode11@0.9.0':
     resolution: {integrity: sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==}
+
+  '@xterm/addon-web-links@0.12.0':
+    resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
   '@xterm/addon-webgl@0.19.0':
     resolution: {integrity: sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==}
@@ -3462,6 +3468,8 @@ snapshots:
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-unicode11@0.9.0': {}
+
+  '@xterm/addon-web-links@0.12.0': {}
 
   '@xterm/addon-webgl@0.19.0': {}
 

--- a/src/components/BuildTerminal.tsx
+++ b/src/components/BuildTerminal.tsx
@@ -22,6 +22,7 @@ import { Terminal as XTerm } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { WebglAddon } from '@xterm/addon-webgl';
+import { createWebLinksAddon } from '../lib/terminalLinks';
 import {
   openPtySession,
   attachPtySession,
@@ -108,6 +109,7 @@ export function BuildTerminal({
     const unicode11 = new Unicode11Addon();
     term.loadAddon(fit);
     term.loadAddon(unicode11);
+    term.loadAddon(createWebLinksAddon());
     term.unicode.activeVersion = '11';
     term.open(container);
     termRef.current = term;

--- a/src/components/DevServerLogs.tsx
+++ b/src/components/DevServerLogs.tsx
@@ -16,6 +16,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Terminal as XTerm } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
+import { createWebLinksAddon } from '../lib/terminalLinks';
 import { loadNerdFonts } from '../lib/fonts';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { useOptionalToast } from '../contexts/ToastContext';
@@ -130,6 +131,7 @@ export function DevServerLogs({ output, outputVersion, onSendToAgent }: DevServe
 
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
+    term.loadAddon(createWebLinksAddon());
 
     term.open(container);
 

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -290,6 +290,19 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     onUserResize: () => setPinnedBreakpoint(null),
   });
 
+  // Fullscreen: the container goes position:fixed over the whole window, so
+  // only the preview + its toolbar are visible. The iframe never remounts,
+  // so the page state survives entering/leaving. ESC exits.
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  useEffect(() => {
+    if (!isFullscreen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsFullscreen(false);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isFullscreen]);
+
   // Inspect-panel vertical resize. Null = use the default 1fr split from CSS;
   // a number = explicit panel height in px (overrides via inline grid-template-rows).
   const [inspectPanelHeight, setInspectPanelHeight] = useState<number | null>(null);
@@ -605,7 +618,7 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
 
   return (
     <div
-      className="preview-container"
+      className={`preview-container${isFullscreen ? ' preview-container--fullscreen' : ''}`}
       data-logs={showLogs ? 'open' : 'closed'}
       style={
         showLogs && inspectPanelHeight !== null
@@ -637,7 +650,7 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
             >
               <path d="M4 4l7.07 17 2.51-7.39L21 11.07z" />
             </svg>
-            <span>Edit (Beta)</span>
+            <span>Edit</span>
             <span
               className={`preview-edit-toggle-switch ${editor.editMode ? 'is-on' : ''}`}
               aria-hidden
@@ -746,6 +759,42 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
           data-education-id="preview-refresh"
         >
           ↻
+        </button>
+
+        <button
+          type="button"
+          className="preview-fullscreen-btn"
+          onClick={() => setIsFullscreen((f) => !f)}
+          title={isFullscreen ? 'Exit fullscreen (Esc)' : 'Fullscreen preview'}
+          aria-pressed={isFullscreen}
+        >
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            {isFullscreen ? (
+              <>
+                <polyline points="4 14 10 14 10 20" />
+                <polyline points="20 10 14 10 14 4" />
+                <line x1="14" y1="10" x2="21" y2="3" />
+                <line x1="3" y1="21" x2="10" y2="14" />
+              </>
+            ) : (
+              <>
+                <polyline points="15 3 21 3 21 9" />
+                <polyline points="9 21 3 21 3 15" />
+                <line x1="21" y1="3" x2="14" y2="10" />
+                <line x1="3" y1="21" x2="10" y2="14" />
+              </>
+            )}
+          </svg>
         </button>
 
         {previewPlugins}

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -335,8 +335,6 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     });
   }, []);
 
-  const containerRef = useRef<HTMLDivElement>(null);
-
   // Inspect-panel vertical resize. Null = use the default 1fr split from CSS;
   // a number = explicit panel height in px (overrides via inline grid-template-rows).
   const [inspectPanelHeight, setInspectPanelHeight] = useState<number | null>(null);
@@ -510,29 +508,6 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     onToast,
   });
 
-  // The pinned sidebar matches the preview container's vertical bounds — in
-  // normal mode the container sits below the workspace tab bar, in fullscreen
-  // it starts right under the header, and the inspect panel changes its
-  // height. Measured so the sidebar never overlaps surrounding chrome.
-  const [pinnedRect, setPinnedRect] = useState({ top: 0, height: 0 });
-  useEffect(() => {
-    if (!(editor.editMode && editorPinned)) return;
-    const el = containerRef.current;
-    if (!el) return;
-    const measure = () => {
-      const r = el.getBoundingClientRect();
-      setPinnedRect({ top: Math.round(r.top), height: Math.round(r.height) });
-    };
-    measure();
-    const ro = new ResizeObserver(measure);
-    ro.observe(el);
-    window.addEventListener('resize', measure);
-    return () => {
-      ro.disconnect();
-      window.removeEventListener('resize', measure);
-    };
-  }, [editor.editMode, editorPinned, isFullscreen]);
-
   const [iframeSize, setIframeSize] = useState<{ w: number; h: number } | null>(null);
   const iframeSizeObserverRef = useRef<ResizeObserver | null>(null);
 
@@ -675,7 +650,6 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
 
   return (
     <div
-      ref={containerRef}
       className={`preview-container${isFullscreen ? ' preview-container--fullscreen' : ''}${
         editor.editMode && editorPinned ? ' preview-container--editor-pinned' : ''
       }`}
@@ -1015,40 +989,44 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
         onHealthOutput={onHealthOutput}
       />
       {editor.editMode &&
-        createPortal(
-          <VisualEditorPanel
-            selection={editor.selection}
-            currentClass={editor.currentClass}
-            textResolution={editor.textResolution}
-            textBlockedNonce={editor.textBlockedNonce}
-            breakpoints={breakpoints}
-            activeBreakpoint={activeBreakpoint}
-            breakpointTooWide={breakpointTooWide}
-            onSelectBreakpoint={(bp) => {
-              setPinnedBreakpoint(bp);
-              // Jump the canvas to a breakpoint's width so you can see it; Base
-              // applies at all widths, so leave the canvas where it is.
-              if (bp.minPx > 0) resize.previewAtWidth(bp.minPx);
-            }}
-            autoSave={editor.autoSave}
-            onToggleAutoSave={editor.toggleAutoSave}
-            onStepGap={(dir) => editor.stepSpacing('gap', dir)}
-            onSetSide={editor.setBoxSide}
-            onApplyEnum={editor.applyEnum}
-            onReset={editor.reset}
-            multiTarget={editor.multiTarget}
-            onMultiTargetChange={editor.setMultiTarget}
-            usage={editor.usage}
-            onOpenInCode={onOpenInCode}
-            onCommit={() => void editor.commit()}
-            onClose={editor.toggleEditMode}
-            pinned={editorPinned}
-            onTogglePin={toggleEditorPinned}
-            pinnedTop={pinnedRect.top}
-            pinnedHeight={pinnedRect.height}
-          />,
-          document.body
-        )}
+        (() => {
+          // Floating mode portals to <body> (position:fixed is the only way to
+          // composite above the iframe in WebKit). Pinned mode renders in-tree
+          // as the container's second grid column — it never overlaps the
+          // iframe, and the grid guarantees it can't cover surrounding chrome.
+          const panel = (
+            <VisualEditorPanel
+              selection={editor.selection}
+              currentClass={editor.currentClass}
+              textResolution={editor.textResolution}
+              textBlockedNonce={editor.textBlockedNonce}
+              breakpoints={breakpoints}
+              activeBreakpoint={activeBreakpoint}
+              breakpointTooWide={breakpointTooWide}
+              onSelectBreakpoint={(bp) => {
+                setPinnedBreakpoint(bp);
+                // Jump the canvas to a breakpoint's width so you can see it; Base
+                // applies at all widths, so leave the canvas where it is.
+                if (bp.minPx > 0) resize.previewAtWidth(bp.minPx);
+              }}
+              autoSave={editor.autoSave}
+              onToggleAutoSave={editor.toggleAutoSave}
+              onStepGap={(dir) => editor.stepSpacing('gap', dir)}
+              onSetSide={editor.setBoxSide}
+              onApplyEnum={editor.applyEnum}
+              onReset={editor.reset}
+              multiTarget={editor.multiTarget}
+              onMultiTargetChange={editor.setMultiTarget}
+              usage={editor.usage}
+              onOpenInCode={onOpenInCode}
+              onCommit={() => void editor.commit()}
+              onClose={editor.toggleEditMode}
+              pinned={editorPinned}
+              onTogglePin={toggleEditorPinned}
+            />
+          );
+          return editorPinned ? panel : createPortal(panel, document.body);
+        })()}
     </div>
   );
 });

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -51,7 +51,8 @@ import type { ProjectType } from '../lib/static-server';
 // SVG icons for breakpoints
 const BreakpointIcon = ({ type }: { type: Breakpoint }) => {
   if (type === 'full') {
-    // Expand/maximize icon for full width
+    // Horizontal stretch-to-edges for full width — deliberately distinct from
+    // the diagonal expand arrows on the fullscreen toolbar button.
     return (
       <svg
         width="16"
@@ -60,11 +61,14 @@ const BreakpointIcon = ({ type }: { type: Breakpoint }) => {
         fill="none"
         stroke="currentColor"
         strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       >
-        <polyline points="15 3 21 3 21 9" />
-        <polyline points="9 21 3 21 3 15" />
-        <line x1="21" y1="3" x2="14" y2="10" />
-        <line x1="3" y1="21" x2="10" y2="14" />
+        <line x1="3" y1="4" x2="3" y2="20" />
+        <line x1="21" y1="4" x2="21" y2="20" />
+        <line x1="7" y1="12" x2="17" y2="12" />
+        <polyline points="10 9 7 12 10 15" />
+        <polyline points="14 9 17 12 14 15" />
       </svg>
     );
   }
@@ -317,9 +321,10 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     return () => window.removeEventListener('keydown', handler);
   }, [isFullscreen]);
 
-  // Pin the visual editor as a full-height sidebar (instead of a floating
-  // panel over the canvas) — persisted across sessions. The preview makes
-  // room via a class on the container, in both normal and fullscreen modes.
+  // Pin the visual editor as a sidebar (instead of a floating panel over the
+  // canvas) — persisted in localStorage, so it's a cross-project setting.
+  // The preview makes room via a class on the container, in both normal and
+  // fullscreen modes.
   const [editorPinned, setEditorPinned] = useState(
     () => localStorage.getItem('visualEditorPinned') === '1'
   );
@@ -329,6 +334,8 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
       return !p;
     });
   }, []);
+
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Inspect-panel vertical resize. Null = use the default 1fr split from CSS;
   // a number = explicit panel height in px (overrides via inline grid-template-rows).
@@ -503,6 +510,29 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     onToast,
   });
 
+  // The pinned sidebar matches the preview container's vertical bounds — in
+  // normal mode the container sits below the workspace tab bar, in fullscreen
+  // it starts right under the header, and the inspect panel changes its
+  // height. Measured so the sidebar never overlaps surrounding chrome.
+  const [pinnedRect, setPinnedRect] = useState({ top: 0, height: 0 });
+  useEffect(() => {
+    if (!(editor.editMode && editorPinned)) return;
+    const el = containerRef.current;
+    if (!el) return;
+    const measure = () => {
+      const r = el.getBoundingClientRect();
+      setPinnedRect({ top: Math.round(r.top), height: Math.round(r.height) });
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    window.addEventListener('resize', measure);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('resize', measure);
+    };
+  }, [editor.editMode, editorPinned, isFullscreen]);
+
   const [iframeSize, setIframeSize] = useState<{ w: number; h: number } | null>(null);
   const iframeSizeObserverRef = useRef<ResizeObserver | null>(null);
 
@@ -645,6 +675,7 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
 
   return (
     <div
+      ref={containerRef}
       className={`preview-container${isFullscreen ? ' preview-container--fullscreen' : ''}${
         editor.editMode && editorPinned ? ' preview-container--editor-pinned' : ''
       }`}
@@ -1013,7 +1044,8 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
             onClose={editor.toggleEditMode}
             pinned={editorPinned}
             onTogglePin={toggleEditorPinned}
-            pinnedTop={chromeTop}
+            pinnedTop={pinnedRect.top}
+            pinnedHeight={pinnedRect.height}
           />,
           document.body
         )}

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -290,10 +290,23 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     onUserResize: () => setPinnedBreakpoint(null),
   });
 
-  // Fullscreen: the container goes position:fixed over the whole window, so
-  // only the preview + its toolbar are visible. The iframe never remounts,
-  // so the page state survives entering/leaving. ESC exits.
+  // Fullscreen: the container goes position:fixed over the window below the
+  // workspace header (kept visible — it carries the project name and makes
+  // room for the macOS traffic lights). The iframe never remounts, so the
+  // page state survives entering/leaving. ESC exits.
   const [isFullscreen, setIsFullscreen] = useState(false);
+  // Bottom edge of the workspace header — the top of the fullscreen overlay
+  // and of the pinned editor sidebar. Measured (the header has no fixed height).
+  const [chromeTop, setChromeTop] = useState(0);
+  useEffect(() => {
+    const measure = () => {
+      const header = document.querySelector('.workspace-header');
+      setChromeTop(header ? Math.round(header.getBoundingClientRect().bottom) : 0);
+    };
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, []);
   useEffect(() => {
     if (!isFullscreen) return;
     const handler = (e: KeyboardEvent) => {
@@ -302,6 +315,19 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [isFullscreen]);
+
+  // Pin the visual editor as a full-height sidebar (instead of a floating
+  // panel over the canvas) — persisted across sessions. The preview makes
+  // room via a class on the container, in both normal and fullscreen modes.
+  const [editorPinned, setEditorPinned] = useState(
+    () => localStorage.getItem('visualEditorPinned') === '1'
+  );
+  const toggleEditorPinned = useCallback(() => {
+    setEditorPinned((p) => {
+      localStorage.setItem('visualEditorPinned', p ? '0' : '1');
+      return !p;
+    });
+  }, []);
 
   // Inspect-panel vertical resize. Null = use the default 1fr split from CSS;
   // a number = explicit panel height in px (overrides via inline grid-template-rows).
@@ -618,15 +644,18 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
 
   return (
     <div
-      className={`preview-container${isFullscreen ? ' preview-container--fullscreen' : ''}`}
+      className={`preview-container${isFullscreen ? ' preview-container--fullscreen' : ''}${
+        editor.editMode && editorPinned ? ' preview-container--editor-pinned' : ''
+      }`}
       data-logs={showLogs ? 'open' : 'closed'}
-      style={
-        showLogs && inspectPanelHeight !== null
+      style={{
+        ...(showLogs && inspectPanelHeight !== null
           ? {
               gridTemplateRows: `auto minmax(0, 1fr) var(--handle-size) ${inspectPanelHeight}px`,
             }
-          : undefined
-      }
+          : undefined),
+        ...(isFullscreen ? { top: chromeTop } : undefined),
+      }}
     >
       <div className="preview-toolbar">
         {editorEnabled && (
@@ -1007,6 +1036,9 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
             onOpenInCode={onOpenInCode}
             onCommit={() => void editor.commit()}
             onClose={editor.toggleEditMode}
+            pinned={editorPinned}
+            onTogglePin={toggleEditorPinned}
+            pinnedTop={chromeTop}
           />,
           document.body
         )}

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -44,6 +44,7 @@ import { useBreakpoints } from '../hooks/useBreakpoints';
 import { BASE_BREAKPOINT, isTailwindActive, type Breakpoint as TwBreakpoint } from '../lib/edit';
 import { VisualEditorPanel } from './edit/VisualEditorPanel';
 import { PreviewLocaleSwitcher, type PreviewLocaleConfig } from './PreviewLocaleSwitcher';
+import { CompactIcon, ExpandIcon, ResetIcon } from './icons';
 import { pathLocale, switchPathLocale } from '../lib/i18n';
 import type { ProjectType } from '../lib/static-server';
 
@@ -787,7 +788,7 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
           title="Refresh preview"
           data-education-id="preview-refresh"
         >
-          ↻
+          <ResetIcon size={14} />
         </button>
 
         <button
@@ -797,33 +798,7 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
           title={isFullscreen ? 'Exit fullscreen (Esc)' : 'Fullscreen preview'}
           aria-pressed={isFullscreen}
         >
-          <svg
-            width="13"
-            height="13"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            {isFullscreen ? (
-              <>
-                <polyline points="4 14 10 14 10 20" />
-                <polyline points="20 10 14 10 14 4" />
-                <line x1="14" y1="10" x2="21" y2="3" />
-                <line x1="3" y1="21" x2="10" y2="14" />
-              </>
-            ) : (
-              <>
-                <polyline points="15 3 21 3 21 9" />
-                <polyline points="9 21 3 21 3 15" />
-                <line x1="21" y1="3" x2="14" y2="10" />
-                <line x1="3" y1="21" x2="10" y2="14" />
-              </>
-            )}
-          </svg>
+          {isFullscreen ? <CompactIcon size={14} /> : <ExpandIcon size={14} />}
         </button>
 
         {previewPlugins}

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -14,6 +14,7 @@
 
 import { useEffect, useRef, useCallback, useState, forwardRef, useImperativeHandle } from 'react';
 import { Terminal as XTerm } from '@xterm/xterm';
+import { createWebLinksAddon } from '../lib/terminalLinks';
 import { FitAddon } from '@xterm/addon-fit';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { WebglAddon } from '@xterm/addon-webgl';
@@ -338,6 +339,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     const unicode11Addon = new Unicode11Addon();
     term.loadAddon(fitAddon);
     term.loadAddon(unicode11Addon);
+    term.loadAddon(createWebLinksAddon());
     term.unicode.activeVersion = '11';
 
     // Open terminal in container

--- a/src/components/edit/VisualEditorPanel.tsx
+++ b/src/components/edit/VisualEditorPanel.tsx
@@ -272,6 +272,11 @@ interface Props {
   onOpenInCode?: (file: string, line: number) => void;
   onCommit: () => void;
   onClose: () => void;
+  /** Docked as a full-height right sidebar instead of floating over the canvas. */
+  pinned?: boolean;
+  onTogglePin?: () => void;
+  /** Top edge when pinned (bottom of the workspace header). */
+  pinnedTop?: number;
 }
 
 const PANEL_WIDTH = 264;
@@ -304,6 +309,9 @@ export function VisualEditorPanel({
   onOpenInCode,
   onCommit,
   onClose,
+  pinned = false,
+  onTogglePin,
+  pinnedTop = 0,
 }: Props) {
   const resolution = selection?.resolution ?? null;
   // Both 'resolved' (one spot) and 'multi' (several identical spots) are editable.
@@ -376,28 +384,68 @@ export function VisualEditorPanel({
   return (
     <div
       ref={rootRef}
-      className="ss-edit-panel"
+      className={`ss-edit-panel${pinned ? ' ss-edit-panel--pinned' : ''}`}
       data-testid="visual-editor-panel"
-      style={{
-        position: 'fixed',
-        top: pos.top,
-        left: pos.left,
-        right: 'auto',
-        zIndex: 1000,
-        // Cap shorter than the viewport; the body scrolls, the footer stays put.
-        maxHeight: `min(520px, calc(100vh - ${pos.top + 16}px))`,
-      }}
+      style={
+        pinned
+          ? {
+              // Docked: full-height sidebar at the window's right edge, below
+              // the workspace header. The preview reserves matching space via
+              // .preview-container--editor-pinned.
+              position: 'fixed',
+              top: pinnedTop,
+              right: 0,
+              bottom: 0,
+              left: 'auto',
+              zIndex: 1000,
+              maxHeight: 'none',
+            }
+          : {
+              position: 'fixed',
+              top: pos.top,
+              left: pos.left,
+              right: 'auto',
+              zIndex: 1000,
+              // Cap shorter than the viewport; the body scrolls, the footer stays put.
+              maxHeight: `min(520px, calc(100vh - ${pos.top + 16}px))`,
+            }
+      }
     >
       <div
         className="ss-edit-panel__header"
-        onPointerDown={onHeaderPointerDown}
-        onPointerMove={onHeaderPointerMove}
-        onPointerUp={onHeaderPointerUp}
+        onPointerDown={pinned ? undefined : onHeaderPointerDown}
+        onPointerMove={pinned ? undefined : onHeaderPointerMove}
+        onPointerUp={pinned ? undefined : onHeaderPointerUp}
       >
         <span className="ss-edit-panel__title">Edit</span>
-        <button className="ss-edit-panel__close" onClick={onClose} aria-label="Exit edit mode">
-          ×
-        </button>
+        <span className="ss-edit-panel__header-actions">
+          {onTogglePin && (
+            <button
+              className={`ss-edit-panel__pin${pinned ? ' is-pinned' : ''}`}
+              onClick={onTogglePin}
+              title={pinned ? 'Unpin — float over the preview' : 'Pin as sidebar'}
+              aria-pressed={pinned}
+            >
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M12 17v5" />
+                <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1z" />
+              </svg>
+            </button>
+          )}
+          <button className="ss-edit-panel__close" onClick={onClose} aria-label="Exit edit mode">
+            ×
+          </button>
+        </span>
       </div>
 
       <div className="ss-edit-panel__body">

--- a/src/components/edit/VisualEditorPanel.tsx
+++ b/src/components/edit/VisualEditorPanel.tsx
@@ -273,11 +273,12 @@ interface Props {
   onOpenInCode?: (file: string, line: number) => void;
   onCommit: () => void;
   onClose: () => void;
-  /** Docked as a full-height right sidebar instead of floating over the canvas. */
+  /** Docked as a right sidebar instead of floating over the canvas. */
   pinned?: boolean;
   onTogglePin?: () => void;
-  /** Top edge when pinned (bottom of the workspace header). */
+  /** Vertical bounds when pinned — matches the preview container. */
   pinnedTop?: number;
+  pinnedHeight?: number;
 }
 
 const PANEL_WIDTH = 264;
@@ -313,6 +314,7 @@ export function VisualEditorPanel({
   pinned = false,
   onTogglePin,
   pinnedTop = 0,
+  pinnedHeight = 0,
 }: Props) {
   const resolution = selection?.resolution ?? null;
   // Both 'resolved' (one spot) and 'multi' (several identical spots) are editable.
@@ -391,14 +393,14 @@ export function VisualEditorPanel({
       style={
         pinned
           ? {
-              // Docked: full-height sidebar at the window's right edge, below
-              // the workspace header. The preview reserves matching space via
-              // .preview-container--editor-pinned.
+              // Docked: sidebar at the window's right edge spanning exactly
+              // the preview container's height. The preview reserves matching
+              // space via .preview-container--editor-pinned.
               position: 'fixed',
               top: pinnedTop,
               right: 0,
-              bottom: 0,
               left: 'auto',
+              ...(pinnedHeight > 0 ? { height: pinnedHeight } : { bottom: 0 }),
               zIndex: 1000,
               maxHeight: 'none',
             }

--- a/src/components/edit/VisualEditorPanel.tsx
+++ b/src/components/edit/VisualEditorPanel.tsx
@@ -273,12 +273,10 @@ interface Props {
   onOpenInCode?: (file: string, line: number) => void;
   onCommit: () => void;
   onClose: () => void;
-  /** Docked as a right sidebar instead of floating over the canvas. */
+  /** Docked as a sidebar column inside the preview container instead of
+   *  floating over the canvas. Positioning comes from the container's grid. */
   pinned?: boolean;
   onTogglePin?: () => void;
-  /** Vertical bounds when pinned — matches the preview container. */
-  pinnedTop?: number;
-  pinnedHeight?: number;
 }
 
 const PANEL_WIDTH = 264;
@@ -313,8 +311,6 @@ export function VisualEditorPanel({
   onClose,
   pinned = false,
   onTogglePin,
-  pinnedTop = 0,
-  pinnedHeight = 0,
 }: Props) {
   const resolution = selection?.resolution ?? null;
   // Both 'resolved' (one spot) and 'multi' (several identical spots) are editable.
@@ -391,19 +387,9 @@ export function VisualEditorPanel({
       className={`ss-edit-panel${pinned ? ' ss-edit-panel--pinned' : ''}`}
       data-testid="visual-editor-panel"
       style={
+        // Pinned positioning is entirely CSS (the container's grid column).
         pinned
-          ? {
-              // Docked: sidebar at the window's right edge spanning exactly
-              // the preview container's height. The preview reserves matching
-              // space via .preview-container--editor-pinned.
-              position: 'fixed',
-              top: pinnedTop,
-              right: 0,
-              left: 'auto',
-              ...(pinnedHeight > 0 ? { height: pinnedHeight } : { bottom: 0 }),
-              zIndex: 1000,
-              maxHeight: 'none',
-            }
+          ? undefined
           : {
               position: 'fixed',
               top: pos.top,

--- a/src/components/edit/VisualEditorPanel.tsx
+++ b/src/components/edit/VisualEditorPanel.tsx
@@ -22,6 +22,7 @@ import { MultiSourceControl } from './MultiSourceControl';
 import { UsageScope } from './UsageScope';
 import { CodeIcon } from './CodeIcon';
 import { SlackIcon } from '../icons/brand';
+import { PinIcon } from '../icons/layout';
 import { PropSection } from './PropSection';
 import { PropControlRenderer, type ControlRenderCtx } from './PropControlRenderer';
 import { CONTROL_SECTIONS } from '../../lib/editControls';
@@ -359,8 +360,9 @@ export function VisualEditorPanel({
   const dragRef = useRef<{ dx: number; dy: number } | null>(null);
 
   const onHeaderPointerDown = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
-    // Don't start a drag from the close button.
-    if ((e.target as HTMLElement).closest('.ss-edit-panel__close')) return;
+    // Don't start a drag from the header buttons (pin/close) — pointer capture
+    // would swallow their click events.
+    if ((e.target as HTMLElement).closest('.ss-edit-panel__header-actions')) return;
     const r = rootRef.current?.getBoundingClientRect();
     if (!r) return;
     dragRef.current = { dx: e.clientX - r.left, dy: e.clientY - r.top };
@@ -426,20 +428,7 @@ export function VisualEditorPanel({
               title={pinned ? 'Unpin — float over the preview' : 'Pin as sidebar'}
               aria-pressed={pinned}
             >
-              <svg
-                width="13"
-                height="13"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-              >
-                <path d="M12 17v5" />
-                <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1z" />
-              </svg>
+              <PinIcon size={13} />
             </button>
           )}
           <button className="ss-edit-panel__close" onClick={onClose} aria-label="Exit edit mode">

--- a/src/components/setup/OnboardingTerminal.tsx
+++ b/src/components/setup/OnboardingTerminal.tsx
@@ -8,6 +8,7 @@
 
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { Terminal as XTerm } from '@xterm/xterm';
+import { createWebLinksAddon } from '../../lib/terminalLinks';
 import { FitAddon } from '@xterm/addon-fit';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { spawn, IPty } from 'tauri-pty';
@@ -122,6 +123,7 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
     const unicode11Addon = new Unicode11Addon();
     term.loadAddon(fitAddon);
     term.loadAddon(unicode11Addon);
+    term.loadAddon(createWebLinksAddon());
     term.unicode.activeVersion = '11';
 
     // Open terminal in container

--- a/src/lib/terminalLinks.ts
+++ b/src/lib/terminalLinks.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared web-links addon factory for xterm terminals.
+ *
+ * Makes plain-text URLs (e.g. a dev server printing http://localhost:3000)
+ * clickable. OSC 8 explicit hyperlinks already work via xterm's built-in
+ * support; this covers everything that isn't emitted as a hyperlink escape.
+ * Links open in the system browser via the Tauri opener plugin — the
+ * addon's default window.open is wrong inside a Tauri webview.
+ *
+ * @module lib/terminalLinks
+ */
+
+import { WebLinksAddon } from '@xterm/addon-web-links';
+import { openUrl } from '@tauri-apps/plugin-opener';
+import { logger } from './logger';
+
+/** Create a WebLinksAddon that opens links in the system browser. */
+export function createWebLinksAddon(): WebLinksAddon {
+  return new WebLinksAddon((_event, uri) => {
+    openUrl(uri).catch((err: unknown) => {
+      logger.warn('[terminalLinks] Failed to open link', { uri, error: String(err) });
+    });
+  });
+}

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -271,18 +271,23 @@
 }
 
 /* ===== Visual editor pin-as-sidebar =====
-   The container grows a second grid column that hosts the panel in-tree (it
-   spans every row, so it can never overlap surrounding chrome). The default
-   children auto-place into column 1. Works unchanged in fullscreen mode. */
+   The container grows a second grid column that hosts the panel in-tree. The
+   toolbar keeps the full width (row 1 spans both columns); the panel sits
+   below it, spanning the canvas + inspect rows, so it matches the preview's
+   height and can never overlap any bar. Works unchanged in fullscreen mode. */
 .preview-container--editor-pinned {
   grid-template-columns: minmax(0, 1fr) var(--editor-panel-w);
+}
+
+.preview-container--editor-pinned .preview-toolbar {
+  grid-column: 1 / -1;
 }
 
 /* Compound selector: this file loads before visual-editor.css, so the pinned
    overrides need higher specificity than the base .ss-edit-panel rules. */
 .ss-edit-panel.ss-edit-panel--pinned {
   position: static;
-  grid-area: 1 / 2 / -1 / 3;
+  grid-area: 2 / 2 / -1 / 3;
   width: auto;
   min-width: 0;
   max-height: none;
@@ -293,7 +298,8 @@
   box-shadow: none;
 }
 
-/* Line the pinned header up with the preview toolbar beside it; no drag. */
+/* The pinned header is its own bar below the toolbar — keep the same bar
+   height as the toolbar for consistency; no drag affordance while docked. */
 .ss-edit-panel.ss-edit-panel--pinned .ss-edit-panel__header {
   height: var(--preview-toolbar-h);
   flex-shrink: 0;

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -265,13 +265,26 @@
   color: var(--text-primary);
 }
 
-/* Fullscreen: the container covers the window so only the preview and its
-   toolbar are visible. position:fixed (not a remount) keeps the iframe alive. */
+/* Fullscreen: the container covers the window below the workspace header
+   (the component sets `top` inline from the measured header height — the
+   header stays visible so the project name + macOS traffic lights keep their
+   room). position:fixed (not a remount) keeps the iframe alive. */
 .preview-container--fullscreen {
   position: fixed;
   inset: 0;
   z-index: var(--z-preview-fullscreen);
   background: var(--bg-primary);
+}
+
+/* Edit panel pinned as a sidebar: the preview reserves its width.
+   Must match --editor-panel-w in visual-editor.css (264px). */
+.preview-container--editor-pinned {
+  margin-right: 264px;
+}
+
+.preview-container--fullscreen.preview-container--editor-pinned {
+  margin-right: 0;
+  right: 264px;
 }
 
 .capture-spinner {

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -278,7 +278,9 @@
   grid-template-columns: minmax(0, 1fr) var(--editor-panel-w);
 }
 
-.ss-edit-panel--pinned {
+/* Compound selector: this file loads before visual-editor.css, so the pinned
+   overrides need higher specificity than the base .ss-edit-panel rules. */
+.ss-edit-panel.ss-edit-panel--pinned {
   position: static;
   grid-area: 1 / 2 / -1 / 3;
   width: auto;
@@ -292,12 +294,12 @@
 }
 
 /* Line the pinned header up with the preview toolbar beside it; no drag. */
-.ss-edit-panel--pinned .ss-edit-panel__header {
+.ss-edit-panel.ss-edit-panel--pinned .ss-edit-panel__header {
   height: var(--preview-toolbar-h);
   flex-shrink: 0;
 }
-.ss-edit-panel--pinned .ss-edit-panel__header,
-.ss-edit-panel--pinned .ss-edit-panel__header:active {
+.ss-edit-panel.ss-edit-panel--pinned .ss-edit-panel__header,
+.ss-edit-panel.ss-edit-panel--pinned .ss-edit-panel__header:active {
   cursor: default;
 }
 

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -244,6 +244,36 @@
   background: var(--bg-tertiary);
 }
 
+/* Fullscreen toggle — sits right of the refresh button */
+.preview-fullscreen-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition:
+    background-color var(--transition),
+    color var(--transition);
+}
+
+.preview-fullscreen-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+/* Fullscreen: the container covers the window so only the preview and its
+   toolbar are visible. position:fixed (not a remount) keeps the iframe alive. */
+.preview-container--fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-preview-fullscreen);
+  background: var(--bg-primary);
+}
+
 .capture-spinner {
   width: 14px;
   height: 14px;

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -93,6 +93,7 @@
   display: flex;
   align-items: center;
   gap: 12px;
+  height: var(--preview-toolbar-h);
   padding: 9px 12px;
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
@@ -269,15 +270,63 @@
   background: var(--bg-primary);
 }
 
-/* Edit panel pinned as a sidebar: the preview reserves its width.
-   Must match --editor-panel-w in visual-editor.css (264px). */
+/* ===== Visual editor pin-as-sidebar =====
+   The container grows a second grid column that hosts the panel in-tree (it
+   spans every row, so it can never overlap surrounding chrome). The default
+   children auto-place into column 1. Works unchanged in fullscreen mode. */
 .preview-container--editor-pinned {
-  margin-right: 264px;
+  grid-template-columns: minmax(0, 1fr) var(--editor-panel-w);
 }
 
-.preview-container--fullscreen.preview-container--editor-pinned {
-  margin-right: 0;
-  right: 264px;
+.ss-edit-panel--pinned {
+  position: static;
+  grid-area: 1 / 2 / -1 / 3;
+  width: auto;
+  min-width: 0;
+  max-height: none;
+  border-radius: 0;
+  border-top: none;
+  border-right: none;
+  border-bottom: none;
+  box-shadow: none;
+}
+
+/* Line the pinned header up with the preview toolbar beside it; no drag. */
+.ss-edit-panel--pinned .ss-edit-panel__header {
+  height: var(--preview-toolbar-h);
+  flex-shrink: 0;
+}
+.ss-edit-panel--pinned .ss-edit-panel__header,
+.ss-edit-panel--pinned .ss-edit-panel__header:active {
+  cursor: default;
+}
+
+.ss-edit-panel__header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.ss-edit-panel__pin {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-xs);
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition:
+    background-color var(--transition),
+    color var(--transition);
+}
+.ss-edit-panel__pin:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+.ss-edit-panel__pin.is-pinned {
+  color: var(--accent);
 }
 
 .capture-spinner {

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -234,21 +234,13 @@
   color: var(--text-muted);
 }
 
-.preview-refresh {
-  padding: 4px 8px;
-  font-size: 16px;
-  background: transparent;
-}
-
-.preview-refresh:hover {
-  background: var(--bg-tertiary);
-}
-
-/* Fullscreen toggle — sits right of the refresh button */
+/* Refresh + fullscreen — matched icon buttons (same icon pack, same height) */
+.preview-refresh,
 .preview-fullscreen-btn {
   display: flex;
   align-items: center;
   justify-content: center;
+  height: 28px;
   padding: var(--spacing-xs) var(--spacing-sm);
   background: transparent;
   border: none;
@@ -260,6 +252,7 @@
     color var(--transition);
 }
 
+.preview-refresh:hover,
 .preview-fullscreen-btn:hover {
   background: var(--bg-tertiary);
   color: var(--text-primary);

--- a/src/styles/features/visual-editor.css
+++ b/src/styles/features/visual-editor.css
@@ -65,11 +65,14 @@
   /* Portaled to <body>; position/top/left/max-height are set inline by the
      component (it owns drag). position:fixed at the document root is the only
      reliable way to sit ABOVE the preview iframe in WebKit — an in-tree overlay
-     (even with z-index or a promoted layer) gets composited under it. */
+     (even with z-index or a promoted layer) gets composited under it.
+     Width MUST match PANEL_WIDTH in VisualEditorPanel.tsx and the reserved
+     space in .preview-container--editor-pinned (preview.css). */
+  --editor-panel-w: 264px;
   position: fixed;
   display: flex;
   flex-direction: column;
-  width: 264px;
+  width: var(--editor-panel-w);
   /* Header + footer are fixed; only the body scrolls. Panel clips; max-height is
      set inline by the component. */
   overflow: hidden;
@@ -78,6 +81,16 @@
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-md);
   font-size: 13px;
+}
+
+/* Pinned: a full-height sidebar docked at the window's right edge. The
+   preview reserves matching space via .preview-container--editor-pinned. */
+.ss-edit-panel--pinned {
+  border-radius: 0;
+  border-top: none;
+  border-right: none;
+  border-bottom: none;
+  box-shadow: none;
 }
 
 .ss-edit-panel__header {
@@ -94,6 +107,38 @@
 }
 .ss-edit-panel__header:active {
   cursor: grabbing;
+}
+.ss-edit-panel--pinned .ss-edit-panel__header,
+.ss-edit-panel--pinned .ss-edit-panel__header:active {
+  cursor: default;
+}
+
+.ss-edit-panel__header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.ss-edit-panel__pin {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-xs);
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition:
+    background-color var(--transition),
+    color var(--transition);
+}
+.ss-edit-panel__pin:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+.ss-edit-panel__pin.is-pinned {
+  color: var(--accent);
 }
 
 .ss-edit-panel__title {

--- a/src/styles/features/visual-editor.css
+++ b/src/styles/features/visual-editor.css
@@ -62,13 +62,12 @@
 }
 
 .ss-edit-panel {
-  /* Portaled to <body>; position/top/left/max-height are set inline by the
-     component (it owns drag). position:fixed at the document root is the only
-     reliable way to sit ABOVE the preview iframe in WebKit — an in-tree overlay
-     (even with z-index or a promoted layer) gets composited under it.
-     Width MUST match PANEL_WIDTH in VisualEditorPanel.tsx and the reserved
-     space in .preview-container--editor-pinned (preview.css). */
-  --editor-panel-w: 264px;
+  /* Floating mode is portaled to <body>; position/top/left/max-height are set
+     inline by the component (it owns drag). position:fixed at the document
+     root is the only reliable way to sit ABOVE the preview iframe in WebKit —
+     an in-tree overlay (even with z-index or a promoted layer) gets composited
+     under it. Width comes from --editor-panel-w (base.css), which MUST match
+     PANEL_WIDTH in VisualEditorPanel.tsx. */
   position: fixed;
   display: flex;
   flex-direction: column;
@@ -83,15 +82,8 @@
   font-size: 13px;
 }
 
-/* Pinned: a full-height sidebar docked at the window's right edge. The
-   preview reserves matching space via .preview-container--editor-pinned. */
-.ss-edit-panel--pinned {
-  border-radius: 0;
-  border-top: none;
-  border-right: none;
-  border-bottom: none;
-  box-shadow: none;
-}
+/* Pin-as-sidebar styles (pin button, header actions, pinned layout) live in
+   preview.css — they integrate the panel into the preview container's grid. */
 
 .ss-edit-panel__header {
   display: flex;
@@ -107,38 +99,6 @@
 }
 .ss-edit-panel__header:active {
   cursor: grabbing;
-}
-.ss-edit-panel--pinned .ss-edit-panel__header,
-.ss-edit-panel--pinned .ss-edit-panel__header:active {
-  cursor: default;
-}
-
-.ss-edit-panel__header-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-}
-
-.ss-edit-panel__pin {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--spacing-xs);
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-  transition:
-    background-color var(--transition),
-    color var(--transition);
-}
-.ss-edit-panel__pin:hover {
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-}
-.ss-edit-panel__pin.is-pinned {
-  color: var(--accent);
 }
 
 .ss-edit-panel__title {

--- a/src/styles/global/base.css
+++ b/src/styles/global/base.css
@@ -83,6 +83,13 @@
   --z-dropdown: 100;
   /* Fullscreen preview overlay — above workspace chrome, below modals. */
   --z-preview-fullscreen: 900;
+  /* Visual editor panel width — shared by the panel itself (visual-editor.css)
+     and the preview grid column that hosts it when pinned (preview.css).
+     MUST match PANEL_WIDTH in VisualEditorPanel.tsx. */
+  --editor-panel-w: 264px;
+  /* Preview toolbar height — also sizes the pinned editor panel's header so
+     the two bars line up. */
+  --preview-toolbar-h: 47px;
   --z-modal-overlay: 1000;
   --z-modal: 1001;
   --z-tooltip: 1100;

--- a/src/styles/global/base.css
+++ b/src/styles/global/base.css
@@ -81,6 +81,8 @@
    *               used 10000+ here; the tokens preserve that layering.
    */
   --z-dropdown: 100;
+  /* Fullscreen preview overlay — above workspace chrome, below modals. */
+  --z-preview-fullscreen: 900;
   --z-modal-overlay: 1000;
   --z-modal: 1001;
   --z-tooltip: 1100;


### PR DESCRIPTION
## Summary
- **Clickable URLs in all terminals** — plain-text URLs (dev server, build logs) open in the system browser via @xterm/addon-web-links + Tauri opener (OSC 8 links already worked)
- **Fullscreen preview** — new toolbar button (right of refresh) pins the preview over the window below the workspace header (traffic lights + project name stay visible); ESC exits; iframe never remounts
- **Pin the visual editor as a sidebar** (requested by Bradford) — pin toggle in the panel header docks it as a grid column below the toolbar, matching the canvas height; the preview reserves its width; works in fullscreen; persisted cross-project in localStorage
- Polish: "Edit (Beta)" → "Edit"; refresh/fullscreen buttons share the icon set and height; distinct stretch-to-edges icon for the full-width breakpoint

## Test plan
- [x] 580 frontend tests, typecheck, lint, prettier, check:all (incl. LOC guard) green
- [x] Manual: link clicks from terminal/logs, fullscreen with traffic lights clear, pin/unpin in normal + fullscreen, toolbar uncut with panel docked, header alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)