### PR TITLE
Element tree navigator for the visual editor

### DIFF
--- a/src-tauri/src/proxy/select_script.html
+++ b/src-tauri/src/proxy/select_script.html
@@ -275,7 +275,22 @@ function updateFmtBar(){
 }
 function onDbl(e){if(!active||txtEditing)return;var el=textTarget(e.target);if(!el||!txtEditable)return;e.preventDefault();e.stopPropagation();startText(el,e.clientX,e.clientY);}
 function onMove(e){if(!active||txtEditing)return;ensureHover();var t=pickTarget(e.target);if(t&&selectedSet.indexOf(t)!==-1)t=null;place(hoverBox,t);}
-function onClick(e){if(!active||txtEditing)return;var el=pickTarget(e.target);if(!el)return;e.preventDefault();e.stopPropagation();restoreSel();selectedSet=matching(el);selPrimary=el;curMark=String(++pvId);for(var i=0;i<selectedSet.length;i++)selectedSet[i].setAttribute('data-ss-sel',curMark);snapshotOrig();placeSet();place(hoverBox,null);txtEditable=true;window.parent.postMessage({type:'ss:select',signature:sig(el),count:selectedSet.length,leafText:isEditableText(el)},'*');}
+function selectEl(el){restoreSel();selectedSet=matching(el);selPrimary=el;curMark=String(++pvId);for(var i=0;i<selectedSet.length;i++)selectedSet[i].setAttribute('data-ss-sel',curMark);snapshotOrig();placeSet();place(hoverBox,null);txtEditable=true;window.parent.postMessage({type:'ss:select',signature:sig(el),count:selectedSet.length,leafText:isEditableText(el),nodeId:treeIdFor(el)},'*');}
+function onClick(e){if(!active||txtEditing)return;var el=pickTarget(e.target);if(!el)return;e.preventDefault();e.stopPropagation();selectEl(el);}
+/* ===== Element tree (read-only navigator) =====
+   The parent requests a lightweight DOM snapshot; nodes get ephemeral ids so
+   the parent can select/hover them. nodeById is rebuilt on every snapshot so
+   stale elements from previous renders don't accumulate. */
+var treeIds=new WeakMap(),treeById={},treeNextId=1,treeOn=false,treeObserver=null,treeTimer=null;
+var TREE_MAX_NODES=4000,TREE_MAX_DEPTH=60;
+function treeIdFor(el){var id=treeIds.get(el);if(!id){id=treeNextId++;treeIds.set(el,id);}treeById[id]=el;return id;}
+function treeSkip(el){if(el.nodeType!==1)return true;var t=el.tagName;if(t==='SCRIPT'||t==='STYLE'||t==='NOSCRIPT'||t==='TEMPLATE'||t==='LINK'||t==='META')return true;if(el.getAttribute('data-ss-overlay'))return true;return false;}
+function treeOwnText(el){var s='';for(var i=0;i<el.childNodes.length;i++){var c=el.childNodes[i];if(c.nodeType===3)s+=c.nodeValue;}return s.replace(/\s+/g,' ').trim().slice(0,48);}
+function treeBuild(el,depth,budget){var kids=[];if(depth<TREE_MAX_DEPTH){for(var i=0;i<el.children.length;i++){var c=el.children[i];if(treeSkip(c))continue;if(budget.n>=TREE_MAX_NODES)break;budget.n++;kids.push(treeBuild(c,depth+1,budget));}}return{i:treeIdFor(el),t:(el.tagName||'').toLowerCase(),c:(el.getAttribute('class')||'').trim().slice(0,120),x:treeOwnText(el),k:kids};}
+function treeSend(){treeById={};var budget={n:0};var root=treeBuild(document.body,0,budget);window.parent.postMessage({type:'ss:tree',tree:root,truncated:budget.n>=TREE_MAX_NODES},'*');}
+function treeIsSsNode(n){return n.nodeType===1&&(n.getAttribute('data-ss-overlay')||(n.id&&n.id.indexOf('ss-')===0));}
+function treeDirty(){if(!treeOn)return;if(treeTimer)clearTimeout(treeTimer);treeTimer=setTimeout(function(){if(treeOn)window.parent.postMessage({type:'ss:treeDirty'},'*');},300);}
+function treeEnsureObserver(){if(treeObserver)return;treeObserver=new MutationObserver(function(ms){for(var i=0;i<ms.length;i++){var m=ms[i],j;for(j=0;j<m.addedNodes.length;j++)if(!treeIsSsNode(m.addedNodes[j])){treeDirty();return;}for(j=0;j<m.removedNodes.length;j++)if(!treeIsSsNode(m.removedNodes[j])){treeDirty();return;}}});treeObserver.observe(document.body,{childList:true,subtree:true});}
 function reposition(){if(txtEditing)place(hoverBox,txtEl);else if(active)placeSet();}
 window.addEventListener('message',function(e){var d=e.data||{};
 if(d.type==='ss:activate'){active=true;ensureHover();var de=document.documentElement;de.style.cursor='crosshair';de.style.userSelect='none';de.style.webkitUserSelect='none';}
@@ -292,7 +307,11 @@ else if(d.type==='ss:mutate'){for(var i=0;i<selectedSet.length;i++){var el=selec
    (no longer reverted on deselect/deactivate) and re-baseline the class. HMR re-renders
    from source and the real compiled CSS takes over. */
 else if(d.type==='ss:suppressReload'){window.__ssSuppressUntil=Date.now()+3000;}
-else if(d.type==='ss:commit'){pendingMark=null;txtRevertEl=null;snapshotOrig();window.__ssSuppressUntil=Date.now()+2000;}});
+else if(d.type==='ss:commit'){pendingMark=null;txtRevertEl=null;snapshotOrig();window.__ssSuppressUntil=Date.now()+2000;}
+else if(d.type==='ss:requestTree'){treeOn=true;treeEnsureObserver();treeSend();}
+else if(d.type==='ss:treeOff'){treeOn=false;}
+else if(d.type==='ss:selectNode'){var tn=treeById[d.id];if(tn&&tn.isConnected&&active&&!txtEditing){try{tn.scrollIntoView({block:'nearest'});}catch(err){}selectEl(tn);}}
+else if(d.type==='ss:hoverNode'){if(!active)return;var th=d.id!=null?treeById[d.id]:null;ensureHover();place(hoverBox,th&&th.isConnected?th:null);}});
 document.addEventListener('mousemove',onMove,true);
 document.addEventListener('click',onClick,true);
 document.addEventListener('dblclick',onDbl,true);

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -46,7 +46,7 @@ import { VisualEditorPanel } from './edit/VisualEditorPanel';
 import { ElementTreePanel } from './edit/ElementTreePanel';
 import { useElementTree } from '../hooks/useElementTree';
 import { PreviewLocaleSwitcher, type PreviewLocaleConfig } from './PreviewLocaleSwitcher';
