### PR TITLE
Design system PR 1: token completion, CSS color migration, real enforcement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,6 +397,15 @@ The tokens live at the top of [src/styles/global/base.css](src/styles/global/bas
 
 Need a value that doesn't exist yet? Add the token to `:root` in [base.css](src/styles/global/base.css) first, then use it.
 
+**Raw color literals fail CI** (`pnpm check:patterns`). The rules:
+
+- Colors used in 2+ files or belonging to a semantic family (status, info, purple, ANSI) → global token in base.css. Alpha tints use the RGB-triplet companions: `rgba(var(--error-rgb), 0.1)`, white tints use `--tint/--tint-subtle/--tint-strong`, black scrims use `--overlay-30…80`.
+- Intentional one-off colors (brand hues, feature-specific accents) → a file-local token in a `:root` block at the top of that feature's CSS file, prefixed with the feature name (`--dm-failed-red`, `--setup-wizard-green`).
+- A raw value that genuinely must stay (e.g. backgrounds matching xterm's theme) → tag the line with a `/* css-ok: reason */` comment.
+- Font sizes use the type scale (`--font-size-xs` … `--font-size-3xl`). Off-scale sizes (15px, 17px…) are migration debt — round to the nearest token when touching that code.
+- `@keyframes` names are **global** in CSS. Shared keyframes (`spin`, `fadeIn`, `skeleton-pulse`) live in base.css only; feature-specific ones must be feature-prefixed. Duplicates fail CI (a duplicate silently overrides every consumer app-wide based on import order).
+- `var(--something)` referencing a token that's defined nowhere fails CI — an undefined var makes the declaration invalid and the style silently doesn't apply.
+
 ### New CSS file → mind the folder structure
 
 CSS lives under this folder structure:

--- a/scripts/check-patterns.sh
+++ b/scripts/check-patterns.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # Lightweight grep-based pattern check. Runs in CI to catch regressions into
 # pre-refactor patterns. Each rule below returns exit 1 if it finds an
-# offender; the last rule's exit status is the script's exit status.
+# offender; failures accumulate and the script exits non-zero at the end.
 #
-# Deliberately kept simple — no AST, no TypeScript program, just ripgrep.
-# Whenever a new guardrail is needed, add a new block below.
+# Deliberately kept simple — no AST, no TypeScript program, just POSIX grep.
+# (It used ripgrep originally; rg wasn't installed in CI or on dev machines,
+# so every rg-based rule silently reported zero offenders for months. Plain
+# grep is slower but cannot silently vanish.)
 #
 # Exempt directories/files are listed per-rule because the primitives and
 # implementation files legitimately contain the patterns they're meant to
@@ -30,44 +32,91 @@ echo
 # 1. New Result<T, String> in Rust command signatures (only warn — existing
 #    callers still use this; flag only fresh introductions)
 echo "Checking Rust command signatures for Result<T, String> (informational)…"
-RUST_STRING_RESULTS=$(rg -c 'Result<.*, String>' src-tauri/src/commands/ 2>/dev/null || true)
-if [ -n "$RUST_STRING_RESULTS" ]; then
-  echo "  (informational) $(rg -c 'Result<.*, String>' src-tauri/src/commands/ | awk -F: '{s+=$2} END{print s}') Result<T,String> sites remain — see Block 8.3–8.5 in DX_REFACTOR_PLAN.md"
-fi
+RUST_STRING_RESULTS=$(grep -rE 'Result<.*, String>' src-tauri/src/commands/ 2>/dev/null | wc -l | tr -d ' ')
+echo "  (informational) $RUST_STRING_RESULTS Result<T,String> sites remain — see Block 8.3–8.5 in DX_REFACTOR_PLAN.md"
 echo
 
 # 2. Direct navigator.clipboard.writeText in components/src (outside primitives)
 echo "Checking for raw navigator.clipboard.writeText in components…"
-CLIPBOARD_VIOLATIONS=$(rg -l 'navigator\.clipboard\.writeText' src/ \
-  --glob '!src/hooks/useCopyToClipboard.ts' \
-  --glob '!src/components/primitives/**' \
-  --glob '!src/**/*.test.{ts,tsx}' 2>/dev/null | wc -l | tr -d ' ')
-# Inform, don't fail — existing migration debt tracked in Block 5.4.
+CLIPBOARD_VIOLATIONS=$(grep -rl 'navigator\.clipboard\.writeText' src/ \
+  --include='*.ts' --include='*.tsx' \
+  --exclude='useCopyToClipboard.ts' \
+  --exclude='*.test.ts' --exclude='*.test.tsx' \
+  --exclude-dir='primitives' 2>/dev/null | wc -l | tr -d ' ')
 echo "  (informational) $CLIPBOARD_VIOLATIONS file(s) still use navigator.clipboard directly"
 echo
 
-# 3. Raw hex colors in CSS (informational — ongoing migration tracked in Block 3)
-# base.css holds canonical token values; setup.css has branded install-button
-# colors that aren't yet in the token scale. Allowlisted until Block 13 cleanup.
-echo "Checking for raw hex colors in src/styles (informational)…"
-HEX_COUNT=$(rg -c --no-heading '(color|background|border)(-[a-z-]+)?\s*:\s*#[0-9a-fA-F]{3,8}' src/styles/ \
-  --glob '!src/styles/base.css' \
-  --glob '!src/styles/setup.css' 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
-echo "  (informational) $HEX_COUNT hex color offender(s) outside base.css/setup.css"
+# 3. Raw color literals in CSS — FAILS on any offender.
+# All colors live in design tokens: global ones in src/styles/global/base.css,
+# intentional one-offs as file-local tokens in a :root block at the top of the
+# feature file. Allowed lines: custom-property definitions (--x: #hex) and
+# lines tagged with a `css-ok` comment explaining why the raw value must stay.
+echo "Checking for raw color literals in src/styles…"
+RAW_COLORS=$(grep -rnE '#[0-9a-fA-F]{3,8}\b|rgba?\([0-9]' src/styles --include='*.css' 2>/dev/null |
+  grep -v 'css-ok' |
+  grep -vE '^[^:]+:[0-9]+:[[:space:]]*(/\*|\*)' |
+  grep -vE '^[^:]+:[0-9]+:[[:space:]]*--[a-zA-Z0-9-]+[[:space:]]*:' || true)
+if [ -n "$RAW_COLORS" ]; then
+  echo "  Raw color literals (use a token, or define a file-local token in :root):"
+  echo "$RAW_COLORS" | head -20 | sed 's/^/    /'
+  rule "raw color literals in CSS" 1
+else
+  rule "raw color literals in CSS" 0
+fi
+echo
+
+# 3b. var() references to custom properties that are never defined anywhere.
+# An undefined var() makes the declaration invalid at computed-value time —
+# the style silently doesn't apply (this bit us: hover states rendering as
+# transparent for months). Definitions may live in CSS or be set from TS/TSX.
+echo "Checking for undefined CSS custom properties…"
+DEFINED=$(mktemp) && USED=$(mktemp)
+{
+  grep -rhoE '\-\-[a-zA-Z0-9-]+[[:space:]]*:' src/styles --include='*.css' 2>/dev/null | sed 's/[[:space:]]*:$//'
+  grep -rhoE "['\"]--[a-zA-Z0-9-]+['\"]" src --include='*.ts' --include='*.tsx' 2>/dev/null | tr -d "'\""
+} | sort -u > "$DEFINED"
+grep -rhoE 'var\([[:space:]]*--[a-zA-Z0-9-]+' src/styles --include='*.css' 2>/dev/null |
+  grep -oE '\-\-[a-zA-Z0-9-]+' | sort -u > "$USED"
+UNDEFINED=$(comm -13 "$DEFINED" "$USED")
+rm -f "$DEFINED" "$USED"
+if [ -n "$UNDEFINED" ]; then
+  echo "  var() references with no definition in CSS or TS/TSX:"
+  for v in $UNDEFINED; do
+    echo "    $v"
+    grep -rn "var($v" src/styles --include='*.css' | head -2 | sed 's/^/      /'
+  done
+  rule "undefined CSS custom properties" 1
+else
+  rule "undefined CSS custom properties" 0
+fi
+echo
+
+# 3c. Duplicate @keyframes names. Keyframe names are GLOBAL — a feature-file
+# duplicate silently overrides every consumer app-wide based on import order
+# (skeleton-pulse rendered the "wrong" values for months this way). Shared
+# keyframes belong in base.css; feature-specific ones get a feature prefix.
+echo "Checking for duplicate @keyframes names…"
+DUP_KEYFRAMES=$(grep -rhoE '@keyframes[[:space:]]+[a-zA-Z0-9_-]+' src/styles --include='*.css' 2>/dev/null |
+  awk '{print $2}' | sort | uniq -d)
+if [ -n "$DUP_KEYFRAMES" ]; then
+  echo "  Keyframe names defined more than once:"
+  for k in $DUP_KEYFRAMES; do
+    echo "    $k"
+    grep -rnE "@keyframes[[:space:]]+$k\{?" src/styles --include='*.css' | sed 's/^/      /'
+  done
+  rule "duplicate @keyframes names" 1
+else
+  rule "duplicate @keyframes names" 0
+fi
 echo
 
 # 4. New onToast?: prop interface introductions (the prop-drilling pattern we killed in Block 5.6)
 echo "Checking for new onToast?: prop interfaces…"
-TOAST_PROPS=$(rg -c 'onToast\?:' src/components/ 2>/dev/null || true)
+TOAST_PROPS=$(grep -rn 'onToast?:' src/components/ 2>/dev/null || true)
 if [ -n "$TOAST_PROPS" ]; then
-  TOTAL=$(echo "$TOAST_PROPS" | awk -F: '{s+=$2} END{print s}')
-  if [ "${TOTAL:-0}" -gt 0 ]; then
-    echo "  Offenders (use useOptionalToast from contexts/ToastContext instead):"
-    echo "$TOAST_PROPS" | head -5 | sed 's/^/    /'
-    rule "onToast?: prop drilling" 1
-  else
-    rule "onToast?: prop drilling" 0
-  fi
+  echo "  Offenders (use useOptionalToast from contexts/ToastContext instead):"
+  echo "$TOAST_PROPS" | head -5 | sed 's/^/    /'
+  rule "onToast?: prop drilling" 1
 else
   rule "onToast?: prop drilling" 0
 fi

--- a/src/styles/components/command-palette.css
+++ b/src/styles/components/command-palette.css
@@ -60,7 +60,7 @@
   align-items: center;
   gap: var(--spacing-sm);
   padding: var(--spacing-sm) var(--spacing-lg);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   background: var(--bg-primary);
   border-bottom: 1px solid var(--border);
 }
@@ -69,7 +69,7 @@
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  font-size: 10px;
+  font-size: var(--font-size-xs);
 }
 
 .command-palette-scope-value {
@@ -94,7 +94,7 @@
   appearance: none;
   -webkit-appearance: none;
   padding: var(--spacing-md) 0;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-muted);
   cursor: pointer;
   font-family: inherit;
@@ -139,7 +139,7 @@
   padding: var(--spacing-2xl) var(--spacing-lg);
   color: var(--text-muted);
   text-align: center;
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .command-palette-group + .command-palette-group {
@@ -151,7 +151,7 @@
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 600;
 }
 
@@ -169,7 +169,7 @@
   color: var(--text-primary);
   cursor: pointer;
   font-family: inherit;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   transition: background-color var(--transition-fast);
   min-height: 40px;
 }
@@ -202,7 +202,7 @@
 }
 
 .command-palette-row-title {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -211,7 +211,7 @@
 }
 
 .command-palette-row-subtitle {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -238,7 +238,7 @@
   border-radius: var(--radius-sm);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1;
   height: 20px;
 }
@@ -251,7 +251,7 @@
   padding: var(--spacing-sm) var(--spacing-lg);
   border-top: 1px solid var(--border);
   background: var(--bg-primary);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 

--- a/src/styles/components/modal.css
+++ b/src/styles/components/modal.css
@@ -1,3 +1,13 @@
+/* Modal-local colors — intentional one-offs, not part of the global scale. */
+:root {
+  /* Hover state for .btn-danger — lighter step of --error. */
+  --modal-danger-hover: #ff5252;
+  /* --action (#54e36e) as an rgb triplet for alpha tints (no global --action-rgb). */
+  --modal-action-green-rgb: 84, 227, 110;
+  /* --action-text (#1e1e1e) as an rgb triplet for the spinner track tint. */
+  --modal-action-text-rgb: 30, 30, 30;
+}
+
 /* Hints */
 .hint {
   color: var(--text-muted);
@@ -11,7 +21,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: var(--overlay-70);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -46,12 +56,12 @@
 
 .btn-danger {
   background: var(--error);
-  color: white;
+  color: var(--text-bright);
   font-weight: 600;
 }
 
 .btn-danger:hover {
-  background: #ff5252;
+  background: var(--modal-danger-hover);
 }
 
 .btn-danger:disabled {
@@ -115,8 +125,8 @@
   height: 56px;
   margin: 0 auto 20px;
   border-radius: 14px;
-  background: rgba(84, 227, 110, 0.1);
-  border: 1px solid rgba(84, 227, 110, 0.15);
+  background: rgba(var(--modal-action-green-rgb), 0.1);
+  border: 1px solid rgba(var(--modal-action-green-rgb), 0.15);
   color: var(--action);
 }
 
@@ -156,9 +166,9 @@
   font-weight: 500;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .plugin-suggestion-dismiss:hover {
@@ -181,9 +191,9 @@
   font-weight: 600;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .plugin-suggestion-install:hover {
@@ -198,7 +208,7 @@
 .plugin-suggestion-spinner {
   width: 14px;
   height: 14px;
-  border: 2px solid rgba(30, 30, 30, 0.3);
+  border: 2px solid rgba(var(--modal-action-text-rgb), 0.3);
   border-top-color: var(--action-text);
   border-radius: var(--radius-full);
   animation: spin 0.8s linear infinite;

--- a/src/styles/components/modal.css
+++ b/src/styles/components/modal.css
@@ -1,7 +1,7 @@
 /* Hints */
 .hint {
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 /* Modal */
@@ -28,7 +28,7 @@
 }
 
 .modal h3 {
-  font-size: 18px;
+  font-size: var(--font-size-2xl);
   margin-bottom: 12px;
 }
 
@@ -72,7 +72,7 @@
 
 .quit-confirm-modal p {
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   margin: 0 0 20px;
 }
 
@@ -85,7 +85,7 @@
 .quit-confirm-actions button {
   min-width: 80px;
   padding: 8px 16px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 /* Plugin Suggestion Modal */
@@ -128,7 +128,7 @@
 }
 
 .plugin-suggestion-desc {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   line-height: 1.55;
   color: var(--text-secondary);
   margin-bottom: 0;
@@ -152,7 +152,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -177,7 +177,7 @@
   border: none;
   border-radius: var(--radius-md);
   color: var(--action-text);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   cursor: pointer;
   transition:

--- a/src/styles/features/agents-panel.css
+++ b/src/styles/features/agents-panel.css
@@ -19,14 +19,14 @@
 }
 
 .agents-panel-title {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--text-primary);
   margin: 0;
 }
 
 .agents-panel-subtitle {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   margin: 2px 0 0 0;
 }
@@ -78,7 +78,7 @@
 }
 
 .agents-panel-row-name {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   color: var(--text-primary);
   overflow: hidden;
@@ -87,7 +87,7 @@
 }
 
 .agents-panel-row-status {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -112,7 +112,7 @@
   color: var(--text-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   line-height: 1.4;
   cursor: pointer;
@@ -221,7 +221,7 @@
   background: transparent;
   border: none;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   text-align: left;
   cursor: pointer;
   border-radius: var(--radius-sm);
@@ -259,7 +259,7 @@
 
 .agents-panel-confirm-body {
   padding: var(--spacing-lg) var(--spacing-xl) var(--spacing-xl);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   line-height: 1.5;
 }
@@ -294,14 +294,14 @@
 }
 
 .dashboard-card-title {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--text-primary);
   margin: 0;
 }
 
 .dashboard-card-subtitle {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   margin: 2px 0 0 0;
 }
@@ -375,7 +375,7 @@ button.dashboard-card-row {
 }
 
 .dashboard-card-row-name {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   color: var(--text-primary);
   overflow: hidden;
@@ -384,7 +384,7 @@ button.dashboard-card-row {
 }
 
 .dashboard-card-row-status {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/styles/features/agents-panel.css
+++ b/src/styles/features/agents-panel.css
@@ -247,7 +247,7 @@
 .agents-panel-terminal-body {
   flex: 1;
   min-height: 0;
-  background: #1e1e1e;
+  background: #1e1e1e; /* css-ok: must match xterm theme bg */
   border-radius: var(--radius);
   overflow: hidden;
 }

--- a/src/styles/features/assets-panel.css
+++ b/src/styles/features/assets-panel.css
@@ -57,7 +57,7 @@
 }
 
 .assets-search:focus-within {
-  border-color: #3b82f6;
+  border-color: var(--info);
 }
 
 .assets-search svg {
@@ -124,9 +124,9 @@
   cursor: pointer;
   border-radius: var(--radius-sm);
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .assets-breadcrumb-btn:hover {
@@ -253,9 +253,9 @@
   font-size: var(--font-size-md);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .assets-toolbar-btn:hover:not(:disabled) {
@@ -291,9 +291,9 @@
   color: var(--text-muted);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .assets-view-btn:hover {
@@ -334,7 +334,7 @@
 
 .assets-new-folder input:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--info);
 }
 
 .assets-new-folder input::placeholder {
@@ -522,7 +522,7 @@
 
 .assets-rename-input:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--info);
 }
 
 /* Item actions */
@@ -562,7 +562,7 @@
 .assets-drag-overlay {
   position: absolute;
   inset: 0;
-  background: rgba(var(--accent-rgb, 34, 197, 94), 0.1);
+  background: rgba(var(--success-light-rgb), 0.1);
   border: 2px dashed var(--accent);
   border-radius: var(--radius-md);
   display: flex;
@@ -585,7 +585,7 @@
   color: var(--error);
   font-size: var(--font-size-md);
   padding: 8px 12px;
-  background: rgba(244, 71, 71, 0.1);
+  background: rgba(var(--error-rgb), 0.1);
   border-radius: var(--radius);
 }
 
@@ -608,9 +608,9 @@
   border-radius: var(--radius-md);
   cursor: default;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   position: relative;
 }
 
@@ -703,9 +703,9 @@
 /* Delete button armed state (ready to confirm) */
 .assets-action-btn.assets-action-delete.armed {
   background: var(--error-light);
-  color: white;
+  color: var(--text-bright);
 }
 
 .assets-action-btn.assets-action-delete.armed:hover {
-  background: #dc2626;
+  background: var(--error-deep);
 }

--- a/src/styles/features/assets-panel.css
+++ b/src/styles/features/assets-panel.css
@@ -15,7 +15,7 @@
 }
 
 .assets-panel-header h3 {
-  font-size: 18px;
+  font-size: var(--font-size-2xl);
   font-weight: 600;
   margin: 0;
 }
@@ -70,7 +70,7 @@
   background: transparent;
   border: none;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   outline: none;
 }
 
@@ -120,7 +120,7 @@
   background: transparent;
   border: none;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   border-radius: var(--radius-sm);
   transition:
@@ -188,7 +188,7 @@
   background: transparent;
   border: none;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   border-radius: var(--radius-sm);
@@ -226,7 +226,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .assets-root-custom input:focus {
@@ -250,7 +250,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -329,7 +329,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .assets-new-folder input:focus {
@@ -410,12 +410,12 @@
 .assets-empty p {
   margin: 0;
   color: var(--text-secondary);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
 }
 
 .assets-empty p.assets-empty-hint {
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   margin-top: 4px;
 }
 
@@ -495,7 +495,7 @@
 
 .assets-item-name {
   flex: 1;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -503,7 +503,7 @@
 }
 
 .assets-item-size {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   margin-left: 8px;
   flex-shrink: 0;
@@ -517,7 +517,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .assets-rename-input:focus {
@@ -576,14 +576,14 @@
 
 .assets-drag-overlay p {
   margin: 0;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
 }
 
 /* Error */
 .assets-error {
   color: var(--error);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   padding: 8px 12px;
   background: rgba(244, 71, 71, 0.1);
   border-radius: var(--radius);
@@ -660,7 +660,7 @@
 
 .assets-grid-name {
   display: block;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -671,7 +671,7 @@
 .assets-grid-item .assets-rename-input {
   width: 100%;
   text-align: center;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   padding: 2px 4px;
 }
 

--- a/src/styles/features/backups-modal.css
+++ b/src/styles/features/backups-modal.css
@@ -41,8 +41,8 @@
   justify-content: center;
   border-radius: var(--radius-sm);
   transition:
-    background-color 0.15s,
-    color 0.15s;
+    background-color var(--transition),
+    color var(--transition);
 }
 
 .backups-close-btn:hover {
@@ -81,8 +81,8 @@
 }
 
 .backups-error {
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  background: rgba(var(--error-light-rgb), 0.1);
+  border: 1px solid rgba(var(--error-light-rgb), 0.3);
   color: var(--error-light);
   padding: 10px 12px;
   border-radius: var(--radius-md);
@@ -91,8 +91,8 @@
 }
 
 .backups-success {
-  background: rgba(34, 197, 94, 0.1);
-  border: 1px solid rgba(34, 197, 94, 0.3);
+  background: rgba(var(--success-light-rgb), 0.1);
+  border: 1px solid rgba(var(--success-light-rgb), 0.3);
   color: var(--success-light);
   padding: 10px 12px;
   border-radius: var(--radius-md);
@@ -161,8 +161,8 @@
   color: var(--text-primary);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    border-color var(--transition);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -264,9 +264,9 @@
   color: var(--text-secondary);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    border-color 0.15s,
-    color 0.15s;
+    background-color var(--transition),
+    border-color var(--transition),
+    color var(--transition);
 }
 
 .backups-confirm-cancel:hover:not(:disabled) {
@@ -290,8 +290,8 @@
   color: var(--text-primary);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    border-color var(--transition);
   display: flex;
   align-items: center;
   gap: 6px;
@@ -326,7 +326,7 @@
   width: 48px;
   height: 48px;
   border-radius: var(--radius-full);
-  background: rgba(34, 197, 94, 0.1);
+  background: rgba(var(--success-light-rgb), 0.1);
   color: var(--success-light);
   display: flex;
   align-items: center;
@@ -352,8 +352,8 @@
 }
 
 .backups-badge-preview {
-  color: rgba(96, 165, 250, 0.9);
-  background: rgba(96, 165, 250, 0.12);
+  color: rgba(var(--info-light-rgb), 0.9);
+  background: rgba(var(--info-light-rgb), 0.12);
 }
 
 .backups-branch-name {
@@ -398,8 +398,8 @@
   color: var(--text-primary);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    border-color var(--transition);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -422,9 +422,9 @@
   color: var(--text-secondary);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    border-color 0.15s,
-    color 0.15s;
+    background-color var(--transition),
+    border-color var(--transition),
+    color var(--transition);
   width: 100%;
 }
 

--- a/src/styles/features/backups-modal.css
+++ b/src/styles/features/backups-modal.css
@@ -25,7 +25,7 @@
 }
 
 .backups-modal-subtitle {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   margin: 4px 0 0 0;
 }
@@ -72,11 +72,11 @@
   gap: 12px;
   padding: 40px 20px;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .backups-empty-hint {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   opacity: 0.7;
 }
 
@@ -86,7 +86,7 @@
   color: var(--error-light);
   padding: 10px 12px;
   border-radius: var(--radius-md);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   margin-bottom: 12px;
 }
 
@@ -96,7 +96,7 @@
   color: var(--success-light);
   padding: 10px 12px;
   border-radius: var(--radius-md);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   margin-bottom: 12px;
   display: flex;
   align-items: center;
@@ -130,7 +130,7 @@
 }
 
 .backup-message {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -142,7 +142,7 @@
   align-items: center;
   gap: 8px;
   margin-top: 4px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
@@ -153,7 +153,7 @@
 
 .backup-restore-btn {
   padding: 6px 12px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
@@ -180,7 +180,7 @@
 }
 
 .backup-current {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   padding: 4px 8px;
   background: var(--bg-tertiary);
@@ -196,7 +196,7 @@
 }
 
 .backups-footer-hint {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
@@ -221,7 +221,7 @@
 }
 
 .backups-confirm-description {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   margin: 0;
   line-height: 1.5;
@@ -234,7 +234,7 @@
 }
 
 .backups-confirm-backup .backup-message {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-primary);
   margin-bottom: 4px;
 }
@@ -243,7 +243,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
@@ -256,7 +256,7 @@
 
 .backups-confirm-cancel {
   padding: 8px 16px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
@@ -282,7 +282,7 @@
 
 .backups-confirm-restore {
   padding: 8px 16px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
@@ -343,7 +343,7 @@
 }
 
 .backups-badge {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   padding: 3px 6px;
@@ -358,12 +358,12 @@
 
 .backups-branch-name {
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-primary);
 }
 
 .backups-success-description {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   margin: 0;
 }
@@ -372,7 +372,7 @@
   text-align: left;
   margin: 4px 0 12px;
   padding-left: 20px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
 }
 
@@ -390,7 +390,7 @@
 
 .backups-success-pr-btn {
   padding: 10px 16px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
@@ -414,7 +414,7 @@
 
 .backups-success-close-btn {
   padding: 8px 16px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   background: transparent;
   border: 1px solid var(--border);

--- a/src/styles/features/branches/branch-actions.css
+++ b/src/styles/features/branches/branch-actions.css
@@ -15,14 +15,14 @@
 
 .branch-selector-header h2 {
   margin: 0 0 4px 0;
-  font-size: 18px;
+  font-size: var(--font-size-2xl);
   font-weight: 600;
   color: var(--text-primary);
 }
 
 .branch-selector-header p {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
 }
 
@@ -38,7 +38,7 @@
 
 .branch-selector-section-label {
   padding: 8px 24px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
@@ -101,20 +101,20 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
   color: var(--text-primary);
 }
 
 .branch-selector-meta {
   margin-top: 4px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
 }
 
 .branch-selector-warning {
   margin-top: 6px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--warning);
 }
 
@@ -133,7 +133,7 @@
   background: none;
   border: none;
   color: #3b82f6;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   transition: color var(--transition);
 }
@@ -153,7 +153,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   outline: none;
   transition: border-color var(--transition);
 }
@@ -171,7 +171,7 @@
   align-items: center;
   gap: 8px;
   margin-top: 8px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
 }
 
@@ -181,7 +181,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 /* Branch Selector Footer */
@@ -220,7 +220,7 @@
 
 .publish-branch-header h2 {
   margin: 0;
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   color: var(--text-primary);
 }
@@ -251,14 +251,14 @@
 }
 
 .publish-branch-name {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
   color: var(--text-primary);
 }
 
 .publish-branch-description {
   margin-bottom: 12px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   line-height: 1.4;
 }
@@ -272,7 +272,7 @@
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
   border-radius: var(--radius);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--error-light);
   line-height: 1.4;
 }
@@ -282,7 +282,7 @@
   margin-bottom: 8px;
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 .publish-branch-url-label {
@@ -331,7 +331,7 @@
 
 .post-merge-header h3 {
   margin: 0;
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   color: var(--text-primary);
 }
@@ -342,7 +342,7 @@
 
 .post-merge-body p {
   margin: 0;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   color: var(--text-secondary);
   line-height: 1.5;
 }
@@ -356,7 +356,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-xs);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   text-decoration: none;
   margin-top: var(--spacing-md);
@@ -425,7 +425,7 @@
 }
 
 .pr-card-title {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
   color: var(--text-primary);
   white-space: nowrap;
@@ -434,14 +434,14 @@
 }
 
 .pr-card-number {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 400;
   color: var(--text-muted);
   flex-shrink: 0;
 }
 
 .pr-card-meta {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
 }
 
@@ -455,7 +455,7 @@
   padding: 2px 6px;
   background: var(--bg-tertiary);
   border-radius: var(--radius-sm);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-family: monospace;
 }
 
@@ -467,7 +467,7 @@
   padding: 6px 10px;
   background: rgba(245, 158, 11, 0.1);
   border-radius: var(--radius);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--warning);
 }
 
@@ -493,7 +493,7 @@
 
 /* TODO: Replace hard-coded #3b82f6 with var(--accent) for theme consistency */
 .pr-card-current-label {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: #3b82f6;
   font-weight: 500;
   flex-shrink: 0;
@@ -533,7 +533,7 @@
 
 .git-error-header h2 {
   margin: 0;
-  font-size: 18px;
+  font-size: var(--font-size-2xl);
   font-weight: 600;
   color: var(--text-primary);
 }
@@ -543,7 +543,7 @@
 }
 
 .git-error-description {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   color: var(--text-secondary);
   line-height: 1.5;
   margin-bottom: 16px;
@@ -554,7 +554,7 @@
 }
 
 .git-error-prompt-label {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   margin-bottom: 8px;
 }
