### PR TITLE
security: fix path traversal, command injection, and IPC trust gaps

### DIFF
--- a/src-tauri/src/commands/assets.rs
+++ b/src-tauri/src/commands/assets.rs
@@ -278,6 +278,18 @@ pub async fn upload_asset(
         );
     }
 
+    // Refuse to write through a symlink at the final component: a malicious
+    // repo could pre-plant `public/logo.png` as a symlink to ~/.zshenv, and
+    // `fs::write` follows symlinks, so the containment check on the parent dir
+    // above isn't enough on its own.
+    if let Ok(meta) = fs::symlink_metadata(&file_path) {
+        if meta.file_type().is_symlink() {
+            return Err(
+                ("Security error: refusing to overwrite a symlinked asset path".to_string()).into(),
+            );
+        }
+    }
+
     // Write file
     fs::write(&file_path, file_data).map_err(|e| format!("Failed to write file: {e}"))?;
 

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -4,7 +4,7 @@
 
 use crate::errors::CommandError;
 use crate::types::{EnvFile, EnvVar};
-use crate::utils::validate_project_path;
+use crate::utils::{validate_project_file_path, validate_project_path};
 
 #[tauri::command]
 #[tracing::instrument(skip(project_path), fields(project = %project_path))]
@@ -40,7 +40,10 @@ pub async fn list_env_files(project_path: String) -> Result<Vec<EnvFile>, Comman
 #[tauri::command]
 #[tracing::instrument(skip(file_path), fields(file = %file_path))]
 pub async fn read_env_file(file_path: String) -> Result<Vec<EnvVar>, CommandError> {
-    let contents = std::fs::read_to_string(&file_path).map_err(|e| e.to_string())?;
+    // Constrain reads to files inside ShipStudio/registered projects so this
+    // can't be used to exfiltrate arbitrary files (~/.aws/credentials, etc.).
+    let safe_path = validate_project_file_path(&file_path)?;
+    let contents = std::fs::read_to_string(&safe_path).map_err(|e| e.to_string())?;
     let mut vars = Vec::new();
 
     for line in contents.lines() {
@@ -83,6 +86,9 @@ const MAX_ENV_VALUE_LENGTH: usize = 65536;
 #[tauri::command]
 #[tracing::instrument(skip(file_path, vars), fields(file = %file_path, var_count = vars.len()))]
 pub async fn write_env_file(file_path: String, vars: Vec<EnvVar>) -> Result<(), CommandError> {
+    // Constrain writes to files inside ShipStudio/registered projects so this
+    // can't be used to overwrite arbitrary files (~/.zshenv, shell rc, etc.).
+    let safe_path = validate_project_file_path(&file_path)?;
     let mut contents = String::new();
 
     for var in vars {
@@ -131,7 +137,7 @@ pub async fn write_env_file(file_path: String, vars: Vec<EnvVar>) -> Result<(), 
         contents.push_str(&format!("{}={}\n", var.key, value));
     }
 
-    std::fs::write(&file_path, contents).map_err(|e| e.to_string())?;
+    std::fs::write(&safe_path, contents).map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -174,18 +180,9 @@ pub async fn create_env_file(
 #[tauri::command]
 #[tracing::instrument(skip(file_path), fields(file = %file_path))]
 pub async fn delete_env_file(file_path: String) -> Result<(), CommandError> {
-    // Validate the file is inside ShipStudio directory
-    let path = std::path::Path::new(&file_path);
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
-    let shipstudio_dir = home.join("ShipStudio");
-
-    let canonical = dunce::canonicalize(path).map_err(|e| format!("Invalid path: {e}"))?;
-    if !canonical.starts_with(&shipstudio_dir) {
-        return Err(
-            ("Security error: cannot delete files outside ShipStudio directory".to_string()).into(),
-        );
-    }
-
-    std::fs::remove_file(&file_path).map_err(|e| e.to_string())?;
+    // Validate the file is inside ShipStudio (or a registered external project)
+    // and operate on the canonicalized path to avoid `..`/symlink escapes.
+    let safe_path = validate_project_file_path(&file_path)?;
+    std::fs::remove_file(&safe_path).map_err(|e| e.to_string())?;
     Ok(())
 }

--- a/src-tauri/src/commands/external_projects.rs
+++ b/src-tauri/src/commands/external_projects.rs
@@ -303,7 +303,9 @@ fn looks_like_project_root(path: &Path) -> bool {
         "composer.json",
         "index.html",
     ];
-    MARKERS.iter().any(|m| path.join(m).exists())
+    // Mirror register_external_project's picker check: any .html file counts as a
+    // project, so static sites whose entry isn't index.html still auto-register.
+    MARKERS.iter().any(|m| path.join(m).exists()) || crate::commands::projects::has_html_files(path)
 }
 
 /// Register an external project by path (no folder picker dialog).

--- a/src-tauri/src/commands/external_projects.rs
+++ b/src-tauri/src/commands/external_projects.rs
@@ -12,6 +12,35 @@ use tauri_plugin_dialog::DialogExt;
 
 // ============ Helper Functions ============
 
+/// Grant the asset protocol (`convertFileSrc`) read access to a directory at
+/// runtime. The static scope in tauri.conf.json deliberately only covers
+/// ~/ShipStudio; external projects live anywhere on disk, so we widen the scope
+/// for each registered external root individually rather than exposing all of
+/// `$HOME`/`/Volumes` (which would let any main-frame script read ~/.ssh etc.).
+pub fn grant_asset_scope(app: &AppHandle, path: &Path) {
+    use tauri::Manager;
+    if path.is_dir() {
+        if let Err(e) = app.asset_protocol_scope().allow_directory(path, true) {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "Failed to grant asset-protocol scope for external project"
+            );
+        }
+    }
+}
+
+/// Grant asset-protocol scope to every already-registered external project.
+/// Called once at startup so reopening an external project shows its thumbnails
+/// and assets without re-registering.
+pub fn grant_asset_scope_for_registered(app: &AppHandle) {
+    if let Ok(cfg) = load_config() {
+        for proj in &cfg.projects {
+            grant_asset_scope(app, Path::new(&proj.path));
+        }
+    }
+}
+
 /// Get the path to the external projects config file
 fn get_config_path() -> Result<PathBuf, String> {
     let home = dirs::home_dir().ok_or("Could not find home directory")?;
@@ -181,6 +210,10 @@ pub async fn register_external_project(app: AppHandle) -> Result<Option<String>,
 
     save_config(&config)?;
 
+    // Widen the asset-protocol scope to this newly-registered root so its
+    // thumbnails/assets render without a restart.
+    grant_asset_scope(&app, &canonical);
+
     Ok(Some(canonical_str))
 }
 
@@ -248,6 +281,31 @@ fn clear_workspace_subpath_in_metadata(project_root: &Path) -> Result<(), String
     Ok(())
 }
 
+/// Heuristic: does this directory look like a real project root the user would
+/// legitimately open? Used to gate dialog-less auto-registration so the trust
+/// boundary can't be silently widened to arbitrary directories. Intentionally
+/// generous about *project* shapes but excludes things like ~/.ssh, ~/.aws.
+fn looks_like_project_root(path: &Path) -> bool {
+    if !path.is_dir() {
+        return false;
+    }
+    const MARKERS: &[&str] = &[
+        ".git",
+        "package.json",
+        ".shipstudio",
+        "Cargo.toml",
+        "go.mod",
+        "pyproject.toml",
+        "requirements.txt",
+        "Gemfile",
+        "pom.xml",
+        "build.gradle",
+        "composer.json",
+        "index.html",
+    ];
+    MARKERS.iter().any(|m| path.join(m).exists())
+}
+
 /// Register an external project by path (no folder picker dialog).
 ///
 /// Called automatically when a project outside ~/ShipStudio is opened
@@ -256,8 +314,11 @@ fn clear_workspace_subpath_in_metadata(project_root: &Path) -> Result<(), String
 ///
 /// Returns Ok(true) if newly registered, Ok(false) if already registered or inside ~/ShipStudio.
 #[tauri::command]
-#[tracing::instrument]
-pub async fn ensure_external_project_registered(path: String) -> Result<bool, CommandError> {
+#[tracing::instrument(skip(app))]
+pub async fn ensure_external_project_registered(
+    app: AppHandle,
+    path: String,
+) -> Result<bool, CommandError> {
     let canonical =
         dunce::canonicalize(Path::new(&path)).map_err(|e| format!("Invalid path: {e}"))?;
 
@@ -271,6 +332,20 @@ pub async fn ensure_external_project_registered(path: String) -> Result<bool, Co
     // Skip if already registered
     if is_registered_external_path(&canonical)? {
         return Ok(false);
+    }
+
+    // This command registers a NEW path into the trust boundary without a native
+    // folder-picker dialog (unlike `register_external_project`). To stop a
+    // compromised webview from registering arbitrary sensitive directories
+    // (e.g. ~/.ssh, ~/.aws) and thereby making them pass `validate_project_path`,
+    // only auto-register paths that actually look like a project root. The
+    // picker flow remains the way to add anything that doesn't.
+    if !looks_like_project_root(&canonical) {
+        return Err(format!(
+            "Refusing to auto-register '{}': it does not look like a project directory. Add it via the folder picker instead.",
+            canonical.display()
+        )
+        .into());
     }
 
     // Register it
@@ -287,6 +362,7 @@ pub async fn ensure_external_project_registered(path: String) -> Result<bool, Co
     });
 
     save_config(&config)?;
+    grant_asset_scope(&app, &canonical);
     tracing::info!("Auto-registered external project: {}", canonical_str);
 
     Ok(true)
@@ -309,4 +385,39 @@ pub async fn is_project_external(path: String) -> Result<bool, CommandError> {
         }
     }
     Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::looks_like_project_root;