-import { CompactIcon, ExpandIcon, ResetIcon } from './icons';
+import { CompactIcon, ExpandIcon, PanelLeftIcon, ResetIcon } from './icons';
 import { pathLocale, switchPathLocale } from '../lib/i18n';
 import type { ProjectType } from '../lib/static-server';
 
@@ -511,8 +511,18 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
   });
 
   // Element tree (navigator) — left column in fullscreen edit mode, like
-  // Webflow's navigator: read-only, select-only.
-  const showTree = isFullscreen && editor.editMode;
+  // Webflow's navigator: read-only, select-only. Toggleable from the toolbar;
+  // the choice persists cross-project like the editor pin.
+  const [treeVisible, setTreeVisible] = useState(
+    () => localStorage.getItem('elementTreeVisible') !== '0'
+  );
+  const toggleTreeVisible = useCallback(() => {
+    setTreeVisible((v) => {
+      localStorage.setItem('elementTreeVisible', v ? '0' : '1');
+      return !v;
+    });
+  }, []);
+  const showTree = isFullscreen && editor.editMode && treeVisible;
   const elementTree = useElementTree({ iframeRef, enabled: showTree });
 
   const [iframeSize, setIframeSize] = useState<{ w: number; h: number } | null>(null);
@@ -812,6 +822,18 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
         >
           {isFullscreen ? <CompactIcon size={14} /> : <ExpandIcon size={14} />}
         </button>