@@ -564,7 +564,7 @@
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   line-height: 1.5;
   font-family: inherit;
@@ -625,7 +625,7 @@
 
 .submit-review-header h2 {
   margin: 0;
-  font-size: 18px;
+  font-size: var(--font-size-2xl);
   font-weight: 600;
   color: var(--text-primary);
 }
@@ -639,7 +639,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -692,7 +692,7 @@
 
 .submit-review-commit-prompt p {
   margin: 0 0 10px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   line-height: 1.4;
 }
@@ -706,7 +706,7 @@
   border: none;
   border-radius: var(--radius);
   color: #fff;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   cursor: pointer;
   transition: background var(--transition);
@@ -731,7 +731,7 @@
 
 .submit-review-label {
   display: block;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   margin-bottom: 6px;
 }
@@ -743,7 +743,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   outline: none;
   transition: border-color var(--transition);
   box-sizing: border-box;
@@ -770,7 +770,7 @@ select.submit-review-input {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-family: inherit;
   resize: vertical;
   outline: none;
@@ -801,7 +801,7 @@ select.submit-review-input {
 
 .unsaved-changes-body p {
   margin: 0;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   color: var(--text-secondary);
   line-height: 1.5;
 }

--- a/src/styles/features/branches/branch-actions.css
+++ b/src/styles/features/branches/branch-actions.css
@@ -63,7 +63,7 @@
 }
 
 .branch-selector-item.selected {
-  background: rgba(59, 130, 246, 0.1);
+  background: rgba(var(--info-rgb), 0.1);
 }
 
 .branch-selector-radio {
@@ -75,20 +75,20 @@
   margin-top: 2px;
   position: relative;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .branch-selector-item.selected .branch-selector-radio {
-  border-color: #3b82f6;
+  border-color: var(--info);
 }
 
 .branch-selector-item.selected .branch-selector-radio::after {
   content: '';
   position: absolute;
   inset: 3px;
-  background: #3b82f6;
+  background: var(--info);
   border-radius: var(--radius-full);
 }
 
@@ -132,14 +132,14 @@
   padding: 0;
   background: none;
   border: none;
-  color: #3b82f6;
+  color: var(--info);
   font-size: var(--font-size-md);
   cursor: pointer;
   transition: color var(--transition);
 }
 
 .branch-create-toggle:hover {
-  color: #60a5fa;
+  color: var(--info-light);
 }
 
 .branch-create-form {
@@ -159,7 +159,7 @@
 }
 
 .branch-create-input:focus {
-  border-color: #3b82f6;
+  border-color: var(--info);
 }
 
 .branch-create-input::placeholder {
@@ -198,7 +198,7 @@
 .publish-branch-modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--overlay-60);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -269,8 +269,8 @@
   gap: 8px;
   margin-bottom: 12px;
   padding: 10px 12px;
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  background: rgba(var(--error-light-rgb), 0.1);
+  border: 1px solid rgba(var(--error-light-rgb), 0.3);
   border-radius: var(--radius);
   font-size: var(--font-size-base);
   color: var(--error-light);
@@ -308,7 +308,7 @@
 .post-merge-modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--overlay-60);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -417,7 +417,7 @@
 }
 
 .pr-card-status.merged {
-  background: #a855f7;
+  background: var(--purple);
 }
 
 .pr-card-status.closed {
@@ -465,7 +465,7 @@
   gap: 6px;
   margin-top: 8px;
   padding: 6px 10px;
-  background: rgba(245, 158, 11, 0.1);
+  background: rgba(var(--warning-rgb), 0.1);
   border-radius: var(--radius);
   font-size: var(--font-size-base);
   color: var(--warning);
@@ -485,16 +485,14 @@
   justify-content: center;
 }
 
-/* TODO: Replace hard-coded #3b82f6 with var(--accent) for theme consistency */
 .pr-card-checked-out {
-  border-color: #3b82f6;
-  background: rgba(59, 130, 246, 0.05);
+  border-color: var(--info);
+  background: rgba(var(--info-rgb), 0.05);
 }
 
-/* TODO: Replace hard-coded #3b82f6 with var(--accent) for theme consistency */
 .pr-card-current-label {
   font-size: var(--font-size-sm);
-  color: #3b82f6;
+  color: var(--info);
   font-weight: 500;
   flex-shrink: 0;
 }
@@ -503,7 +501,7 @@
 .git-error-modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--overlay-60);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -583,7 +581,7 @@
 .submit-review-modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--overlay-60);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -643,16 +641,16 @@
   font-weight: 500;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   white-space: nowrap;
 }
 
 .submit-review-generate-btn:hover:not(:disabled) {
   background: var(--bg-tertiary);
   color: var(--text-primary);
-  border-color: #3b82f6;
+  border-color: var(--info);
 }
 
 .submit-review-generate-btn:disabled {
@@ -668,16 +666,10 @@
   border: 2px solid var(--border);
   border-top-color: var(--text-primary);
   border-radius: var(--radius-full);
-  animation: submit-review-spin 0.6s linear infinite;
+  animation: spin 0.6s linear infinite;
 }
 
-@keyframes submit-review-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.submit-review-body {
+@keyframes.submit-review-body {
   padding: 20px 24px;
 }
 
@@ -702,10 +694,10 @@
   align-items: center;
   gap: 6px;
   padding: 8px 16px;
-  background: #3b82f6;
+  background: var(--info);
   border: none;
   border-radius: var(--radius);
-  color: #fff;
+  color: var(--text-bright);
   font-size: var(--font-size-md);
   font-weight: 500;
   cursor: pointer;
@@ -713,7 +705,7 @@
 }
 
 .submit-review-commit-btn:hover:not(:disabled) {
-  background: #2563eb;
+  background: var(--info-hover);
 }
 
 .submit-review-commit-btn:disabled {
@@ -759,7 +751,7 @@ select.submit-review-input {
 }
 
 .submit-review-input:focus {
-  border-color: #3b82f6;
+  border-color: var(--info);
 }
 
 .submit-review-textarea {
@@ -778,7 +770,7 @@ select.submit-review-input {
 }
 
 .submit-review-textarea:focus {
-  border-color: #3b82f6;
+  border-color: var(--info);
 }
 
 .submit-review-footer {
@@ -820,8 +812,4 @@ select.submit-review-input {
   background: var(--bg-tertiary);
 }
 
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
+@keyframes;

--- a/src/styles/features/branches/branch-actions.css
+++ b/src/styles/features/branches/branch-actions.css
@@ -669,7 +669,7 @@
   animation: spin 0.6s linear infinite;
 }
 
-@keyframes.submit-review-body {
+.submit-review-body {
   padding: 20px 24px;
 }
 
@@ -811,5 +811,3 @@ select.submit-review-input {
   border-top: 1px solid var(--border);
   background: var(--bg-tertiary);
 }
-
-@keyframes;

--- a/src/styles/features/branches/main.css
+++ b/src/styles/features/branches/main.css
@@ -15,9 +15,9 @@
   font-size: var(--font-size-md);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .preview-tabs-bar .branch-indicator {
@@ -35,14 +35,14 @@
 
 /* Main branch warning style */
 .branch-indicator-button.main-branch {
-  background: rgba(245, 158, 11, 0.15);
-  border-color: rgba(245, 158, 11, 0.4);
+  background: rgba(var(--warning-rgb), 0.15);
+  border-color: rgba(var(--warning-rgb), 0.4);
   color: var(--warning);
 }
 
 .branch-indicator-button.main-branch:hover {
-  background: rgba(245, 158, 11, 0.25);
-  border-color: rgba(245, 158, 11, 0.6);
+  background: rgba(var(--warning-rgb), 0.25);
+  border-color: rgba(var(--warning-rgb), 0.6);
   color: var(--warning-light);
 }
 
@@ -61,7 +61,7 @@
 .branch-live-badge {
   font-size: var(--font-size-xs);
   padding: 1px 5px;
-  background: rgba(34, 197, 94, 0.15);
+  background: rgba(var(--success-light-rgb), 0.15);
   color: var(--success-light);
   border-radius: 3px;
   font-weight: 500;
@@ -78,7 +78,7 @@
 .branch-unsaved-badge {
   font-size: var(--font-size-xs);
   padding: 1px 5px;
-  background: rgba(245, 158, 11, 0.15);
+  background: rgba(var(--warning-rgb), 0.15);
   color: var(--warning);
   border-radius: 3px;
   font-weight: 500;
@@ -156,23 +156,23 @@
 }
 
 .change-modified {
-  background: rgba(234, 179, 8, 0.2);
+  background: rgba(var(--modified-yellow-rgb), 0.2);
   color: var(--warning);
 }
 
 .change-added {
-  background: rgba(34, 197, 94, 0.2);
+  background: rgba(var(--success-light-rgb), 0.2);
   color: var(--success);
 }
 
 .change-deleted {
-  background: rgba(239, 68, 68, 0.2);
+  background: rgba(var(--error-light-rgb), 0.2);
   color: var(--error);
 }
 
 .change-renamed {
-  background: rgba(168, 85, 247, 0.2);
-  color: #a855f7;
+  background: rgba(var(--purple-rgb), 0.2);
+  color: var(--purple);
 }
 
 .branch-changes-path {
@@ -207,21 +207,21 @@
   align-items: center;
   gap: 6px;
   padding: 6px 12px;
-  background: var(--primary);
+  background: var(--info);
   border: none;
   border-radius: var(--radius-sm);
-  color: white;
+  color: var(--text-bright);
   font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .branch-changes-save-btn:hover {
-  background: var(--primary-hover);
+  background: var(--info-hover);
 }
 
 .branch-changes-discard-btn {
@@ -236,13 +236,13 @@
   font-size: var(--font-size-base);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .branch-changes-discard-btn:hover:not(:disabled) {
-  background: rgba(239, 68, 68, 0.1);
+  background: rgba(var(--error-light-rgb), 0.1);
   border-color: var(--error);
 }
 
@@ -254,7 +254,7 @@
 .branch-changes-discard-btn.confirming {
   background: var(--error);
   border-color: var(--error);
-  color: white;
+  color: var(--text-bright);
   animation: pulse-danger 0.6s ease-in-out infinite;
 }
 
@@ -362,7 +362,7 @@
 }
 
 .branch-item-badge.live {
-  background: rgba(34, 197, 94, 0.15);
+  background: rgba(var(--success-light-rgb), 0.15);
   border-color: transparent;
   color: var(--success-light);
 }
@@ -397,17 +397,17 @@
   padding: 8px 14px;
   background: none;
   border: none;
-  color: #3b82f6;
+  color: var(--info);
   font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .branch-dropdown-link:hover {
-  color: #60a5fa;
+  color: var(--info-light);
   background: var(--bg-secondary);
 }

--- a/src/styles/features/branches/main.css
+++ b/src/styles/features/branches/main.css
@@ -12,7 +12,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -59,7 +59,7 @@
 }
 
 .branch-live-badge {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   padding: 1px 5px;
   background: rgba(34, 197, 94, 0.15);
   color: var(--success-light);
@@ -76,7 +76,7 @@
 }
 
 .branch-unsaved-badge {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   padding: 1px 5px;
   background: rgba(245, 158, 11, 0.15);
   color: var(--warning);
@@ -107,7 +107,7 @@
 .branch-changes-header {
   padding: 10px 12px;
   border-bottom: 1px solid var(--border);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   color: var(--text-secondary);
 }
@@ -123,7 +123,7 @@
   gap: 8px;
   padding: 8px 12px;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   transition: background var(--transition-fast);
 }
 
@@ -146,7 +146,7 @@
   justify-content: center;
   width: 16px;
   height: 16px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   line-height: 1;
   border-radius: 3px;
@@ -211,7 +211,7 @@
   border: none;
   border-radius: var(--radius-sm);
   color: white;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -233,7 +233,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--error);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -288,7 +288,7 @@
 
 .branch-dropdown-header {
   padding: 12px 14px 8px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
@@ -301,7 +301,7 @@
 
 .branch-dropdown-section-label {
   padding: 8px 14px 4px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
@@ -315,7 +315,7 @@
   border: none;
   border-radius: 0;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   transition: background var(--transition);
@@ -353,7 +353,7 @@
 }
 
 .branch-item-badge {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   padding: 1px 5px;
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
@@ -368,7 +368,7 @@
 }
 
 .branch-item-meta {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
@@ -398,7 +398,7 @@
   background: none;
   border: none;
   color: #3b82f6;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   transition:

--- a/src/styles/features/branches/pr-list.css
+++ b/src/styles/features/branches/pr-list.css
@@ -31,16 +31,16 @@
   font-size: var(--font-size-md);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   width: 100%;
 }
 
 .branches-new-branch-btn:hover {
   background: var(--bg-tertiary);
-  border-color: #3b82f6;
-  color: #3b82f6;
+  border-color: var(--info);
+  color: var(--info);
 }
 
 .branches-new-branch-form {
@@ -61,7 +61,7 @@
 }
 
 .branches-new-branch-input-wrapper:focus-within {
-  border-color: #3b82f6;
+  border-color: var(--info);
 }
 
 .branches-new-branch-prefix {
@@ -112,7 +112,7 @@
   height: 14px;
   margin: 0;
   cursor: pointer;
-  accent-color: #3b82f6;
+  accent-color: var(--info);
 }
 
 .branches-new-branch-checkbox:hover {
@@ -142,8 +142,8 @@
 }
 
 .branch-card.current {
-  border-color: #3b82f6;
-  background: rgba(59, 130, 246, 0.05);
+  border-color: var(--info);
+  background: rgba(var(--info-rgb), 0.05);
 }
 
 .branch-card-info {
@@ -177,7 +177,7 @@
 
 .branch-card-current-label {
   font-size: var(--font-size-sm);
-  color: #3b82f6;
+  color: var(--info);
   font-weight: 500;
 }
 
@@ -202,12 +202,12 @@
 }
 
 .branch-card-badge.ahead {
-  background: rgba(59, 130, 246, 0.1);
-  color: #3b82f6;
+  background: rgba(var(--info-rgb), 0.1);
+  color: var(--info);
 }
 
 .branch-card-badge.behind {
-  background: rgba(245, 158, 11, 0.1);
+  background: rgba(var(--warning-rgb), 0.1);
   color: var(--warning);
 }
 
@@ -229,9 +229,9 @@
   font-size: var(--font-size-base);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .branch-card-action:hover {
@@ -254,19 +254,19 @@
 }
 
 .branch-card-action.danger:hover {
-  background: rgba(239, 68, 68, 0.1);
-  border-color: rgba(239, 68, 68, 0.3);
+  background: rgba(var(--error-light-rgb), 0.1);
+  border-color: rgba(var(--error-light-rgb), 0.3);
 }
 
 .branch-card-action.danger-outline {
   background: transparent;
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid rgba(var(--error-light-rgb), 0.3);
   color: var(--error-light);
 }
 
 .branch-card-action.danger-outline:hover {
-  background: rgba(239, 68, 68, 0.1);
-  border-color: rgba(239, 68, 68, 0.5);
+  background: rgba(var(--error-light-rgb), 0.1);
+  border-color: rgba(var(--error-light-rgb), 0.5);
 }
 
 .branch-card-action.danger-outline:disabled {

--- a/src/styles/features/branches/pr-list.css
+++ b/src/styles/features/branches/pr-list.css
@@ -10,7 +10,7 @@
 }
 
 .branches-tab-section-header {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
@@ -28,7 +28,7 @@
   border: 1px dashed var(--border);
   border-radius: var(--radius-md);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -67,7 +67,7 @@
 .branches-new-branch-prefix {
   padding: 10px 0 10px 12px;
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   white-space: nowrap;
   user-select: none;
 }
@@ -79,7 +79,7 @@
   border: none;
   border-radius: 0;
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   outline: none;
 }
 
@@ -101,7 +101,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   cursor: pointer;
   user-select: none;
@@ -156,7 +156,7 @@
   align-items: center;
   gap: 8px;
   min-width: 0;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
   color: var(--text-primary);
   margin-bottom: 4px;
@@ -176,13 +176,13 @@
 }
 
 .branch-card-current-label {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: #3b82f6;
   font-weight: 500;
 }
 
 .branch-card-meta {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
 }
 
@@ -194,7 +194,7 @@
 }
 
 .branch-card-badge {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   padding: 2px 6px;
   border-radius: var(--radius-sm);
   background: var(--bg-tertiary);
@@ -226,7 +226,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -289,7 +289,7 @@
   justify-content: center;
   gap: 16px;
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
 }
 
 .prs-tab-loading .branch-item-spinner {
@@ -306,7 +306,7 @@
   justify-content: center;
   gap: 16px;
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
 }
 
 .prs-tab-error button {
@@ -327,7 +327,7 @@
 }
 
 .prs-tab-section-header {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
@@ -366,7 +366,7 @@
 
 .prs-tab-empty-title {
   margin: 0 0 8px 0;
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   color: var(--text-primary);
 }
@@ -374,7 +374,7 @@
 .prs-tab-empty-description {
   margin: 0 0 20px 0;
   max-width: 320px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   line-height: 1.5;
 }
@@ -385,7 +385,7 @@
   border: none;
   border-radius: var(--radius);
   color: var(--action-text);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   cursor: pointer;
   transition: background var(--transition);
@@ -393,5 +393,5 @@
 
 .prs-tab-empty-action:hover {
   background: var(--action-hover);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }

--- a/src/styles/features/browser-dropdown.css
+++ b/src/styles/features/browser-dropdown.css
@@ -44,7 +44,7 @@
   border: none;
   border-radius: 0;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   transition:

--- a/src/styles/features/browser-tools.css
+++ b/src/styles/features/browser-tools.css
@@ -28,7 +28,7 @@
   border-radius: 0;
   color: var(--text-muted);
   font-family: inherit;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition: color var(--transition);
@@ -66,7 +66,7 @@
   background: var(--bg-tertiary);
   border-radius: var(--radius-sm);
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 600;
 }
 
@@ -93,7 +93,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   cursor: pointer;
   transition:
     color var(--transition),
@@ -147,7 +147,7 @@
   justify-content: center;
   flex: 1;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 /* ===== Console view ===== */
@@ -160,7 +160,7 @@
      content reflows horizontally on tab switch. */
   scrollbar-gutter: stable;
   font-family: 'JetBrainsMono NF', Menlo, Monaco, 'Courier New', monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 .console-row {
@@ -176,7 +176,7 @@
   flex-shrink: 0;
   min-width: 44px;
   text-transform: uppercase;
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   letter-spacing: 0.5px;
   padding-top: 2px;
@@ -225,7 +225,7 @@
   display: flex;
   flex-direction: column;
   font-family: 'JetBrainsMono NF', Menlo, Monaco, 'Courier New', monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 .network-header {
@@ -236,7 +236,7 @@
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -308,7 +308,7 @@
   display: flex;
   flex-direction: column;
   font-family: 'JetBrainsMono NF', Menlo, Monaco, 'Courier New', monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   background: var(--bg-primary);
 }
 
@@ -317,7 +317,7 @@
   background: rgba(229, 229, 16, 0.1);
   border-bottom: 1px solid rgba(229, 229, 16, 0.3);
   color: #e5e510;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   flex-shrink: 0;
 }
 

--- a/src/styles/features/browser-tools.css
+++ b/src/styles/features/browser-tools.css
@@ -168,7 +168,7 @@
   align-items: flex-start;
   gap: var(--spacing-sm);
   padding: 4px var(--spacing-md);
-  border-bottom: 1px solid rgba(60, 60, 60, 0.3);
+  border-bottom: 1px solid rgba(var(--border-rgb), 0.3);
   line-height: 1.5;
 }
 
@@ -194,24 +194,24 @@
 }
 
 .console-row-warn {
-  background: rgba(229, 229, 16, 0.05);
+  background: rgba(var(--ansi-yellow-rgb), 0.05);
 }
 
 .console-row-warn .console-row-level {
-  color: #e5e510;
+  color: var(--ansi-yellow);
 }
 
 .console-row-error {
-  background: rgba(241, 76, 76, 0.08);
+  background: rgba(var(--ansi-red-rgb), 0.08);
 }
 
 .console-row-error .console-row-level,
 .console-row-error .console-row-args {
-  color: #f14c4c;
+  color: var(--ansi-red);
 }
 
 .console-row-info .console-row-level {
-  color: #3b8eea;
+  color: var(--ansi-blue);
 }
 
 .console-row-debug {
@@ -254,7 +254,7 @@
   grid-template-columns: 70px 70px 1fr 80px;
   gap: var(--spacing-md);
   padding: 4px var(--spacing-md);
-  border-bottom: 1px solid rgba(60, 60, 60, 0.3);
+  border-bottom: 1px solid rgba(var(--border-rgb), 0.3);
   color: var(--text-primary);
   cursor: default;
 }
@@ -289,16 +289,16 @@
 }
 
 .network-row.status-ok .network-col-status {
-  color: #23d18b;
+  color: var(--ansi-bright-green);
 }
 
 .network-row.status-bad .network-col-status {
-  color: #e5e510;
+  color: var(--ansi-yellow);
 }
 
 .network-row.status-err .network-col-status,
 .network-row.status-err .network-col-url {
-  color: #f14c4c;
+  color: var(--ansi-red);
 }
 
 /* ===== Elements view ===== */
@@ -314,9 +314,9 @@
 
 .elements-truncated-banner {
   padding: 6px var(--spacing-md);
-  background: rgba(229, 229, 16, 0.1);
-  border-bottom: 1px solid rgba(229, 229, 16, 0.3);
-  color: #e5e510;
+  background: rgba(var(--ansi-yellow-rgb), 0.1);
+  border-bottom: 1px solid rgba(var(--ansi-yellow-rgb), 0.3);
+  color: var(--ansi-yellow);
   font-size: var(--font-size-sm);
   flex-shrink: 0;
 }
@@ -357,7 +357,7 @@
 }
 
 .el-row-comment .el-comment {
-  color: #6a9955;
+  color: var(--code-comment);
   font-style: italic;
 }
 
@@ -371,7 +371,7 @@
   flex-shrink: 0;
   color: var(--text-muted);
   font-size: 8px;
-  transition: transform 0.1s ease;
+  transition: transform var(--transition-fast);
 }
 
 .el-toggle.is-open {
@@ -387,7 +387,7 @@
 }
 
 .el-tag {
-  color: #569cd6;
+  color: var(--code-keyword);
 }
 
 .el-attr {
@@ -395,7 +395,7 @@
 }
 
 .el-attr-name {
-  color: #9cdcfe;
+  color: var(--code-property);
 }
 
 .el-attr-eq {
@@ -403,7 +403,7 @@
 }
 
 .el-attr-value {
-  color: #ce9178;
+  color: var(--code-string);
 }
 
 .el-ellipsis {

--- a/src/styles/features/changelog.css
+++ b/src/styles/features/changelog.css
@@ -133,7 +133,7 @@
 .rewind-modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.8);
+  background: var(--overlay-80);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/styles/features/changelog.css
+++ b/src/styles/features/changelog.css
@@ -30,14 +30,14 @@
 }
 
 .changelog-header h3 {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--text-primary);
   margin: 0;
 }
 
 .changelog-subtitle {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   margin-top: 2px;
   display: block;
@@ -71,7 +71,7 @@
 }
 
 .changelog-version {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--accent);
   font-family: 'SF Mono', Monaco, monospace;
@@ -113,7 +113,7 @@
 }
 
 .changelog-items li {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   padding: 1px 0;
   padding-left: 10px;
@@ -126,7 +126,7 @@
   position: absolute;
   left: 0;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--font-size-xs);
 }
 
 /* Rewind Modal */
@@ -172,7 +172,7 @@
 
 .rewind-body p {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   line-height: 1.5;
 }
