### PR TITLE
Visual editor: resolve workspace_subpath in Tailwind detection (Edit toggle missing for monorepos)

### DIFF
--- a/src-tauri/src/commands/edit.rs
+++ b/src-tauri/src/commands/edit.rs
@@ -19,7 +19,7 @@
 //! time — so the resolver never guesses a single wrong edit target.
 
 use crate::errors::CommandError;
-use crate::utils::validate_project_path;
+use crate::utils::{resolve_workspace_path, validate_project_path};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -1815,6 +1815,8 @@ fn apply_v3_screens(config: &str, map: &mut std::collections::BTreeMap<String, u
 #[tracing::instrument(fields(project = %project_path))]
 pub fn is_tailwind_active(project_path: String) -> Result<bool, CommandError> {
     let root = validate_project_path(&project_path)?;
+    // Monorepo projects wire Tailwind inside the chosen app, not the repo root.
+    let root = resolve_workspace_path(&root);
     Ok(tailwind_active_at(&root))
 }
 
@@ -1866,6 +1868,8 @@ fn tailwind_active_at(root: &Path) -> bool {
 #[tracing::instrument(fields(project = %project_path))]
 pub fn detect_breakpoints(project_path: String) -> Result<Vec<Breakpoint>, CommandError> {
     let root = validate_project_path(&project_path)?;
+    // Monorepo projects keep their CSS and Tailwind config inside the chosen app.
+    let root = resolve_workspace_path(&root);
     let mut map: std::collections::BTreeMap<String, u32> = DEFAULT_BREAKPOINTS
         .iter()
         .map(|(n, px)| (n.to_string(), *px))
@@ -2819,6 +2823,37 @@ const items = [];
         std::fs::create_dir_all(&c).unwrap();
         std::fs::write(c.join("tailwind.config.js"), "module.exports = {{}}").unwrap();
         assert!(chk(&c), "tailwind.config.js present → active");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn tailwind_detection_follows_workspace_subpath() {
+        let dir = std::env::temp_dir().join(format!("ss-tw-sub-{}", std::process::id()));
+        let repo = dir.join("monorepo");
+        std::fs::create_dir_all(repo.join(".shipstudio")).unwrap();
+        std::fs::write(
+            repo.join(".shipstudio").join("project.json"),
+            r#"{"_description":"","publish":{"staging":null,"production":null},"workspace_subpath":"website"}"#,
+        )
+        .unwrap();
+        let app = repo.join("website");
+        std::fs::create_dir_all(&app).unwrap();
+        std::fs::write(
+            app.join("postcss.config.mjs"),
+            "export default { plugins: { \"@tailwindcss/postcss\": {} } };",
+        )
+        .unwrap();
+
+        // The repo root has no Tailwind wiring of its own…
+        assert!(!tailwind_active_at(&repo), "repo root alone → not active");
+        // …but the resolved workspace does — the path is_tailwind_active now checks.
+        let workspace = crate::utils::resolve_workspace_path(&repo);
+        assert_eq!(workspace, app, "subpath resolves to the chosen app");
+        assert!(
+            tailwind_active_at(&workspace),
+            "workspace wires tailwind → active"
+        );
 
         std::fs::remove_dir_all(&dir).ok();
     }


### PR DESCRIPTION
Fixes #83.

## What

For monorepo projects — where the user picked an app at import and `.shipstudio/project.json` carries a `workspace_subpath` — the **Edit** toggle never appears in the Preview tab. The editor is gated on `is_tailwind_active`, which validated the project path but never applied `resolve_workspace_path`, so it scanned the repo root for Tailwind wiring and found nothing (the configs live inside the chosen app, e.g. `website/postcss.config.mjs`).

## How

`is_tailwind_active` and `detect_breakpoints` now resolve the workspace before detection, mirroring what `detect_project_type_command` (and the dev server, assets, etc.) already do:

```rust
let root = validate_project_path(&project_path)?;
let root = resolve_workspace_path(&root);
```

I deliberately left the source-resolution commands (`resolve_classname_source`, `apply_*`, `find_component_usage`) at the repo root: their relative paths feed jump-to-code (`openInCode` → the Code tab), which browses from the repo root — rebasing them to the workspace would break those links. Scoping the occurrence index to the workspace (and translating paths back to repo-root-relative) could be a follow-up; it would also avoid cross-package `Multi` matches when sibling packages share class strings (issue #83 has details).

## Testing

- Added `tailwind_detection_follows_workspace_subpath`: a temp monorepo with `workspace_subpath: "website"` and Tailwind v4 wired via `website/postcss.config.mjs` — asserts the root alone is not active, the resolved workspace is, and `resolve_workspace_path` lands on the app dir.
- `cargo fmt --check` passes locally. I wasn't able to run `cargo test`/`clippy` on this machine, so leaning on CI for those — happy to fix anything it flags.
- Real-world check: the reproduction in #83 (Next.js + Tailwind v4 app under `website/`) currently needs a stub root `tailwind.config.js` for the toggle to appear; with this change the stub is unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tailwind detection in monorepo projects to accurately identify configurations in workspace subdirectories.
  * Enhanced breakpoint detection for Tailwind in multi-package workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->