+
+        {isFullscreen && editor.editMode && (
+          <button
+            type="button"
+            className={`preview-tree-btn${treeVisible ? ' active' : ''}`}
+            onClick={toggleTreeVisible}
+            title={treeVisible ? 'Hide element tree' : 'Show element tree'}
+            aria-pressed={treeVisible}
+          >
+            <PanelLeftIcon size={14} />
+          </button>
+        )}
 
         {previewPlugins}
 

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -43,6 +43,8 @@ import { useVisualEditor } from '../hooks/useVisualEditor';
 import { useBreakpoints } from '../hooks/useBreakpoints';
 import { BASE_BREAKPOINT, isTailwindActive, type Breakpoint as TwBreakpoint } from '../lib/edit';
 import { VisualEditorPanel } from './edit/VisualEditorPanel';
+import { ElementTreePanel } from './edit/ElementTreePanel';
+import { useElementTree } from '../hooks/useElementTree';
 import { PreviewLocaleSwitcher, type PreviewLocaleConfig } from './PreviewLocaleSwitcher';
 import { CompactIcon, ExpandIcon, ResetIcon } from './icons';
 import { pathLocale, switchPathLocale } from '../lib/i18n';
@@ -508,6 +510,11 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     onToast,
   });
 
+  // Element tree (navigator) — left column in fullscreen edit mode, like
+  // Webflow's navigator: read-only, select-only.
+  const showTree = isFullscreen && editor.editMode;
+  const elementTree = useElementTree({ iframeRef, enabled: showTree });
+
   const [iframeSize, setIframeSize] = useState<{ w: number; h: number } | null>(null);
   const iframeSizeObserverRef = useRef<ResizeObserver | null>(null);
 