@@ -213,7 +213,7 @@
 .rewind-body p.rewind-error-text {
   color: var(--error);
   font-family: 'SF Mono', Monaco, monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 .rewind-actions {

--- a/src/styles/features/conflicts.css
+++ b/src/styles/features/conflicts.css
@@ -74,7 +74,7 @@
 
 .conflict-header h2 {
   margin: 0 0 4px 0;
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   color: var(--text-primary);
 }
@@ -83,7 +83,7 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .conflict-file-name {
@@ -96,13 +96,13 @@
 
 .conflict-progress {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 /* Explanation */
 .conflict-explanation {
   padding: 12px 24px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   background: var(--bg-tertiary);
   border-bottom: 1px solid var(--border);
@@ -141,7 +141,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 8px 12px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -162,7 +162,7 @@
 
 .conflict-branch-name {
   font-weight: 400;
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   text-transform: none;
   letter-spacing: 0;
   color: var(--text-muted);
@@ -176,14 +176,14 @@
   flex: 1;
   padding: 12px;
   overflow: auto;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   line-height: 1.5;
 }
 
 .conflict-panel-content pre {
   margin: 0;
   font-family: 'SF Mono', 'Monaco', 'Menlo', monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   white-space: pre-wrap;
   word-break: break-word;
   color: var(--text-primary);
@@ -199,7 +199,7 @@
   padding-top: 8px;
   border-top: 1px dashed var(--border);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-style: italic;
 }
 
@@ -227,7 +227,7 @@
 .conflict-btn {
   padding: 10px 20px;
   border-radius: var(--radius);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -306,7 +306,7 @@
   background: rgba(59, 130, 246, 0.08);
   border: 1px solid rgba(59, 130, 246, 0.2);
   border-radius: var(--radius-md);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   line-height: 1.5;
 }
@@ -340,7 +340,7 @@
   background: none;
   border: none;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   transition: color var(--transition);
   text-align: left;
@@ -373,7 +373,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -391,7 +391,7 @@
 }
 
 .conflict-context-label {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--text-muted);
   margin-bottom: 6px;
@@ -406,7 +406,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   font-family: 'SF Mono', 'Monaco', 'Menlo', monospace;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   white-space: pre-wrap;
   word-break: break-word;
@@ -427,7 +427,7 @@
 }
 
 .conflict-diff-label {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   margin-bottom: 6px;
   text-transform: uppercase;
@@ -449,7 +449,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   font-family: 'SF Mono', 'Monaco', 'Menlo', monospace;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   white-space: pre-wrap;
   word-break: break-word;

--- a/src/styles/features/conflicts.css
+++ b/src/styles/features/conflicts.css
@@ -1,9 +1,15 @@
 /* Merge Conflict Resolution Modal */
 
+/* Conflict-local colors — intentional one-offs, not part of the global scale. */
+:root {
+  /* Hover state for the "theirs" (green) button — darker step of --success-light. */
+  --conflict-theirs-hover: #16a34a;
+}
+
 .conflict-modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: var(--overlay-70);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -149,15 +155,15 @@
 }
 
 .conflict-panel-header.yours {
-  color: #3b82f6;
-  border-color: #3b82f6;
-  background: rgba(59, 130, 246, 0.05);
+  color: var(--info);
+  border-color: var(--info);
+  background: rgba(var(--info-rgb), 0.05);
 }
 
 .conflict-panel-header.theirs {
   color: var(--success-light);
   border-color: var(--success-light);
-  background: rgba(34, 197, 94, 0.05);
+  background: rgba(var(--success-light-rgb), 0.05);
 }
 
 .conflict-branch-name {
@@ -231,9 +237,9 @@
   font-weight: 500;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   display: flex;
   align-items: center;
   gap: 6px;
@@ -250,23 +256,23 @@
 }
 
 .conflict-btn.yours {
-  background: #3b82f6;
-  border: 1px solid #3b82f6;
-  color: white;
+  background: var(--info);
+  border: 1px solid var(--info);
+  color: var(--text-bright);
 }
 
 .conflict-btn.yours:hover:not(:disabled) {
-  background: #2563eb;
+  background: var(--info-hover);
 }
 
 .conflict-btn.theirs {
   background: var(--success-light);
   border: 1px solid var(--success-light);
-  color: white;
+  color: var(--text-bright);
 }
 
 .conflict-btn.theirs:hover:not(:disabled) {
-  background: #16a34a;
+  background: var(--conflict-theirs-hover);
 }
 
 .conflict-btn.secondary {
@@ -282,13 +288,13 @@
 
 .conflict-btn.danger-outline {
   background: transparent;
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid rgba(var(--error-light-rgb), 0.3);
   color: var(--error-light);
 }
 
 .conflict-btn.danger-outline:hover:not(:disabled) {
-  background: rgba(239, 68, 68, 0.1);
-  border-color: rgba(239, 68, 68, 0.5);
+  background: rgba(var(--error-light-rgb), 0.1);
+  border-color: rgba(var(--error-light-rgb), 0.5);
 }
 
 .conflict-btn:disabled {
@@ -303,8 +309,8 @@
   gap: 10px;
   margin: 0 24px 16px;
   padding: 12px 14px;
-  background: rgba(59, 130, 246, 0.08);
-  border: 1px solid rgba(59, 130, 246, 0.2);
+  background: rgba(var(--info-rgb), 0.08);
+  border: 1px solid rgba(var(--info-rgb), 0.2);
   border-radius: var(--radius-md);
   font-size: var(--font-size-base);
   color: var(--text-secondary);
@@ -313,7 +319,7 @@
 
 .conflict-callout-icon {
   flex-shrink: 0;
-  color: #3b82f6;
+  color: var(--info);
 }
 
 .conflict-callout > span:nth-child(2) {
@@ -376,9 +382,9 @@
   font-size: var(--font-size-base);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .conflict-copy-btn:hover {
@@ -435,7 +441,7 @@
 }
 
 .conflict-diff-label.yours {
-  color: #3b82f6;
+  color: var(--info);
 }
 
 .conflict-diff-label.theirs {
@@ -467,8 +473,4 @@
   background: var(--bg-secondary);
 }
 
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
+@keyframes;

--- a/src/styles/features/conflicts.css
+++ b/src/styles/features/conflicts.css
@@ -472,5 +472,3 @@
   border-top: 1px solid var(--border);
   background: var(--bg-secondary);
 }
-
-@keyframes;

--- a/src/styles/features/create-project.css
+++ b/src/styles/features/create-project.css
@@ -21,7 +21,7 @@
   animation: fadeIn 0.15s ease-out;
 }
 
-@keyframes@keyframes slideUp {
+@keyframes slideUp {
   from {
     opacity: 0;
     transform: translateY(10px) scale(0.98);

--- a/src/styles/features/create-project.css
+++ b/src/styles/features/create-project.css
@@ -1,11 +1,18 @@
 /* Create Project Modal */
+
+/* Create-project-local colors — intentional one-offs, not part of the global scale. */
+:root {
+  --create-default-green: #34c759;
+  --create-default-green-rgb: 52, 199, 89;
+}
+
 .create-modal-overlay {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.8);
+  background: var(--overlay-80);
   backdrop-filter: blur(4px);
   display: flex;
   align-items: center;
@@ -14,16 +21,7 @@
   animation: fadeIn 0.15s ease-out;
 }
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes slideUp {
+@keyframes@keyframes slideUp {
   from {
     opacity: 0;
     transform: translateY(10px) scale(0.98);
@@ -43,7 +41,7 @@
   max-height: 90vh;
   overflow-y: auto;
   animation: slideUp 0.2s ease-out;
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 25px 50px -12px var(--overlay-50);
 }
 
 .create-modal-content {
@@ -87,9 +85,9 @@
   cursor: pointer;
   border-radius: var(--radius);
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   margin: -4px -4px 0 0;
 }
 
@@ -118,8 +116,8 @@
   font-weight: 500;
   cursor: pointer;
   transition:
-    color 0.15s,
-    border-color 0.15s;
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .create-tab:hover {
@@ -153,9 +151,9 @@
   cursor: pointer;
   text-align: left;
   transition:
-    border-color 0.15s,
-    background-color 0.15s,
-    box-shadow 0.15s;
+    border-color var(--transition),
+    background-color var(--transition),
+    box-shadow var(--transition);
 }
 
 .stack-card:hover {
@@ -217,14 +215,14 @@
   color: var(--text-primary);
   font-size: 15px;
   transition:
-    border-color 0.15s,
-    box-shadow 0.15s;
+    border-color var(--transition),
+    box-shadow var(--transition);
 }
 
 .create-modal-content input:focus {
   outline: none;
   border-color: var(--text-muted);
-  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.05);
+  box-shadow: 0 0 0 3px var(--tint-subtle);
 }
 
 .create-modal-content input::placeholder {
@@ -327,8 +325,8 @@
   gap: 14px;
   padding: 16px 20px;
   margin-top: 24px;
-  background: rgba(244, 71, 71, 0.1);
-  border: 1px solid rgba(244, 71, 71, 0.3);
+  background: rgba(var(--error-rgb), 0.1);
+  border: 1px solid rgba(var(--error-rgb), 0.3);
   border-radius: var(--radius-md);
   text-align: center;
   width: 100%;
@@ -354,9 +352,9 @@
   cursor: pointer;
   text-align: center;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .template-default-toggle:hover {
@@ -365,9 +363,9 @@
 }
 
 .template-default-toggle.active {
-  border-color: #34c759;
-  color: #34c759;
-  background: rgba(52, 199, 89, 0.08);
+  border-color: var(--create-default-green);
+  color: var(--create-default-green);
+  background: rgba(var(--create-default-green-rgb), 0.08);
 }
 
 .template-context {
@@ -415,9 +413,9 @@
   border-radius: 10px;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   margin-bottom: 0;
 }
 
@@ -428,7 +426,7 @@
 
 .template-dropzone.dragging {
   border-color: var(--accent);
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--tint-subtle);
 }
 
 .template-dropzone svg {
@@ -452,7 +450,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 12px 14px;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--tint-subtle);
   border: 1px solid var(--accent);
   border-radius: 10px;
   margin-bottom: 0;
@@ -486,9 +484,9 @@
   cursor: pointer;
   border-radius: var(--radius-sm);
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   flex-shrink: 0;
 }
 
@@ -526,15 +524,15 @@
   color: var(--text-primary);
   font-size: var(--font-size-md);
   transition:
-    border-color 0.15s,
-    box-shadow 0.15s;
+    border-color var(--transition),
+    box-shadow var(--transition);
   box-sizing: border-box;
 }
 
 .create-modal-content input.tg-search-input:focus {
   outline: none;
   border-color: var(--text-muted);
-  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.05);
+  box-shadow: 0 0 0 3px var(--tint-subtle);
 }
 
 .create-modal-content input.tg-search-input::placeholder {
@@ -556,8 +554,8 @@
   align-items: center;
   justify-content: center;
   transition:
-    background-color 0.15s,
-    color 0.15s;
+    background-color var(--transition),
+    color var(--transition);
 }
 
 .tg-search-clear:hover {
@@ -600,11 +598,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 2px 8px var(--overlay-30);
   transition:
-    background-color 0.15s,
-    border-color 0.15s,
-    color 0.15s;
+    background-color var(--transition),
+    border-color var(--transition),
+    color var(--transition);
 }
 
 .tg-scroll-btn:hover {
@@ -631,9 +629,9 @@
   overflow: hidden;
   cursor: pointer;
   transition:
-    border-color 0.15s,
-    background-color 0.15s,
-    box-shadow 0.15s;
+    border-color var(--transition),
+    background-color var(--transition),
+    box-shadow var(--transition);
   text-align: left;
   padding: 0;
   position: relative;
@@ -729,7 +727,7 @@
   background: linear-gradient(
     90deg,
     var(--bg-tertiary) 0%,
-    rgba(255, 255, 255, 0.06) 50%,
+    rgba(var(--white-rgb), 0.06) 50%,
     var(--bg-tertiary) 100%
   );
   background-size: 200px 100%;

--- a/src/styles/features/create-project.css
+++ b/src/styles/features/create-project.css
@@ -74,7 +74,7 @@
 }
 
 .create-modal-header p {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   color: var(--text-secondary);
   margin: 0;
 }
@@ -114,7 +114,7 @@
   border-bottom: 2px solid transparent;
   border-radius: 0;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -168,13 +168,13 @@
 }
 
 .stack-card-name {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--text-primary);
 }
 
 .stack-card-desc {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   line-height: 1.3;
 }
@@ -204,7 +204,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   color: var(--text-secondary);
 }
@@ -233,7 +233,7 @@
 
 .create-modal-content .error {
   color: var(--error);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   margin: -8px 0 0 0;
 }
 
@@ -247,7 +247,7 @@
 
 .create-actions button {
   padding: 10px 18px;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
 }
 
@@ -276,7 +276,7 @@
 
 .create-status {
   color: var(--text-secondary);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   margin-bottom: 32px;
 }
 
@@ -294,7 +294,7 @@
   align-items: center;
   gap: 12px;
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   transition: color 0.2s;
 }
 
@@ -337,7 +337,7 @@
 
 .create-error p {
   color: var(--error);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   margin: 0;
 }
 
@@ -349,7 +349,7 @@
   padding: 10px 14px;
   margin-top: 16px;
   margin-bottom: 0;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-muted);
   cursor: pointer;
   text-align: center;
@@ -372,7 +372,7 @@
 
 .template-context {
   color: var(--text-secondary);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   margin: 0;
 }
 
@@ -397,7 +397,7 @@
 }
 
 .template-divider span {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   white-space: nowrap;
 }
@@ -437,12 +437,12 @@
 
 .template-dropzone p {
   margin: 0;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   color: var(--text-secondary);
 }
 
 .template-dropzone span {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
 }
 
@@ -463,7 +463,7 @@
   align-items: center;
   gap: 10px;
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   min-width: 0;
 }
 
@@ -524,7 +524,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   transition:
     border-color 0.15s,
     box-shadow 0.15s;
@@ -676,7 +676,7 @@
 }
 
 .tg-card-name {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--text-primary);
   white-space: nowrap;
@@ -685,7 +685,7 @@
 }
 
 .tg-card-desc {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -695,7 +695,7 @@
 }
 
 .tg-card-author {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   color: var(--text-muted);
   margin-top: 2px;
 }
@@ -775,5 +775,5 @@
   min-height: 80px;
   width: 100%;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }

--- a/src/styles/features/dashboard/folders.css
+++ b/src/styles/features/dashboard/folders.css
@@ -90,7 +90,7 @@
 
 .folder-card-open-label {
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
 }
 
@@ -120,7 +120,7 @@
 }
 
 .folder-card-count {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
 }
 
@@ -134,7 +134,7 @@
   background: transparent;
   border: none;
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   letter-spacing: 1px;
   cursor: pointer;
   border-radius: var(--radius-sm);
@@ -172,7 +172,7 @@
   background: transparent;
   border: none;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   transition:
@@ -209,7 +209,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -228,7 +228,7 @@
 }
 
 .folder-breadcrumb-current {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   color: var(--text-primary);
 }

--- a/src/styles/features/dashboard/folders.css
+++ b/src/styles/features/dashboard/folders.css
@@ -76,7 +76,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--overlay-60);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -139,9 +139,9 @@
   cursor: pointer;
   border-radius: var(--radius-sm);
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .folder-card-menu-btn:hover {
@@ -176,9 +176,9 @@
   text-align: left;
   cursor: pointer;
   transition:
-    background-color 0.1s,
-    color 0.1s,
-    border-color 0.1s;
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 .folder-card-menu-item:hover {
@@ -187,7 +187,7 @@
 }
 
 .folder-card-menu-item-danger:hover {
-  background: rgba(239, 68, 68, 0.1);
+  background: rgba(var(--error-light-rgb), 0.1);
   color: var(--error);
 }
 
@@ -212,9 +212,9 @@
   font-size: var(--font-size-md);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .folder-breadcrumb-back:hover {

--- a/src/styles/features/dashboard/main.css
+++ b/src/styles/features/dashboard/main.css
@@ -121,7 +121,7 @@
 }
 
 .slack-cta-content span {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   line-height: 1.4;
 }
@@ -137,7 +137,7 @@
   border: 1px solid rgba(147, 51, 234, 0.3);
   border-radius: var(--radius);
   color: #c4b5fd;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -197,7 +197,7 @@
     background-color var(--transition);
   height: 30px;
   font: inherit;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   color: var(--text-muted);
@@ -220,12 +220,12 @@
 .dashboard-search-placeholder {
   flex: 1;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   line-height: 1;
 }
 
 .dashboard-search-shortcut {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   padding: 2px 5px;
   background: var(--bg-tertiary);
@@ -243,7 +243,7 @@
 /* Compact button styles for dashboard header - matches editor UI */
 .dashboard-header-actions button {
   padding: 6px 12px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 .dashboard-header-actions .btn-secondary {

--- a/src/styles/features/dashboard/main.css
+++ b/src/styles/features/dashboard/main.css
@@ -1,5 +1,11 @@
 /* ============ Dashboard Styles ============ */
 
+/* Dashboard-local colors — intentional one-offs (Slack CTA purples), not part of the global scale. */
+:root {
+  --dash-slack-grad-start: rgba(97, 31, 105, 0.15);
+  --dash-slack-grad-end: rgba(78, 29, 129, 0.1);
+}
+
 /* Dashboard with changelog sidebar layout */
 .dashboard-with-changelog {
   display: flex;
@@ -102,8 +108,12 @@
   gap: 16px;
   padding: 12px 16px;
   margin-bottom: 20px;
-  background: linear-gradient(135deg, rgba(97, 31, 105, 0.15) 0%, rgba(78, 29, 129, 0.1) 100%);
-  border: 1px solid rgba(147, 51, 234, 0.2);
+  background: linear-gradient(
+    135deg,
+    var(--dash-slack-grad-start) 0%,
+    var(--dash-slack-grad-end) 100%
+  );
+  border: 1px solid rgba(var(--purple-deep-rgb), 0.2);
   border-radius: 10px;
 }
 
@@ -117,7 +127,7 @@
 
 .slack-cta-content svg {
   flex-shrink: 0;
-  color: #e9a7fb;
+  color: var(--slack-pink);
 }
 
 .slack-cta-content span {
@@ -133,25 +143,25 @@
 
 .slack-cta-join {
   padding: 4px 10px;
-  background: rgba(147, 51, 234, 0.2);
-  border: 1px solid rgba(147, 51, 234, 0.3);
+  background: rgba(var(--purple-deep-rgb), 0.2);
+  border: 1px solid rgba(var(--purple-deep-rgb), 0.3);
   border-radius: var(--radius);
-  color: #c4b5fd;
+  color: var(--slack-lavender);
   font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   white-space: nowrap;
   flex-shrink: 0;
 }
 
 .slack-cta-join:hover {
-  background: rgba(147, 51, 234, 0.3);
-  border-color: rgba(147, 51, 234, 0.5);
-  color: #ddd6fe;
+  background: rgba(var(--purple-deep-rgb), 0.3);
+  border-color: rgba(var(--purple-deep-rgb), 0.5);
+  color: var(--slack-lavender-bright);
 }
 
 .slack-cta-hide {
@@ -163,8 +173,8 @@
   flex-shrink: 0;
   border-radius: var(--radius-sm);
   transition:
-    color 0.15s,
-    background-color 0.15s;
+    color var(--transition),
+    background-color var(--transition);
 }
 
 .slack-cta-hide:hover {

--- a/src/styles/features/dashboard/move-folder.css
+++ b/src/styles/features/dashboard/move-folder.css
@@ -7,7 +7,7 @@
 .move-folder-modal .modal-subtitle {
   margin-bottom: 16px;
   color: var(--text-secondary);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
 }
 
 .move-folder-loading {
@@ -36,7 +36,7 @@
   border: 1px solid transparent;
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   transition:
@@ -69,7 +69,7 @@
 }
 
 .move-folder-item-count {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
 }
 
@@ -85,7 +85,7 @@
   text-align: center;
   padding: 24px;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .move-folder-item.move-folder-new-btn {
@@ -120,7 +120,7 @@
   border: none;
   outline: none;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-family: inherit;
   padding: 4px 0;
 }
@@ -135,7 +135,7 @@
   color: var(--bg-primary);
   border: none;
   border-radius: var(--radius-sm);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 600;
   cursor: pointer;
   white-space: nowrap;
@@ -159,7 +159,7 @@
 .form-group label {
   display: block;
   margin-bottom: 6px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   color: var(--text-secondary);
 }
@@ -171,7 +171,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   transition: border-color var(--transition);
 }
 
@@ -188,5 +188,5 @@
   margin-top: 8px;
   margin-bottom: 0;
   color: var(--error);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }

--- a/src/styles/features/dashboard/move-folder.css
+++ b/src/styles/features/dashboard/move-folder.css
@@ -40,9 +40,9 @@
   text-align: left;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .move-folder-item:hover:not(:disabled) {
@@ -52,7 +52,7 @@
 }
 
 .move-folder-item.active {
-  background: rgba(78, 205, 196, 0.1);
+  background: rgba(var(--success-rgb), 0.1);
   border-color: var(--success);
   color: var(--text-primary);
 }

--- a/src/styles/features/dashboard/projects.css
+++ b/src/styles/features/dashboard/projects.css
@@ -56,9 +56,9 @@
   font-size: var(--font-size-base);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .sort-dropdown-btn:hover {
@@ -95,9 +95,9 @@
   text-align: left;
   cursor: pointer;
   transition:
-    background-color 0.1s,
-    color 0.1s,
-    border-color 0.1s;
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 .sort-dropdown-item:hover {
@@ -271,15 +271,15 @@
   font-size: var(--font-size-base);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .integration-bar-item-connect:hover {
   background: var(--accent);
   border-color: var(--accent);
-  color: white;
+  color: var(--text-bright);
 }
 
 /* ============ Project Card Menu ============ */
@@ -315,9 +315,9 @@
   text-align: left;
   cursor: pointer;
   transition:
-    background-color 0.1s,
-    color 0.1s,
-    border-color 0.1s;
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 .project-card-menu-item:hover {
@@ -326,7 +326,7 @@
 }
 
 .project-card-menu-item-danger:hover {
-  background: rgba(239, 68, 68, 0.1);
+  background: rgba(var(--error-light-rgb), 0.1);
   color: var(--error);
 }
 

--- a/src/styles/features/dashboard/projects.css
+++ b/src/styles/features/dashboard/projects.css
@@ -7,7 +7,7 @@
 }
 
 .dashboard-section-title {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   color: var(--text-secondary);
 }
@@ -28,7 +28,7 @@
   background: transparent;
   border: 1px solid var(--border);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 .dashboard-section-controls .btn-icon:hover {
@@ -53,7 +53,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -91,7 +91,7 @@
   border: none;
   border-radius: 0;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   transition:
@@ -119,7 +119,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   margin-top: 2px;
   min-width: 0;
@@ -154,7 +154,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   margin-top: 4px;
   min-width: 0;
@@ -268,7 +268,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -311,7 +311,7 @@
   background: transparent;
   border: none;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   transition:
@@ -385,7 +385,7 @@
   .dashboard-header-actions .btn-primary,
   .dashboard-header-actions .btn-secondary {
     padding: 6px 10px;
-    font-size: 11px;
+    font-size: var(--font-size-sm);
   }
 
   /* Section header adjustments */
@@ -395,7 +395,7 @@
   }
 
   .dashboard-section-title {
-    font-size: 13px;
+    font-size: var(--font-size-md);
   }
 
   /* Integration card — tighter spacing on narrow screens */

--- a/src/styles/features/device-mirror.css
+++ b/src/styles/features/device-mirror.css
@@ -1,5 +1,10 @@
 /* Native mobile preview (iOS Simulator mirror). See components/DeviceMirror.tsx. */
 
+/* Device-mirror-local colors — intentional one-offs, not in the global scale. */
+:root {
+  --dm-failed-red: #e5484d; /* build-failed state (was a dead var(--danger) fallback) */
+}
+
 .device-mirror {
   flex: 1;
   display: flex;
@@ -55,7 +60,7 @@
 
 .device-mirror-platform-btn.active {
   background: var(--accent);
-  color: var(--action-text); /* --accent is #fff in this theme → needs dark text */
+  color: var(--action-text); /* --accent is white in this theme → needs dark text */
 }
 
 .device-mirror-stage {
@@ -79,7 +84,7 @@
   object-fit: contain;
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-md);
-  background: #000;
+  background: #000; /* css-ok: true-black letterbox behind device frame */
   cursor: pointer;
   touch-action: none;
   user-select: none;
@@ -137,11 +142,11 @@
 }
 
 .device-mirror-build-toggle[data-state='failed'] {
-  color: var(--danger, #e5484d);
+  color: var(--dm-failed-red);
 }
 
 .device-mirror-build-toggle[data-state='launched'] {
-  color: var(--success, #46a758);
+  color: var(--success);
 }
 
 .device-mirror-build-title {
@@ -201,7 +206,7 @@
   margin: 0;
   padding: var(--spacing-xs) var(--spacing-md);
   font-size: var(--font-size-sm);
-  color: var(--warning, #f59e0b);
+  color: var(--warning);
 }
 
 .device-mirror-build-hint code {

--- a/src/styles/features/device-mirror.css
+++ b/src/styles/features/device-mirror.css
@@ -18,7 +18,7 @@
 }
 
 .device-mirror-label {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   margin-right: auto;
 }
@@ -37,7 +37,7 @@
   border: none;
   background: none;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   padding: 2px var(--spacing-sm);
   /* Concentric with the container (radius − the 2px padding) so the active pill's
@@ -125,7 +125,7 @@
   border: none;
   border-radius: 0;
   background: transparent;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   cursor: pointer;
   text-align: left;
@@ -158,7 +158,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   cursor: pointer;
   white-space: nowrap;
   transition:
@@ -200,7 +200,7 @@
 .device-mirror-build-hint {
   margin: 0;
   padding: var(--spacing-xs) var(--spacing-md);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--warning, #f59e0b);
 }
 

--- a/src/styles/features/diff-modal.css
+++ b/src/styles/features/diff-modal.css
@@ -245,7 +245,7 @@
   animation: spin 1s linear infinite;
 }
 
-@keyframes /* Error state */
+/* Error state */
 .diff-error {
   display: flex;
   flex-direction: column;

--- a/src/styles/features/diff-modal.css
+++ b/src/styles/features/diff-modal.css
@@ -3,7 +3,7 @@
 .diff-modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: var(--overlay-70);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -63,23 +63,23 @@
 }
 
 .diff-status-modified {
-  background: rgba(234, 179, 8, 0.2);
-  color: #eab308;
+  background: rgba(var(--modified-yellow-rgb), 0.2);
+  color: var(--modified-yellow);
 }
 
 .diff-status-added {
-  background: rgba(34, 197, 94, 0.2);
+  background: rgba(var(--success-light-rgb), 0.2);
   color: var(--success-light);
 }
 
 .diff-status-deleted {
-  background: rgba(239, 68, 68, 0.2);
+  background: rgba(var(--error-light-rgb), 0.2);
   color: var(--error-light);
 }
 
 .diff-status-renamed {
-  background: rgba(168, 85, 247, 0.2);
-  color: #a855f7;
+  background: rgba(var(--purple-rgb), 0.2);
+  color: var(--purple);
 }
 
 .diff-close-btn {
@@ -90,9 +90,9 @@
   color: var(--text-muted);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   flex-shrink: 0;
 }
 
@@ -186,7 +186,7 @@
 }
 
 .diff-line-add {
-  background: rgba(34, 197, 94, 0.15);
+  background: rgba(var(--success-light-rgb), 0.15);
 }
 
 .diff-line-add .diff-line-prefix,
@@ -195,7 +195,7 @@
 }
 
 .diff-line-delete {
-  background: rgba(239, 68, 68, 0.15);
+  background: rgba(var(--error-light-rgb), 0.15);
 }
 
 .diff-line-delete .diff-line-prefix,
@@ -204,8 +204,8 @@
 }
 
 .diff-line-hunk {
-  background: rgba(59, 130, 246, 0.1);
-  color: #3b82f6;
+  background: rgba(var(--info-rgb), 0.1);
+  color: var(--info);
   font-weight: 500;
   padding-top: 8px;
   padding-bottom: 8px;
@@ -242,16 +242,10 @@
   border: 3px solid var(--border);
   border-top-color: var(--text-muted);
   border-radius: var(--radius-full);
-  animation: diff-spin 1s linear infinite;
+  animation: spin 1s linear infinite;
 }
 
-@keyframes diff-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-/* Error state */
+@keyframes /* Error state */
 .diff-error {
   display: flex;
   flex-direction: column;
@@ -270,9 +264,9 @@
   cursor: pointer;
   font-size: var(--font-size-md);
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .diff-error button:hover {

--- a/src/styles/features/diff-modal.css
+++ b/src/styles/features/diff-modal.css
@@ -55,7 +55,7 @@
 }
 
 .diff-status {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   padding: 2px 8px;
   border-radius: var(--radius-sm);
   font-weight: 500;
@@ -104,7 +104,7 @@
 /* File path */
 .diff-path {
   padding: 8px 20px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-family: 'SF Mono', 'Monaco', 'Menlo', monospace;
   color: var(--text-muted);
   background: var(--bg-tertiary);
@@ -122,7 +122,7 @@
   padding: 10px 20px;
   background: var(--bg-tertiary);
   border-bottom: 1px solid var(--border);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   font-family: 'SF Mono', 'Monaco', 'Menlo', monospace;
   flex-shrink: 0;
@@ -148,7 +148,7 @@
   margin: 0;
   padding: 0;
   font-family: 'SF Mono', 'Monaco', 'Menlo', monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   line-height: 1.5;
 }
 
@@ -222,7 +222,7 @@
   padding: 48px 24px;
   text-align: center;
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
 }
 
 /* Loading state */
@@ -268,7 +268,7 @@
   border-radius: var(--radius);
   color: var(--text-primary);
   cursor: pointer;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   transition:
     background-color 0.15s,
     color 0.15s,

--- a/src/styles/features/element-tree.css
+++ b/src/styles/features/element-tree.css
@@ -9,7 +9,7 @@
   min-width: 0;
   background: var(--bg-secondary);
   border-right: 1px solid var(--border);
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 .ss-tree-panel__header {
@@ -26,7 +26,7 @@
 .ss-tree-panel__title {
   font-weight: 600;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .ss-tree-panel__body {

--- a/src/styles/features/env-editor.css
+++ b/src/styles/features/env-editor.css
@@ -15,7 +15,7 @@
 }
 
 .env-editor-header h3 {
-  font-size: 18px;
+  font-size: var(--font-size-2xl);
   font-weight: 600;
   margin: 0;
 }
@@ -59,7 +59,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-family: monospace;
   cursor: pointer;
   transition:
@@ -82,7 +82,7 @@
 .env-file-tab.env-add-file {
   padding: 6px 10px;
   font-family: inherit;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
 }
 
@@ -98,7 +98,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-family: monospace;
   width: 140px;
 }
@@ -155,7 +155,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-family: monospace;
 }
 
@@ -176,7 +176,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-family: monospace;
 }
 
@@ -245,7 +245,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -264,7 +264,7 @@
   border: none;
   border-radius: var(--radius);
   color: #1e1e1e;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   cursor: pointer;
   transition:
@@ -289,7 +289,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -307,7 +307,7 @@
   padding: 40px 20px;
   text-align: center;
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
 }
 
 .env-empty-state {
@@ -336,14 +336,14 @@
 }
 
 .env-empty-state h4 {
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   color: var(--text-primary);
   margin: 0 0 8px 0;
 }
 
 .env-empty-state p {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-muted);
   margin: 0 0 20px 0;
   max-width: 260px;
@@ -355,7 +355,7 @@
   border: none;
   border-radius: var(--radius);
   color: #1e1e1e;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   cursor: pointer;
   transition:
@@ -376,7 +376,7 @@
 
 .env-error {
   color: var(--error);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   padding: 8px 12px;
   background: rgba(244, 71, 71, 0.1);
   border-radius: var(--radius);
@@ -407,7 +407,7 @@
   align-items: center;
   gap: 8px;
   color: var(--warning-light);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .env-sync-info svg {
@@ -420,7 +420,7 @@
   border: 1px solid rgba(251, 191, 36, 0.4);
   border-radius: var(--radius);
   color: var(--warning-light);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   white-space: nowrap;
@@ -445,7 +445,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -493,14 +493,14 @@
 }
 
 .env-paste-header h4 {
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   margin: 0;
   color: var(--text-primary);
 }
 
 .env-paste-hint {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-muted);
   margin: 0;
 }
@@ -513,7 +513,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-family: monospace;
   line-height: 1.5;
   resize: vertical;
@@ -542,7 +542,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -561,7 +561,7 @@
   border: none;
   border-radius: var(--radius);
   color: #1e1e1e;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   cursor: pointer;
   transition:

--- a/src/styles/features/env-editor.css
+++ b/src/styles/features/env-editor.css
@@ -63,9 +63,9 @@
   font-family: monospace;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .env-file-tab:hover {
@@ -76,7 +76,7 @@
 .env-file-tab.active {
   background: var(--accent);
   border-color: var(--accent);
-  color: #1e1e1e;
+  color: var(--bg-primary);
 }
 
 .env-file-tab.env-add-file {
@@ -248,9 +248,9 @@
   font-size: var(--font-size-md);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .env-add-btn:hover {
@@ -263,14 +263,14 @@
   background: var(--accent);
   border: none;
   border-radius: var(--radius);
-  color: #1e1e1e;
+  color: var(--bg-primary);
   font-size: var(--font-size-md);
   font-weight: 600;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .env-save-btn:hover:not(:disabled) {
@@ -292,13 +292,13 @@
   font-size: var(--font-size-md);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .env-delete-file-btn:hover {
-  background: rgba(244, 71, 71, 0.1);
+  background: rgba(var(--error-rgb), 0.1);
   border-color: var(--error);
   color: var(--error);
 }
@@ -354,14 +354,14 @@
   background: var(--accent);
   border: none;
   border-radius: var(--radius);
-  color: #1e1e1e;
+  color: var(--bg-primary);
   font-size: var(--font-size-md);
   font-weight: 600;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .env-create-btn:hover {
@@ -378,7 +378,7 @@
   color: var(--error);
   font-size: var(--font-size-md);
   padding: 8px 12px;
-  background: rgba(244, 71, 71, 0.1);
+  background: rgba(var(--error-rgb), 0.1);
   border-radius: var(--radius);
 }
 
@@ -390,8 +390,8 @@
   flex-direction: column;
   gap: 8px;
   padding: 12px;
-  background: rgba(251, 191, 36, 0.1);
-  border: 1px solid rgba(251, 191, 36, 0.3);
+  background: rgba(var(--warning-light-rgb), 0.1);
+  border: 1px solid rgba(var(--warning-light-rgb), 0.3);
   border-radius: var(--radius-md);
 }
 
@@ -416,8 +416,8 @@
 
 .env-sync-btn {
   padding: 6px 12px;
-  background: rgba(251, 191, 36, 0.2);
-  border: 1px solid rgba(251, 191, 36, 0.4);
+  background: rgba(var(--warning-light-rgb), 0.2);
+  border: 1px solid rgba(var(--warning-light-rgb), 0.4);
   border-radius: var(--radius);
   color: var(--warning-light);
   font-size: var(--font-size-base);
@@ -425,13 +425,13 @@
   cursor: pointer;
   white-space: nowrap;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .env-sync-btn:hover {
-  background: rgba(251, 191, 36, 0.3);
+  background: rgba(var(--warning-light-rgb), 0.3);
   border-color: var(--warning-light);
 }
 
@@ -448,9 +448,9 @@
   font-size: var(--font-size-md);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .env-paste-btn:hover {
@@ -466,7 +466,7 @@
 .env-paste-overlay {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--overlay-60);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -545,9 +545,9 @@
   font-size: var(--font-size-md);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .env-paste-cancel:hover {
@@ -560,14 +560,14 @@
   background: var(--accent);
   border: none;
   border-radius: var(--radius);
-  color: #1e1e1e;
+  color: var(--bg-primary);
   font-size: var(--font-size-md);
   font-weight: 600;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .env-paste-confirm:hover:not(:disabled) {

--- a/src/styles/features/github.css
+++ b/src/styles/features/github.css
@@ -1,3 +1,8 @@
+/* GitHub-local colors — intentional one-offs, not part of the global scale. */
+:root {
+  --github-publish-hover-teal: #5ed9d0;
+}
+
 /* GitHub Integration - Project List */
 .project-list-actions {
   display: flex;
@@ -68,9 +73,9 @@
   border-radius: var(--radius);
   border: 1px solid var(--border);
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .github-button.github-install,
@@ -96,13 +101,13 @@
 
 .github-button.github-publish {
   background: var(--success);
-  color: #1e1e1e;
+  color: var(--bg-primary);
   font-weight: 600;
   margin-left: auto;
 }
 
 .github-button.github-publish:hover:not(:disabled) {
-  background: #5ed9d0;
+  background: var(--github-publish-hover-teal);
 }
 
 .github-button.github-publish:disabled,
@@ -281,9 +286,9 @@
   position: relative;
   flex-shrink: 0;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .visibility-option input[type='radio']:checked {
@@ -298,7 +303,7 @@
   top: 50%;
   width: 6px;
   height: 6px;
-  background: #1e1e1e;
+  background: var(--bg-primary);
   border-radius: var(--radius-full);
   transform: translate(-50%, -50%);
 }
@@ -324,7 +329,7 @@
 .github-form .github-error {
   margin: 0;
   padding: 12px 20px;
-  background: rgba(244, 71, 71, 0.1);
+  background: rgba(var(--error-rgb), 0.1);
   font-size: var(--font-size-md);
 }
 

--- a/src/styles/features/github.css
+++ b/src/styles/features/github.css
@@ -15,7 +15,7 @@
   align-items: center;
   gap: 8px;
   padding: 8px 12px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   border-radius: var(--radius);
 }
 
@@ -38,7 +38,7 @@
   align-items: center;
   gap: 8px;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .github-status-connected svg {
@@ -64,7 +64,7 @@
   gap: 6px;
   padding: 0 8px;
   height: 28px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   border-radius: var(--radius);
   border: 1px solid var(--border);
   transition:
@@ -139,7 +139,7 @@
 
 .github-error {
   color: var(--error);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   margin-left: 8px;
 }
 
@@ -154,14 +154,14 @@
 
 .github-modal h3 {
   padding: 20px 20px 0;
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   margin: 0;
 }
 
 .github-modal > p {
   padding: 6px 20px 0;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-muted);
   margin: 0;
 }
@@ -176,7 +176,7 @@
 .github-form > label:first-child,
 .github-form > label:nth-child(2) {
   padding: 0 20px 16px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   color: var(--text-secondary);
   display: flex;
@@ -191,7 +191,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-family: monospace;
   outline: none;
   cursor: pointer;
@@ -230,7 +230,7 @@
   padding: 12px 0 12px 14px;
   color: var(--text-muted);
   font-family: monospace;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   white-space: nowrap;
 }
 
@@ -241,7 +241,7 @@
   border: none;
   color: var(--text-primary);
   font-family: monospace;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   outline: none;
 }
@@ -312,20 +312,20 @@
 
 .visibility-option strong {
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
 }
 
 .visibility-option span {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 .github-form .github-error {
   margin: 0;
   padding: 12px 20px;
   background: rgba(244, 71, 71, 0.1);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 /* GitHub Modal Actions */

--- a/src/styles/features/health-tab.css
+++ b/src/styles/features/health-tab.css
@@ -7,7 +7,7 @@
   min-height: 0;
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 .health-tab--empty {
@@ -26,7 +26,7 @@
 }
 
 .health-tab-empty-title {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--text-primary);
 }
@@ -62,7 +62,7 @@
   gap: 4px;
   padding: 2px 8px;
   border-radius: 999px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   background: var(--bg-tertiary);
 }
 
@@ -226,7 +226,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-sm);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 400;
   line-height: 1.4;
   white-space: normal;
@@ -245,7 +245,7 @@
 
 .health-tab-row-status {
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
 }
 
 .health-tab-row--pass .health-tab-row-status {
@@ -263,7 +263,7 @@
 .health-tab-row-meta,
 .health-tab-row-time {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -349,7 +349,7 @@
 .health-tab-output-meta {
   color: var(--text-muted);
   font-weight: 400;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-variant-numeric: tabular-nums;
 }
 
@@ -365,7 +365,7 @@
   padding: var(--spacing-md);
   overflow: auto;
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   color: var(--text-primary);
   background: var(--bg-primary);
@@ -398,7 +398,7 @@
 }
 
 .health-tab-suggestions-title {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--text-secondary);
   text-transform: uppercase;
@@ -418,7 +418,7 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
 }
 
 .health-tab-suggestion-code {
@@ -439,7 +439,7 @@
   margin: 0;
   padding: var(--spacing-md);
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   color: var(--text-primary);
   background: var(--bg-primary);

--- a/src/styles/features/health.css
+++ b/src/styles/features/health.css
@@ -16,7 +16,7 @@
     background-color 0.15s,
     color 0.15s,
     border-color 0.15s;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   flex-shrink: 0;
   white-space: nowrap;
@@ -77,7 +77,7 @@
   border: 1px solid transparent;
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -155,7 +155,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -188,7 +188,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   font-family: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
   cursor: pointer;
@@ -292,7 +292,7 @@
 }
 
 .health-count {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
@@ -315,7 +315,7 @@
   border: 1px solid rgba(59, 142, 234, 0.4);
   border-radius: var(--radius);
   color: #3b8eea;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   font-family: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
   flex-shrink: 0;
@@ -364,7 +364,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   white-space: nowrap;
   z-index: var(--z-dropdown);
@@ -466,7 +466,7 @@
   background: #1a1a1a;
   border-radius: var(--radius-md);
   font-family: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   line-height: 1.5;
   color: var(--text-secondary);
   white-space: pre-wrap;
@@ -488,7 +488,7 @@
   display: flex;
   align-items: center;
   gap: 16px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
 }
 
@@ -504,7 +504,7 @@
   gap: 6px;
   padding: 8px 14px;
   border-radius: var(--radius);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -561,7 +561,7 @@
   border: 1px solid rgba(255, 193, 7, 0.3);
   border-radius: var(--radius);
   color: #ffc107;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -581,7 +581,7 @@
 
 .health-suggestions-intro {
   margin: 0 0 16px 0;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   line-height: 1.5;
 }
@@ -607,13 +607,13 @@
 }
 
 .health-suggestion-category {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--text-primary);
 }
 
 .health-suggestion-reason {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   background: rgba(255, 255, 255, 0.05);
   padding: 2px 8px;
@@ -631,7 +631,7 @@
 
 .health-suggestion-script code {
   font-family: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: #0dbc79;
 }
 

--- a/src/styles/features/health.css
+++ b/src/styles/features/health.css
@@ -1,5 +1,12 @@
 /* Code Health Panel Styles */
 
+/* Health-local colors — intentional one-offs, not part of the global scale. */
+:root {
+  --health-amber: #ffc107;
+  --health-amber-rgb: 255, 193, 7;
+  --health-dot-idle: #666;
+}
+
 /* Health toggle button - appears inline in the terminal toolbar */
 .health-toggle {
   display: flex;
@@ -13,9 +20,9 @@
   color: var(--text-secondary);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   font-size: var(--font-size-base);
   font-weight: 500;
   flex-shrink: 0;
@@ -23,7 +30,7 @@
 }
 
 .health-toggle:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--tint-subtle);
   color: var(--text-primary);
   border-color: var(--border);
 }
@@ -44,7 +51,7 @@
   display: flex;
   align-items: center;
   padding: 9px 12px;
-  background: #252525;
+  background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
   gap: 8px;
   min-height: 48px;
@@ -73,22 +80,22 @@
   gap: 6px;
   height: 28px;
   padding: 0 10px;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--tint-subtle);
   border: 1px solid transparent;
   border-radius: var(--radius);
   color: var(--text-secondary);
   font-size: var(--font-size-base);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   white-space: nowrap;
   flex-shrink: 0;
 }
 
 .health-button:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--tint);
   color: var(--text-primary);
 }
 
@@ -97,26 +104,26 @@
 }
 
 .health-button.pass {
-  border-color: rgba(13, 188, 121, 0.3);
-  color: #0dbc79;
+  border-color: rgba(var(--ansi-green-rgb), 0.3);
+  color: var(--ansi-green);
 }
 
 .health-button.pass:hover {
-  background: rgba(13, 188, 121, 0.1);
+  background: rgba(var(--ansi-green-rgb), 0.1);
 }
 
 .health-button.fail {
-  border-color: rgba(241, 76, 76, 0.3);
-  color: #f14c4c;
+  border-color: rgba(var(--ansi-red-rgb), 0.3);
+  color: var(--ansi-red);
 }
 
 .health-button.fail:hover {
-  background: rgba(241, 76, 76, 0.1);
+  background: rgba(var(--ansi-red-rgb), 0.1);
 }
 
 .health-button.running {
-  border-color: rgba(36, 114, 200, 0.3);
-  color: #2472c8;
+  border-color: rgba(var(--ansi-blue-dark-rgb), 0.3);
+  color: var(--ansi-blue-dark);
 }
 
 .health-rerun {
@@ -133,13 +140,13 @@
   color: var(--text-muted);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .health-rerun:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--tint-strong);
   color: var(--text-primary);
 }
 