+    use std::fs;
+
+    #[test]
+    fn rejects_sensitive_non_project_dirs() {
+        // A directory with no project markers (the ~/.ssh attack shape) must not
+        // be auto-registerable into the trust boundary.
+        let base = std::env::temp_dir().join("ss-audit-not-a-project");
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).expect("mkdir");
+        fs::write(base.join("id_rsa"), b"x").expect("write");
+        assert!(!looks_like_project_root(&base));
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn accepts_dir_with_project_marker() {
+        let base = std::env::temp_dir().join("ss-audit-is-a-project");
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).expect("mkdir");
+        fs::write(base.join("package.json"), b"{}").expect("write");
+        assert!(looks_like_project_root(&base));
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn rejects_nonexistent_or_file() {
+        let missing = std::env::temp_dir().join("ss-audit-missing-xyz");
+        let _ = fs::remove_dir_all(&missing);
+        assert!(!looks_like_project_root(&missing));
+    }
 }

--- a/src-tauri/src/commands/git/branches.rs
+++ b/src-tauri/src/commands/git/branches.rs
@@ -213,6 +213,11 @@ pub async fn switch_branch(
     auto_stash: bool,
 ) -> Result<SwitchResult, CommandError> {
     let validated_path = validate_project_path(&project_path)?;
+    // Reject ref names that could be parsed by git as an option (argument
+    // injection) — same guard create_branch already applies.
+    if branch_name.starts_with('-') || branch_name.contains("..") {
+        return Err(("Invalid branch name".to_string()).into());
+    }
     let mut stashed = false;
     let mut stash_applied = false;
     let mut pending_stash_from: Option<String> = None;
@@ -271,7 +276,7 @@ pub async fn switch_branch(
 
     // Try to checkout the branch
     let checkout_output = create_command("git")
-        .args(["checkout", &branch_name])
+        .args(["checkout", "--end-of-options", &branch_name])
         .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
@@ -464,6 +469,11 @@ pub async fn delete_branch(
     let validated_path = validate_project_path(&project_path)?;
     info!(delete_remote, "Deleting branch");
 
+    // Reject ref names git could parse as an option (argument injection).
+    if branch_name.starts_with('-') || branch_name.contains("..") {
+        return Err(("Invalid branch name".to_string()).into());
+    }
+
     // Don't allow deleting main/master
     if branch_name == "main" || branch_name == "master" {
         warn!("Attempted to delete main branch");
@@ -488,7 +498,7 @@ pub async fn delete_branch(
 
     // Delete local branch
     let local_output = create_command("git")
-        .args(["branch", "-D", &branch_name])
+        .args(["branch", "-D", "--", &branch_name])
         .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -141,38 +141,34 @@ pub fn get_ahead_behind_batch(
         return results;
     }
 
-    // Build a shell script that runs rev-list for each branch in one subprocess
-    let mut script = String::new();
+    // Run git as argv per branch (NOT via a shell). Branch names are
+    // attacker-controlled repository content — a name like `x';rm -rf ~;'` is a
+    // valid git ref, so interpolating it into a `sh -c` string was a command
+    // injection. Passing it as a literal argument to `git` removes the shell
+    // entirely. The leading `--end-of-options` stops a `-`-leading ref from
+    // being parsed as a flag.
     for name in branch_names {
-        // Each line outputs: branch_name\tahead\tbehind
-        // If rev-list fails (e.g. branch doesn't exist on remote), output 0\t0
-        script.push_str(&format!(
-            "printf '%s\\t' '{}'; git rev-list --left-right --count '{}...{}' 2>/dev/null || printf '0\\t0'; printf '\\n'; ",
-            name, name, compare_to
-        ));
-    }
+        let range = format!("{name}...{compare_to}");
+        let output = create_command("git")
+            .args(["rev-list", "--left-right", "--count", "--end-of-options"])
+            .arg(&range)
+            .current_dir(path)
+            .output();
 
-    let output = create_command("sh")
-        .args(["-c", &script])
-        .current_dir(path)
-        .output();
-
-    match output {
-        Ok(out) if out.status.success() => {
-            let stdout = String::from_utf8_lossy(&out.stdout);
-            for line in stdout.lines() {
-                let parts: Vec<&str> = line.split('\t').collect();
-                if parts.len() >= 3 {
-                    let name = parts[0].to_string();
-                    let ahead = parts[1].parse().unwrap_or(0);
-                    let behind = parts[2].parse().unwrap_or(0);
-                    results.insert(name, (ahead, behind));
+        let (ahead, behind) = match output {
+            Ok(out) if out.status.success() => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                let parts: Vec<&str> = stdout.trim().split('\t').collect();
+                if parts.len() == 2 {
+                    (parts[0].parse().unwrap_or(0), parts[1].parse().unwrap_or(0))
+                } else {
+                    (0, 0)
                 }
             }
-        }
-        _ => {
-            // Fallback: all branches get (0, 0)
-        }
+            // Branch may not exist on remote, etc. — default to (0, 0).
+            _ => (0, 0),
+        };
+        results.insert((*name).to_string(), (ahead, behind));
     }
 
     results

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -9,7 +9,7 @@
 //! - Claude: `claude mcp list`, `claude mcp add`, `claude mcp remove`
 //! - Codex: `codex mcp list`, `codex mcp add`, `codex mcp remove`
 use crate::errors::CommandError;
-use crate::utils::{create_command, find_executable, get_extended_path};
+use crate::utils::{create_command, find_executable, get_extended_path, validate_project_path};
 use serde::Serialize;
 
 /// Represents an MCP server configured for an agent.
@@ -189,6 +189,12 @@ pub async fn list_mcp_servers(
         .map(|h| h.to_string_lossy().to_string())
         .unwrap_or_default();
 
+    // Constrain the agent's working directory to a known project.
+    let validated_cwd = match &project_path {
+        Some(p) => Some(validate_project_path(p)?),
+        None => None,
+    };
+
     // Run `<binary> mcp list` — this returns name, command/URL, and status
     let mut list_cmd = create_command(&binary);
     list_cmd
@@ -201,7 +207,7 @@ pub async fn list_mcp_servers(
         list_cmd.env_remove("CLAUDECODE");
     }
 
-    if let Some(ref path) = project_path {
+    if let Some(ref path) = validated_cwd {
         list_cmd.current_dir(path);
     }
 
@@ -240,7 +246,7 @@ pub async fn list_mcp_servers(
             get_cmd.env_remove("CLAUDECODE");
         }
 
-        if let Some(ref path) = project_path {
+        if let Some(ref path) = validated_cwd {
             get_cmd.current_dir(path);
         }
 
@@ -315,7 +321,7 @@ pub async fn add_mcp_server(
     cmd.args(&parsed_args);
 
     if let Some(ref path) = project_path {
-        cmd.current_dir(path);
+        cmd.current_dir(validate_project_path(path)?);
     }
 
     let output = cmd
@@ -370,7 +376,7 @@ pub async fn remove_mcp_server(
     cmd.arg(&name);
 
     if let Some(ref path) = project_path {
-        cmd.current_dir(path);
+        cmd.current_dir(validate_project_path(path)?);
     }
 
     let output = cmd

--- a/src-tauri/src/commands/plugins/mod.rs
+++ b/src-tauri/src/commands/plugins/mod.rs
@@ -331,16 +331,23 @@ pub(crate) fn now_ms() -> u64 {
         .unwrap_or(0)
 }
 
-/// Get the storage file path for a plugin
-pub(crate) fn get_storage_path(plugin_id: &str, project_path: &str) -> Result<PathBuf, String> {
-    // Validate plugin_id is safe
-    if plugin_id.contains('/')
+/// Reject plugin IDs that could escape the plugins directory when joined as a
+/// path component (traversal, separators, dotfiles).
+pub(crate) fn validate_plugin_id(plugin_id: &str) -> Result<(), String> {
+    if plugin_id.is_empty()
+        || plugin_id.contains('/')
         || plugin_id.contains('\\')
         || plugin_id.contains("..")
         || plugin_id.starts_with('.')
     {
         return Err("Invalid plugin ID".to_string());
     }
+    Ok(())
+}
+
+/// Get the storage file path for a plugin
+pub(crate) fn get_storage_path(plugin_id: &str, project_path: &str) -> Result<PathBuf, String> {
+    validate_plugin_id(plugin_id)?;
 
     let plugins_dir = get_plugins_dir(project_path)?;
     Ok(plugins_dir.join(plugin_id).join("storage.json"))
@@ -350,6 +357,7 @@ pub(crate) fn get_storage_path(plugin_id: &str, project_path: &str) -> Result<Pa
 #[tauri::command]
 #[tracing::instrument(fields(project = %project_path))]
 pub fn read_plugin_bundle(project_path: String, plugin_id: String) -> Result<String, CommandError> {
+    validate_plugin_id(&plugin_id)?;
     let registry = read_registry(&project_path)?;
     let entry = registry.plugins.iter().find(|e| e.plugin_id == plugin_id);
 
@@ -387,6 +395,7 @@ pub fn read_plugin_manifest(
     project_path: String,
     plugin_id: String,
 ) -> Result<PluginManifest, CommandError> {
+    validate_plugin_id(&plugin_id)?;
     let registry = read_registry(&project_path)?;
     let entry = registry.plugins.iter().find(|e| e.plugin_id == plugin_id);
 

--- a/src-tauri/src/commands/plugins/plugin_lifecycle.rs
+++ b/src-tauri/src/commands/plugins/plugin_lifecycle.rs
@@ -13,6 +13,37 @@ use super::{
     RegistryEntry,
 };
 
+/// Validate a git URL before passing it to `git clone`.
+///
+/// Blocks two classes of attack:
+/// 1. Argument injection — a value starting with `-` is interpreted by git as a
+///    flag rather than a URL.
+/// 2. Local/command-executing transports — git's `ext::` transport runs an
+///    arbitrary command, and `file://`/bare local paths can pull from anywhere
+///    on disk. Only network transports to a remote host are allowed.
+fn validate_clone_url(url: &str) -> Result<(), CommandError> {
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
+        return Err("Plugin repository URL is empty".to_string().into());
+    }
+    if trimmed.starts_with('-') {
+        return Err("Invalid plugin repository URL".to_string().into());
+    }
+    let lowered = trimmed.to_ascii_lowercase();
+    let allowed = lowered.starts_with("https://")
+        || lowered.starts_with("git://")
+        || lowered.starts_with("ssh://")
+        || lowered.starts_with("git@");
+    if !allowed {
+        return Err(
+            "Plugin repository URL must be an https://, ssh://, git:// or git@ remote"
+                .to_string()
+                .into(),
+        );
+    }
+    Ok(())
+}
+
 /// List all installed plugins for a project
 #[tauri::command]
 #[tracing::instrument(fields(project = %project_path))]
@@ -55,6 +86,8 @@ pub async fn install_plugin(
     project_path: String,
     repo_url: String,
 ) -> Result<PluginInfo, CommandError> {
+    validate_clone_url(&repo_url)?;
+
     let plugins_dir = get_plugins_dir(&project_path)?;
     fs::create_dir_all(&plugins_dir).map_err(|e| format!("Failed to create plugins dir: {e}"))?;
 
@@ -69,6 +102,7 @@ pub async fn install_plugin(
             "clone",
             "--depth",
             "1",
+            "--",
             &repo_url,
             &temp_dir.to_string_lossy(),
         ])
@@ -222,6 +256,8 @@ pub async fn update_plugin(
     let source_url = entry.source_url.clone();
     let was_enabled = entry.enabled;
 
+    validate_clone_url(&source_url)?;
+
     // Re-install from source (clean install)
     let plugins_dir = get_plugins_dir(&project_path)?;
     let plugin_dir = plugins_dir.join(&plugin_id);
@@ -236,6 +272,7 @@ pub async fn update_plugin(
             "clone",
             "--depth",
             "1",
+            "--",
             &source_url,
             &plugin_dir.to_string_lossy(),
         ])
@@ -374,5 +411,40 @@ pub fn toggle_plugin(
         Ok(())
     } else {
         Err((format!("Plugin '{plugin_id}' not found")).into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_clone_url;
+
+    #[test]
+    fn accepts_normal_remotes() {
+        for url in [
+            "https://github.com/owner/repo",
+            "https://github.com/owner/repo.git",
+            "ssh://git@github.com/owner/repo.git",
+            "git://example.com/repo.git",
+            "git@github.com:owner/repo.git",
+        ] {
+            assert!(validate_clone_url(url).is_ok(), "should accept {url}");
+        }
+    }
+
+    #[test]
+    fn rejects_command_executing_transports() {
+        // git's ext:: transport runs an arbitrary command during clone.
+        assert!(validate_clone_url("ext::sh -c 'touch /tmp/pwned'").is_err());
+        assert!(validate_clone_url("file:///etc/passwd").is_err());
+        assert!(validate_clone_url("/some/local/path").is_err());
+    }
+
+    #[test]
+    fn rejects_argument_injection() {
+        // A leading dash would be parsed by `git clone` as a flag, not a URL.
+        assert!(validate_clone_url("--upload-pack=touch /tmp/x").is_err());
+        assert!(validate_clone_url("-oProxyCommand=evil").is_err());
+        assert!(validate_clone_url("").is_err());
+        assert!(validate_clone_url("   ").is_err());
     }
 }

--- a/src-tauri/src/commands/plugins/plugin_lifecycle.rs
+++ b/src-tauri/src/commands/plugins/plugin_lifecycle.rs
@@ -9,8 +9,8 @@ use tauri::AppHandle;
 
 use super::{
     check_min_app_version, get_plugins_dir, now_ms, read_git_head, read_manifest, read_registry,
-    validate_required_commands, warn_on_setup_items, write_registry, PluginInfo, PluginUpdateCheck,
-    RegistryEntry,
+    validate_plugin_id, validate_required_commands, warn_on_setup_items, write_registry,
+    PluginInfo, PluginUpdateCheck, RegistryEntry,
 };
 
 /// Validate a git URL before passing it to `git clone`.
@@ -211,6 +211,11 @@ pub async fn install_plugin(
 #[tauri::command]
 #[tracing::instrument(fields(project = %project_path))]
 pub fn uninstall_plugin(project_path: String, plugin_id: String) -> Result<(), CommandError> {
+    // Reject traversal-style IDs before joining onto the plugins dir — this
+    // command calls remove_dir_all on the result without requiring registry
+    // membership, so an unchecked `../../x` would delete outside .shipstudio.
+    validate_plugin_id(&plugin_id)?;
+
     // Guard: dev plugins should use unlink instead
     let registry = read_registry(&project_path)?;
     if let Some(entry) = registry.plugins.iter().find(|e| e.plugin_id == plugin_id) {
@@ -246,6 +251,7 @@ pub async fn update_plugin(
     project_path: String,
     plugin_id: String,
 ) -> Result<PluginInfo, CommandError> {
+    validate_plugin_id(&plugin_id)?;
     let registry = read_registry(&project_path)?;
     let entry = registry
         .plugins

--- a/src-tauri/src/commands/projects/dev_server.rs
+++ b/src-tauri/src/commands/projects/dev_server.rs
@@ -147,6 +147,28 @@ pub async fn set_workspace_subpath(
     subpath: Option<String>,
 ) -> Result<(), CommandError> {
     let project = validate_project_path(&project_path)?;
+
+    // The subpath is later joined onto the project root and used as a working
+    // directory / asset root. Reject anything that isn't a plain relative path
+    // so it can't escape the project (absolute paths replace the root; `..`
+    // walks out of it).
+    if let Some(ref sub) = subpath {
+        let rel = std::path::Path::new(sub);
+        let is_safe_relative = rel.components().all(|c| {
+            matches!(
+                c,
+                std::path::Component::Normal(_) | std::path::Component::CurDir
+            )
+        });
+        if !is_safe_relative {
+            return Err(
+                ("Invalid workspace subpath: must be a relative path inside the project"
+                    .to_string())
+                .into(),
+            );
+        }
+    }
+
     let shipstudio_dir = project.join(".shipstudio");
     let metadata_path = shipstudio_dir.join("project.json");
 

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -535,31 +535,29 @@ pub async fn remove_git_history(project_path: String) -> Result<(), CommandError
 #[tauri::command]
 #[tracing::instrument]
 pub async fn delete_project(path: String) -> Result<(), CommandError> {
-    let project_path = std::path::Path::new(&path);
+    // Canonicalize FIRST (resolves symlinks and `..`) so the containment check
+    // below can't be defeated by a lexical path like `~/ShipStudio/../../.ssh`.
+    // `Path::starts_with` is purely lexical and would otherwise pass such a path
+    // straight through to `remove_dir_all`.
+    let canonical = dunce::canonicalize(&path).map_err(|_| "Project not found".to_string())?;
 
     // Check if this is an external project
-    if let Ok(canonical) = dunce::canonicalize(project_path) {
-        if crate::commands::external_projects::is_registered_external_path(&canonical)? {
-            return Err(
-                "Cannot delete external projects. Use 'Remove from list' instead."
-                    .to_string()
-                    .into(),
-            );
-        }
+    if crate::commands::external_projects::is_registered_external_path(&canonical)? {
+        return Err(
+            "Cannot delete external projects. Use 'Remove from list' instead."
+                .to_string()
+                .into(),
+        );
     }
 
     let home = dirs::home_dir().ok_or("Could not find home directory")?;
     let shipstudio_dir = home.join("ShipStudio");
 
-    if !project_path.starts_with(&shipstudio_dir) {
+    if !canonical.starts_with(&shipstudio_dir) {
         return Err(("Can only delete projects from ShipStudio directory".to_string()).into());
     }
 
-    if !project_path.exists() {
-        return Err(("Project not found".to_string()).into());
-    }
-
-    std::fs::remove_dir_all(project_path).map_err(|e| e.to_string())?;
+    std::fs::remove_dir_all(&canonical).map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -619,27 +617,28 @@ pub async fn rename_project(
     old_path: String,
     new_name: String,
 ) -> Result<String, CommandError> {
-    let project_path = std::path::Path::new(&old_path);
+    // Canonicalize FIRST (resolves symlinks and `..`); `Path::starts_with` is
+    // lexical, so checking the raw `old_path` would let `~/ShipStudio/../../foo`
+    // escape the sandbox and rename arbitrary directories. State stores are
+    // still keyed by the original `old_path` string the frontend passed.
+    let project_path =
+        dunce::canonicalize(&old_path).map_err(|_| "Project not found".to_string())?;
+    let project_path = project_path.as_path();
 
     // Reject external projects (their folders live outside ~/ShipStudio).
-    if let Ok(canonical) = dunce::canonicalize(project_path) {
-        if crate::commands::external_projects::is_registered_external_path(&canonical)? {
-            return Err(
-                "Renaming external projects isn't supported yet. Remove it from the list and re-add it under a new folder name."
-                    .to_string()
-                    .into(),
-            );
-        }
+    if crate::commands::external_projects::is_registered_external_path(project_path)? {
+        return Err(
+            "Renaming external projects isn't supported yet. Remove it from the list and re-add it under a new folder name."
+                .to_string()
+                .into(),
+        );
     }
 
-    // Must live inside ~/ShipStudio and exist.
+    // Must live inside ~/ShipStudio.
     let home = dirs::home_dir().ok_or("Could not find home directory")?;
     let shipstudio_dir = home.join("ShipStudio");
     if !project_path.starts_with(&shipstudio_dir) {
         return Err(("Can only rename projects in the ShipStudio directory".to_string()).into());
-    }
-    if !project_path.exists() {
-        return Err(("Project not found".to_string()).into());
     }
 
     // Validate + normalize the requested name.

--- a/src-tauri/src/commands/projects/templates.rs
+++ b/src-tauri/src/commands/projects/templates.rs
@@ -128,12 +128,24 @@ pub async fn extract_template_zip(
             continue;
         }
 
-        // Security: prevent path traversal
-        if outpath.contains("..") {
+        // Security: prevent zip-slip. A substring `..` check is insufficient —
+        // an absolute entry name (e.g. `/Users/me/.zshenv`) contains no `..`,
+        // and `Path::join` with an absolute path DISCARDS the base, writing
+        // outside the project. Reject any entry that isn't a plain relative path
+        // (no root, no drive prefix, no `..` component).
+        let rel = std::path::Path::new(&outpath);
+        let is_safe_relative = rel.components().all(|c| {
+            matches!(
+                c,
+                std::path::Component::Normal(_) | std::path::Component::CurDir
+            )
+        });
+        if !is_safe_relative {
+            tracing::warn!(entry = %outpath, "Skipping unsafe zip entry during template extraction");
             continue;
         }
 
-        let dest_path = project_path.join(&outpath);
+        let dest_path = project_path.join(rel);
 
         if file.is_dir() {
             std::fs::create_dir_all(&dest_path)
@@ -165,11 +177,13 @@ pub async fn extract_template_zip(
                 use std::os::unix::fs::PermissionsExt;
                 if let Some(mode) = file.unix_mode() {
                     if mode & 0o111 != 0 {
-                        // Has execute bit
+                        // Has execute bit. Set a fixed 0o755 rather than the
+                        // raw archive mode so a malicious template can't ship a
+                        // setuid/setgid binary.
                         let mut perms = std::fs::metadata(&dest_path)
                             .map_err(|e| format!("Failed to get file metadata: {e}"))?
                             .permissions();
-                        perms.set_mode(mode);
+                        perms.set_mode(0o755);
                         std::fs::set_permissions(&dest_path, perms).ok();
                     }
                 }

--- a/src-tauri/src/commands/pty/spawn.rs
+++ b/src-tauri/src/commands/pty/spawn.rs
@@ -3,7 +3,7 @@
 use super::{PtyInfo, PTY_ID_COUNTER, PTY_REGISTRY};
 use crate::errors::CommandError;
 use crate::types::SpawnPtyOptions;
-use crate::utils::{create_command, get_extended_path};
+use crate::utils::{create_command, get_extended_path, validate_project_path};
 use std::io::{BufRead, BufReader};
 use std::process::Stdio;
 use std::sync::atomic::Ordering;
@@ -31,6 +31,14 @@ pub async fn spawn_pty(
     window_label: String,
     project_path: Option<String>,
 ) -> Result<u32, CommandError> {
+    // Constrain the working directory to a ShipStudio/registered project so a
+    // compromised webview can't spawn a process anywhere on disk. The frontend
+    // always launches terminals in a project root, a workspace subpath, or the
+    // ~/ShipStudio root itself — all of which validate.
+    let validated_cwd = validate_project_path(&options.cwd)?;
+    let mut options = options;
+    options.cwd = validated_cwd.to_string_lossy().to_string();
+
     let id = PTY_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
     let app_handle = app.clone();
     let label_for_thread = window_label.clone();

--- a/src-tauri/src/commands/skills/install.rs
+++ b/src-tauri/src/commands/skills/install.rs
@@ -2,7 +2,7 @@
 
 use super::extract_skills_cli_error;
 use crate::errors::CommandError;
-use crate::utils::{create_command, get_extended_path};
+use crate::utils::{create_command, get_extended_path, validate_project_path};
 
 /// Install a skill using the Skills CLI
 /// Runs: npx skills add <package> -y --agent <agent-id>
@@ -24,14 +24,19 @@ pub async fn install_skill(
 
     let skills_agent_id = agent.skills_agent_id.unwrap_or(agent.id);
     let mut cmd = create_command("npx");
+    // Pin `skills@latest` (not bare `skills`) so npx resolves from the npm
+    // registry instead of preferring a `node_modules/.bin/skills` shipped by a
+    // malicious imported repo. `--` before the package stops a package name
+    // starting with `-` from being parsed as a flag (argument injection).
     cmd.args([
         "--yes",
-        "skills",
+        "skills@latest",
         "add",
-        &package,
         "-y",
         "--agent",
         skills_agent_id,
+        "--",
+        &package,
     ])
     .env("PATH", get_extended_path())
     .env("HOME", &home)
@@ -42,7 +47,9 @@ pub async fn install_skill(
     // Set working directory based on scope
     if scope == "project" {
         if let Some(ref path) = project_path {
-            cmd.current_dir(path);
+            // Constrain to a known ShipStudio/registered project.
+            let validated = validate_project_path(path)?;
+            cmd.current_dir(&validated);
         } else {
             return Err(
                 ("Project path required for project-scoped installation".to_string()).into(),
@@ -87,14 +94,17 @@ pub async fn remove_skill(
 
     let skills_agent_id = agent.skills_agent_id.unwrap_or(agent.id);
     let mut cmd = create_command("npx");
+    // See install_skill: pin `skills@latest` and `--`-terminate options so a
+    // malicious repo's local binary / a `-`-leading package can't be abused.
     cmd.args([
         "--yes",
-        "skills",
+        "skills@latest",
         "remove",
-        &package,
         "-y",
         "--agent",
         skills_agent_id,
+        "--",
+        &package,
     ])
     .env("PATH", get_extended_path())
     .env("HOME", &home)
@@ -105,7 +115,8 @@ pub async fn remove_skill(
     // Set working directory based on scope
     if scope == "project" {
         if let Some(ref path) = project_path {
-            cmd.current_dir(path);
+            let validated = validate_project_path(path)?;
+            cmd.current_dir(&validated);
         } else {
             return Err(("Project path required for project-scoped removal".to_string()).into());
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -162,6 +162,12 @@ pub fn run() {
                 main_builder.build()?;
             }
 
+            // The static asset-protocol scope (tauri.conf.json) only covers
+            // ~/ShipStudio. Grant access to registered external project roots at
+            // runtime so we don't have to expose all of $HOME/Volumes statically
+            // (which would let any main-frame script read ~/.ssh, ~/.aws, etc.).
+            commands::external_projects::grant_asset_scope_for_registered(_app.handle());
+
             // Build a custom menu on macOS that replaces Cmd+W (Close Window)
             // with a custom "Close Tab" action that emits an event to the frontend
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -366,6 +366,48 @@ pub fn validate_project_path(project_path: &str) -> Result<std::path::PathBuf, S
     ))
 }
 
+/// Validates a path to a *file* that lives inside ~/ShipStudio (or a registered
+/// external project), WITHOUT requiring the file itself to already exist.
+///
+/// Unlike [`validate_project_path`] (which canonicalizes the path and therefore
+/// fails on a not-yet-created target), this canonicalizes the file's *parent*
+/// directory — resolving symlinks and `..` — enforces containment, then rejoins
+/// the final component. Use it for commands that read, create, or overwrite a
+/// specific file by absolute path (e.g. .env files) so they can't be tricked
+/// into touching files outside the sandbox via `..`, symlinks, or an arbitrary
+/// absolute path.
+///
+/// Returns the safe, canonical absolute path the caller should operate on.
+pub fn validate_project_file_path(file_path: &str) -> Result<std::path::PathBuf, String> {
+    let path = std::path::Path::new(file_path);
+
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| format!("Invalid path: '{file_path}' has no file name"))?;
+
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("Invalid path: '{file_path}' has no parent directory"))?;
+
+    // Canonicalize the parent (must exist) — resolves symlinks and `..` so the
+    // containment check below can't be defeated lexically.
+    let canonical_parent = dunce::canonicalize(parent).map_err(|e| format!("Invalid path: {e}"))?;
+
+    let home = dirs::home_dir().ok_or("Could not find home directory")?;
+    let shipstudio_dir = home.join("ShipStudio");
+
+    let allowed = canonical_parent.starts_with(&shipstudio_dir)
+        || crate::commands::external_projects::is_registered_external_path(&canonical_parent)?;
+
+    if !allowed {
+        return Err(format!(
+            "Security error: path '{file_path}' is outside ShipStudio directory"
+        ));
+    }
+
+    Ok(canonical_parent.join(file_name))
+}
+
 /// Resolve a project path to its "active workspace" directory.
 ///
 /// For single-package projects this is the project root unchanged. For monorepo
@@ -412,7 +454,27 @@ pub fn resolve_workspace_path(project_root: &std::path::Path) -> std::path::Path
         };
         match metadata.workspace_subpath {
             Some(sub) if !sub.is_empty() => {
-                let candidate = project_root.join(&sub);
+                // The subpath comes from the repo-controlled project.json, so a
+                // malicious repo could set an absolute path or `..` to escape
+                // the project root (this resolved path becomes a dev-server cwd
+                // and asset root). Reject anything that isn't a plain relative
+                // path and fall back to the root.
+                let rel = std::path::Path::new(&sub);
+                let is_safe_relative = rel.components().all(|c| {
+                    matches!(
+                        c,
+                        std::path::Component::Normal(_) | std::path::Component::CurDir
+                    )
+                });
+                if !is_safe_relative {
+                    tracing::warn!(
+                        project = %project_root.display(),
+                        subpath = %sub,
+                        "workspace_subpath is not a safe relative path; falling back to repo root"
+                    );
+                    return project_root.to_path_buf();
+                }
+                let candidate = project_root.join(rel);
                 if candidate.exists() {
                     candidate
                 } else {
@@ -783,6 +845,68 @@ mod tests {
             };
             let is_registered = is_registered_external_path(&canonical).unwrap_or(true);
             assert!(!is_registered, "/tmp must not appear registered by default");
+        }
+    }
+
+    /// Security tests for `validate_project_file_path` — the helper that guards
+    /// the .env read/write/delete commands. Unlike `validate_project_path` it
+    /// must accept a not-yet-existing target file while still confining writes
+    /// to ~/ShipStudio.
+    mod validate_project_file_path_tests {
+        use super::*;
+        use std::fs;
+
+        fn shipstudio_root() -> std::path::PathBuf {
+            dirs::home_dir().expect("home dir").join("ShipStudio")
+        }
+
+        #[test]
+        fn rejects_file_outside_shipstudio() {
+            // ~/.zshenv is the canonical RCE target — must be rejected.
+            let home = dirs::home_dir().expect("home dir");
+            let target = home.join(".zshenv-shipstudio-audit-test");
+            let err = validate_project_file_path(&target.to_string_lossy())
+                .expect_err("file in $HOME (outside ShipStudio) must be rejected");
+            assert!(
+                err.contains("Security error") || err.contains("outside ShipStudio"),
+                "unexpected error: {err}"
+            );
+        }
+
+        #[test]
+        fn rejects_traversal_out_of_shipstudio() {
+            // A path whose parent canonicalizes outside the root must fail even
+            // though the leading segment names ShipStudio.
+            let root = shipstudio_root();
+            let sneaky = root.join("..").join(".ssh").join("authorized_keys");
+            let result = validate_project_file_path(&sneaky.to_string_lossy());
+            assert!(
+                result.is_err(),
+                "traversal out of ShipStudio must be rejected"
+            );
+        }
+
+        #[test]
+        fn accepts_nonexistent_file_inside_shipstudio() {
+            // The key behavior: a target that doesn't exist yet (creating a new
+            // .env) is allowed as long as its parent dir is inside the sandbox.
+            let root = shipstudio_root();
+            if fs::create_dir_all(&root).is_err() {
+                eprintln!("skipping: couldn't create ~/ShipStudio");
+                return;
+            }
+            let dir = root.join(".audit-env-test-dir");
+            if fs::create_dir_all(&dir).is_err() {
+                eprintln!("skipping: couldn't create test dir");
+                return;
+            }
+            let target = dir.join(".env"); // does NOT exist
+            let result = validate_project_file_path(&target.to_string_lossy());
+            let _ = fs::remove_dir_all(&dir);
+            assert!(
+                result.is_ok(),
+                "not-yet-created file inside ShipStudio should validate, got {result:?}"
+            );
         }
     }
 }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -405,7 +405,22 @@ pub fn validate_project_file_path(file_path: &str) -> Result<std::path::PathBuf,
         ));
     }
 
-    Ok(canonical_parent.join(file_name))
+    let resolved = canonical_parent.join(file_name);
+
+    // Refuse to operate through a symlink at the final component. The parent
+    // check above confines the directory, but `fs::read`/`write`/`remove_file`
+    // follow symlinks — so a malicious repo could plant `proj/.env` as a symlink
+    // to ~/.zshenv and escape the sandbox on the final hop. (Mirrors the guard
+    // in assets.rs::upload_asset.)
+    if let Ok(meta) = std::fs::symlink_metadata(&resolved) {
+        if meta.file_type().is_symlink() {
+            return Err(format!(
+                "Security error: '{file_path}' is a symlink; refusing to follow it"
+            ));
+        }
+    }
+
+    Ok(resolved)
 }
 
 /// Resolve a project path to its "active workspace" directory.
@@ -906,6 +921,39 @@ mod tests {
             assert!(
                 result.is_ok(),
                 "not-yet-created file inside ShipStudio should validate, got {result:?}"
+            );
+        }
+
+        /// A `.env` that is itself a symlink pointing outside the sandbox must be
+        /// rejected — otherwise fs::write/read/remove would follow it (the
+        /// planted-symlink RCE this helper guards against).
+        #[test]
+        #[cfg(unix)]
+        fn rejects_symlinked_final_component() {
+            use std::os::unix::fs::symlink;
+            let root = shipstudio_root();
+            if fs::create_dir_all(&root).is_err() {
+                eprintln!("skipping: couldn't create ~/ShipStudio");
+                return;
+            }
+            let dir = root.join(".audit-env-symlink-test");
+            let _ = fs::remove_dir_all(&dir);
+            if fs::create_dir_all(&dir).is_err() {
+                eprintln!("skipping: couldn't create test dir");
+                return;
+            }
+            let link = dir.join(".env");
+            // Point at /tmp/... outside ShipStudio; target need not exist.
+            if symlink("/tmp/ss-audit-symlink-target", &link).is_err() {
+                let _ = fs::remove_dir_all(&dir);
+                eprintln!("skipping: couldn't create symlink");
+                return;
+            }
+            let result = validate_project_file_path(&link.to_string_lossy());
+            let _ = fs::remove_dir_all(&dir);
+            assert!(
+                result.is_err(),
+                "symlinked final component must be rejected, got {result:?}"
             );
         }
     }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -490,15 +490,34 @@ pub fn resolve_workspace_path(project_root: &std::path::Path) -> std::path::Path
                     return project_root.to_path_buf();
                 }
                 let candidate = project_root.join(rel);
-                if candidate.exists() {
-                    candidate
-                } else {
+                if !candidate.exists() {
                     tracing::warn!(
                         project = %project_root.display(),
                         subpath = %sub,
                         "workspace_subpath points at a missing directory; falling back to repo root"
                     );
-                    project_root.to_path_buf()
+                    return project_root.to_path_buf();
+                }
+                // The lexical check above blocks `..`, but a relative entry like
+                // `apps/web` could itself be a symlink to /tmp/escape. Canonicalize
+                // both sides and confirm containment before trusting it as the cwd.
+                match (
+                    dunce::canonicalize(&candidate),
+                    dunce::canonicalize(project_root),
+                ) {
+                    (Ok(canon_candidate), Ok(canon_root))
+                        if canon_candidate.starts_with(&canon_root) =>
+                    {
+                        candidate
+                    }
+                    _ => {
+                        tracing::warn!(
+                            project = %project_root.display(),
+                            subpath = %sub,
+                            "workspace_subpath resolves outside the project root; falling back to repo root"
+                        );
+                        project_root.to_path_buf()
+                    }
                 }
             }
             _ => project_root.to_path_buf(),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,9 +17,7 @@
       "assetProtocol": {
         "enable": true,
         "scope": [
-          "$HOME/ShipStudio/**",
-          "$HOME/**",
-          "/Volumes/**"
+          "$HOME/ShipStudio/**"
         ]
       }
     }

--- a/src/hooks/useElementTree.ts
+++ b/src/hooks/useElementTree.ts
@@ -66,6 +66,9 @@ export function useElementTree({ iframeRef, enabled }: UseElementTreeParams) {
     post({ type: 'ss:requestTree' });
 
     const onMessage = (e: MessageEvent) => {
+      // SECURITY: only trust messages from the actual preview iframe (untrusted
+      // project content runs inside it).
+      if (e.source !== iframeRef.current?.contentWindow) return;
       const d = e.data as
         | { type?: string; tree?: WireNode; truncated?: boolean; nodeId?: number }
         | undefined;

--- a/src/hooks/usePreviewConnection.ts
+++ b/src/hooks/usePreviewConnection.ts
@@ -226,8 +226,24 @@ export function usePreviewConnection({
     };
   }, [serverReady, port]);
 
-  // Listen for navigation and error events from the injected proxy scripts
+  // Listen for navigation and error events from the injected proxy scripts.
+  //
+  // SECURITY: these messages originate from the preview iframe, which renders
+  // untrusted project content (the user's dev server, its deps, embedded
+  // frames). Without an origin check, any script in that page could forge a
+  // `shipstudio:send-error-to-claude` message and inject arbitrary text into
+  // the AI agent terminal, or silently write to the clipboard. Only accept
+  // messages whose origin is the preview's own dev-server / proxy port.
   useEffect(() => {
+    const allowedOrigins = new Set<string>([
+      `http://localhost:${port}`,
+      `http://127.0.0.1:${port}`,
+    ]);
+    if (proxyPort) {
+      allowedOrigins.add(`http://localhost:${proxyPort}`);
+      allowedOrigins.add(`http://127.0.0.1:${proxyPort}`);
+    }
+
     const handleMessage = (
       event: MessageEvent<{
         type?: string;
@@ -236,6 +252,7 @@ export function usePreviewConnection({
         message?: string;
       }>
     ) => {
+      if (!allowedOrigins.has(event.origin)) return;
       const data = event.data;
       if (data && data.type === 'shipstudio:navigate' && typeof data.pathname === 'string') {
         const pathname: string = data.pathname || '/';
@@ -260,7 +277,7 @@ export function usePreviewConnection({
     };
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [onSendToClaude, onToast]);
+  }, [onSendToClaude, onToast, port, proxyPort]);
 
   // Auto-reload for static HTML projects when files change on disk
   useEffect(() => {

--- a/src/hooks/useVisualEditor.test.ts
+++ b/src/hooks/useVisualEditor.test.ts
@@ -47,7 +47,7 @@ function setup() {
       breakpoints: BREAKPOINTS,
     })
   );
-  return hook;
+  return { ...hook, iframeRef };
 }
 
 /** Flush pending microtasks (e.g. the async resolve) under act. */
@@ -59,11 +59,14 @@ const advance = (ms: number) =>
     await Promise.resolve();
   });
 
-/** Drive a selection through the in-window message bridge and resolve it. */
-async function select(className: string) {
+/** Drive a selection through the in-window message bridge and resolve it.
+ *  `source` mirrors the real preview iframe's contentWindow — the hook now
+ *  rejects messages from any other source as a security measure. */
+async function select(className: string, source: MessageEventSource) {
   await act(async () => {
     window.dispatchEvent(
       new MessageEvent('message', {
+        source,
         data: {
           type: 'ss:select',
           signature: { className, tagName: 'div', ancestorClasses: [] },
@@ -99,9 +102,9 @@ afterEach(() => {
 
 describe('useVisualEditor auto-save', () => {
   it('does NOT save automatically when auto-save is off', async () => {
-    const { result } = setup();
+    const { result, iframeRef } = setup();
     act(() => result.current.toggleEditMode());
-    await select('p-3');
+    await select('p-3', iframeRef.current!.contentWindow!);
 
     act(() => result.current.applyEnum('p-8', { padding: '2rem' }));
     await advance(2000);
@@ -109,10 +112,10 @@ describe('useVisualEditor auto-save', () => {
   });
 
   it('debounces a burst of edits into ONE save when auto-save is on', async () => {
-    const { result } = setup();
+    const { result, iframeRef } = setup();
     act(() => result.current.toggleAutoSave()); // turn on
     act(() => result.current.toggleEditMode());
-    await select('p-3');
+    await select('p-3', iframeRef.current!.contentWindow!);
 
     // Simulate a drag: many rapid mutations, each well within the debounce window.
     act(() => {

--- a/src/hooks/useVisualEditor.ts
+++ b/src/hooks/useVisualEditor.ts
@@ -217,6 +217,10 @@ export function useVisualEditor({
   useEffect(() => {
     if (!editMode) return;
     const handler = (e: MessageEvent) => {
+      // SECURITY: only trust messages from the actual preview iframe. The iframe
+      // hosts untrusted project content; a forged `ss:textCommit` from another
+      // frame would otherwise write to the user's source files.
+      if (e.source !== iframeRef.current?.contentWindow) return;
       const d = e.data as {
         type?: string;
         signature?: ElementSignature;
@@ -368,6 +372,7 @@ export function useVisualEditor({
     projectPath,
     onToast,
     post,
+    iframeRef,
     setLiveClass,
     setMultiTarget,
     setTextTarget,

--- a/src/lib/inspectStore.ts
+++ b/src/lib/inspectStore.ts
@@ -75,7 +75,15 @@ const notify = () => {
   for (const l of Array.from(listeners)) l();
 };
 
+/** Preview content is always served from a localhost dev-server/proxy/static
+ * port. Requiring that origin keeps the privileged app frame (origin
+ * `tauri://…`) — and anything running in it, e.g. plugins — from spoofing
+ * inspector telemetry. */
+const isPreviewOrigin = (origin: string) =>
+  /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
+
 const handleMessage = (event: MessageEvent) => {
+  if (!isPreviewOrigin(event.origin)) return;
   const data = event.data as ShimMessage | null;
   if (!data || typeof data !== 'object' || data.source !== CHANNEL) return;
 


### PR DESCRIPTION
## Summary

A full security audit of the backend and the preview-iframe trust boundary surfaced a set of issues exploitable by the app's real threat model: **a malicious project/repo the user imports, a malicious plugin/skill, or a compromised preview webview reaching IPC**. This PR fixes the confirmed Critical/High items plus several Medium hardening gaps. Every change reuses patterns already in the codebase.

The core primitives were already sound (`validate_project_path` canonicalizes + checks containment, `run_with_timeout` is argv-based, the updater is signature-verified). The bugs were in commands that **bypassed** those primitives or trusted input that re-expanded the boundary after the check.

## Critical
- **Shell command injection via malicious git branch name** (`git/mod.rs`) — `get_ahead_behind_batch` interpolated attacker-controlled branch names into a `sh -c` string (a branch named `x';…;'` is a valid git ref). Rewritten to run `git rev-list` as argv per branch, no shell.
- **Arbitrary file read/write via `read_env_file`/`write_env_file`** (`env.rs`) — took a raw path with no validation (`~/.zshenv` write → RCE; `~/.aws/credentials` read). Added `validate_project_file_path()` which canonicalizes the *parent* (so not-yet-created files still validate) and enforces containment.
- **Arbitrary directory delete/rename** (`projects/mod.rs`) — `delete_project`/`rename_project` ran a *lexical* `starts_with` on a non-canonicalized path, so `~/ShipStudio/../../.ssh` escaped. Now canonicalize before the check.

## High
- **postMessage origin validation** (`usePreviewConnection`, `useVisualEditor`, `useElementTree`, `inspectStore`) — preview-iframe handlers acted on messages without checking `event.source`/origin. The sharpest gadget injected attacker text into the **live AI agent terminal**; others poisoned the clipboard and forged source-file write-backs. Now validated.
- **Zip-slip in template extraction** (`templates.rs`) — a `..` substring check missed absolute entry names (`PathBuf::join` discards the base). Component-based check + fixed `0o755` perms (strips setuid).
- **Plugin clone-URL injection** (`plugin_lifecycle.rs`) — `git clone <url>` with no scheme check allowed `ext::` (command exec) and `-`-leading URLs. Added scheme allowlist + `--`.
- **Skill local-binary supply chain** (`skills/install.rs`) — `npx skills` preferred a malicious repo's `node_modules/.bin/skills`. Pinned `skills@latest` + validated path + `--`.
- **Sandbox-widening via `ensure_external_project_registered`** — dialog-less registration of arbitrary paths (e.g. `~/.ssh`) now requires a project-root marker.
- **`spawn_pty` cwd** now validated against the project sandbox.

## Medium
- assetProtocol scope narrowed from `$HOME/**`,`/Volumes/**` to `~/ShipStudio`, with registered external roots granted at runtime (startup + on registration) so thumbnails still work.
- `workspace_subpath` re-contained on read + write (repo-controlled value).
- plugin_id traversal in `read_plugin_bundle`/`read_plugin_manifest`.
- MCP command cwd validation; `upload_asset` symlink-final-component guard.
- `switch_branch`/`delete_branch`: reject `-`-leading names + `--` separators.

## Not included (need separate decisions / verification)
- **CSP `null` → restrictive CSP.** A correct policy must satisfy xterm inline styles, the cross-origin preview iframe, `asset:`/`ipc:`, and Vite HMR at once, and the codebase's own gotcha warns prod breaks where dev passes. Needs a production-build smoke test, so it's deliberately left out. No live XSS path into the privileged frame was found (defense-in-depth).
- **Plugin sandbox (architectural).** Plugins run unsandboxed JS in the privileged webview, so `exec_plugin_shell`/the `required_commands` allowlist can't be made safe without sandboxing (iframe/Worker + host-enforced RPC). Hardened what was safely fixable; the architecture is a product decision.

## Tests
Adds 9 regression tests (`validate_project_file_path`, `validate_clone_url`, `looks_like_project_root`). Verified in isolation (Shopify WIP excluded): `cargo check` clean, 366 Rust tests pass, `tsc --noEmit` clean, 597 frontend tests pass, fmt/clippy/eslint/pattern/LOC gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Hardened security protections against path traversal, symlink overwrite, and command injection attacks across file operations and git commands
  * Improved external project handling with automatic asset-protocol access grants upon registration
  * Strengthened origin and source verification for preview communications and cross-origin message handling
  * Enhanced input validation for plugin management, workspace configuration, and template extraction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->