@@ -652,7 +659,7 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     <div
       className={`preview-container${isFullscreen ? ' preview-container--fullscreen' : ''}${
         editor.editMode && editorPinned ? ' preview-container--editor-pinned' : ''
-      }`}
+      }${showTree ? ' preview-container--tree' : ''}`}
       data-logs={showLogs ? 'open' : 'closed'}
       style={{
         ...(showLogs && inspectPanelHeight !== null
@@ -988,6 +995,15 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
         healthPanelRef={healthPanelRef}
         onHealthOutput={onHealthOutput}
       />
+      {showTree && (
+        <ElementTreePanel
+          tree={elementTree.tree}
+          truncated={elementTree.truncated}
+          selectedId={elementTree.selectedId}
+          onSelect={elementTree.selectNode}
+          onHover={elementTree.hoverNode}
+        />
+      )}
       {editor.editMode &&
         (() => {
           // Floating mode portals to <body> (position:fixed is the only way to

--- a/src/components/edit/ElementTreePanel.tsx
+++ b/src/components/edit/ElementTreePanel.tsx
@@ -1,0 +1,156 @@
+/**
+ * Element tree panel — a read-only, Webflow-style navigator for the preview.
+ *
+ * Shows the rendered DOM as a collapsible tree; clicking a row selects the
+ * element through the same path as clicking it on the canvas, so the visual
+ * editor panel picks it up. No editing or renaming here by design.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronRightIcon } from '../icons';
+import type { ElementTreeNode } from '../../hooks/useElementTree';
+
+interface Props {
+  tree: ElementTreeNode | null;
+  truncated: boolean;
+  selectedId: number | null;
+  onSelect: (id: number) => void;
+  onHover: (id: number | null) => void;
+}
+
+/** Rows at depth < this start expanded so the tree isn't a single chevron. */
+const AUTO_EXPAND_DEPTH = 3;
+
+/** Map of node id → ancestor id chain, for auto-expanding to a selection. */
+function buildAncestors(root: ElementTreeNode): Map<number, number[]> {
+  const out = new Map<number, number[]>();
+  const walk = (node: ElementTreeNode, chain: number[]) => {
+    out.set(node.id, chain);
+    const next = [...chain, node.id];
+    for (const child of node.children) walk(child, next);
+  };
+  walk(root, []);
+  return out;
+}
+
+function RowLabel({ node }: { node: ElementTreeNode }) {
+  const firstClass = node.cls.split(/\s+/)[0] ?? '';
+  return (
+    <>
+      <span className="ss-tree-tag">{node.tag}</span>
+      {firstClass && <span className="ss-tree-class">.{firstClass}</span>}
+      {node.text && <span className="ss-tree-text">{node.text}</span>}
+    </>
+  );
+}
+
+export function ElementTreePanel({ tree, truncated, selectedId, onSelect, onHover }: Props) {
+  const [collapsed, setCollapsed] = useState<Set<number>>(new Set());
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  const ancestors = useMemo(() => (tree ? buildAncestors(tree) : null), [tree]);
+
+  // Selecting on the canvas should reveal the row: expand its ancestor chain
+  // (presence in `collapsed` is depth-inverted — see collapsedState). Done as
+  // a render-time state adjustment (the sanctioned "derive from prop change"
+  // pattern) rather than an effect, so there's no cascading re-render.
+  const [revealedFor, setRevealedFor] = useState<number | null>(null);
+  if (selectedId !== revealedFor) {
+    setRevealedFor(selectedId);
+    const chain = selectedId != null ? ancestors?.get(selectedId) : undefined;
+    if (chain) {
+      let changed = false;
+      const next = new Set(collapsed);
+      chain.forEach((id, depth) => {
+        const wantPresence = depth >= AUTO_EXPAND_DEPTH; // presence = expanded there
+        if (wantPresence && !next.has(id)) {
+          next.add(id);
+          changed = true;
+        } else if (!wantPresence && next.has(id)) {
+          next.delete(id);
+          changed = true;
+        }
+      });
+      if (changed) setCollapsed(next);
+    }
+  }
+
+  // Scroll the selected row into view once it exists in the DOM.
+  useEffect(() => {
+    if (selectedId == null) return;
+    const raf = requestAnimationFrame(() => {
+      bodyRef.current
+        ?.querySelector(`[data-tree-id="${selectedId}"]`)
+        ?.scrollIntoView({ block: 'nearest' });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [selectedId]);
+
+  const toggle = (id: number) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  // Presence in `collapsed` flips the depth-based default: shallow nodes
+  // default open (presence = collapsed), deep nodes default closed
+  // (presence = expanded).
+  const collapsedState = (id: number, depth: number) =>
+    depth < AUTO_EXPAND_DEPTH ? collapsed.has(id) : !collapsed.has(id);
+
+  const renderNode = (node: ElementTreeNode, depth: number) => {
+    const hasChildren = node.children.length > 0;
+    // Collapsed = explicitly collapsed, or deep and never explicitly expanded.
+    // The `collapsed` set tracks explicit toggles both ways via presence.
+    const isCollapsed = hasChildren && collapsedState(node.id, depth);
+    return (
+      <div key={node.id}>
+        <div
+          className={`ss-tree-row${node.id === selectedId ? ' selected' : ''}`}
+          style={{ paddingLeft: depth * 14 + 6 }}
+          data-tree-id={node.id}
+          onClick={() => onSelect(node.id)}
+          onMouseEnter={() => onHover(node.id)}
+          onMouseLeave={() => onHover(null)}
+        >
+          {hasChildren ? (
+            <button
+              type="button"
+              className={`ss-tree-chevron${isCollapsed ? '' : ' open'}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                toggle(node.id);
+              }}
+              aria-label={isCollapsed ? 'Expand' : 'Collapse'}
+            >
+              <ChevronRightIcon size={10} />
+            </button>
+          ) : (
+            <span className="ss-tree-chevron-spacer" />
+          )}
+          <RowLabel node={node} />
+        </div>
+        {hasChildren && !isCollapsed && node.children.map((c) => renderNode(c, depth + 1))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="ss-tree-panel" data-testid="element-tree-panel">
+      <div className="ss-tree-panel__header">
+        <span className="ss-tree-panel__title">Elements</span>
+      </div>
+      <div className="ss-tree-panel__body" ref={bodyRef} onMouseLeave={() => onHover(null)}>
+        {tree ? renderNode(tree, 0) : <div className="ss-tree-panel__empty">Loading elements…</div>}
+        {truncated && (
+          <div className="ss-tree-panel__note">
+            Large page — showing the first part of the tree.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useElementTree.ts
+++ b/src/hooks/useElementTree.ts
@@ -1,0 +1,109 @@
+/**
+ * Element tree (read-only navigator) for the visual editor.
+ *
+ * Talks to the proxy-injected select script over the same postMessage
+ * protocol the editor uses: requests a lightweight DOM snapshot
+ * (`ss:requestTree` → `ss:tree`), refetches when the page mutates
+ * (`ss:treeDirty`, debounced iframe-side), and selects/hovers elements by
+ * ephemeral node id (`ss:selectNode` / `ss:hoverNode`). Selecting a node runs
+ * the exact same selection path as clicking it on the canvas, so the edit
+ * panel populates identically; canvas clicks carry a `nodeId` back so the
+ * tree row highlights in sync.
+ *
+ * @module hooks/useElementTree
+ */
+
+import { useCallback, useEffect, useState, type RefObject } from 'react';
+
+/** One element in the snapshot, mapped from the compact wire format. */
+export interface ElementTreeNode {
+  id: number;
+  tag: string;
+  /** The element's class attribute (truncated iframe-side). */
+  cls: string;
+  /** Direct text content snippet (children's text not included). */
+  text: string;
+  children: ElementTreeNode[];
+}
+
+interface WireNode {
+  i: number;
+  t: string;
+  c: string;
+  x: string;
+  k: WireNode[];
+}
+
+function mapNode(n: WireNode): ElementTreeNode {
+  return {
+    id: n.i,
+    tag: n.t,
+    cls: n.c,
+    text: n.x,
+    children: (n.k ?? []).map(mapNode),
+  };
+}
+
+interface UseElementTreeParams {
+  iframeRef: RefObject<HTMLIFrameElement | null>;
+  /** Fetch + track the tree only while the navigator is visible. */
+  enabled: boolean;
+}
+
+export function useElementTree({ iframeRef, enabled }: UseElementTreeParams) {
+  const [tree, setTree] = useState<ElementTreeNode | null>(null);
+  const [truncated, setTruncated] = useState(false);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const post = useCallback(
+    (msg: unknown) => iframeRef.current?.contentWindow?.postMessage(msg, '*'),
+    [iframeRef]
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    post({ type: 'ss:requestTree' });
+
+    const onMessage = (e: MessageEvent) => {
+      const d = e.data as
+        | { type?: string; tree?: WireNode; truncated?: boolean; nodeId?: number }
+        | undefined;
+      if (!d || typeof d.type !== 'string') return;
+      if (d.type === 'ss:tree' && d.tree) {
+        setTree(mapNode(d.tree));
+        setTruncated(!!d.truncated);
+      } else if (d.type === 'ss:treeDirty') {
+        post({ type: 'ss:requestTree' });
+      } else if (d.type === 'ss:select') {
+        setSelectedId(typeof d.nodeId === 'number' ? d.nodeId : null);
+      }
+    };
+    window.addEventListener('message', onMessage);
+
+    // A full page reload re-initializes the injected script (treeOn resets),
+    // so re-request on iframe load to keep the navigator alive across HMR
+    // full-reloads and manual refreshes.
+    const iframe = iframeRef.current;
+    const onLoad = () => post({ type: 'ss:requestTree' });
+    iframe?.addEventListener('load', onLoad);
+
+    return () => {
+      post({ type: 'ss:treeOff' });
+      window.removeEventListener('message', onMessage);
+      iframe?.removeEventListener('load', onLoad);
+    };
+  }, [enabled, post, iframeRef]);
+
+  const selectNode = useCallback((id: number) => post({ type: 'ss:selectNode', id }), [post]);
+  const hoverNode = useCallback((id: number | null) => post({ type: 'ss:hoverNode', id }), [post]);
+
+  // Stale data is kept while disabled (cheap) but never exposed.
+  return {
+    tree: enabled ? tree : null,
+    truncated,
+    selectedId: enabled ? selectedId : null,
+    selectNode,
+    hoverNode,
+  };
+}

--- a/src/styles/features/element-tree.css
+++ b/src/styles/features/element-tree.css
@@ -18,7 +18,8 @@
   height: var(--preview-toolbar-h);
   flex-shrink: 0;
   padding: 0 var(--spacing-md);
-  background: var(--bg-tertiary);
+  /* Same surface as the preview toolbar so the bars read as one row. */
+  background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
 }
 

--- a/src/styles/features/element-tree.css
+++ b/src/styles/features/element-tree.css
@@ -1,0 +1,108 @@
+/* Element tree panel — read-only navigator shown as the preview container's
+   left grid column in fullscreen edit mode (see preview.css for the grid). */
+
+.ss-tree-panel {
+  grid-area: 2 / 1 / -1 / 2;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border);
+  font-size: 12px;
+}
+
+.ss-tree-panel__header {
+  display: flex;
+  align-items: center;
+  height: var(--preview-toolbar-h);
+  flex-shrink: 0;
+  padding: 0 var(--spacing-md);
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border);
+}
+
+.ss-tree-panel__title {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.ss-tree-panel__body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--spacing-xs) 0;
+}
+
+.ss-tree-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  height: 24px;
+  padding-right: var(--spacing-sm);
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  color: var(--text-secondary);
+}
+
+.ss-tree-row:hover {
+  background: var(--bg-tertiary);
+}
+
+.ss-tree-row.selected {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  box-shadow: inset 2px 0 0 var(--accent);
+}
+
+.ss-tree-chevron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: transform var(--transition);
+}
+
+.ss-tree-chevron.open {
+  transform: rotate(90deg);
+}
+
+.ss-tree-chevron-spacer {
+  flex-shrink: 0;
+  width: 14px;
+}
+
+.ss-tree-tag {
+  flex-shrink: 0;
+  color: var(--text-primary);
+  font-family: monospace;
+}
+
+.ss-tree-class {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-muted);
+  font-family: monospace;
+}
+
+.ss-tree-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.ss-tree-panel__empty,
+.ss-tree-panel__note {
+  padding: var(--spacing-md);
+  color: var(--text-muted);
+}

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -235,9 +235,10 @@
   color: var(--text-muted);
 }
 