@@ -151,22 +158,22 @@
   height: 28px;
   padding: 0 12px;
   margin-left: auto;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--tint-subtle);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
   font-size: var(--font-size-base);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   white-space: nowrap;
   flex-shrink: 0;
 }
 
 .health-run-all:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--tint);
   color: var(--text-primary);
   border-color: var(--text-muted);
 }
@@ -184,7 +191,7 @@
   min-width: 28px;
   height: 28px;
   padding: 0 8px;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--tint-subtle);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-muted);
@@ -193,28 +200,28 @@
   font-family: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   flex-shrink: 0;
   white-space: nowrap;
 }
 
 .health-auto-run:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--tint);
   color: var(--text-primary);
   border-color: var(--text-muted);
 }
 
 .health-auto-run.active {
-  background: rgba(59, 142, 234, 0.15);
-  border-color: rgba(59, 142, 234, 0.4);
-  color: #3b8eea;
+  background: rgba(var(--ansi-blue-rgb), 0.15);
+  border-color: rgba(var(--ansi-blue-rgb), 0.4);
+  color: var(--ansi-blue);
 }
 
 .health-auto-run.active:hover {
-  background: rgba(59, 142, 234, 0.2);
-  border-color: rgba(59, 142, 234, 0.6);
+  background: rgba(var(--ansi-blue-rgb), 0.2);
+  border-color: rgba(var(--ansi-blue-rgb), 0.6);
 }
 
 .health-auto-run:disabled {
@@ -229,20 +236,20 @@
   width: 28px;
   height: 28px;
   padding: 0;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--tint-subtle);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-muted);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   flex-shrink: 0;
 }
 
 .health-pkg-json:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--tint);
   color: var(--text-primary);
   border-color: var(--text-muted);
 }
@@ -259,20 +266,20 @@
   width: 28px;
   height: 28px;
   padding: 0;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--tint-subtle);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-muted);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   flex-shrink: 0;
 }
 
 .health-refresh:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--tint);
   color: var(--text-primary);
   border-color: var(--text-muted);
 }
@@ -297,11 +304,11 @@
 }
 
 .health-count.pass {
-  color: #0dbc79;
+  color: var(--ansi-green);
 }
 
 .health-count.fail {
-  color: #f14c4c;
+  color: var(--ansi-red);
 }
 
 .health-countdown {
@@ -311,10 +318,10 @@
   height: 28px;
   padding: 0 8px;
   margin-left: 4px;
-  background: rgba(59, 142, 234, 0.15);
-  border: 1px solid rgba(59, 142, 234, 0.4);
+  background: rgba(var(--ansi-blue-rgb), 0.15);
+  border: 1px solid rgba(var(--ansi-blue-rgb), 0.4);
   border-radius: var(--radius);
-  color: #3b8eea;
+  color: var(--ansi-blue);
   font-size: var(--font-size-sm);
   font-weight: 500;
   font-family: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
@@ -336,20 +343,20 @@
 }
 
 .status-dot.idle {
-  color: #666;
+  color: var(--health-dot-idle);
 }
 
 .status-dot.running {
-  color: #2472c8;
+  color: var(--ansi-blue-dark);
   animation: spin 1s linear infinite;
 }
 
 .status-dot.pass {
-  color: #0dbc79;
+  color: var(--ansi-green);
 }
 
 .status-dot.fail {
-  color: #f14c4c;
+  color: var(--ansi-red);
 }
 
 /* Tooltip */
@@ -393,7 +400,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--overlay-60);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -428,7 +435,7 @@
   gap: 10px;
   font-size: 15px;
   font-weight: 600;
-  color: #f14c4c;
+  color: var(--ansi-red);
 }
 
 .health-modal-close {
@@ -444,13 +451,13 @@
   color: var(--text-muted);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .health-modal-close:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--tint-strong);
   color: var(--text-primary);
 }
 
@@ -463,7 +470,7 @@
 .health-modal-output {
   margin: 0;
   padding: 16px;
-  background: #1a1a1a;
+  background: var(--bg-deep);
   border-radius: var(--radius-md);
   font-family: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
   font-size: var(--font-size-base);
@@ -508,19 +515,19 @@
   font-weight: 500;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .health-modal-btn.secondary {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--tint-subtle);
   border: 1px solid var(--border);
   color: var(--text-secondary);
 }
 
 .health-modal-btn.secondary:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--tint);
   color: var(--text-primary);
 }
 
@@ -557,24 +564,24 @@
   gap: 4px;
   height: 28px;
   padding: 0 10px;
-  background: rgba(255, 193, 7, 0.1);
-  border: 1px solid rgba(255, 193, 7, 0.3);
+  background: rgba(var(--health-amber-rgb), 0.1);
+  border: 1px solid rgba(var(--health-amber-rgb), 0.3);
   border-radius: var(--radius);
-  color: #ffc107;
+  color: var(--health-amber);
   font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   flex-shrink: 0;
   white-space: nowrap;
 }
 
 .health-suggestions-btn:hover {
-  background: rgba(255, 193, 7, 0.15);
-  border-color: rgba(255, 193, 7, 0.5);
+  background: rgba(var(--health-amber-rgb), 0.15);
+  border-color: rgba(var(--health-amber-rgb), 0.5);
 }
 
 /* Suggestions Modal Content */
@@ -594,7 +601,7 @@
 
 .health-suggestion-item {
   padding: 12px;
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(var(--white-rgb), 0.03);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
 }
@@ -615,7 +622,7 @@
 .health-suggestion-reason {
   font-size: var(--font-size-sm);
   color: var(--text-muted);
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--tint-subtle);
   padding: 2px 8px;
   border-radius: var(--radius-sm);
 }
@@ -625,14 +632,14 @@
   align-items: center;
   justify-content: space-between;
   padding: 8px 12px;
-  background: #1a1a1a;
+  background: var(--bg-deep);
   border-radius: var(--radius);
 }
 
 .health-suggestion-script code {
   font-family: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
   font-size: var(--font-size-base);
-  color: #0dbc79;
+  color: var(--ansi-green);
 }
 
 .health-suggestion-copy {
@@ -646,23 +653,16 @@
   color: var(--text-muted);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .health-suggestion-copy:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--tint-strong);
   color: var(--text-primary);
 }
 
 /* Spinner Animation */
 
-@keyframes spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
+@keyframes;

--- a/src/styles/features/health.css
+++ b/src/styles/features/health.css
@@ -664,5 +664,3 @@
 }
 
 /* Spinner Animation */
-
-@keyframes;

--- a/src/styles/features/help-modal.css
+++ b/src/styles/features/help-modal.css
@@ -61,7 +61,7 @@
 }
 
 .help-section-title {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
@@ -99,13 +99,13 @@
 
 .help-command-name {
   font-family: 'SF Mono', Monaco, 'Courier New', monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   color: var(--text-primary);
 }
 
 .help-command-desc {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -120,7 +120,7 @@
 }
 
 .help-tip {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   padding: 10px 12px;
   line-height: 1.4;
@@ -142,7 +142,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   font-family: 'SF Mono', Monaco, monospace;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   margin: 0 2px;
 }
@@ -154,7 +154,7 @@
 }
 
 .help-example-category {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--text-muted);
   padding: 0 4px;
@@ -166,7 +166,7 @@
 }
 
 .help-example {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   background: var(--bg-tertiary);
   padding: 10px 12px;
@@ -198,7 +198,7 @@
 }
 
 .help-footer-hint {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
 }
 
@@ -230,7 +230,7 @@
 
 .help-skill-name {
   font-family: 'SF Mono', Monaco, 'Courier New', monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   color: var(--text-primary);
   display: flex;
@@ -239,7 +239,7 @@
 }
 
 .help-skill-toggle {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 400;
   color: var(--text-muted);
   width: 16px;
@@ -248,7 +248,7 @@
 }
 
 .help-skill-desc {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   line-height: 1.5;
   margin-top: 8px;
@@ -263,7 +263,7 @@
   background: transparent;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 400;
   color: var(--text-muted);
   text-transform: uppercase;
@@ -271,7 +271,7 @@
 }
 
 .help-loading {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-muted);
   font-style: italic;
   padding: 0 10px;

--- a/src/styles/features/ide-dropdown.css
+++ b/src/styles/features/ide-dropdown.css
@@ -30,7 +30,7 @@
   border: none;
   border-radius: 0;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   transition:
@@ -61,6 +61,6 @@
 .ide-dropdown-empty {
   padding: 12px 16px;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: center;
 }

--- a/src/styles/features/import-picker.css
+++ b/src/styles/features/import-picker.css
@@ -83,12 +83,12 @@
 }
 
 .import-picker-title {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   color: var(--text-primary);
 }
 
 .import-picker-subtitle {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
 }

--- a/src/styles/features/import-project.css
+++ b/src/styles/features/import-project.css
@@ -55,7 +55,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   color: white;
   flex-shrink: 0;
@@ -78,13 +78,13 @@
 }
 
 .import-owner-name {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
   color: var(--text-primary);
 }
 
 .import-owner-type {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
 }
 
@@ -100,7 +100,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   transition:
     border-color 0.15s,
     box-shadow 0.15s;
@@ -165,13 +165,13 @@
 }
 
 .import-repo-name {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
   color: var(--text-primary);
 }
 
 .import-repo-badge {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   padding: 2px 6px;
   border-radius: var(--radius-sm);
   font-weight: 500;
@@ -188,7 +188,7 @@
 }
 
 .import-repo-description {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   margin: 0;
   line-height: 1.4;
@@ -208,7 +208,7 @@
   gap: 12px;
   padding: 32px 16px;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .import-repo-loading {
@@ -232,14 +232,14 @@
 }
 
 .workspace-picker-title {
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   color: var(--text-primary);
   margin: 0 0 var(--spacing-xs);
 }
 
 .workspace-picker-subtitle {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   line-height: 1.5;
   color: var(--text-secondary);
   margin: 0;
@@ -316,7 +316,7 @@
 }
 
 .workspace-picker-item-name {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   color: var(--text-primary);
   white-space: nowrap;
@@ -325,7 +325,7 @@
 }
 
 .workspace-picker-item-sub {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   line-height: 1.4;
   white-space: nowrap;
@@ -335,7 +335,7 @@
 
 .workspace-picker-item-sub-mono {
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
 }
 
 .workspace-picker-item-meta {
@@ -346,7 +346,7 @@
 }
 
 .workspace-picker-item-script {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   background: var(--bg-tertiary);
   padding: 2px 6px;
@@ -359,7 +359,7 @@
 }
 
 .workspace-picker-item-port {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   font-family: var(--font-mono, ui-monospace, monospace);
 }

--- a/src/styles/features/import-project.css
+++ b/src/styles/features/import-project.css
@@ -1,5 +1,16 @@
 /* Import Project Modal Styles */
 
+/* Import-local colors — marketing gradient stops and one-offs, not part of the global scale. */
+:root {
+  --imp-avatar-user-start: #667eea;
+  --imp-avatar-user-end: #764ba2;
+  --imp-avatar-org-start: #11998e;
+  --imp-avatar-org-end: #38ef7d;
+  --imp-avatar-collab-start: #f093fb;
+  --imp-avatar-collab-end: #f5576c;
+  --imp-private-badge-violet-rgb: 139, 92, 246;
+}
+
 .import-modal {
   max-width: 560px;
   max-height: 85vh;
@@ -31,9 +42,9 @@
   border-radius: 10px;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   text-align: left;
 }
 
@@ -44,30 +55,42 @@
 
 .import-owner-btn.selected {
   border-color: var(--accent);
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--tint-subtle);
 }
 
 .import-owner-avatar {
   width: 36px;
   height: 36px;
   border-radius: var(--radius-full);
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(
+    135deg,
+    var(--imp-avatar-user-start) 0%,
+    var(--imp-avatar-user-end) 100%
+  );
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: var(--font-size-lg);
   font-weight: 600;
-  color: white;
+  color: var(--text-bright);
   flex-shrink: 0;
 }
 
 .import-owner-avatar.org {
   border-radius: var(--radius-md);
-  background: linear-gradient(135deg, #11998e 0%, #38ef7d 100%);
+  background: linear-gradient(
+    135deg,
+    var(--imp-avatar-org-start) 0%,
+    var(--imp-avatar-org-end) 100%
+  );
 }
 
 .import-owner-avatar.collab {
-  background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+  background: linear-gradient(
+    135deg,
+    var(--imp-avatar-collab-start) 0%,
+    var(--imp-avatar-collab-end) 100%
+  );
 }
 
 .import-owner-info {
@@ -102,14 +125,14 @@
   color: var(--text-primary);
   font-size: var(--font-size-lg);
   transition:
-    border-color 0.15s,
-    box-shadow 0.15s;
+    border-color var(--transition),
+    box-shadow var(--transition);
 }
 
 .import-search input:focus {
   outline: none;
   border-color: var(--text-muted);
-  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.05);
+  box-shadow: 0 0 0 3px var(--tint-subtle);
 }
 
 .import-search input::placeholder {
@@ -141,9 +164,9 @@
   border-radius: var(--radius-md);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   text-align: left;
 }
 
@@ -154,7 +177,7 @@
 
 .import-repo-item.selected {
   border-color: var(--accent);
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--tint-subtle);
 }
 
 .import-repo-header {
@@ -178,8 +201,8 @@
 }
 
 .import-repo-badge.private {
-  background: rgba(139, 92, 246, 0.2);
-  color: #a78bfa;
+  background: rgba(var(--imp-private-badge-violet-rgb), 0.2);
+  color: var(--purple-light);
 }
 
 .import-repo-badge.lang {

--- a/src/styles/features/languages-modal.css
+++ b/src/styles/features/languages-modal.css
@@ -12,7 +12,7 @@
   padding: var(--spacing-xl);
   justify-content: center;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 /* Standalone load-error (no editor wrapper) */
@@ -36,7 +36,7 @@
 .languages-unsupported p {
   margin: 0;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   line-height: 1.5;
   max-width: 360px;
 }
@@ -51,7 +51,7 @@
 .languages-intro {
   margin: 0;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   line-height: 1.5;
 }
 
@@ -61,7 +61,7 @@
 
 .languages-intro code {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   background: var(--bg-tertiary);
   padding: 1px var(--spacing-xs);
   border-radius: var(--radius-sm);
@@ -75,7 +75,7 @@
   flex-direction: column;
   gap: var(--spacing-xs);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   line-height: 1.5;
 }
 
@@ -90,7 +90,7 @@
 }
 
 .languages-section-label {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -117,13 +117,13 @@
 }
 
 .languages-row-name {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-primary);
 }
 
 .languages-row-code {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   background: var(--bg-tertiary);
   padding: 1px var(--spacing-xs);
@@ -138,7 +138,7 @@
 }
 
 .languages-row-badge {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -153,7 +153,7 @@
   background: none;
   border: none;
   padding: 0;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   cursor: pointer;
   transition: color var(--transition);
@@ -194,7 +194,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: var(--spacing-sm) var(--spacing-md);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   outline: none;
   transition: border-color var(--transition);
 }
@@ -208,7 +208,7 @@
 }
 
 .languages-pills-empty {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   padding: var(--spacing-sm) 0;
 }
@@ -231,7 +231,7 @@
   border: 1px solid transparent;
   border-radius: var(--radius-lg);
   padding: var(--spacing-xs) var(--spacing-md);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   cursor: pointer;
   transition:
@@ -251,7 +251,7 @@
 /* Prompt review box — the exact text handed to the agent */
 .languages-prompt-box {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   color: var(--text-secondary);
   background: var(--bg-primary);
@@ -266,7 +266,7 @@
 }
 
 .languages-note {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--warning);
   line-height: 1.4;
 }
@@ -276,7 +276,7 @@
   flex-direction: column;
   gap: var(--spacing-sm);
   align-items: flex-start;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--error-light);
   line-height: 1.4;
 }
@@ -293,7 +293,7 @@
 }
 
 .languages-footer-note {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   line-height: 1.4;
   max-width: 240px;

--- a/src/styles/features/main-branch-banner.css
+++ b/src/styles/features/main-branch-banner.css
@@ -24,7 +24,7 @@
 }
 
 .main-branch-banner-text {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--warning-light);
   white-space: nowrap;
   overflow: hidden;
@@ -62,7 +62,7 @@
   border: 1px solid rgba(245, 158, 11, 0.3);
   border-radius: var(--radius-sm);
   color: var(--warning-light);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -82,7 +82,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--warning-light);
   cursor: pointer;
   white-space: nowrap;

