### PR TITLE
Fix project rename: stale open-project guards + [object Object] errors

### DIFF
--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -606,14 +606,19 @@ fn validate_project_name(name: &str) -> Result<String, CommandError> {
 /// Renames a project's directory on disk and rekeys all path-keyed stores.
 ///
 /// Only ~/ShipStudio projects can be renamed (external projects are rejected,
-/// matching `delete_project`). Refuses to rename while the project is open in a
-/// window or has an active background session, to avoid racing live PTYs and
-/// reserved ports. Everything inside the directory — git remotes, `.vercel`,
-/// `.shipstudio` metadata — travels with the move untouched. Returns the new
-/// absolute path.
+/// matching `delete_project`). Refuses to rename while the project is open in
+/// a *different* window; a hot background session (the rail keeps PTYs and dev
+/// servers alive after the user returns to the dashboard) is suspended first
+/// so the folder isn't moved out from under live processes. Everything inside
+/// the directory — git remotes, `.vercel`, `.shipstudio` metadata — travels
+/// with the move untouched. Returns the new absolute path.
 #[tauri::command]
-#[tracing::instrument]
-pub async fn rename_project(old_path: String, new_name: String) -> Result<String, CommandError> {
+#[tracing::instrument(skip(window))]
+pub async fn rename_project(
+    window: tauri::Window,
+    old_path: String,
+    new_name: String,
+) -> Result<String, CommandError> {
     let project_path = std::path::Path::new(&old_path);
 
     // Reject external projects (their folders live outside ~/ShipStudio).
@@ -640,15 +645,34 @@ pub async fn rename_project(old_path: String, new_name: String) -> Result<String
     // Validate + normalize the requested name.
     let new_name = validate_project_name(&new_name)?;
 
-    // Refuse to rename a project that's currently open or actively running —
-    // moving the directory out from under live PTYs / reserved ports is a
-    // recipe for corruption. Suspended pinned sessions are fine (rekeyed below).
-    if crate::state::get_window_for_project(&old_path).is_some() {
-        return Err(("Close this project before renaming it.".to_string()).into());
+    // The rename UI only exists on the dashboard, so if the window registry
+    // says *this* window owns the project, the entry is stale — the user
+    // navigated back to the dashboard, which never unregisters (hot-session
+    // contract). Clear it and continue. A *different* window owning it means
+    // the project may genuinely be on screen there: refuse.
+    if let Some(owning_label) = crate::state::get_window_for_project(&old_path) {
+        if owning_label != window.label() {
+            return Err(
+                "This project is open in another window. Close that window, then rename."
+                    .to_string()
+                    .into(),
+            );
+        }
+        crate::state::unregister_project_window(&old_path);
     }
+
+    // A hot background session (PTYs / dev server kept alive by the rail)
+    // would have the folder moved out from under its live processes. Suspend
+    // it first — same teardown as the rail's close button; the pin survives
+    // and is rekeyed below, so the user can cold-start it at the new path.
     if let Some(session) = crate::state::get_session(&old_path) {
         if session.status == crate::state::SessionStatus::Active {
-            return Err(("Close this project before renaming it.".to_string()).into());
+            let killed = sessions::suspend_session_internal(&old_path).await;
+            tracing::info!(
+                "Suspended hot session before rename: project={}, killed_ptys={}",
+                old_path,
+                killed
+            );
         }
     }
 

--- a/src-tauri/src/commands/projects/sessions.rs
+++ b/src-tauri/src/commands/projects/sessions.rs
@@ -103,18 +103,27 @@ pub async fn register_project_session(
 #[tauri::command]
 #[tracing::instrument]
 pub async fn suspend_project_session(project_path: String) -> Result<u32, CommandError> {
-    let killed = kill_project_pty_internal(&project_path);
+    Ok(suspend_session_internal(&project_path).await)
+}
+
+/// Shared suspension teardown: kill the project's PTYs, tear down its mobile
+/// preview, and mark the registry entry `Suspended`. Used by the
+/// `suspend_project_session` command and by `rename_project`, which suspends
+/// a hot background session before moving the folder out from under it.
+/// Returns the number of PTYs killed.
+pub async fn suspend_session_internal(project_path: &str) -> u32 {
+    let killed = kill_project_pty_internal(project_path);
     // Suspending frees the project's resources — the mobile preview (serve-sim
     // daemon + app-build pty_session) lives in registries the PTY sweep above
     // doesn't reach, so tear it down explicitly here too.
-    crate::commands::mobile::teardown_mobile_preview(project_path.clone()).await;
-    mark_session_suspended(&project_path);
+    crate::commands::mobile::teardown_mobile_preview(project_path.to_string()).await;
+    mark_session_suspended(project_path);
     tracing::info!(
         "Suspended session: project={}, killed_ptys={}",
         project_path,
         killed
     );
-    Ok(killed)
+    killed
 }
 
 /// Fully remove a project session from the registry.

--- a/src/components/ProjectList.tsx
+++ b/src/components/ProjectList.tsx
@@ -26,6 +26,7 @@ import {
   exportProjectAsTemplate,
 } from '../lib/project';
 import { unregisterExternalProject } from '../lib/external-projects';
+import { asCommandError, formatCommandError } from '../lib/errors';
 import { logger } from '../lib/logger';
 import { trackEvent, trackError } from '../lib/analytics';
 import {
@@ -311,7 +312,7 @@ export function ProjectList({
       logger.error('Failed to delete project', {
         error: error instanceof Error ? error.message : String(error),
       });
-      alert('Failed to delete project: ' + String(error));
+      alert('Failed to delete project: ' + formatCommandError(asCommandError(error)));
     } finally {
       setDeleting(false);
     }

--- a/src/components/RenameProjectModal.test.tsx
+++ b/src/components/RenameProjectModal.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Tests for RenameProjectModal — rename a project's folder from the dashboard.
+ *
+ * Covers:
+ *   - submit calls onRename with the trimmed new name and closes on success
+ *   - submit disabled while the name is unchanged or empty
+ *   - backend CommandError objects render their message (regression: these
+ *     used to display as "[object Object]")
+ *   - plain string / Error rejections also render readable messages
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { RenameProjectModal } from './RenameProjectModal';
+
+describe('RenameProjectModal', () => {
+  const onClose = vi.fn();
+  const onRename = vi.fn<(newName: string) => Promise<void>>();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onRename.mockResolvedValue(undefined);
+  });
+
+  function open() {
+    render(
+      <RenameProjectModal
+        isOpen={true}
+        onClose={onClose}
+        currentName="my-project"
+        onRename={onRename}
+      />
+    );
+  }
+
+  it('renames with the trimmed value and closes on success', async () => {
+    open();
+    fireEvent.change(screen.getByLabelText('Project name'), {
+      target: { value: '  renamed-project  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+
+    await waitFor(() => expect(onRename).toHaveBeenCalledWith('renamed-project'));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('disables submit while the name is unchanged', () => {
+    open();
+    expect(screen.getByRole('button', { name: 'Rename' })).toBeDisabled();
+  });
+
+  it('renders the message from a CommandError object (not [object Object])', async () => {
+    onRename.mockRejectedValue({
+      type: 'Other',
+      message: 'This project is open in another window. Close that window, then rename.',
+    });
+    open();
+    fireEvent.change(screen.getByLabelText('Project name'), {
+      target: { value: 'new-name' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('This project is open in another window. Close that window, then rename.')
+      ).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/object Object/)).not.toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('renders a Validation CommandError with field and reason', async () => {
+    onRename.mockRejectedValue({
+      type: 'Validation',
+      field: 'new_name',
+      reason: 'Project name cannot contain slashes',
+    });
+    open();
+    fireEvent.change(screen.getByLabelText('Project name'), {
+      target: { value: 'a/b' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Project name cannot contain slashes/)).toBeInTheDocument()
+    );
+  });
+
+  it('renders plain string rejections as-is', async () => {
+    onRename.mockRejectedValue('Project not found');
+    open();
+    fireEvent.change(screen.getByLabelText('Project name'), {
+      target: { value: 'new-name' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+
+    await waitFor(() => expect(screen.getByText('Project not found')).toBeInTheDocument());
+  });
+});

--- a/src/components/RenameProjectModal.tsx
+++ b/src/components/RenameProjectModal.tsx
@@ -11,6 +11,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { ModalFrame } from './primitives/ModalFrame';
 import { Button } from './primitives/Button';
+import { asCommandError, formatCommandError } from '../lib/errors';
 
 interface RenameProjectModalProps {
   /** Whether the modal is open */
@@ -57,7 +58,7 @@ export function RenameProjectModal({
       await onRename(trimmed);
       onClose();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(formatCommandError(asCommandError(err)));
     } finally {
       setLoading(false);
     }
@@ -83,7 +84,7 @@ export function RenameProjectModal({
         </div>
         <p className="hint">
           This renames the folder on disk. Git history, deployments, and project settings are
-          preserved.
+          preserved. If the project is running in the background, it will be stopped first.
         </p>
         {error && <p className="form-error">{error}</p>}
         <div className="modal-actions">


### PR DESCRIPTION
## The bug (reported by Pia)

Renaming a project failed with an inscrutable `[object Object]` error — for **any** project, **any** name, including a freshly created test project.

Two compounding issues:

1. **The rename always failed after opening a project once.** Going back to the dashboard is a *view switch* (hot-session contract): the window-registry entry is never unregistered and the session stays `Active`. `rename_project`'s "is this open?" guards therefore refused with *"Close this project before renaming it."* until app restart.
2. **The error was unreadable.** The modal did `String(err)` on the rejected `CommandError` object → `[object Object]`.

## The fix

- `rename_project` now receives the invoking window. The rename modal only exists on the dashboard, so a window-registry entry owned by the **same** window is provably stale — it's cleared and the rename proceeds. A **different** window owning the project still refuses, now with a clear message.
- A hot background session is **auto-suspended** before the move (identical teardown to the rail's close button: PTYs killed, mobile preview torn down, entry marked `Suspended`) instead of blocking. Pins/folders/session entries are rekeyed as before, so the project cold-starts at its new path.
- `RenameProjectModal` (and the delete-project alert) format errors via the existing `formatCommandError(asCommandError(...))` helpers.
- Modal hint discloses that a running project is stopped first.

## Tests

- New `RenameProjectModal.test.tsx` (5 cases) including the `[object Object]` regression.
- `pnpm check:all` ✅ · 585 frontend tests ✅ · 349 Rust tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects with active development sessions can now be renamed; active sessions are automatically suspended during the rename process.

* **Bug Fixes**
  * Improved error message formatting for project deletion and rename operations to provide clearer feedback on failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->