-/* Refresh + fullscreen — matched icon buttons (same icon pack, same height) */
+/* Refresh + fullscreen + tree toggle — matched icon buttons */
 .preview-refresh,
-.preview-fullscreen-btn {
+.preview-fullscreen-btn,
+.preview-tree-btn {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -254,9 +255,14 @@
 }
 
 .preview-refresh:hover,
-.preview-fullscreen-btn:hover {
+.preview-fullscreen-btn:hover,
+.preview-tree-btn:hover {
   background: var(--bg-tertiary);
   color: var(--text-primary);
+}
+
+.preview-tree-btn.active {
+  color: var(--accent);
 }
 
 /* Fullscreen: the container covers the window below the workspace header
@@ -310,11 +316,12 @@
   box-shadow: none;
 }
 
-/* The pinned header is its own bar below the toolbar — keep the same bar
-   height as the toolbar for consistency; no drag affordance while docked. */
+/* The pinned header is its own bar below the toolbar — same bar height and
+   surface as the toolbar for consistency; no drag affordance while docked. */
 .ss-edit-panel.ss-edit-panel--pinned .ss-edit-panel__header {
   height: var(--preview-toolbar-h);
   flex-shrink: 0;
+  background: var(--bg-secondary);
 }
 .ss-edit-panel.ss-edit-panel--pinned .ss-edit-panel__header,
 .ss-edit-panel.ss-edit-panel--pinned .ss-edit-panel__header:active {

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -279,7 +279,19 @@
   grid-template-columns: minmax(0, 1fr) var(--editor-panel-w);
 }
 
-.preview-container--editor-pinned .preview-toolbar {
+/* Element tree (navigator) on the left in fullscreen edit mode. Composes with
+   the pinned editor: tree | canvas | editor. Panels use negative column lines
+   so each works with or without the other. */
+.preview-container--tree {
+  grid-template-columns: var(--tree-panel-w) minmax(0, 1fr);
+}
+
+.preview-container--tree.preview-container--editor-pinned {
+  grid-template-columns: var(--tree-panel-w) minmax(0, 1fr) var(--editor-panel-w);
+}
+
+.preview-container--editor-pinned .preview-toolbar,
+.preview-container--tree .preview-toolbar {
   grid-column: 1 / -1;
 }
 
@@ -287,7 +299,7 @@
    overrides need higher specificity than the base .ss-edit-panel rules. */
 .ss-edit-panel.ss-edit-panel--pinned {
   position: static;
-  grid-area: 2 / 2 / -1 / 3;
+  grid-area: 2 / -2 / -1 / -1;
   width: auto;
   min-width: 0;
   max-height: none;

--- a/src/styles/global/base.css
+++ b/src/styles/global/base.css
@@ -90,6 +90,9 @@
   /* Preview toolbar height — also sizes the pinned editor panel's header so
      the two bars line up. */
   --preview-toolbar-h: 47px;
+  /* Element tree (navigator) panel width — the preview's left grid column in
+     fullscreen edit mode. */
+  --tree-panel-w: 240px;
   --z-modal-overlay: 1000;
   --z-modal: 1001;
   --z-tooltip: 1100;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -24,6 +24,7 @@
 @import './features/toolbar.css';
 @import './features/preview.css';
 @import './features/visual-editor.css';
+@import './features/element-tree.css';
 @import './features/device-mirror.css';
 @import './features/browser-tools.css';
 @import './features/github.css';


### PR DESCRIPTION
## Summary
- Read-only, Webflow-style element tree as the preview's left column in fullscreen + edit mode: collapsible DOM tree, click to select (same path as canvas clicks, so the edit panel populates identically), two-way selection sync with auto-expand + scroll-into-view, hover outlines
- Proxy-injected script serializes a lightweight snapshot (ephemeral node ids, overlays excluded, 4000-node cap) and refetches via debounced MutationObserver — survives HMR and full reloads
- Toolbar toggle (PanelLeftIcon, fullscreen+edit only), persisted cross-project; tree/pinned-editor headers share the toolbar surface so the bars read as one row
- Composes with the pinned editor via negative grid lines: tree | canvas | edit panel

## Test plan
- [x] 580 frontend tests, typecheck, lint, prettier, LOC guard green
- [x] Manual: tree renders, both-way selection sync, hover outline, collapse/expand, toggle persistence, three-column layout with pinned editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)