--- a/src/styles/features/main-branch-banner.css
+++ b/src/styles/features/main-branch-banner.css
@@ -1,3 +1,8 @@
+/* Main-branch-banner-local colors — intentional one-offs, not part of the global scale. */
+:root {
+  --banner-amber-bright: #fcd34d;
+}
+
 /* Main Branch Warning Banner */
 .main-branch-banner {
   display: flex;
@@ -5,7 +10,7 @@
   justify-content: space-between;
   gap: 12px;
   padding: 8px 16px;
-  background: rgba(245, 158, 11, 0.1);
+  background: rgba(var(--warning-rgb), 0.1);
   border-bottom: 1px solid var(--border);
   flex-wrap: wrap;
 }
@@ -50,7 +55,7 @@
 
 .main-branch-banner-text strong {
   font-weight: 600;
-  color: #fcd34d;
+  color: var(--banner-amber-bright);
 }
 
 .main-branch-banner-action {
@@ -58,24 +63,24 @@
   align-items: center;
   gap: 6px;
   padding: 4px 10px;
-  background: rgba(245, 158, 11, 0.2);
-  border: 1px solid rgba(245, 158, 11, 0.3);
+  background: rgba(var(--warning-rgb), 0.2);
+  border: 1px solid rgba(var(--warning-rgb), 0.3);
   border-radius: var(--radius-sm);
   color: var(--warning-light);
   font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   white-space: nowrap;
 }
 
 .main-branch-banner-action:hover {
-  background: rgba(245, 158, 11, 0.3);
-  border-color: rgba(245, 158, 11, 0.5);
-  color: #fcd34d;
+  background: rgba(var(--warning-rgb), 0.3);
+  border-color: rgba(var(--warning-rgb), 0.5);
+  color: var(--banner-amber-bright);
 }
 
 .main-branch-banner-checkbox {
@@ -99,19 +104,19 @@
   -webkit-appearance: none;
   width: 14px;
   height: 14px;
-  border: 1px solid rgba(251, 191, 36, 0.4);
+  border: 1px solid rgba(var(--warning-light-rgb), 0.4);
   border-radius: 3px;
   background: transparent;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .main-branch-banner-checkbox input[type='checkbox']:hover {
-  border-color: rgba(251, 191, 36, 0.6);
-  background: rgba(245, 158, 11, 0.1);
+  border-color: rgba(var(--warning-light-rgb), 0.6);
+  background: rgba(var(--warning-rgb), 0.1);
 }
 
 .main-branch-banner-checkbox input[type='checkbox']:checked {
@@ -126,7 +131,7 @@
   content: '';
   width: 4px;
   height: 8px;
-  border: solid #1a1a1a;
+  border: solid var(--bg-deep);
   border-width: 0 2px 2px 0;
   transform: rotate(45deg) translateY(-1px);
 }
@@ -143,12 +148,12 @@
   cursor: pointer;
   opacity: 0.6;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .main-branch-banner-close:hover {
   opacity: 1;
-  background: rgba(245, 158, 11, 0.2);
+  background: rgba(var(--warning-rgb), 0.2);
 }

--- a/src/styles/features/mcp-modal.css
+++ b/src/styles/features/mcp-modal.css
@@ -56,7 +56,7 @@
   align-items: center;
   height: 28px;
   padding: 0 12px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   color: var(--text-muted);
   background: transparent;
@@ -125,7 +125,7 @@
   background: transparent;
   border: none;
   outline: none;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-primary);
   padding: 0;
   min-width: 0;
@@ -147,7 +147,7 @@
   align-items: center;
   height: 26px;
   padding: 0 10px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--text-muted);
   background: transparent;
@@ -226,7 +226,7 @@
 }
 
 .mcp-server-name {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   color: var(--text-primary);
 }
@@ -239,7 +239,7 @@
 }
 
 .mcp-status-label {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
@@ -250,7 +250,7 @@
   background: transparent;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.3px;
@@ -262,7 +262,7 @@
 }
 
 .mcp-server-command {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   margin-top: 6px;
   line-height: 1.4;
@@ -276,7 +276,7 @@
 
 .mcp-remove-btn {
   padding: 6px 12px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--text-muted);
   background: transparent;
@@ -307,7 +307,7 @@
 }
 
 .mcp-add-description {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   margin: 2px 0 12px;
   line-height: 1.5;
@@ -319,7 +319,7 @@
   border: 1px solid var(--border);
   border-radius: 3px;
   font-family: 'SF Mono', Monaco, monospace;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-primary);
 }
 
@@ -331,7 +331,7 @@
 .mcp-add-input {
   flex: 1;
   padding: 8px 12px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-primary);
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
@@ -352,7 +352,7 @@
 
 .mcp-add-btn {
   padding: 8px 14px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   color: var(--action-text);
   background: var(--action);
@@ -383,7 +383,7 @@
 }
 
 .mcp-scope-toggle-label {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   margin-right: 4px;
 }
@@ -393,7 +393,7 @@
   align-items: center;
   height: 26px;
   padding: 0 10px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--text-muted);
   background: transparent;
@@ -428,7 +428,7 @@
   padding: 32px 16px;
   text-align: center;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .mcp-loading-spinner {
@@ -453,7 +453,7 @@
   border: 1px solid rgba(220, 38, 38, 0.3);
   border-radius: var(--radius);
   color: var(--error);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   margin-bottom: 12px;
 }
 
@@ -463,7 +463,7 @@
   border: 1px solid rgba(78, 205, 196, 0.3);
   border-radius: var(--radius);
   color: var(--success-light);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   margin-bottom: 12px;
 }
 
@@ -478,6 +478,6 @@
 }
 
 .mcp-footer-hint {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
 }

--- a/src/styles/features/mcp-modal.css
+++ b/src/styles/features/mcp-modal.css
@@ -441,7 +441,7 @@
   margin: 0 auto 12px;
 }
 
-@keyframes.mcp-error {
+.mcp-error {
   padding: 12px;
   background: rgba(var(--error-deep-rgb), 0.1);
   border: 1px solid rgba(var(--error-deep-rgb), 0.3);

--- a/src/styles/features/mcp-modal.css
+++ b/src/styles/features/mcp-modal.css
@@ -35,8 +35,8 @@
   justify-content: center;
   border-radius: var(--radius-sm);
   transition:
-    background-color 0.15s,
-    color 0.15s;
+    background-color var(--transition),
+    color var(--transition);
 }
 
 .mcp-close-btn:hover {
@@ -64,9 +64,9 @@
   border-radius: var(--radius);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .mcp-tab:hover {
@@ -155,9 +155,9 @@
   border-radius: var(--radius);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .mcp-filter-btn:hover {
@@ -218,7 +218,7 @@
 }
 
 .mcp-status-dot.needs_auth {
-  background: #eab308;
+  background: var(--modified-yellow);
 }
 
 .mcp-status-dot.error {
@@ -257,8 +257,8 @@
 }
 
 .mcp-scope-badge.project {
-  color: #a78bfa;
-  border-color: rgba(167, 139, 250, 0.4);
+  color: var(--purple-light);
+  border-color: rgba(var(--purple-light-rgb), 0.4);
 }
 
 .mcp-server-command {
@@ -284,9 +284,9 @@
   border-radius: var(--radius);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   flex-shrink: 0;
 }
 
@@ -360,9 +360,9 @@
   border-radius: var(--radius);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .mcp-add-btn:hover {
@@ -401,9 +401,9 @@
   border-radius: var(--radius);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .mcp-scope-btn:hover {
@@ -437,20 +437,14 @@
   border: 2px solid var(--border);
   border-top-color: var(--accent);
   border-radius: var(--radius-full);
-  animation: mcp-spin 0.8s linear infinite;
+  animation: spin 0.8s linear infinite;
   margin: 0 auto 12px;
 }
 
-@keyframes mcp-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.mcp-error {
+@keyframes.mcp-error {
   padding: 12px;
-  background: rgba(220, 38, 38, 0.1);
-  border: 1px solid rgba(220, 38, 38, 0.3);
+  background: rgba(var(--error-deep-rgb), 0.1);
+  border: 1px solid rgba(var(--error-deep-rgb), 0.3);
   border-radius: var(--radius);
   color: var(--error);
   font-size: var(--font-size-md);
@@ -459,8 +453,8 @@
 
 .mcp-success {
   padding: 12px;
-  background: rgba(78, 205, 196, 0.1);
-  border: 1px solid rgba(78, 205, 196, 0.3);
+  background: rgba(var(--success-rgb), 0.1);
+  border: 1px solid rgba(var(--success-rgb), 0.3);
   border-radius: var(--radius);
   color: var(--success-light);
   font-size: var(--font-size-md);

--- a/src/styles/features/notifications.css
+++ b/src/styles/features/notifications.css
@@ -29,14 +29,14 @@
 
 .notification-settings-header h2 {
   margin: 0 0 4px 0;
-  font-size: 18px;
+  font-size: var(--font-size-2xl);
   font-weight: 600;
   color: var(--text-primary);
 }
 
 .notification-settings-header p {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
 }
 
@@ -65,13 +65,13 @@
 }
 
 .notification-setting-title {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
   color: var(--text-primary);
 }
 
 .notification-setting-description {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   margin-top: 2px;
 }
@@ -143,7 +143,7 @@
 
 .notification-sound-option {
   padding: 6px 12px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -167,7 +167,7 @@
 }
 
 .notification-custom-path {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   padding: 4px 8px;
   background: var(--bg-tertiary);
@@ -182,7 +182,7 @@
   align-items: center;
   gap: 6px;
   padding: 6px 12px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   background: none;
   border: 1px solid var(--border);
   border-radius: var(--radius);

--- a/src/styles/features/notifications.css
+++ b/src/styles/features/notifications.css
@@ -2,7 +2,7 @@
 .notification-settings-modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--overlay-60);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -119,13 +119,13 @@
 }
 
 .notification-toggle input:checked + .notification-toggle-slider {
-  background: #3b82f6;
-  border-color: #3b82f6;
+  background: var(--info);
+  border-color: var(--info);
 }
 
 .notification-toggle input:checked + .notification-toggle-slider::before {
   transform: translateX(18px);
-  background: white;
+  background: var(--text-bright);
 }
 
 /* Sound Picker */
@@ -150,9 +150,9 @@
   color: var(--text-secondary);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .notification-sound-option:hover {
@@ -161,9 +161,9 @@
 }
 
 .notification-sound-option.selected {
-  background: rgba(59, 130, 246, 0.15);
-  border-color: rgba(59, 130, 246, 0.4);
-  color: #3b82f6;
+  background: rgba(var(--info-rgb), 0.15);
+  border-color: rgba(var(--info-rgb), 0.4);
+  color: var(--info);
 }
 
 .notification-custom-path {
@@ -189,9 +189,9 @@
   color: var(--text-secondary);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   width: fit-content;
 }
 

--- a/src/styles/features/plugins.css
+++ b/src/styles/features/plugins.css
@@ -56,7 +56,7 @@
   align-items: center;
   height: 28px;
   padding: 0 12px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   color: var(--text-secondary);
   background: transparent;
@@ -111,7 +111,7 @@
   background: transparent;
   border: none;
   outline: none;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-primary);
   padding: 0;
   min-width: 0;
@@ -139,7 +139,7 @@
   gap: 8px;
   padding: 32px 0;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .plugins-loading-spinner {
@@ -161,12 +161,12 @@
   text-align: center;
   padding: 32px 0;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 /* Beta notice */
 .plugins-beta-notice {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   background: rgba(245, 158, 11, 0.08);
   border: 1px solid rgba(245, 158, 11, 0.25);
@@ -259,20 +259,20 @@
 }
 
 .plugin-name {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--text-primary);
 }
 
 .plugin-meta {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   margin-left: 6px;
   vertical-align: middle;
 }
 
 .plugin-desc {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   margin-top: 4px;
   line-height: 1.4;
@@ -287,7 +287,7 @@
 }
 
 .plugin-action-link {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   background: none;
   border: none;
@@ -318,12 +318,12 @@
 }
 
 .plugin-action-status {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
 .plugin-toggle-btn {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   padding: 3px 10px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
@@ -348,7 +348,7 @@
 
 /* Library: Install / Installed badges */
 .plugin-library-install-btn {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   padding: 3px 14px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--success) 40;
@@ -372,14 +372,14 @@
 }
 
 .plugin-installed-badge {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   flex-shrink: 0;
 }
 
 .plugin-category-badge {
   display: inline-block;
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   padding: 2px 7px;
   margin-top: 6px;
   border-radius: var(--radius-sm);
@@ -411,7 +411,7 @@
 }
 
 .plugins-url-toggle {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   background: none;
   border: none;
@@ -426,7 +426,7 @@
 
 /* Install input (shared between URL and old add tab) */
 .plugins-install-hint {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   margin: 0 0 12px;
 }
@@ -440,7 +440,7 @@
   flex: 1;
   height: 32px;
   padding: 0 10px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -461,7 +461,7 @@
 .plugins-install-btn {
   height: 32px;
   padding: 0 16px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   background: var(--success);
   color: #fff;
@@ -485,7 +485,7 @@
 .plugins-error {
   margin-top: 8px;
   padding: 8px 12px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--error-light);
   background: var(--error-light) 10;
   border: 1px solid var(--error-light) 30;
@@ -502,7 +502,7 @@
 }
 
 .plugins-footer-hint {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
 }
 
@@ -525,7 +525,7 @@
 
 /* Dev Plugin Local Path */
 .plugin-local-path {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-family: 'JetBrains Mono', 'SF Mono', monospace;
   color: var(--text-secondary);
   margin-top: 2px;
@@ -540,7 +540,7 @@
   width: 100%;
   margin-top: 12px;
   padding: 10px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   color: var(--warning);
   background: transparent;
@@ -572,7 +572,7 @@
   border-radius: var(--radius-full);
   background: var(--error-light) 20;
   color: var(--error-light);
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 700;
   cursor: help;
 }

--- a/src/styles/features/plugins.css
+++ b/src/styles/features/plugins.css
@@ -35,8 +35,8 @@
   justify-content: center;
   border-radius: var(--radius-sm);
   transition:
-    background-color 0.15s,
-    color 0.15s;
+    background-color var(--transition),
+    color var(--transition);
 }
 
 .plugins-close-btn:hover {
@@ -64,9 +64,9 @@
   border-radius: var(--radius);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .plugins-tab:hover {
@@ -151,13 +151,7 @@
   animation: spin 0.6s linear infinite;
 }
 
-@keyframes plugins-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.plugins-empty {
+@keyframes.plugins-empty {
   text-align: center;
   padding: 32px 0;
   color: var(--text-secondary);
@@ -168,8 +162,8 @@
 .plugins-beta-notice {
   font-size: var(--font-size-base);
   color: var(--text-secondary);
-  background: rgba(245, 158, 11, 0.08);
-  border: 1px solid rgba(245, 158, 11, 0.25);
+  background: rgba(var(--warning-rgb), 0.08);
+  border: 1px solid rgba(var(--warning-rgb), 0.25);
   border-radius: var(--radius);
   padding: 8px 12px;
   margin-bottom: 12px;
@@ -306,11 +300,11 @@
 }
 
 .plugin-action-link.plugin-action-update {
-  color: #3b82f6;
+  color: var(--info);
 }
 
 .plugin-action-link.plugin-action-update:hover {
-  color: #60a5fa;
+  color: var(--info-light);
 }
 
 .plugin-action-link.plugin-action-danger:hover:not(:disabled) {
@@ -332,14 +326,14 @@
   cursor: pointer;
   flex-shrink: 0;
   transition:
-    background-color 0.15s,
-    color 0.15s;
+    background-color var(--transition),
+    color var(--transition);
 }
 
 .plugin-toggle-btn.enabled {
   background: var(--success);
   border-color: var(--success);
-  color: #fff;
+  color: var(--text-bright);
 }
 
 .plugin-toggle-btn:hover {
@@ -358,8 +352,8 @@
   font-weight: 500;
   flex-shrink: 0;
   transition:
-    background-color 0.15s,
-    opacity 0.15s;
+    background-color var(--transition),
+    opacity var(--transition);
 }
 
 .plugin-library-install-btn:hover:not(:disabled) {
@@ -464,7 +458,7 @@
   font-size: var(--font-size-base);
   font-weight: 500;
   background: var(--success);
-  color: #fff;
+  color: var(--text-bright);
   border: none;
   border-radius: var(--radius);
   cursor: pointer;
@@ -548,8 +542,8 @@
   border-radius: var(--radius-md);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    border-color var(--transition);
 }
 
 .plugins-link-dev-btn:hover:not(:disabled) {

--- a/src/styles/features/plugins.css
+++ b/src/styles/features/plugins.css
@@ -151,7 +151,7 @@
   animation: spin 0.6s linear infinite;
 }
 
-@keyframes.plugins-empty {
+.plugins-empty {
   text-align: center;
   padding: 32px 0;
   color: var(--text-secondary);

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -118,9 +118,9 @@
   font-size: var(--font-size-md);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .page-switcher-btn:hover {
@@ -196,9 +196,9 @@
   text-align: left;
   cursor: pointer;
   transition:
-    background-color 0.1s,
-    color 0.1s,
-    border-color 0.1s;
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 .page-item:hover {
@@ -207,7 +207,7 @@
 }
 
 .page-item.active {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--tint);
   color: var(--text-primary);
 }
 
@@ -379,9 +379,9 @@
   white-space: nowrap;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .preview-dimensions:hover:not(:disabled) {
@@ -429,7 +429,7 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: color 0.15s;
+  transition: color var(--transition);
   outline: none;
 }
 
@@ -526,16 +526,10 @@
   border: 3px solid var(--border);
   border-top-color: var(--accent);
   border-radius: var(--radius-full);
-  animation: preview-spin 0.8s linear infinite;
+  animation: spin 0.8s linear infinite;
 }
 
-@keyframes preview-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-/* Preview Viewport */
+@keyframes /* Preview Viewport */
 .preview-viewport {
   flex: 1;
   display: flex;
@@ -596,7 +590,7 @@
   width: 100%;
   height: 100%;
   border: none;
-  background: #1e1e1e;
+  background: var(--bg-primary);
 }
 
 /* Preview resize overlay (captures mouse during drag) */
@@ -625,8 +619,8 @@
   align-items: center;
   justify-content: center;
   transition:
-    background 0.15s,
-    border-color 0.15s;
+    background var(--transition),
+    border-color var(--transition);
 }
 
 .preview-resize-handle:hover {
@@ -720,7 +714,7 @@
 
 .preview-logs-toggle-switch.is-on::after {
   transform: translateX(10px);
-  background: #ffffff;
+  background: var(--text-bright);
 }
 
 /* Collapsible dev server logs panel (bottom of preview) */
@@ -729,7 +723,7 @@
   flex-direction: column;
   min-height: 0;
   overflow: hidden;
-  background: #1a1a1a;
+  background: #1a1a1a; /* css-ok: must match xterm theme bg */
   border-top: 1px solid var(--border);
   /* Isolate the panel's internal layout from ancestors: any Network
      row / DOM tree / console line change inside the panel won't
@@ -861,7 +855,7 @@
 }
 
 /* DevServerLogs layout: optional toolbar above the xterm container.
-   The terminal area keeps its hard-coded #1a1a1a to match xterm's
+   The terminal area keeps its hard-coded 1a1a1a to match xterm's
    theme background exactly — tokenizing this pulls in a theme-aware
    value that won't match the renderer. */
 .dev-server-logs {
@@ -870,7 +864,7 @@
   width: 100%;
   height: 100%;
   min-height: 0;
-  background: #1a1a1a;
+  background: #1a1a1a; /* css-ok: must match xterm theme bg */
 }
 
 .dev-server-logs-toolbar {
@@ -918,7 +912,7 @@
 .dev-server-logs-terminal {
   flex: 1;
   min-height: 0;
-  background: #1a1a1a;
+  background: #1a1a1a; /* css-ok: must match xterm theme bg */
 }
 
 /* Crop selection overlay */
@@ -934,9 +928,9 @@
 
 .crop-selection {
   position: absolute;
-  border: 1px solid rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(var(--white-rgb), 0.8);
   background: transparent;
-  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 0 0 9999px var(--overlay-50);
   pointer-events: none;
 }
 
@@ -945,8 +939,8 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background: rgba(0, 0, 0, 0.8);
-  color: #fff;
+  background: var(--overlay-80);
+  color: var(--text-bright);
   padding: 16px 24px;
   border-radius: var(--radius-md);
   font-size: var(--font-size-lg);
@@ -959,7 +953,7 @@
 
 .crop-hint {
   font-size: var(--font-size-base);
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(var(--white-rgb), 0.6);
 }
 
 /* Preview loading and error states */

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -115,7 +115,7 @@
   border-radius: var(--radius);
   color: var(--text-primary);
   font-family: monospace;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -160,7 +160,7 @@
   border: none;
   border-bottom: 1px solid var(--border);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   outline: none;
 }
 
@@ -177,7 +177,7 @@
   padding: 16px;
   text-align: center;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .page-item {
@@ -192,7 +192,7 @@
   border-radius: 0;
   color: var(--text-secondary);
   font-family: monospace;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   transition:
@@ -224,14 +224,14 @@
 
 .page-item-hint {
   font-family: inherit;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   font-style: italic;
 }
 
 .preview-url {
   font-family: monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
 }
 
@@ -372,7 +372,7 @@
   border-radius: var(--radius-sm);
   background: transparent;
   font: inherit;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-variant-numeric: tabular-nums;
   color: var(--text-muted);
   user-select: none;
@@ -475,7 +475,7 @@
   background: transparent;
   border-radius: var(--radius-sm);
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -493,7 +493,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   text-align: center;
 }
 
@@ -517,7 +517,7 @@
   gap: 16px;
   z-index: var(--z-dropdown);
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
 }
 
 .preview-branch-switching-spinner {
@@ -670,7 +670,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   transition:
     background var(--transition),
@@ -760,7 +760,7 @@
   border-radius: 0;
   color: var(--text-muted);
   font-family: inherit;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   cursor: pointer;
   transition: color var(--transition);
@@ -886,7 +886,7 @@
 
 .dev-server-logs-hint {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -898,7 +898,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   cursor: pointer;
   transition:
     color var(--transition),
@@ -949,7 +949,7 @@
   color: #fff;
   padding: 16px 24px;
   border-radius: var(--radius-md);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   text-align: center;
   pointer-events: none;
   display: flex;
@@ -958,7 +958,7 @@
 }
 
 .crop-hint {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: rgba(255, 255, 255, 0.6);
 }
 
@@ -977,7 +977,7 @@
 .preview-loading .hint,
 .preview-error .hint {
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
 }
 
 .preview-install-prompt {
@@ -993,14 +993,14 @@
 }
 
 .preview-install-prompt h3 {
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   color: var(--text-primary);
   margin: var(--spacing-xs) 0 0;
 }
 
 .preview-install-prompt .hint {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-muted);
   margin: 0 0 var(--spacing-md);
 }
@@ -1010,7 +1010,7 @@
   background: var(--bg-tertiary);
   padding: 1px 5px;
   border-radius: var(--radius-sm);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
 }
 
@@ -1033,7 +1033,7 @@
 }
 .preview-status .hint {
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   margin: 0;
   max-width: 420px;
 }
@@ -1050,7 +1050,7 @@
   color: var(--warning);
 }
 .preview-status__attempt {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   margin: 0;
 }
@@ -1070,7 +1070,7 @@
   align-items: center;
   gap: 5px;
   cursor: pointer;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--text-secondary);
   padding: 2px 0;
@@ -1096,7 +1096,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   color: var(--text-secondary);
   white-space: pre-wrap;
@@ -1115,7 +1115,7 @@
 
 .preview-status__logs-hint {
   margin: var(--spacing-xs) 0 0;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
@@ -1134,7 +1134,7 @@
   border-radius: var(--radius);
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   transition: border-color var(--transition);
 }
@@ -1171,7 +1171,7 @@
   background: none;
   border: none;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   transition: background var(--transition);
@@ -1187,6 +1187,6 @@
 
 .locale-item-code {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -529,7 +529,7 @@
   animation: spin 0.8s linear infinite;
 }
 
-@keyframes /* Preview Viewport */
+/* Preview Viewport */
 .preview-viewport {
   flex: 1;
   display: flex;

--- a/src/styles/features/project-grid.css
+++ b/src/styles/features/project-grid.css
@@ -1,4 +1,10 @@
 /* Project Grid */
+
+/* Project-grid-local colors — intentional one-offs, not part of the global scale. */
+:root {
+  --grid-on-warning-text: #000000;
+}
+
 .project-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -114,8 +120,8 @@
   cursor: pointer;
   border-radius: var(--radius-sm);
   transition:
-    background 0.15s,
-    color 0.15s;
+    background var(--transition),
+    color var(--transition);
 }
 
 .project-card-menu:hover {
@@ -185,7 +191,7 @@
 }
 
 .project-card-dropdown-item.danger:hover {
-  background: rgba(239, 68, 68, 0.1);
+  background: rgba(var(--error-light-rgb), 0.1);
 }
 
 .project-card-dropdown-item .toggle-indicator {
@@ -199,7 +205,7 @@
 }
 
 .project-card-dropdown-item .toggle-indicator.on {
-  background: rgba(34, 197, 94, 0.2);
+  background: rgba(var(--success-light-rgb), 0.2);
   color: var(--success);
 }
 
@@ -223,7 +229,7 @@
   width: 16px;
   height: 16px;
   border-radius: var(--radius-sm);
-  background: rgba(251, 191, 36, 0.2);
+  background: rgba(var(--warning-light-rgb), 0.2);
   color: var(--warning-light);
   flex-shrink: 0;
 }
@@ -242,7 +248,7 @@
   height: 64px;
   margin: 0 auto 16px;
   border-radius: var(--radius-full);
-  background: rgba(251, 191, 36, 0.15);
+  background: rgba(var(--warning-light-rgb), 0.15);
   color: var(--warning-light);
 }
 
@@ -278,7 +284,7 @@
 
 .btn-warning {
   background: var(--warning-light);
-  color: var(--text-on-warning, #000);
+  color: var(--grid-on-warning-text);
 }
 
 .btn-warning:hover {

--- a/src/styles/features/project-grid.css
+++ b/src/styles/features/project-grid.css
@@ -50,7 +50,7 @@
   align-items: center;
   justify-content: center;
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
 }
 
 .project-card-info {
@@ -84,7 +84,7 @@
 }
 
 .project-card-path {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   font-family: monospace;
   white-space: nowrap;
@@ -93,7 +93,7 @@
 }
 
 .project-card-workspace {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   font-family: monospace;
   white-space: nowrap;
@@ -109,7 +109,7 @@
   background: transparent;
   border: none;
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   letter-spacing: 1px;
   cursor: pointer;
   border-radius: var(--radius-sm);
@@ -134,7 +134,7 @@
 }
 
 .project-list-cleanup-status {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   margin: 0;
 }
@@ -168,7 +168,7 @@
   border: none;
   background: transparent;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   border-radius: var(--radius-sm);
@@ -190,7 +190,7 @@
 
 .project-card-dropdown-item .toggle-indicator {
   margin-left: auto;
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   padding: 2px 6px;
   border-radius: var(--radius-sm);
@@ -248,7 +248,7 @@
 
 .auto-accept-warning-modal h3 {
   margin: 0 0 12px;
-  font-size: 18px;
+  font-size: var(--font-size-2xl);
 }
 
 .auto-accept-warning-modal p {
@@ -272,7 +272,7 @@
   padding: 12px;
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   margin-bottom: 20px;
 }
 
@@ -299,7 +299,7 @@
   }
 
   .project-card-name {
-    font-size: 14px;
+    font-size: var(--font-size-lg);
   }
 
   .folder-card-info {
@@ -307,7 +307,7 @@
   }
 
   .folder-card-name {
-    font-size: 14px;
+    font-size: var(--font-size-lg);
   }
 }
 
@@ -323,15 +323,15 @@
   }
 
   .project-card-name {
-    font-size: 14px;
+    font-size: var(--font-size-lg);
   }
 
   .project-card-meta {
-    font-size: 11px;
+    font-size: var(--font-size-sm);
   }
 
   .project-card-deployment {
-    font-size: 11px;
+    font-size: var(--font-size-sm);
   }
 
   .folder-card-info {
@@ -339,11 +339,11 @@
   }
 
   .folder-card-name {
-    font-size: 14px;
+    font-size: var(--font-size-lg);
   }
 
   .folder-card-count {
-    font-size: 11px;
+    font-size: var(--font-size-sm);
   }
 
   /* Smaller dropdown for narrow screens */
@@ -353,6 +353,6 @@
 
   .project-card-dropdown-item {
     padding: 8px 10px;
-    font-size: 12px;
+    font-size: var(--font-size-base);
   }
 }

