### PR TITLE
Fix GitHub import of non-npm repos (Flutter, etc.)

### DIFF
--- a/src/components/ImportProject.tsx
+++ b/src/components/ImportProject.tsx
@@ -14,6 +14,7 @@
 
 import { useState, useEffect } from 'react';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
+import { readTextFile } from '@tauri-apps/plugin-fs';
 import { trackError } from '../lib/analytics';
 import {
   getGitHubUsername,
@@ -327,11 +328,24 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
   /** Resume install + setup after clone (and optionally after the workspace picker). */
   const finishImport = async (projectPath: string) => {
     try {
-      setCurrentStep('install');
-      const packageManager = await detectPackageManager(projectPath);
-      setImportedPackageManager(packageManager);
+      // Not every repo is an npm project (Flutter, plain HTML, Rust, …).
+      // `npm install` exits ENOENT when there's no package.json, killing the
+      // import after a successful clone — skip the install step instead, the
+      // same way the zip-template path does.
+      let hasPackageJson = true;
+      try {
+        await readTextFile(`${projectPath}/package.json`);
+      } catch {
+        hasPackageJson = false;
+      }
 
-      await runPackageInstall(projectPath, packageManager);
+      if (hasPackageJson) {
+        setCurrentStep('install');
+        const packageManager = await detectPackageManager(projectPath);
+        setImportedPackageManager(packageManager);
+
+        await runPackageInstall(projectPath, packageManager);
+      }
 
       setCurrentStep('setup');
       await ensureGitignoreHasShipstudio(projectPath);


### PR DESCRIPTION
A user importing a Flutter app (Windows) hit `npm error ENOENT ... package.json` / exit `-4058` after a successful clone — the import flow runs `npm install` unconditionally.

Fix: `finishImport` now checks for `package.json` at the repo root and skips the install step when absent, mirroring the existing zip-template path in `useProjectCreation`. Flutter repos then proceed straight to setup and get picked up by the existing mobile-project detection on open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)