--- a/src/styles/features/project-list.css
+++ b/src/styles/features/project-list.css
@@ -82,12 +82,12 @@
 
 .connection-name {
   font-weight: 600;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   color: var(--text-primary);
 }
 
 .connection-status {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--success);
   white-space: nowrap;
   overflow: hidden;
@@ -100,7 +100,7 @@
 
 .connection-action {
   padding: 6px 12px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
@@ -142,7 +142,7 @@
 
 .project-list-empty .hint {
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   margin-top: 8px;
 }
 
@@ -205,7 +205,7 @@
   border: 1px solid var(--border) !important;
   border-radius: 6px !important;
   padding: 6px 10px !important;
-  font-size: 12px !important;
+  font-size: var(--font-size-base) !important;
   color: var(--text-primary) !important;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3) !important;
   z-index: 1000 !important;

--- a/src/styles/features/project-list.css
+++ b/src/styles/features/project-list.css
@@ -49,7 +49,7 @@
 
 .connection-card.connected {
   border-color: var(--success);
-  border-color: rgba(78, 205, 196, 0.3);
+  border-color: rgba(var(--success-rgb), 0.3);
 }
 
 .connection-card.disconnected {
@@ -68,7 +68,7 @@
 }
 
 .connection-card.connected .connection-icon {
-  background: rgba(78, 205, 196, 0.15);
+  background: rgba(var(--success-rgb), 0.15);
   color: var(--success);
 }
 
@@ -108,9 +108,9 @@
   border-radius: var(--radius);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   white-space: nowrap;
 }
 
@@ -172,9 +172,9 @@
   border-radius: var(--radius-sm);
   opacity: 0;
   transition:
-    opacity 0.15s,
-    color 0.15s,
-    background 0.15s;
+    opacity var(--transition),
+    color var(--transition),
+    background var(--transition);
   z-index: 1;
   display: flex;
   align-items: center;
@@ -207,7 +207,7 @@
   padding: 6px 10px !important;
   font-size: var(--font-size-base) !important;
   color: var(--text-primary) !important;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3) !important;
+  box-shadow: var(--shadow) !important;
   z-index: 1000 !important;
 }
 
@@ -232,17 +232,7 @@
   animation: skeleton-pulse 1.5s ease-in-out infinite;
 }
 
-@keyframes skeleton-pulse {
-  0%,
-  100% {
-    opacity: 0.4;
-  }
-  50% {
-    opacity: 0.7;
-  }
-}
-
-/* Hide on narrow screens - same breakpoint as changelog */
+@keyframes /* Hide on narrow screens - same breakpoint as changelog */
 @media (max-width: 1100px) {
   .github-calendar-wrapper {
     display: none;

--- a/src/styles/features/project-list.css
+++ b/src/styles/features/project-list.css
@@ -232,7 +232,7 @@
   animation: skeleton-pulse 1.5s ease-in-out infinite;
 }
 
-@keyframes /* Hide on narrow screens - same breakpoint as changelog */
+/* Hide on narrow screens - same breakpoint as changelog */
 @media (max-width: 1100px) {
   .github-calendar-wrapper {
     display: none;

--- a/src/styles/features/project-rail.css
+++ b/src/styles/features/project-rail.css
@@ -156,7 +156,7 @@ body.rail-drag-active iframe {
 
 .project-rail-placeholder {
   font-family: var(--font-mono, Menlo, monospace);
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   color: var(--text-secondary);
 }
@@ -214,7 +214,7 @@ body.rail-drag-active iframe {
   border-radius: var(--radius-full);
   background: var(--error);
   color: #ffffff;
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   line-height: 16px;
   text-align: center;
@@ -241,7 +241,7 @@ body.rail-drag-active iframe {
   border: none;
   background: transparent;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   border-radius: var(--radius-sm);
 }
@@ -302,7 +302,7 @@ body.rail-drag-active iframe {
   border-bottom: 1px solid var(--border);
   background: var(--bg-secondary);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   outline: none;
 }
 
@@ -326,7 +326,7 @@ body.rail-drag-active iframe {
   border: none;
   background: transparent;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   border-radius: var(--radius-sm);
   white-space: nowrap;
@@ -341,7 +341,7 @@ body.rail-drag-active iframe {
 .project-rail-picker-empty {
   padding: var(--spacing-sm) var(--spacing-md);
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 /* Projects view wrapper: rail + dashboard in a row. */
@@ -368,5 +368,5 @@ body.rail-drag-active iframe {
 
 .project-loading-body p {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }

--- a/src/styles/features/project-rail.css
+++ b/src/styles/features/project-rail.css
@@ -213,7 +213,7 @@ body.rail-drag-active iframe {
   padding: 0 4px;
   border-radius: var(--radius-full);
   background: var(--error);
-  color: #ffffff;
+  color: var(--text-bright);
   font-size: var(--font-size-xs);
   font-weight: 600;
   line-height: 16px;
@@ -256,7 +256,7 @@ body.rail-drag-active iframe {
 
 .project-rail-menu-item.danger:hover {
   background: var(--error);
-  color: #ffffff;
+  color: var(--text-bright);
 }
 
 /* "+" button — last item in the rail list. */

--- a/src/styles/features/publish/dropdown.css
+++ b/src/styles/features/publish/dropdown.css
@@ -13,7 +13,7 @@
   border: 1px solid var(--action-hover);
   border-radius: var(--radius);
   color: var(--action-text);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -83,7 +83,7 @@
   gap: 10px;
   padding: 32px 16px;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .publish-loading-spinner {

--- a/src/styles/features/publish/rows.css
+++ b/src/styles/features/publish/rows.css
@@ -54,13 +54,13 @@
 }
 
 .publish-row-label {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
   color: var(--text-primary);
 }
 
 .publish-row-badge {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   padding: 2px 6px;
   background: var(--bg-tertiary);
   border-radius: var(--radius-sm);
@@ -103,7 +103,7 @@
 }
 
 .url-text {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -133,7 +133,7 @@
 }
 
 .publish-option-status {
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 .deployment-state {
@@ -171,7 +171,7 @@
 }
 
 .branch-status {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   margin-top: 6px;
   padding-left: 26px;
@@ -179,7 +179,7 @@
 
 .publish-hint {
   padding: 12px 16px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   background: var(--bg-tertiary);
   border-top: 1px solid var(--border);
@@ -187,7 +187,7 @@
 
 .publish-error {
   padding: 12px 16px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: #dc2626;
   background: rgba(220, 38, 38, 0.1);
   border-top: 1px solid var(--border);
@@ -211,7 +211,7 @@
   background: none;
   border: none;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   transition: color var(--transition);
 }
@@ -238,7 +238,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -257,7 +257,7 @@
   border: none;
   border-radius: var(--radius);
   color: var(--action-text);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -277,14 +277,14 @@
 
 /* Publish Option Labels (simplified) */
 .publish-option-label {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
   color: var(--text-primary);
   margin-bottom: 2px;
 }
 
 .publish-option-description {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
 }
 
@@ -311,7 +311,7 @@
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   border-radius: var(--radius);
   transition:

--- a/src/styles/features/publish/rows.css
+++ b/src/styles/features/publish/rows.css
@@ -31,9 +31,9 @@
   position: relative;
   flex-shrink: 0;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .publish-row input[type='checkbox']:checked {
@@ -48,7 +48,7 @@
   top: 45%;
   width: 3px;
   height: 6px;
-  border: solid white;
+  border: solid var(--text-bright);
   border-width: 0 1.5px 1.5px 0;
   transform: translate(-50%, -50%) rotate(45deg);
 }
@@ -92,9 +92,9 @@
   align-items: center;
   justify-content: center;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .publish-row-link:hover {
@@ -155,7 +155,7 @@
 }
 
 .deployment-state.state-error {
-  color: #dc2626;
+  color: var(--error-deep);
 }
 
 .deployment-state.state-canceled {
@@ -188,8 +188,8 @@
 .publish-error {
   padding: 12px 16px;
   font-size: var(--font-size-base);
-  color: #dc2626;
-  background: rgba(220, 38, 38, 0.1);
+  color: var(--error-deep);
+  background: rgba(var(--error-deep-rgb), 0.1);
   border-top: 1px solid var(--border);
 }
 
@@ -241,9 +241,9 @@
   font-size: var(--font-size-md);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .publish-close:hover {
@@ -261,9 +261,9 @@
   font-weight: 500;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .publish-submit:hover {
@@ -315,9 +315,9 @@
   cursor: pointer;
   border-radius: var(--radius);
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .publish-quick-link:hover {

--- a/src/styles/features/publish/sites.css
+++ b/src/styles/features/publish/sites.css
@@ -11,7 +11,7 @@
   background: transparent;
   border: none;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   padding: 0;
   transition: color var(--transition);
@@ -30,7 +30,7 @@
 
 .publish-reset-confirm p {
   margin: 0 0 10px 0;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
 }
 
@@ -46,7 +46,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -71,7 +71,7 @@
 }
 
 .publish-live-sites-header {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -107,7 +107,7 @@
 }
 
 .publish-live-site-label {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   color: var(--text-secondary);
   flex-shrink: 0;
@@ -115,7 +115,7 @@
 }
 
 .publish-live-site-badge {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.3px;
@@ -137,7 +137,7 @@
 .publish-live-site-url {
   flex: 1;
   min-width: 0;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-primary);
   font-family: monospace;
   overflow: hidden;
@@ -172,7 +172,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   transition:
     background-color 0.15s,

--- a/src/styles/features/publish/sites.css
+++ b/src/styles/features/publish/sites.css
@@ -1,3 +1,8 @@
+/* Publish-local colors — intentional one-offs, not part of the global scale. */
+:root {
+  --publish-prod-green-rgb: 74, 222, 128;
+}
+
 /* Reset Section */
 .publish-reset-section {
   padding: 12px 16px;
@@ -49,9 +54,9 @@
   font-size: var(--font-size-base);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .publish-reset-options button:hover:not(:disabled) {
@@ -90,9 +95,9 @@
   border-radius: var(--radius);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   margin-bottom: 8px;
   text-align: left;
 }
@@ -125,13 +130,13 @@
 }
 
 .publish-live-site-badge-prod {
-  color: rgba(74, 222, 128, 0.9);
-  background: rgba(74, 222, 128, 0.12);
+  color: rgba(var(--publish-prod-green-rgb), 0.9);
+  background: rgba(var(--publish-prod-green-rgb), 0.12);
 }
 
 .publish-live-site-badge-preview {
-  color: rgba(96, 165, 250, 0.9);
-  background: rgba(96, 165, 250, 0.12);
+  color: rgba(var(--info-light-rgb), 0.9);
+  background: rgba(var(--info-light-rgb), 0.12);
 }
 
 .publish-live-site-url {
@@ -175,9 +180,9 @@
   font-size: var(--font-size-base);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .publish-link-button:hover {

--- a/src/styles/features/publish/states.css
+++ b/src/styles/features/publish/states.css
@@ -15,14 +15,14 @@
 
 .publish-success-message {
   padding: 0 16px 16px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   line-height: 1.5;
 }
 
 .publish-branch-hint {
   padding: 0 16px 12px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   line-height: 1.5;
 }
@@ -44,7 +44,7 @@
 
 .publish-elapsed {
   margin-left: auto;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 400;
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
@@ -67,7 +67,7 @@
 
 .publish-deploying-message {
   padding: 0 16px 16px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   line-height: 1.5;
 }
@@ -75,7 +75,7 @@
 /* Deployed URL */
 .publish-deployed-message {
   padding: 0 16px 12px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   line-height: 1.4;
 }
@@ -90,7 +90,7 @@
 
 .publish-url-text {
   flex: 1;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -109,7 +109,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -134,7 +134,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -176,7 +176,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -206,7 +206,7 @@
 
 .publish-error-message {
   padding: 0 16px 16px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   background: rgba(220, 38, 38, 0.05);
   margin: 0 16px 16px;

--- a/src/styles/features/publish/states.css
+++ b/src/styles/features/publish/states.css
@@ -113,9 +113,9 @@
   font-weight: 500;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .publish-url-btn:hover {
@@ -137,15 +137,15 @@
   font-size: var(--font-size-md);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   font-family: monospace;
 }
 
 .publish-url-button:hover {
   background: var(--border);
-  color: #3b82f6;
+  color: var(--info);
 }
 
 .publish-url-button svg {
@@ -180,9 +180,9 @@
   font-weight: 500;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .publish-done:hover {
@@ -195,7 +195,7 @@
   align-items: center;
   gap: 12px;
   padding: 20px 16px;
-  color: #dc2626;
+  color: var(--error-deep);
   font-size: 15px;
   font-weight: 500;
 }
@@ -208,7 +208,7 @@
   padding: 0 16px 16px;
   font-size: var(--font-size-md);
   color: var(--text-secondary);
-  background: rgba(220, 38, 38, 0.05);
+  background: rgba(var(--error-deep-rgb), 0.05);
   margin: 0 16px 16px;
   padding: 12px;
   border-radius: var(--radius);

--- a/src/styles/features/publish/toasts.css
+++ b/src/styles/features/publish/toasts.css
@@ -90,13 +90,13 @@
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 8px 32px var(--overlay-40);
   cursor: pointer;
   z-index: var(--z-app-modal-content);
   animation: screenshot-toast-in 0.3s ease;
   transition:
-    opacity 0.3s ease,
-    transform 0.3s ease;
+    opacity var(--transition-slow),
+    transform var(--transition-slow);
 }
 
 .screenshot-toast:hover {

--- a/src/styles/features/publish/toasts.css
+++ b/src/styles/features/publish/toasts.css
@@ -20,7 +20,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-primary);
   pointer-events: auto;
   animation: toast-slide-in 0.3s ease;
@@ -135,7 +135,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   color: var(--text-primary);
 }
@@ -145,7 +145,7 @@
 }
 
 .screenshot-toast-hint {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
@@ -208,7 +208,7 @@
 }
 
 .screenshot-preview-path {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-family: monospace;
   color: var(--text-muted);
 }

--- a/src/styles/features/settings.css
+++ b/src/styles/features/settings.css
@@ -17,7 +17,7 @@
 }
 
 .settings-modal-header h2 {
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   color: var(--text-primary);
   margin: 0;
@@ -49,13 +49,13 @@
 }
 
 .settings-row-label {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   color: var(--text-primary);
 }
 
 .settings-row-description {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   line-height: 1.4;
 }

--- a/src/styles/features/settings.css
+++ b/src/styles/features/settings.css
@@ -108,6 +108,6 @@
 
 .settings-toggle.on .settings-toggle-thumb {
   transform: translateX(16px);
-  background: #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  background: var(--text-bright);
+  box-shadow: 0 1px 3px var(--overlay-30);
 }

--- a/src/styles/features/setup.css
+++ b/src/styles/features/setup.css
@@ -143,7 +143,7 @@
 
 .setup-item-name {
   font-weight: 500;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   flex: 1;
 }
 
@@ -155,13 +155,13 @@
 }
 
 .setup-item-info {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   font-family: var(--font-mono);
 }
 
 .setup-item-blocked-text {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   font-style: italic;
 }
@@ -174,12 +174,12 @@
 }
 
 .setup-item-progress-text {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
 }
 
 .setup-item-progress-hint {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
@@ -190,14 +190,14 @@
 }
 
 .setup-item-error-text {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--error);
   max-width: 180px;
 }
 
 .setup-item-btn {
   padding: 6px 14px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   border-radius: var(--radius);
   border: none;
@@ -240,7 +240,7 @@
 }
 
 .setup-item-time-estimate {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
 }
 
@@ -272,7 +272,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 600;
   background: var(--bg-tertiary);
   color: var(--text-muted);
@@ -317,7 +317,7 @@
 }
 
 .wizard-indicator-label {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   text-align: center;
   line-height: 1.3;
@@ -365,7 +365,7 @@
 }
 
 .wizard-step-subtitle {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   color: var(--text-secondary);
 }
 
@@ -389,7 +389,7 @@
 
 .wizard-nav-back {
   padding: 8px 18px;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
@@ -409,7 +409,7 @@
 
 .wizard-nav-next {
   padding: 8px 24px;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
   border-radius: var(--radius-md);
   border: none;
@@ -434,7 +434,7 @@
 /* ============ Agent Step Cards ============ */
 
 .wizard-agent-selection-hint {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   margin-bottom: 4px;
 }
@@ -492,7 +492,7 @@
 }
 
 .wizard-agent-card-badge {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 500;
   padding: 2px 8px;
   border-radius: var(--radius-sm);
@@ -535,13 +535,13 @@
 }
 
 .wizard-hosting-title {
-  font-size: 18px;
+  font-size: var(--font-size-2xl);
   font-weight: 600;
   margin-bottom: 8px;
 }
 
 .wizard-hosting-desc {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   color: var(--text-secondary);
   margin-bottom: 24px;
   max-width: 300px;
@@ -550,7 +550,7 @@
 
 .wizard-hosting-skip-btn {
   padding: 10px 28px;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
@@ -593,7 +593,7 @@
 
 .onboarding-slack-cta span {
   flex: 1;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   line-height: 1.4;
 }
@@ -609,7 +609,7 @@
   border: 1px solid rgba(147, 51, 234, 0.3);
   border-radius: var(--radius);
   color: #c4b5fd;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   flex-shrink: 0;
 }
@@ -670,7 +670,7 @@
 
 .celebration-subtitle {
   color: var(--text-secondary);
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   margin-bottom: 32px;
 }
 
@@ -715,7 +715,7 @@
 }
 
 .prerequisite .status {
-  font-size: 18px;
+  font-size: var(--font-size-2xl);
   width: 24px;
 }
 
@@ -735,7 +735,7 @@
 .prerequisite .path {
   color: var(--text-muted);
   font-family: monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 .prerequisite .install-info {
@@ -758,7 +758,7 @@
   background: var(--bg-tertiary);
   padding: 4px 8px;
   border-radius: var(--radius-sm);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
 }
 
@@ -828,14 +828,14 @@
 }
 
 .onboarding-terminal-title {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
   color: var(--text-primary);
 }
 
 .onboarding-terminal-cancel {
   padding: 6px 14px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   border-radius: var(--radius);
   border: 1px solid var(--border);
@@ -867,7 +867,7 @@
   display: inline-block;
   margin-left: 8px;
   padding: 2px 8px;
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 500;
   color: var(--text-muted);
   background: var(--bg-tertiary);

--- a/src/styles/features/setup.css
+++ b/src/styles/features/setup.css
@@ -1,5 +1,13 @@
 /* Setup/Onboarding Screen Styles */
 
+/* Setup-local colors — intentional one-offs, not part of the global scale.
+   The wizard greens are the onboarding install/CTA brand hue (lighter than
+   --action). */
+:root {
+  --setup-wizard-green: #7fe89a;
+  --setup-wizard-green-hover: #6dd889;
+}
+
 /* ============ Onboarding Screen ============ */
 
 .onboarding-screen {
@@ -57,8 +65,8 @@
 }
 
 .onboarding-error {
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  background: rgba(var(--error-light-rgb), 0.1);
+  border: 1px solid rgba(var(--error-light-rgb), 0.3);
   border-radius: var(--radius-md);
   padding: 16px;
   margin-bottom: 24px;
@@ -90,8 +98,8 @@
   border-radius: 10px;
   border: 1px solid var(--border);
   transition:
-    border-color 0.15s,
-    background-color 0.15s;
+    border-color var(--transition),
+    background-color var(--transition);
 }
 
 .setup-item:hover {
@@ -99,13 +107,13 @@
 }
 
 .setup-item-status-ready {
-  border-color: rgba(34, 197, 94, 0.3);
-  background: rgba(34, 197, 94, 0.05);
+  border-color: rgba(var(--success-light-rgb), 0.3);
+  background: rgba(var(--success-light-rgb), 0.05);
 }
 
 .setup-item-status-error {
-  border-color: rgba(239, 68, 68, 0.3);
-  background: rgba(239, 68, 68, 0.05);
+  border-color: rgba(var(--error-light-rgb), 0.3);
+  background: rgba(var(--error-light-rgb), 0.05);
 }
 
 .setup-item-status-blocked {
@@ -135,13 +143,7 @@
   animation: spin 0.8s linear infinite;
 }
 
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.setup-item-name {
+@keyframes.setup-item-name {
   font-weight: 500;
   font-size: var(--font-size-lg);
   flex: 1;
@@ -203,8 +205,8 @@
   border: none;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    opacity 0.15s;
+    background-color var(--transition),
+    opacity var(--transition);
 }
 
 .setup-item-btn:disabled {
@@ -214,13 +216,13 @@
 
 .setup-item-btn-install,
 .setup-item-btn-connect {
-  background: #7fe89a;
-  color: #1e1e1e;
+  background: var(--setup-wizard-green);
+  color: var(--action-text);
 }
 
 .setup-item-btn-install:hover:not(:disabled),
 .setup-item-btn-connect:hover:not(:disabled) {
-  background: #6dd889;
+  background: var(--setup-wizard-green-hover);
 }
 
 .setup-item-btn-retry {
@@ -286,15 +288,15 @@
 }
 
 .wizard-indicator-dot.current {
-  background: #7fe89a;
-  border-color: #7fe89a;
-  color: #1e1e1e;
+  background: var(--setup-wizard-green);
+  border-color: var(--setup-wizard-green);
+  color: var(--action-text);
 }
 
 .wizard-indicator-dot.completed {
-  background: #7fe89a;
-  border-color: #7fe89a;
-  color: white;
+  background: var(--setup-wizard-green);
+  border-color: var(--setup-wizard-green);
+  color: var(--text-bright);
 }
 
 .wizard-indicator-dot.past {
@@ -313,7 +315,7 @@
 }
 
 .wizard-indicator-line.active {
-  background: #7fe89a;
+  background: var(--setup-wizard-green);
 }
 
 .wizard-indicator-label {
@@ -397,9 +399,9 @@
   color: var(--text-secondary);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .wizard-nav-back:hover {
@@ -413,17 +415,17 @@
   font-weight: 500;
   border-radius: var(--radius-md);
   border: none;
-  background: #7fe89a;
-  color: #1e1e1e;
+  background: var(--setup-wizard-green);
+  color: var(--action-text);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .wizard-nav-next:hover:not(:disabled) {
-  background: #6dd889;
+  background: var(--setup-wizard-green-hover);
 }
 
 .wizard-nav-next:disabled {
@@ -451,12 +453,12 @@
 }
 
 .wizard-agent-card.ready {
-  border-color: rgba(34, 197, 94, 0.3);
+  border-color: rgba(var(--success-light-rgb), 0.3);
 }
 
 .wizard-agent-card.selected {
   border-color: var(--success);
-  background: rgba(34, 197, 94, 0.05);
+  background: rgba(var(--success-light-rgb), 0.05);
   cursor: pointer;
 }
 
@@ -496,8 +498,8 @@
   font-weight: 500;
   padding: 2px 8px;
   border-radius: var(--radius-sm);
-  background: rgba(147, 51, 234, 0.15);
-  color: #c4b5fd;
+  background: rgba(var(--purple-deep-rgb), 0.15);
+  color: var(--slack-lavender);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -558,8 +560,8 @@
   color: var(--text-secondary);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s;
+    background-color var(--transition),
+    color var(--transition);
   margin-top: 8px;
 }
 
@@ -580,15 +582,15 @@
   align-items: center;
   gap: 12px;
   padding: 14px 18px;
-  background: rgba(147, 51, 234, 0.08);
-  border: 1px solid rgba(147, 51, 234, 0.2);
+  background: rgba(var(--purple-deep-rgb), 0.08);
+  border: 1px solid rgba(var(--purple-deep-rgb), 0.2);
   border-radius: 10px;
   margin-top: 16px;
 }
 
 .onboarding-slack-cta svg {
   flex-shrink: 0;
-  color: #e9a7fb;
+  color: var(--slack-pink);
 }
 
 .onboarding-slack-cta span {
@@ -605,19 +607,19 @@
 
 .onboarding-slack-cta button {
   padding: 6px 14px;
-  background: rgba(147, 51, 234, 0.2);
-  border: 1px solid rgba(147, 51, 234, 0.3);
+  background: rgba(var(--purple-deep-rgb), 0.2);
+  border: 1px solid rgba(var(--purple-deep-rgb), 0.3);
   border-radius: var(--radius);
-  color: #c4b5fd;
+  color: var(--slack-lavender);
   font-size: var(--font-size-md);
   font-weight: 500;
   flex-shrink: 0;
 }
 
 .onboarding-slack-cta button:hover {
-  background: rgba(147, 51, 234, 0.3);
-  border-color: rgba(147, 51, 234, 0.5);
-  color: #ddd6fe;
+  background: rgba(var(--purple-deep-rgb), 0.3);
+  border-color: rgba(var(--purple-deep-rgb), 0.5);
+  color: var(--slack-lavender-bright);
 }
 
 /* ============ Celebration Screen ============ */
@@ -779,7 +781,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--overlay-60);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -787,23 +789,14 @@
   animation: fadeIn 0.15s ease-out;
 }
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-.onboarding-terminal-modal {
+@keyframes.onboarding-terminal-modal {
   width: 90%;
   max-width: 700px;
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
   overflow: hidden;
   border: 1px solid var(--border);
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 20px 60px var(--overlay-40);
   animation: scaleIn 0.2s ease-out;
 }
 
@@ -843,8 +836,8 @@
   color: var(--text-secondary);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s;
+    background-color var(--transition),
+    color var(--transition);
 }
 
 .onboarding-terminal-cancel:hover {
@@ -854,7 +847,7 @@
 
 .onboarding-terminal-container {
   height: 350px;
-  background: #1e1e1e;
+  background: var(--bg-primary);
 }
 
 /* ============ Optional Items ============ */

--- a/src/styles/features/setup.css
+++ b/src/styles/features/setup.css
@@ -143,7 +143,7 @@
   animation: spin 0.8s linear infinite;
 }
 
-@keyframes.setup-item-name {
+.setup-item-name {
   font-weight: 500;
   font-size: var(--font-size-lg);
   flex: 1;
@@ -789,7 +789,7 @@
   animation: fadeIn 0.15s ease-out;
 }
 
-@keyframes.onboarding-terminal-modal {
+.onboarding-terminal-modal {
   width: 90%;
   max-width: 700px;
   background: var(--bg-secondary);

--- a/src/styles/features/skills-modal.css
+++ b/src/styles/features/skills-modal.css
@@ -482,7 +482,7 @@
   margin: 0 auto 12px;
 }
 
-@keyframes.skills-error {
+.skills-error {
   padding: 12px;
   background: rgba(var(--error-deep-rgb), 0.1);
   border: 1px solid rgba(var(--error-deep-rgb), 0.3);

--- a/src/styles/features/skills-modal.css
+++ b/src/styles/features/skills-modal.css
@@ -35,8 +35,8 @@
   justify-content: center;
   border-radius: var(--radius-sm);
   transition:
-    background-color 0.15s,
-    color 0.15s;
+    background-color var(--transition),
+    color var(--transition);
 }
 
 .skills-close-btn:hover {
@@ -64,9 +64,9 @@
   border-radius: var(--radius);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .skills-tab:hover {
@@ -155,9 +155,9 @@
   border-radius: var(--radius);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .skills-filter-btn:hover {
@@ -232,8 +232,8 @@
 }
 
 .skill-scope-badge.project {
-  color: #a78bfa;
-  border-color: rgba(167, 139, 250, 0.4);
+  color: var(--purple-light);
+  border-color: rgba(var(--purple-light-rgb), 0.4);
 }
 
 .skill-desc {
@@ -257,9 +257,9 @@
   border-radius: var(--radius);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   flex-shrink: 0;
 }
 
@@ -314,9 +314,9 @@
   border-radius: var(--radius);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .skills-search-btn:hover {
@@ -355,9 +355,9 @@
   border-radius: var(--radius);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
 }
 
 .skills-scope-btn:hover {
@@ -443,9 +443,9 @@
   border-radius: var(--radius);
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   flex-shrink: 0;
 }
 
@@ -478,20 +478,14 @@
   border: 2px solid var(--border);
   border-top-color: var(--accent);
   border-radius: var(--radius-full);
-  animation: skills-spin 0.8s linear infinite;
+  animation: spin 0.8s linear infinite;
   margin: 0 auto 12px;
 }
 
-@keyframes skills-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.skills-error {
+@keyframes.skills-error {
   padding: 12px;
-  background: rgba(220, 38, 38, 0.1);
-  border: 1px solid rgba(220, 38, 38, 0.3);
+  background: rgba(var(--error-deep-rgb), 0.1);
+  border: 1px solid rgba(var(--error-deep-rgb), 0.3);
   border-radius: var(--radius);
   color: var(--error);
   font-size: var(--font-size-md);

--- a/src/styles/features/skills-modal.css
+++ b/src/styles/features/skills-modal.css
@@ -56,7 +56,7 @@
   align-items: center;
   height: 28px;
   padding: 0 12px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   color: var(--text-muted);
   background: transparent;
@@ -125,7 +125,7 @@
   background: transparent;
   border: none;
   outline: none;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-primary);
   padding: 0;
   min-width: 0;
@@ -147,7 +147,7 @@
   align-items: center;
   height: 26px;
   padding: 0 10px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--text-muted);
   background: transparent;
@@ -200,7 +200,7 @@
 }
 
 .skill-name {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   color: var(--text-primary);
 }
@@ -213,7 +213,7 @@
 }
 
 .skill-plugin {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   font-family: 'SF Mono', Monaco, monospace;
 }
@@ -225,7 +225,7 @@
   background: transparent;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.3px;
@@ -237,7 +237,7 @@
 }
 
 .skill-desc {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   margin-top: 6px;
   line-height: 1.4;
@@ -249,7 +249,7 @@
 
 .skill-remove-btn {
   padding: 6px 12px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--text-muted);
   background: transparent;
@@ -287,7 +287,7 @@
 .skills-search-input {
   flex: 1;
   padding: 8px 12px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-primary);
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
@@ -306,7 +306,7 @@
 
 .skills-search-btn {
   padding: 8px 14px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   color: var(--action-text);
   background: var(--action);
@@ -337,7 +337,7 @@
 }
 
 .skills-scope-toggle-label {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   margin-right: 4px;
 }
@@ -347,7 +347,7 @@
   align-items: center;
   height: 26px;
   padding: 0 10px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--text-muted);
   background: transparent;
@@ -408,20 +408,20 @@
 }
 
 .skills-result-name {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   color: var(--text-primary);
 }
 
 .skills-result-package {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   font-family: 'SF Mono', Monaco, monospace;
   margin-top: 2px;
 }
 
 .skills-result-desc {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   margin-top: 6px;
   line-height: 1.4;
@@ -435,7 +435,7 @@
 
 .skills-install-btn {
   padding: 6px 12px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--action-text);
   background: var(--action);
@@ -469,7 +469,7 @@
   padding: 32px 16px;
   text-align: center;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .skills-loading-spinner {
@@ -494,7 +494,7 @@
   border: 1px solid rgba(220, 38, 38, 0.3);
   border-radius: var(--radius);
   color: var(--error);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   margin-bottom: 12px;
 }
 
@@ -509,14 +509,14 @@
 }
 
 .skills-footer-hint {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
 }
 
 .skills-footer-link {
   display: flex;
   align-items: center;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   text-decoration: none;
   transition: color var(--transition);
@@ -533,7 +533,7 @@
 }
 
 .skills-cli-unavailable p {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   margin: 0 0 12px;
 }
@@ -545,6 +545,6 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   font-family: 'SF Mono', Monaco, monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-primary);
 }

--- a/src/styles/features/support-panel.css
+++ b/src/styles/features/support-panel.css
@@ -53,7 +53,7 @@
 }
 
 .support-panel-header h2 {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   margin: 0;
   color: var(--text-primary);
@@ -67,7 +67,7 @@
   cursor: pointer;
   padding: 4px;
   border-radius: var(--radius-sm);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   display: flex;
   align-items: center;
   gap: 4px;
@@ -85,7 +85,7 @@
   cursor: pointer;
   padding: 4px;
   border-radius: var(--radius-sm);
-  font-size: 18px;
+  font-size: var(--font-size-2xl);
   line-height: 1;
   display: flex;
   align-items: center;
@@ -154,7 +154,7 @@
 .support-slack-cta-text {
   flex: 1;
   min-width: 0;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   line-height: 1.4;
 }
 
@@ -166,7 +166,7 @@
 .support-slack-cta-arrow {
   flex-shrink: 0;
   color: #c4b5fd;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   line-height: 1;
 }
 
@@ -184,7 +184,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-family: inherit;
 }
 
@@ -209,7 +209,7 @@
 /* ─── Section Headers ──────────────────────────────────────────────────────── */
 
 .support-section-label {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
@@ -235,7 +235,7 @@
   border: none;
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   text-align: left;
   width: 100%;
@@ -269,7 +269,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   width: 100%;
   text-align: left;
@@ -281,7 +281,7 @@
 }
 
 .support-action-btn .action-icon {
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   flex-shrink: 0;
   width: 20px;
   text-align: center;
@@ -290,7 +290,7 @@
 .support-action-btn .action-arrow {
   margin-left: auto;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 /* ─── Ticket List ──────────────────────────────────────────────────────────── */
@@ -304,7 +304,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   width: 100%;
   text-align: left;
@@ -318,7 +318,7 @@
 .support-ticket-badge {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   padding: 1px 6px;
   border-radius: 10px;
   margin-left: 4px;
@@ -357,7 +357,7 @@
 }
 
 .support-ticket-item-subject {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-primary);
   flex: 1;
   overflow: hidden;
@@ -366,7 +366,7 @@
 }
 
 .support-ticket-status {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   padding: 2px 6px;
@@ -392,7 +392,7 @@
 }
 
 .support-ticket-item-meta {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
@@ -416,7 +416,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   text-align: center;
   display: flex;
@@ -436,7 +436,7 @@
 }
 
 .support-type-btn .type-icon {
-  font-size: 18px;
+  font-size: var(--font-size-2xl);
 }
 
 .support-field {
@@ -446,7 +446,7 @@
 }
 
 .support-field label {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   color: var(--text-secondary);
 }
@@ -459,7 +459,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-family: inherit;
 }
 
@@ -480,7 +480,7 @@
 }
 
 .support-field .field-hint {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
@@ -494,7 +494,7 @@
 .support-form-actions button {
   padding: 8px 16px;
   border-radius: var(--radius);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   cursor: pointer;
 }
@@ -537,7 +537,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-primary);
   cursor: pointer;
   user-select: none;
@@ -595,7 +595,7 @@
   display: flex;
   align-items: baseline;
   gap: 8px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   line-height: 1.4;
 }
@@ -613,7 +613,7 @@
 }
 
 .support-article-title {
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   color: var(--text-primary);
   margin: 0 0 8px 0;
@@ -624,7 +624,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
@@ -633,12 +633,12 @@
   border: 1px solid var(--border);
   padding: 2px 8px;
   border-radius: var(--radius-sm);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
 }
 
 .support-article-content {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   line-height: 1.7;
   color: var(--text-primary);
   overflow-wrap: break-word;
@@ -654,13 +654,13 @@
 }
 
 .support-article-content h1 {
-  font-size: 18px;
+  font-size: var(--font-size-2xl);
 }
 .support-article-content h2 {
   font-size: 15px;
 }
 .support-article-content h3 {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
 }
 
 .support-article-content p {
@@ -671,7 +671,7 @@
   background: var(--bg-tertiary);
   padding: 2px 6px;
   border-radius: 3px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 .support-article-content pre {
@@ -719,7 +719,7 @@
 }
 
 .support-article-footer p {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   margin: 0 0 8px 0;
 }
@@ -757,14 +757,14 @@
 }
 
 .support-message-sender {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
 .support-message-bubble {
   padding: 8px 12px;
   border-radius: var(--radius-md);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   line-height: 1.5;
   word-wrap: break-word;
 }
@@ -783,7 +783,7 @@
 }
 
 .support-message-time {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   color: var(--text-muted);
 }
 
@@ -802,7 +802,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-family: inherit;
 }
 
@@ -821,7 +821,7 @@
   border: none;
   border-radius: var(--radius);
   color: white;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   cursor: pointer;
 }
@@ -841,7 +841,7 @@
   text-align: center;
   padding: 32px 16px;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .support-empty-icon {
@@ -855,7 +855,7 @@
   justify-content: center;
   padding: 32px;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .support-error {
@@ -864,7 +864,7 @@
   border-radius: var(--radius);
   padding: 10px 12px;
   color: #f87171;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   margin-bottom: 12px;
 }
 
@@ -883,17 +883,17 @@
   height: 48px;
   background: rgba(34, 197, 94, 0.1);
   border-radius: var(--radius-full);
-  font-size: 24px;
+  font-size: var(--font-size-3xl);
   margin-bottom: 12px;
 }
 
 .support-success p {
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   margin: 0 0 4px 0;
 }
 
 .support-success .support-success-sub {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }

--- a/src/styles/features/support-panel.css
+++ b/src/styles/features/support-panel.css
@@ -1,12 +1,29 @@
 /* ─── Support Panel (slide-out from right) ─────────────────────────────────── */
 
+/* Support-local colors — intentional one-offs, not part of the global scale. */
+:root {
+  /* Slack CTA — Slack brand aubergine gradient + lavender accents */
+  --support-slack-aubergine-rgb: 97, 31, 105;
+  --support-slack-violet-rgb: 78, 29, 129;
+  /* Ticket status pills (Tailwind-derived hues with no global token) */
+  --support-ticket-open: #facc15;
+  --support-ticket-open-rgb: 234, 179, 8;
+  --support-ticket-resolved: #4ade80;
+  --support-ticket-closed: #9ca3af;
+  --support-ticket-closed-rgb: 107, 114, 128;
+  /* Form submit hover + soft error banner */
+  --support-submit-hover: #16a34a;
+  --support-error-soft: #f87171;
+  --support-error-soft-rgb: 255, 77, 77;
+}
+
 .support-overlay {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: var(--overlay-40);
   z-index: var(--z-app-overlay);
   animation: support-fade-in 0.2s ease;
 }
@@ -129,26 +146,34 @@
   width: 100%;
   padding: 10px 12px;
   margin-bottom: 20px;
-  background: linear-gradient(135deg, rgba(97, 31, 105, 0.15) 0%, rgba(78, 29, 129, 0.1) 100%);
-  border: 1px solid rgba(147, 51, 234, 0.2);
+  background: linear-gradient(
+    135deg,
+    rgba(var(--support-slack-aubergine-rgb), 0.15) 0%,
+    rgba(var(--support-slack-violet-rgb), 0.1) 100%
+  );
+  border: 1px solid rgba(var(--purple-deep-rgb), 0.2);
   border-radius: 10px;
   color: var(--text-secondary);
   font: inherit;
   text-align: left;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    border-color var(--transition);
 }
 
 .support-slack-cta:hover {
-  background: linear-gradient(135deg, rgba(97, 31, 105, 0.25) 0%, rgba(78, 29, 129, 0.18) 100%);
-  border-color: rgba(147, 51, 234, 0.35);
+  background: linear-gradient(
+    135deg,
+    rgba(var(--support-slack-aubergine-rgb), 0.25) 0%,
+    rgba(var(--support-slack-violet-rgb), 0.18) 100%
+  );
+  border-color: rgba(var(--purple-deep-rgb), 0.35);
 }
 
 .support-slack-cta svg {
   flex-shrink: 0;
-  color: #e9a7fb;
+  color: var(--slack-pink);
 }
 
 .support-slack-cta-text {
@@ -165,7 +190,7 @@
 
 .support-slack-cta-arrow {
   flex-shrink: 0;
-  color: #c4b5fd;
+  color: var(--slack-lavender);
   font-size: var(--font-size-lg);
   line-height: 1;
 }
@@ -375,20 +400,20 @@
 }
 
 .support-ticket-status.new {
-  background: rgba(59, 130, 246, 0.15);
-  color: #60a5fa;
+  background: rgba(var(--info-rgb), 0.15);
+  color: var(--info-light);
 }
 .support-ticket-status.open {
-  background: rgba(234, 179, 8, 0.15);
-  color: #facc15;
+  background: rgba(var(--support-ticket-open-rgb), 0.15);
+  color: var(--support-ticket-open);
 }
 .support-ticket-status.resolved {
-  background: rgba(34, 197, 94, 0.15);
-  color: #4ade80;
+  background: rgba(var(--success-light-rgb), 0.15);
+  color: var(--support-ticket-resolved);
 }
 .support-ticket-status.closed {
-  background: rgba(107, 114, 128, 0.15);
-  color: #9ca3af;
+  background: rgba(var(--support-ticket-closed-rgb), 0.15);
+  color: var(--support-ticket-closed);
 }
 
 .support-ticket-item-meta {
@@ -513,11 +538,11 @@
 .support-form-actions .support-submit-btn {
   background: var(--success-light);
   border: none;
-  color: white;
+  color: var(--text-bright);
 }
 
 .support-form-actions .support-submit-btn:hover:not(:disabled) {
-  background: #16a34a;
+  background: var(--support-submit-hover);
 }
 
 .support-form-actions button:disabled {
@@ -551,8 +576,8 @@
   border: 1px solid var(--border);
   border-radius: 9px;
   transition:
-    background 0.15s,
-    border-color 0.15s;
+    background var(--transition),
+    border-color var(--transition);
   flex-shrink: 0;
 }
 
@@ -566,18 +591,18 @@
   background: var(--text-muted);
   border-radius: var(--radius-full);
   transition:
-    transform 0.15s,
-    background 0.15s;
+    transform var(--transition),
+    background var(--transition);
 }
 
 .support-toggle.on {
-  background: #2563eb;
-  border-color: #2563eb;
+  background: var(--info-hover);
+  border-color: var(--info-hover);
 }
 
 .support-toggle.on::after {
   transform: translateX(14px);
-  background: white;
+  background: var(--text-bright);
 }
 
 .support-project-info-preview {
@@ -688,7 +713,7 @@
 }
 
 .support-article-content a {
-  color: #60a5fa;
+  color: var(--info-light);
   text-decoration: none;
 }
 
@@ -770,8 +795,8 @@
 }
 
 .support-message.customer .support-message-bubble {
-  background: #2563eb;
-  color: white;
+  background: var(--info-hover);
+  color: var(--text-bright);
   border-bottom-right-radius: 2px;
 }
 
@@ -817,17 +842,17 @@
 
 .support-reply-input button {
   padding: 8px 14px;
-  background: #2563eb;
+  background: var(--info-hover);
   border: none;
   border-radius: var(--radius);
-  color: white;
+  color: var(--text-bright);
   font-size: var(--font-size-md);
   font-weight: 500;
   cursor: pointer;
 }
 
 .support-reply-input button:hover:not(:disabled) {
-  background: #1d4ed8;
+  background: var(--info-dark);
 }
 
 .support-reply-input button:disabled {
@@ -859,11 +884,11 @@
 }
 
 .support-error {
-  background: rgba(255, 77, 77, 0.1);
-  border: 1px solid rgba(255, 77, 77, 0.3);
+  background: rgba(var(--support-error-soft-rgb), 0.1);
+  border: 1px solid rgba(var(--support-error-soft-rgb), 0.3);
   border-radius: var(--radius);
   padding: 10px 12px;
-  color: #f87171;
+  color: var(--support-error-soft);
   font-size: var(--font-size-md);
   margin-bottom: 12px;
 }
@@ -881,7 +906,7 @@
   justify-content: center;
   width: 48px;
   height: 48px;
-  background: rgba(34, 197, 94, 0.1);
+  background: rgba(var(--success-light-rgb), 0.1);
   border-radius: var(--radius-full);
   font-size: var(--font-size-3xl);
   margin-bottom: 12px;

--- a/src/styles/features/toolbar.css
+++ b/src/styles/features/toolbar.css
@@ -6,7 +6,7 @@
   background: var(--bg-tertiary);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
 }
 
@@ -17,7 +17,7 @@
 
 .capture-shortcut {
   font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   white-space: nowrap;
 }

--- a/src/styles/features/update-banner.css
+++ b/src/styles/features/update-banner.css
@@ -25,7 +25,7 @@
 .update-banner-badge {
   background: var(--action);
   color: var(--action-text);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   padding: 3px 8px;
   border-radius: var(--radius-sm);
@@ -35,7 +35,7 @@
 
 .update-banner-version {
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
 }
 
@@ -48,7 +48,7 @@
 .update-banner-btn {
   padding: 6px 12px;
   border-radius: var(--radius);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   cursor: pointer;
   border: none;
@@ -100,14 +100,14 @@
 
 .update-banner-progress-text {
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   min-width: 36px;
 }
 
 .update-banner-error {
   color: var(--error);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-family: 'JetBrainsMono NF', monospace;
   max-width: 400px;
   overflow: hidden;
@@ -123,7 +123,7 @@
 
 .update-banner-notes li {
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   line-height: 1.5;
   margin-bottom: 2px;
 }

--- a/src/styles/features/visual-editor-image.css
+++ b/src/styles/features/visual-editor-image.css
@@ -28,7 +28,7 @@
   gap: var(--spacing-xs);
 }
 .ss-edit-image__path {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   color: var(--text-muted);
   background: var(--bg-tertiary);
   border-radius: var(--radius-sm);
@@ -39,7 +39,7 @@
 }
 .ss-edit-image__note {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1.45;
   color: var(--text-muted);
 }

--- a/src/styles/features/visual-editor.css
+++ b/src/styles/features/visual-editor.css
@@ -9,7 +9,7 @@
   gap: var(--spacing-xs);
   height: 28px;
   padding: 0 var(--spacing-sm);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-secondary);
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
@@ -79,7 +79,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-md);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 /* Pin-as-sidebar styles (pin button, header actions, pinned layout) live in
@@ -110,7 +110,7 @@
   background: none;
   border: none;
   color: var(--text-muted);
-  font-size: 18px;
+  font-size: var(--font-size-2xl);
   line-height: 1;
   cursor: pointer;
   padding: 0 var(--spacing-xs);
@@ -154,7 +154,7 @@
 
 /* Shown in the footer while the source location resolves (Save not ready yet). */
 .ss-edit-panel__locating {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
 }
 
@@ -164,7 +164,7 @@
   align-items: center;
   gap: 6px;
   padding: 0;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
   background: none;
   border: none;
@@ -228,7 +228,7 @@
   min-width: 21px;
   height: 20px;
   padding: 0 var(--spacing-sm);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   background: transparent;
   border: none;
@@ -283,7 +283,7 @@
   width: max-content;
   max-width: 100%;
   padding: 6px 9px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 400;
   line-height: 1.45;
   text-align: left;
@@ -310,7 +310,7 @@
 .ss-edit-panel__bp-note {
   margin: 0 0 var(--spacing-sm);
   padding: var(--spacing-sm);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1.4;
   color: var(--text-secondary);
   background: color-mix(in srgb, var(--warning) 12%, transparent);
@@ -345,7 +345,7 @@
   width: max-content;
   max-width: 210px;
   padding: 6px 9px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 400;
   line-height: 1.45;
   text-align: left;
@@ -366,7 +366,7 @@
   visibility: visible;
 }
 .ss-edit-panel__csshint-tip code {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   padding: 1px 4px;
   background: var(--bg-secondary);
   border-radius: var(--radius-sm);
@@ -377,7 +377,7 @@
   margin: var(--spacing-xs) 0 0;
   padding-top: var(--spacing-sm);
   border-top: 1px solid var(--border);
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   line-height: 1.5;
   color: var(--text-muted);
 }
@@ -397,7 +397,7 @@
   border-radius: var(--radius-sm);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   cursor: pointer;
   transition: background var(--transition);
@@ -418,7 +418,7 @@
 }
 .ss-edit-panel__dynhelp p {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   color: var(--text-secondary);
 }
@@ -469,7 +469,7 @@
   min-width: 92px;
   height: 22px;
   padding: 0 var(--spacing-sm);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-primary);
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
@@ -512,7 +512,7 @@
   display: flex;
   align-items: center;
   padding: 4px var(--spacing-sm);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   text-align: left;
   color: var(--text-secondary);
   background: transparent;
@@ -569,7 +569,7 @@
   background-size: 8px 8px;
 }
 .ss-color-swatch__empty {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 
@@ -612,7 +612,7 @@
   width: 100%;
   height: 26px;
   padding: 0 var(--spacing-sm);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-variant-numeric: tabular-nums;
   color: var(--text-primary);
   background: var(--bg-tertiary);
@@ -639,7 +639,7 @@
 }
 .ss-edit-intro__lead {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   line-height: 1.5;
   color: var(--text-secondary);
 }
@@ -676,7 +676,7 @@
 .ss-edit-panel__multi {
   margin: 0;
   padding: 6px var(--spacing-sm);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1.4;
   color: var(--warning, #e0a458);
   background: color-mix(in srgb, var(--warning, #e0a458) 12%, transparent);
@@ -715,7 +715,7 @@
 .ss-edit-panel__locitem {
   width: 100%;
   padding: 4px var(--spacing-sm);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-variant-numeric: tabular-nums;
   text-align: left;
   color: var(--text-secondary);
@@ -738,7 +738,7 @@
 /* Scope hint — where the element's component is used across the project. */
 .ss-edit-panel__scope {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1.4;
   color: var(--text-muted);
 }
@@ -780,7 +780,7 @@
 }
 .ss-usage-modal__name {
   font-family: var(--font-mono);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   color: var(--accent, var(--action));
 }
 .ss-usage-modal__body {
@@ -790,7 +790,7 @@
 .ss-usage-modal__note {
   margin: 0 0 var(--spacing-lg);
   padding: var(--spacing-sm) var(--spacing-md);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   line-height: 1.5;
   color: var(--text-secondary);
   background: color-mix(in srgb, var(--warning, #e0a458) 10%, transparent);
@@ -838,7 +838,7 @@
   background: var(--text-muted);
 }
 .ss-usage-sec__label {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -846,7 +846,7 @@
 }
 .ss-usage-sec__count {
   margin-left: auto;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 .ss-usage-sec__list {
@@ -876,7 +876,7 @@
   flex: 1 1 auto;
   min-width: 0;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 .ss-usage-row__dir {
   flex: 0 1 auto;
@@ -930,7 +930,7 @@
   gap: var(--spacing-sm);
 }
 .ss-edit-panel__source code {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -964,7 +964,7 @@
 
 .ss-edit-panel__badge {
   flex-shrink: 0;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   padding: 2px 6px;
   border-radius: var(--radius-sm);
   background: var(--bg-tertiary);
@@ -995,7 +995,7 @@
   cursor: pointer;
   user-select: none;
   list-style: none;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -1077,7 +1077,7 @@
   margin: 0;
   padding: 0;
   text-align: center;
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   line-height: 1;
   font-variant-numeric: tabular-nums;
   color: var(--text-primary);
@@ -1154,7 +1154,7 @@
 .ss-edit-panel__label {
   display: inline-flex;
   align-items: center;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
 }
 
@@ -1185,7 +1185,7 @@
   position: fixed;
   z-index: calc(var(--z-modal-overlay) + 2);
   padding: 4px 10px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--text-primary);
   background: var(--bg-tertiary);
@@ -1227,7 +1227,7 @@
   gap: 6px;
   height: 28px;
   padding: 0 var(--spacing-md);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   color: var(--text-muted);
   background: var(--bg-tertiary);
@@ -1245,7 +1245,7 @@
   height: 20px;
   padding: 0;
   text-align: center;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-variant-numeric: tabular-nums;
   color: var(--text-primary);
   background: var(--bg-tertiary);
@@ -1269,7 +1269,7 @@
   width: 92px;
   height: 20px;
   padding: 0 var(--spacing-xs);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-primary);
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
@@ -1301,7 +1301,7 @@
   align-items: center;
   gap: var(--spacing-xs);
   padding: 4px 6px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-variant-numeric: tabular-nums;
   color: var(--text-secondary);
   background: var(--bg-tertiary);
@@ -1324,7 +1324,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   line-height: 1;
   color: var(--text-muted);
   background: none;
@@ -1351,7 +1351,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   line-height: 1;
   color: var(--text-secondary);
   background: var(--bg-tertiary);
@@ -1365,11 +1365,11 @@
 }
 .ss-custom-css__hint {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
 }
 .ss-custom-css__hint code {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   padding: 1px 3px;
   background: var(--bg-tertiary);
   border-radius: var(--radius-sm);
@@ -1383,7 +1383,7 @@
 }
 
 .ss-edit-panel__classes {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   color: var(--text-muted);
   background: var(--bg-tertiary);

--- a/src/styles/features/visual-editor.css
+++ b/src/styles/features/visual-editor.css
@@ -58,7 +58,7 @@
 }
 .preview-edit-toggle-switch.is-on::after {
   transform: translateX(10px);
-  background: #ffffff;
+  background: var(--text-bright);
 }
 
 .ss-edit-panel {
@@ -207,7 +207,7 @@
 }
 .ss-edit-panel__switch.is-on::after {
   transform: translateX(10px);
-  background: #ffffff;
+  background: var(--text-bright);
 }
 
 /* Segmented control — a tray with inset, individually-rounded segments so the
@@ -678,8 +678,8 @@
   padding: 6px var(--spacing-sm);
   font-size: var(--font-size-sm);
   line-height: 1.4;
-  color: var(--warning, #e0a458);
-  background: color-mix(in srgb, var(--warning, #e0a458) 12%, transparent);
+  color: var(--warning);
+  background: color-mix(in srgb, var(--warning) 12%, transparent);
   border-radius: var(--radius-sm);
 }
 
@@ -761,10 +761,10 @@
 }
 /* Tone the warning variant (in a layout / every page) with the warning color. */
 .ss-edit-panel__scope--wide {
-  color: var(--warning, #e0a458);
+  color: var(--warning);
 }
 .ss-edit-panel__scope--btn.ss-edit-panel__scope--wide {
-  background: color-mix(in srgb, var(--warning, #e0a458) 12%, transparent);
+  background: color-mix(in srgb, var(--warning) 12%, transparent);
 }
 .ss-edit-panel__scope strong {
   color: inherit;
@@ -793,8 +793,8 @@
   font-size: var(--font-size-base);
   line-height: 1.5;
   color: var(--text-secondary);
-  background: color-mix(in srgb, var(--warning, #e0a458) 10%, transparent);
-  border: 1px solid color-mix(in srgb, var(--warning, #e0a458) 26%, transparent);
+  background: color-mix(in srgb, var(--warning) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warning) 26%, transparent);
   border-radius: var(--radius-md);
 }
 .ss-usage-modal__note strong {
@@ -832,7 +832,7 @@
   background: var(--action);
 }
 .ss-usage-sec__dot--layout {
-  background: var(--warning, #e0a458);
+  background: var(--warning);
 }
 .ss-usage-sec__dot--component {
   background: var(--text-muted);
@@ -972,8 +972,8 @@
   cursor: default;
 }
 .ss-edit-panel__badge--approx {
-  color: var(--warning, #e0a458);
-  background: color-mix(in srgb, var(--warning, #e0a458) 14%, transparent);
+  color: var(--warning);
+  background: color-mix(in srgb, var(--warning) 14%, transparent);
 }
 
 /* Collapsible control sections (Layout, Spacing, Typography, …). Native

--- a/src/styles/features/workspace/compact-workspace.css
+++ b/src/styles/features/workspace/compact-workspace.css
@@ -34,7 +34,7 @@
   border: none;
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   white-space: nowrap;
   overflow: hidden;
@@ -48,7 +48,7 @@
 
 .compact-topbar-project-menu-item.is-subtle {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
 }
 
 /* ---------- Tab strip ---------- */
@@ -98,7 +98,7 @@
   background: transparent;
   border: none;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   cursor: pointer;
   max-width: 160px;
 }
@@ -152,7 +152,7 @@
   border: none;
   border-radius: var(--radius-sm);
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   line-height: 1;
   cursor: pointer;
   transition:

--- a/src/styles/features/workspace/connect-overlay.css
+++ b/src/styles/features/workspace/connect-overlay.css
@@ -1,5 +1,10 @@
 /* ============ Connect Overlay ============ */
 
+/* Connect-overlay-local colors — intentional one-offs, not in the global scale. */
+:root {
+  --connect-success-hover: #3dbdb5; /* darker step of --success for the CTA hover */
+}
+
 .connect-overlay {
   position: absolute;
   top: 0;
@@ -53,7 +58,7 @@
   border-radius: var(--radius-md);
   border: none;
   background: var(--success);
-  color: #1e1e1e;
+  color: var(--action-text); /* dark text on success-colored button */
   cursor: pointer;
   transition:
     background-color 0.15s,
@@ -61,7 +66,7 @@
 }
 
 .connect-overlay-btn:hover:not(:disabled) {
-  background: #3dbdb5;
+  background: var(--connect-success-hover);
 }
 
 .connect-overlay-btn:disabled {

--- a/src/styles/features/workspace/connect-overlay.css
+++ b/src/styles/features/workspace/connect-overlay.css
@@ -30,14 +30,14 @@
 }
 
 .connect-overlay-title {
-  font-size: 18px;
+  font-size: var(--font-size-2xl);
   font-weight: 600;
   margin-bottom: 8px;
   color: var(--text-primary);
 }
 
 .connect-overlay-description {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   color: var(--text-secondary);
   margin-bottom: 24px;
   line-height: 1.5;
@@ -48,7 +48,7 @@
   align-items: center;
   gap: 8px;
   padding: 10px 20px;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 500;
   border-radius: var(--radius-md);
   border: none;

--- a/src/styles/features/workspace/main.css
+++ b/src/styles/features/workspace/main.css
@@ -21,7 +21,7 @@
 }
 
 .workspace-titlebar h1 {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
@@ -32,7 +32,7 @@
 
 .workspace-titlebar .project-path {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-family: monospace;
   white-space: nowrap;
   overflow: hidden;
@@ -53,7 +53,7 @@
 }
 
 .workspace-titlebar .back-link {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   white-space: nowrap;
   flex-shrink: 0;
   background: none;

--- a/src/styles/features/workspace/sidebar.css
+++ b/src/styles/features/workspace/sidebar.css
@@ -9,7 +9,7 @@
   border-right: 1px solid var(--border);
   min-height: 0;
   overflow: hidden;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-primary);
 }
 
@@ -52,7 +52,7 @@
   color: var(--text-primary);
   cursor: pointer;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 600;
   text-align: left;
   flex-shrink: 0;
@@ -102,7 +102,7 @@
   flex-shrink: 0;
   cursor: pointer;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   text-align: left;
   transition: background-color var(--transition-fast);
 }
@@ -124,7 +124,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1;
   letter-spacing: 0.3px;
 }
@@ -193,7 +193,7 @@
   color: var(--text-muted);
   cursor: pointer;
   font: inherit;
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -224,7 +224,7 @@
 .sidebar-group-empty {
   padding: var(--spacing-xs) var(--spacing-md) var(--spacing-sm) 30px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
 }
 
 /* Projects (top-level groups). No vertical padding — we want the row to
@@ -324,7 +324,7 @@
 .sidebar-project-name {
   flex: 1;
   min-width: 0;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
@@ -332,7 +332,7 @@
 }
 
 .sidebar-project-meta {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
   flex-shrink: 0;
@@ -342,7 +342,7 @@
  * instead. Matches the ⌘K badge sizing on the dashboard search trigger. */
 .sidebar-project-initials.is-shortcut {
   font-family: inherit;
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 500;
   letter-spacing: 0.3px;
   color: var(--text-secondary);
@@ -386,7 +386,7 @@
 .sidebar-project-inactive {
   padding: var(--spacing-xs) var(--spacing-md) var(--spacing-sm) 44px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
 }
 
@@ -442,7 +442,7 @@
 }
 
 .sidebar-section-label {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -460,7 +460,7 @@
 }
 
 .sidebar-section-count {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
 }
@@ -476,7 +476,7 @@
   border-radius: var(--radius-sm);
   color: var(--text-muted);
   cursor: pointer;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   line-height: 1;
   padding: 0;
   transition:
@@ -499,7 +499,7 @@
   border-radius: var(--radius-sm);
   color: var(--text-muted);
   font-family: inherit;
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: normal;
   line-height: 1;
   letter-spacing: 0.3px;
@@ -533,7 +533,7 @@
   color: var(--text-primary);
   text-align: left;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
 }
 
@@ -550,7 +550,7 @@
 .sidebar-section-empty {
   padding: 4px var(--spacing-md) 4px 40px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-style: italic;
 }
 
@@ -710,7 +710,7 @@
 .sidebar-row-label {
   flex: 1;
   min-width: 0;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -727,7 +727,7 @@
   min-width: 0;
   padding: 1px 4px;
   margin: 0;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font: inherit;
   color: var(--text-primary);
   background: var(--bg-tertiary);
@@ -739,7 +739,7 @@
 }
 
 .sidebar-row-meta {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   color: var(--text-muted);
   flex-shrink: 0;
   font-variant-numeric: tabular-nums;
@@ -755,7 +755,7 @@
   border: none;
   color: var(--text-muted);
   cursor: pointer;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   line-height: 1;
   padding: 0;
   border-radius: var(--radius-sm);
@@ -850,7 +850,7 @@
   border: none;
   color: var(--text-muted);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -869,7 +869,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   line-height: 1;
 }
 

--- a/src/styles/features/workspace/sidebar.css
+++ b/src/styles/features/workspace/sidebar.css
@@ -688,12 +688,12 @@
 
 .sidebar-row-dot.dot-active {
   background: var(--success-light);
-  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.15);
+  box-shadow: 0 0 0 2px rgba(var(--success-light-rgb), 0.15);
 }
 
 .sidebar-row-dot.dot-attention {
   background: var(--warning);
-  box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.2);
+  box-shadow: 0 0 0 2px rgba(var(--warning-rgb), 0.2);
   animation: sidebar-pulse 1.6s ease-in-out infinite;
 }
 
@@ -802,7 +802,7 @@
 
 .sidebar-row-action:hover:not(:disabled) {
   background: none;
-  color: #fff;
+  color: var(--text-bright);
 }
 
 .sidebar-row-action:disabled {

--- a/src/styles/features/workspace/split-pane.css
+++ b/src/styles/features/workspace/split-pane.css
@@ -112,7 +112,7 @@
 }
 
 .terminal-title {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   font-weight: 500;
 }

--- a/src/styles/features/workspace/split-pane.css
+++ b/src/styles/features/workspace/split-pane.css
@@ -62,7 +62,7 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  background: #1e1e1e;
+  background: #1e1e1e; /* css-ok: must match xterm theme bg */
   display: flex;
   flex-direction: column;
   /* Container query context for the screenshot footer below — lets

--- a/src/styles/features/workspace/tabs.css
+++ b/src/styles/features/workspace/tabs.css
@@ -24,7 +24,7 @@
   border-radius: 0;
   color: var(--text-muted);
   font-family: inherit;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition: color 0.15s;
@@ -85,7 +85,7 @@
 }
 
 .preview-label {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   color: var(--text-muted);
 }
@@ -100,7 +100,7 @@
   border: 1px solid transparent;
   border-radius: var(--radius);
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -175,7 +175,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -239,7 +239,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition:

--- a/src/styles/features/workspace/terminal.css
+++ b/src/styles/features/workspace/terminal.css
@@ -6,7 +6,7 @@
      Settings buttons align vertically with the sidebar toggle above. */
   padding: 9px 10px;
   min-height: 48px;
-  background: #252525;
+  background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
@@ -50,9 +50,9 @@
   font-weight: 500;
   cursor: pointer;
   transition:
-    background-color 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+    background-color var(--transition),
+    color var(--transition),
+    border-color var(--transition);
   outline: none;
 }
 
@@ -199,9 +199,9 @@
   flex-shrink: 0;
   opacity: 0;
   transition:
-    opacity 0.1s,
-    background 0.1s,
-    color 0.1s;
+    opacity var(--transition-fast),
+    background var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .tab-selector-item:hover .tab-selector-close-btn {
@@ -209,7 +209,7 @@
 }
 
 .tab-selector-close-btn:hover {
-  background: rgba(239, 68, 68, 0.15);
+  background: rgba(var(--error-light-rgb), 0.15);
   color: var(--danger);
 }
 
@@ -243,7 +243,7 @@
 .terminal-tab-content[data-agent-id='opencode'] {
   left: 0;
   padding: 0;
-  background: #1e1e1e;
+  background: var(--bg-primary);
 }
 
 .terminal-tab-content[data-agent-id='opencode'] .xterm,
@@ -253,7 +253,7 @@
   height: 100% !important;
   padding: 0 !important;
   margin: 0 !important;
-  background: #1e1e1e !important;
+  background: var(--bg-primary) !important;
 }
 
 .terminal-tab-content[data-agent-id='opencode'] .xterm-viewport {
@@ -594,7 +594,7 @@
 }
 
 .toolbar-dropdown-item .toggle-indicator.on {
-  background: rgba(245, 158, 11, 0.2);
+  background: rgba(var(--warning-rgb), 0.2);
   color: var(--warning);
 }
 

--- a/src/styles/features/workspace/terminal.css
+++ b/src/styles/features/workspace/terminal.css
@@ -46,7 +46,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -72,7 +72,7 @@
 
 .tab-selector-shortcut {
   font-family: 'SF Mono', Monaco, monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   flex-shrink: 0;
   white-space: nowrap;
@@ -80,7 +80,7 @@
 
 .tab-selector-cmd {
   font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-  font-size: 14px;
+  font-size: var(--font-size-lg);
 }
 
 .tab-selector-trigger svg {
@@ -103,7 +103,7 @@
 
 .tab-selector-section-label {
   padding: 4px 10px 2px;
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -130,7 +130,7 @@
   border: none;
   background: transparent;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   text-align: left;
   cursor: pointer;
   border-radius: var(--radius-sm);
@@ -171,7 +171,7 @@
 
 .tab-selector-item-shortcut {
   font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   flex-shrink: 0;
   margin-left: auto;
@@ -422,7 +422,7 @@
   border: none;
   background: transparent;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   border-radius: var(--radius-sm);
@@ -438,7 +438,7 @@
    (e.g. Plugins dropdown with no plugins installed). */
 .toolbar-dropdown-empty-hint {
   padding: 10px 12px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
   font-style: italic;
 }
@@ -517,7 +517,7 @@
 }
 
 .plugin-dropdown-row-label {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-primary);
   pointer-events: none;
   white-space: nowrap;
@@ -585,7 +585,7 @@
 
 .toolbar-dropdown-item .toggle-indicator {
   margin-left: auto;
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   padding: 2px 6px;
   border-radius: var(--radius-sm);

--- a/src/styles/global/base.css
+++ b/src/styles/global/base.css
@@ -57,6 +57,12 @@
   --error: #f44747;
   --error-light: #ef4444;
 
+  /* Deep red — destructive/armed states (delete confirmation, publish errors) */
+  --error-deep: #dc2626;
+
+  /* Modified-state yellow (git modified badges, needs-attention markers) */
+  --modified-yellow: #eab308;
+
   /* Informational blue (links, info banners, "open" PR state, focus accents) */
   --info: #3b82f6;
   --info-hover: #2563eb;
@@ -66,6 +72,13 @@
   /* AI / agent accent (skills, MCP, plugin marketplace) */
   --purple: #a855f7;
   --purple-light: #a78bfa;
+  /* Deeper purple used only for tinted purple backgrounds (#9333ea) */
+  --purple-deep-rgb: 147, 51, 234;
+
+  /* Slack community CTA brand hues (dashboard, setup, support panel) */
+  --slack-pink: #e9a7fb;
+  --slack-lavender: #c4b5fd;
+  --slack-lavender-bright: #ddd6fe;
 
   /* RGB triplets — for alpha tints only: rgba(var(--error-rgb), 0.1).
    * Keep each in sync with its solid token above. */
@@ -75,9 +88,12 @@
   --warning-light-rgb: 251, 191, 36;
   --error-rgb: 244, 71, 71;
   --error-light-rgb: 239, 68, 68;
+  --error-deep-rgb: 220, 38, 38;
+  --modified-yellow-rgb: 234, 179, 8;
   --info-rgb: 59, 130, 246;
   --info-light-rgb: 96, 165, 250;
-  --purple-rgb: 147, 51, 234;
+  --purple-rgb: 168, 85, 247;
+  --purple-light-rgb: 167, 139, 250;
   --border-rgb: 60, 60, 60;
   --white-rgb: 255, 255, 255;
   --black-rgb: 0, 0, 0;
@@ -102,7 +118,11 @@
   --ansi-yellow: #e5e510;
   --ansi-blue: #3b8eea;
   --ansi-blue-dark: #2472c8;
+  --ansi-green-rgb: 13, 188, 121;
+  --ansi-red-rgb: 241, 76, 76;
+  --ansi-yellow-rgb: 229, 229, 16;
   --ansi-blue-rgb: 59, 142, 234;
+  --ansi-blue-dark-rgb: 36, 114, 200;
 
   /* Code syntax colors (VS Code dark palette — code mode, diff rendering) */
   --code-keyword: #569cd6;
@@ -112,6 +132,11 @@
 
   /* Structure */
   --border: #3c3c3c;
+  /* Hover states for list rows / tabs / bordered cards. These names were
+   * referenced (undefined) for months — hovers silently rendered transparent.
+   * Defined conservatively as aliases; tune freely. */
+  --bg-hover: var(--bg-tertiary);
+  --border-hover: var(--text-muted);
 
   /* Spacing scale (use for padding, margin, gap) */
   --spacing-xs: 4px;
@@ -287,9 +312,21 @@ body.compact-mode-active html {
   animation: spin 1s linear infinite;
 }
 
+/* Shared keyframes — keyframe names are GLOBAL in CSS. Define shared ones
+   here only; a feature-file duplicate silently overrides every consumer
+   app-wide depending on import order. */
 @keyframes spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
   }
 }
 
@@ -458,7 +495,7 @@ button:hover {
 
 .toggle-pill-switch.is-on::after {
   transform: translateX(10px);
-  background: #ffffff;
+  background: var(--text-bright);
 }
 
 /* Rotate the chevron 180° when its parent dropdown is open. */
@@ -471,7 +508,7 @@ button:hover {
 .modal-frame-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: var(--overlay-70);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -595,11 +632,11 @@ button:hover {
 .button--danger {
   background: transparent;
   color: var(--error-light);
-  border-color: rgba(239, 68, 68, 0.3);
+  border-color: rgba(var(--error-light-rgb), 0.3);
 }
 
 .button--danger:hover:not(:disabled) {
-  background: rgba(239, 68, 68, 0.1);
+  background: rgba(var(--error-light-rgb), 0.1);
 }
 
 .button--ghost {
@@ -652,15 +689,16 @@ button:hover {
 }
 
 /* ===== Primitive: Skeleton ===== */
+/* 0.4/0.7 (not the 0.5/0.85 once written here) — project-list.css carried a
+   same-named duplicate that loaded later and won everywhere; these are the
+   values the app has always actually rendered. */
 @keyframes skeleton-pulse {
-  0% {
-    opacity: 0.5;
+  0%,
+  100% {
+    opacity: 0.4;
   }
   50% {
-    opacity: 0.85;
-  }
-  100% {
-    opacity: 0.5;
+    opacity: 0.7;
   }
 }
 

--- a/src/styles/global/base.css
+++ b/src/styles/global/base.css
@@ -32,11 +32,15 @@
   --bg-primary: #1e1e1e;
   --bg-secondary: #252526;
   --bg-tertiary: #2d2d2d;
+  /* Recessed wells: terminal panes, log output, code editors */
+  --bg-deep: #1a1a1a;
 
   /* Text */
   --text-primary: #cccccc;
   --text-secondary: #9d9d9d;
   --text-muted: #6d6d6d;
+  /* Pure white — high-emphasis text/icons on dark surfaces */
+  --text-bright: #ffffff;
 
   /* Brand / interactive */
   --accent: #ffffff;
@@ -52,6 +56,59 @@
   --warning-light: #fbbf24;
   --error: #f44747;
   --error-light: #ef4444;
+
+  /* Informational blue (links, info banners, "open" PR state, focus accents) */
+  --info: #3b82f6;
+  --info-hover: #2563eb;
+  --info-light: #60a5fa;
+  --info-dark: #1d4ed8;
+
+  /* AI / agent accent (skills, MCP, plugin marketplace) */
+  --purple: #a855f7;
+  --purple-light: #a78bfa;
+
+  /* RGB triplets — for alpha tints only: rgba(var(--error-rgb), 0.1).
+   * Keep each in sync with its solid token above. */
+  --success-rgb: 78, 205, 196;
+  --success-light-rgb: 34, 197, 94;
+  --warning-rgb: 245, 158, 11;
+  --warning-light-rgb: 251, 191, 36;
+  --error-rgb: 244, 71, 71;
+  --error-light-rgb: 239, 68, 68;
+  --info-rgb: 59, 130, 246;
+  --info-light-rgb: 96, 165, 250;
+  --purple-rgb: 147, 51, 234;
+  --border-rgb: 60, 60, 60;
+  --white-rgb: 255, 255, 255;
+  --black-rgb: 0, 0, 0;
+
+  /* White hover/selection tints on dark surfaces */
+  --tint-subtle: rgba(255, 255, 255, 0.05);
+  --tint: rgba(255, 255, 255, 0.08);
+  --tint-strong: rgba(255, 255, 255, 0.1);
+
+  /* Black scrims (overlays behind modals, image dimming) — suffix = alpha % */
+  --overlay-30: rgba(0, 0, 0, 0.3);
+  --overlay-40: rgba(0, 0, 0, 0.4);
+  --overlay-50: rgba(0, 0, 0, 0.5);
+  --overlay-60: rgba(0, 0, 0, 0.6);
+  --overlay-70: rgba(0, 0, 0, 0.7);
+  --overlay-80: rgba(0, 0, 0, 0.8);
+
+  /* ANSI terminal palette (health diagnostics, browser tools, log rendering) */
+  --ansi-green: #0dbc79;
+  --ansi-bright-green: #23d18b;
+  --ansi-red: #f14c4c;
+  --ansi-yellow: #e5e510;
+  --ansi-blue: #3b8eea;
+  --ansi-blue-dark: #2472c8;
+  --ansi-blue-rgb: 59, 142, 234;
+
+  /* Code syntax colors (VS Code dark palette — code mode, diff rendering) */
+  --code-keyword: #569cd6;
+  --code-string: #ce9178;
+  --code-property: #9cdcfe;
+  --code-comment: #6a9955;
 
   /* Structure */
   --border: #3c3c3c;
@@ -119,6 +176,18 @@
 
   /* Typography */
   --font-mono: 'JetBrainsMono NF', 'JetBrains Mono', Menlo, Consolas, monospace;
+
+  /* Type scale — dense desktop UI, hence 1px steps at the small end.
+   * Off-scale sizes (9px, 15px, 17px…) are migration debt: round to the
+   * nearest token when touching that code, don't add new tokens. */
+  --font-size-xs: 10px; /* fine print, badges, kbd hints */
+  --font-size-sm: 11px; /* secondary labels, metadata */
+  --font-size-base: 12px; /* default UI chrome text */
+  --font-size-md: 13px; /* body / readable paragraphs */
+  --font-size-lg: 14px; /* emphasized body, inputs, buttons */
+  --font-size-xl: 16px; /* section headings */
+  --font-size-2xl: 18px; /* modal titles */
+  --font-size-3xl: 24px; /* hero / celebration screens */
 }
 
 /* Common flex centering utility */
@@ -229,7 +298,7 @@ button {
   cursor: pointer;
   border: none;
   border-radius: var(--radius);
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   padding: 10px 16px;
   transition:
     background-color 0.2s,
@@ -286,7 +355,7 @@ button:hover {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   white-space: nowrap;
   transition:
@@ -341,7 +410,7 @@ button:hover {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
   white-space: nowrap;
   transition:
@@ -434,7 +503,7 @@ button:hover {
 }
 
 .modal-frame-title {
-  font-size: 16px;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   color: var(--text-primary);
   display: flex;
@@ -471,7 +540,7 @@ button:hover {
   padding: var(--spacing-sm) var(--spacing-lg);
   border-radius: var(--radius);
   border: 1px solid transparent;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 500;
   cursor: pointer;
   transition:
@@ -546,7 +615,7 @@ button:hover {
 
 .button--sm {
   padding: var(--spacing-xs) var(--spacing-md);
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 .button--block {
@@ -576,7 +645,7 @@ button:hover {
 }
 
 .empty-state-description {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   max-width: 360px;
   line-height: 1.5;

--- a/src/styles/modes/code-mode.css
+++ b/src/styles/modes/code-mode.css
@@ -28,7 +28,7 @@
 }
 
 .code-tab-sidebar-title {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--text-secondary);
   text-transform: uppercase;
@@ -77,7 +77,7 @@
   border: none;
   background: none;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-family: inherit;
   outline: none;
 }
@@ -108,7 +108,7 @@
   padding: 24px 16px;
   gap: 8px;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--font-size-base);
 }
 
 .code-tab-retry-btn {
@@ -117,7 +117,7 @@
   border-radius: var(--radius-sm);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   cursor: pointer;
 }
 
@@ -173,7 +173,7 @@
   border-radius: 0;
   background: none;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-family: inherit;
   cursor: pointer;
   text-align: left;
@@ -238,7 +238,7 @@
   border-bottom: 1px solid var(--border);
   background: var(--bg-secondary);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   flex-shrink: 0;
 }
 
@@ -251,7 +251,7 @@
 .code-viewer-size {
   margin-left: auto;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   flex-shrink: 0;
 }
 
@@ -264,7 +264,7 @@
   border-radius: var(--radius);
   background: var(--bg-tertiary);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-family: inherit;
   cursor: pointer;
   flex-shrink: 0;
@@ -294,7 +294,7 @@
   flex: 1;
   gap: 12px;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .code-viewer-content {
@@ -334,7 +334,7 @@
   padding-right: 12px;
   text-align: right;
   font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted);
 }
 
@@ -372,7 +372,7 @@
   margin: 0;
   padding: 12px 0 0;
   font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   line-height: 20px;
   color: var(--text-primary);
   white-space: pre;
@@ -381,7 +381,7 @@
 /* Shiki highlighted output */
 .code-viewer-highlighted {
   font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   line-height: 20px;
 }
 
@@ -439,7 +439,7 @@
   border-radius: 0;
   background: var(--bg-tertiary);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
   cursor: pointer;
   text-align: left;
@@ -469,7 +469,7 @@
   border-radius: 0;
   background: var(--bg-primary);
   font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 18px;
   color: var(--text-secondary);
   white-space: pre;
@@ -482,7 +482,7 @@
   border-bottom: 1px solid var(--border);
   background: transparent;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-family: inherit;
   outline: none;
 }
@@ -505,7 +505,7 @@
   border-radius: var(--radius-sm);
   background: none;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-family: inherit;
   cursor: pointer;
 }
@@ -523,7 +523,7 @@
   border-radius: var(--radius-sm);
   background: var(--action);
   color: var(--action-text);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   font-family: inherit;
   cursor: pointer;
 }

--- a/src/styles/modes/education-mode.css
+++ b/src/styles/modes/education-mode.css
@@ -4,7 +4,7 @@
 .education-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay-50);
   z-index: var(--z-app-modal);
   cursor: crosshair;
 }
@@ -13,7 +13,7 @@
 .education-highlight {
   position: fixed;
   pointer-events: none;
-  border: 1px solid #3b82f6;
+  border: 1px solid var(--info);
   border-radius: var(--radius-sm);
   transition:
     background-color 0.15s ease-out,
@@ -25,14 +25,14 @@
 /* Tooltip card */
 .education-tooltip {
   position: fixed;
-  background: var(--bg-primary, #1a1a1a);
-  border: 1px solid var(--border, #333);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
   border-radius: var(--radius-md);
   padding: 12px 16px;
   max-width: 280px;
   min-width: 200px;
   z-index: var(--z-app-modal-max);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 20px var(--overlay-40);
   pointer-events: none;
   animation: education-tooltip-fade-in 0.15s ease-out;
 }
@@ -51,7 +51,7 @@
 .education-tooltip-title {
   font-size: var(--font-size-lg);
   font-weight: 600;
-  color: var(--text-primary, #fff);
+  color: var(--text-primary);
   margin: 0 0 6px 0;
   display: flex;
   align-items: center;
@@ -64,7 +64,7 @@
 
 .education-tooltip-description {
   font-size: var(--font-size-md);
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   margin: 0;
   line-height: 1.5;
 }
@@ -75,25 +75,25 @@
   bottom: 24px;
   left: 50%;
   transform: translateX(-50%);
-  background: var(--bg-primary, #1a1a1a);
-  border: 1px solid var(--border, #333);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 8px 16px;
   font-size: var(--font-size-base);
-  color: var(--text-muted, #666);
+  color: var(--text-muted);
   z-index: var(--z-app-modal-top);
   pointer-events: none;
 }
 
 .education-exit-hint kbd {
   display: inline-block;
-  background: var(--bg-tertiary, #2a2a2a);
-  border: 1px solid var(--border, #333);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
   border-radius: 3px;
   padding: 2px 6px;
   font-family: inherit;
   font-size: var(--font-size-sm);
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   margin: 0 2px;
 }
 

--- a/src/styles/modes/education-mode.css
+++ b/src/styles/modes/education-mode.css
@@ -49,7 +49,7 @@
 }
 
 .education-tooltip-title {
-  font-size: 14px;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   color: var(--text-primary, #fff);
   margin: 0 0 6px 0;
@@ -63,7 +63,7 @@
 }
 
 .education-tooltip-description {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary, #aaa);
   margin: 0;
   line-height: 1.5;
@@ -79,7 +79,7 @@
   border: 1px solid var(--border, #333);
   border-radius: var(--radius);
   padding: 8px 16px;
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--text-muted, #666);
   z-index: var(--z-app-modal-top);
   pointer-events: none;
@@ -92,7 +92,7 @@
   border-radius: 3px;
   padding: 2px 6px;
   font-family: inherit;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary, #aaa);
   margin: 0 2px;
 }


### PR DESCRIPTION
## What this is

First PR of the frontend/design-system cleanup. An audit found the component architecture in good shape but the CSS layer drifting badly — and the CI check meant to catch it silently broken.

## The headline finding

`check:patterns` has been reporting **0 hex color offenders** while the real count was **~355**. Two compounding bugs: the script requires ripgrep, which isn't installed in CI or locally (every `rg` rule errored silently and reported zero), and its exclusion globs pointed at `src/styles/base.css` / `setup.css` — paths that don't exist. The script is now plain POSIX grep (can't silently vanish) and the color rule **fails** instead of informing.

## Changes

**Token layer completed** (`base.css`): type scale (`--font-size-xs…3xl`), info blues, AI purple, ANSI/code-syntax palettes, white tints (`--tint*`), black scrims (`--overlay-30…80`), and RGB-triplet companions for alpha tints (`rgba(var(--error-rgb), 0.1)` — pixel-identical, no `color-mix` compatibility gamble).

**~690 font-size declarations** migrated to the scale (exact matches only; ~49 off-scale sizes documented as rounding debt).

**All ~355 raw color literals migrated** across 40+ CSS files. Semantic families → global tokens; intentional one-offs (brand hues, feature accents) → file-local `:root` tokens; xterm-matching backgrounds → tagged `css-ok`. Every replacement maps to the exact same rendered value.

**Keyframes dedup'd**: 6 identical spinners (`diff-spin`, `mcp-spin`, `plugins-spin`, `preview-spin`, `skills-spin`, `submit-review-spin`) + 4 duplicate `spin` defs collapsed into base.css's canonical `spin`; `fadeIn` centralized; the `skeleton-pulse` name collision resolved by adopting the values the app actually rendered (import order made project-list's copy win everywhere).

**Two new CI checks** born from bugs found during migration:
- *Undefined `var()` references* — an undefined var makes the declaration invalid and the style silently doesn't apply
- *Duplicate `@keyframes` names* — a duplicate silently overrides every consumer app-wide

## Deliberate visual fixes (the only non-pixel-identical changes)

- `--bg-hover` / `--border-hover` were referenced 14× but **never defined** — hover states in the backups modal, workspace tabs, and setup have been rendering transparent. Now defined as conservative aliases (`--bg-tertiary` / `--text-muted`); tune freely.
- `.branch-changes-save-btn` used undefined `--primary`/`--primary-hover` — the save button rendered **white text on a transparent background**. Now `--info`/`--info-hover` (blue).

## Verification

- `pnpm check:all` green (typecheck, lint, format, patterns, LOC)
- 624 tests pass, production Vite build clean
- Undefined-var sweep confirms zero dangling references
- Tolerated exception: `#252525` → `--bg-secondary` (`#252526`) — 1-unit drift removing a typo

## Known debt (deliberately out of scope, next PRs)

- Spacing-token adoption (~30%), 0.2s/0.25s transition durations, off-scale font sizes
- `plugins.css` has pre-existing invalid values (`var(--success) 40`) that silently no-op — needs its own fix since correcting them changes rendering
- Button/Dropdown/Tooltip primitive migration, component folder reorg, docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated CSS style compliance guidelines for color literals, font sizes, and keyframes naming conventions.

* **Chores**
  * Standardized UI typography and colors throughout the application by adopting design token CSS variables across all components for improved consistency and maintainability.
  * Enhanced CI pattern validation to detect raw color literals in CSS, undefined CSS custom properties, and duplicate keyframe definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->