### PR TITLE
Design system PR 2: Spinner primitive, modal migrations, ModalFrame dismissal fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,6 +308,20 @@ import { ModalFrame } from './primitives/ModalFrame';
 
 For toggling state, pair with `useModalState()` from `src/hooks/useModalState.ts`.
 
+### Loading spinner → use `<Spinner>` from `src/components/primitives/Spinner.tsx`
+
+Don't hand-roll `border-top-color` + `animation: spin` divs — there used to be 16 per-feature copies.
+
+```tsx
+import { Spinner } from './primitives/Spinner';
+
+<Spinner size="sm" />                                  {/* 14px — inline, inside buttons */}
+<Spinner />                                            {/* 20px — default */}
+<Spinner size="lg" style={{ color: 'var(--accent)' }} /> {/* 32px — section loading */}
+```
+
+The arc uses `currentColor` — set `color` on the spinner or let it inherit (inside a green action button it's automatically dark).
+
 ### New button → use `<Button variant="...">` from `src/components/primitives/Button.tsx`
 
 Don't invent per-domain button classes (`foo-btn`, `xyz-action`, etc.) — they fragment the design system.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,7 @@ import { UpdateBanner } from './components/UpdateBanner';
 import { MonorepoPickerModal } from './components/MonorepoPickerModal';
 import { ModalFrame } from './components/primitives/ModalFrame';
 import { Button } from './components/primitives/Button';
+import { Spinner } from './components/primitives/Spinner';
 import { ToastContext } from './contexts/ToastContext';
 import { ModalProvider, useModal } from './contexts/ModalContext';
 import { CommandPaletteHost } from './components/CommandPalette/CommandPaletteHost';
@@ -105,6 +106,7 @@ function App({ initialProjectPath }: AppProps) {
 const EMPTY_TAB_TITLES: Map<number, string> = new Map();
 const EMPTY_ATTENTION_TABS: Set<number> = new Set();
 const noop = () => {};
+const loadingSpinner = <Spinner size="lg" style={{ color: 'var(--text-muted)' }} />; // legacy .spinner look
 
 function AppContents({ initialProjectPath }: AppProps) {
   const [view, setView] = useState<AppView>('loading');
@@ -1043,7 +1045,7 @@ function AppContents({ initialProjectPath }: AppProps) {
       <>
         <div className="app loading">
           <img src="/ship_studio_full_noshadow.svg" alt="Ship Studio" className="app-logo" />
-          <div className="spinner" />
+          {loadingSpinner}
         </div>
         {quitConfirmModal}
       </>
@@ -1194,7 +1196,7 @@ function AppContents({ initialProjectPath }: AppProps) {
             isProjectDevServerRunning={isServerRunning}
           />
           <div className="project-loading-body">
-            <div className="spinner" />
+            {loadingSpinner}
             <p>Opening {currentProject?.name}...</p>
           </div>
         </div>
@@ -1207,9 +1209,7 @@ function AppContents({ initialProjectPath }: AppProps) {
   if (!currentProject) {
     return (
       <>
-        <div className="app loading">
-          <div className="spinner" />
-        </div>
+        <div className="app loading">{loadingSpinner}</div>
         {quitConfirmModal}
       </>
     );

--- a/src/components/AgentsPanel.test.tsx
+++ b/src/components/AgentsPanel.test.tsx
@@ -50,7 +50,6 @@ vi.mock('./setup/OnboardingTerminal', () => ({
 // Strip heavy icon SVGs; only need predictable DOM.
 vi.mock('./icons', () => ({
   CheckIcon: () => <span data-testid="check-icon" />,
-  SpinnerIcon: () => <span data-testid="spinner-icon" />,
   ClaudeIcon: () => <span data-testid="claude-icon" />,
 }));
 

--- a/src/components/AgentsPanel.tsx
+++ b/src/components/AgentsPanel.tsx
@@ -26,9 +26,10 @@ import {
 import { OnboardingTerminal } from './setup/OnboardingTerminal';
 import { ModalFrame } from './primitives/ModalFrame';
 import { Button } from './primitives/Button';
+import { Spinner } from './primitives/Spinner';
 import { useOptionalToast } from '../contexts/ToastContext';
 import { logger } from '../lib/logger';
-import { CheckIcon, SpinnerIcon, ClaudeIcon } from './icons';
+import { CheckIcon, ClaudeIcon } from './icons';
 
 function KebabGlyph() {
   return (
@@ -240,7 +241,7 @@ export function AgentsPanel() {
             Install, sign in, or switch the default agent new terminals use.
           </p>
         </div>
-        {loading && <SpinnerIcon size={14} className="agents-panel-spinner" />}
+        {loading && <Spinner size="sm" className="agents-panel-spinner" />}
       </header>
 
       <div className="agents-panel-list">
@@ -301,7 +302,7 @@ export function AgentsPanel() {
                       >
                         <span className="agents-default-pill-radio">
                           {isSwitchingToThis ? (
-                            <SpinnerIcon size={10} className="spinner-icon" />
+                            <Spinner size="sm" />
                           ) : agent.isDefault ? (
                             <CheckIcon size={10} />
                           ) : null}

--- a/src/components/BackupsModal.tsx
+++ b/src/components/BackupsModal.tsx
@@ -8,13 +8,14 @@
  */
 
 import { useEffect, useState, useCallback } from 'react';
-import { SpinnerIcon, CheckIcon, PullRequestIcon } from './icons';
+import { CheckIcon, PullRequestIcon } from './icons';
 import { getBackups, restoreBackup, Backup, RestoreResult } from '../lib/backups';
 import { trackEvent } from '../lib/analytics';
 import { ModalFrame } from './primitives/ModalFrame';
 import { Button } from './primitives/Button';
 import { useAsyncState } from '../hooks/useAsyncState';
 import { EmptyState } from './primitives/EmptyState';
+import { Spinner } from './primitives/Spinner';
 import { useModal } from '../contexts/ModalContext';
 
 interface BackupsModalProps {
@@ -136,9 +137,7 @@ export function BackupsModal({ projectPath, onRestore, onCreatePR }: BackupsModa
               variant="primary"
               onClick={() => void handleConfirmRestore()}
               disabled={isRestoring}
-              leftIcon={
-                isRestoring ? <SpinnerIcon size={14} className="spinner-icon" /> : undefined
-              }
+              leftIcon={isRestoring ? <Spinner size="sm" /> : undefined}
             >
               {isRestoring ? 'Restoring...' : 'Restore'}
             </Button>
@@ -207,7 +206,7 @@ export function BackupsModal({ projectPath, onRestore, onCreatePR }: BackupsModa
 
         {isLoading ? (
           <div className="backups-loading">
-            <SpinnerIcon size={20} className="spinner-icon" />
+            <Spinner />
             <span>Loading backups...</span>
           </div>
         ) : isNotGitRepo ? (

--- a/src/components/CodeTab.tsx
+++ b/src/components/CodeTab.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useFileTree } from '../hooks/useFileTree';
 import { FileTree } from './FileTree';
 import { CodeViewer } from './CodeViewer';
+import { Spinner } from './primitives/Spinner';
 import { ResetIcon, SearchIcon } from './icons';
 import { type FileTreeNode, fileExtensionForAnalytics } from '../lib/code';
 import { trackEvent, trackSearch } from '../lib/analytics';
@@ -141,7 +142,7 @@ export function CodeTab({ projectPath, onSendToAgent, revealTarget }: CodeTabPro
         <div className="code-tab-sidebar-content">
           {isLoadingTree ? (
             <div className="code-tab-sidebar-loading">
-              <div className="capture-spinner" />
+              <Spinner size="sm" style={{ color: 'var(--accent)' }} />
             </div>
           ) : treeError ? (
             <div className="code-tab-sidebar-error">

--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -13,6 +13,7 @@ import { checkIdeAvailability, openInIde } from '../lib/ide';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
 import { useOptionalToast } from '../contexts/ToastContext';
+import { Spinner } from './primitives/Spinner';
 import { ChevronIcon, CodeIcon, FileIcon, VSCodeIcon, CursorIcon, CopyIcon } from './icons';
 import { trackEvent } from '../lib/analytics';
 import { fileExtensionForAnalytics } from '../lib/code';
@@ -393,7 +394,7 @@ export function CodeViewer({
           <span className="code-viewer-path">{filePath}</span>
         </div>
         <div className="code-viewer-placeholder">
-          <div className="capture-spinner" />
+          <Spinner size="sm" style={{ color: 'var(--accent)' }} />
         </div>
       </div>
     );

--- a/src/components/ConflictResolutionModal.tsx
+++ b/src/components/ConflictResolutionModal.tsx
@@ -19,6 +19,7 @@ import { WarningIcon, CopyIcon, ChevronIcon, InfoIcon } from './icons';
 import { trackEvent, trackError } from '../lib/analytics';
 import { ModalFrame } from './primitives/ModalFrame';
 import { Button } from './primitives/Button';
+import { Spinner } from './primitives/Spinner';
 import { useAsyncState } from '../hooks/useAsyncState';
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
 import { useOptionalToast } from '../contexts/ToastContext';
@@ -218,7 +219,7 @@ Please help me understand what each version does and recommend which one to keep
     return (
       <ModalFrame isOpen onClose={handleClose} showCloseButton={false} className="conflict-content">
         <div className="conflict-loading">
-          <div className="conflict-spinner" />
+          <Spinner size="lg" />
           <p>Analyzing conflicts...</p>
         </div>
       </ModalFrame>

--- a/src/components/CreateProject.tsx
+++ b/src/components/CreateProject.tsx
@@ -17,6 +17,7 @@ import { trackEvent } from '../lib/analytics';
 import { logger } from '../lib/logger';
 import { UploadIcon } from './icons';
 import { Button } from './primitives/Button';
+import { Spinner } from './primitives/Spinner';
 import { useProjectCreation, TEMPLATES, STEPS, STATUS_MESSAGES } from '../hooks/useProjectCreation';
 import { TemplateGallery, type CommunityTemplate } from './TemplateGallery';
 
@@ -156,7 +157,7 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
         <div className="create-modal-content creating">
           <h2>Creating "{projectName}"</h2>
 
-          <div className="create-spinner" />
+          <Spinner size="lg" className="create-spinner" />
 
           <p className="create-status">{STATUS_MESSAGES[currentStep]}</p>
 
@@ -177,7 +178,7 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
                       <polyline points="20 6 9 17 4 12" />
                     </svg>
                   ) : status === 'active' ? (
-                    <div className="checklist-spinner" />
+                    <Spinner />
                   ) : (
                     <svg
                       width="18"

--- a/src/components/DevServerStatus.tsx
+++ b/src/components/DevServerStatus.tsx
@@ -11,6 +11,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from './primitives/Button';
+import { Spinner } from './primitives/Spinner';
 import { stripAnsi } from '../lib/ansi';
 
 /** Last N log lines to show inline — enough to catch a compile error or an
@@ -108,7 +109,7 @@ export function DevServerStatus({
   return (
     <div className={`preview-status preview-status--${phase}`}>
       {phase === 'loading' ? (
-        <div className="spinner" />
+        <Spinner size="lg" style={{ color: 'var(--text-muted)' }} />
       ) : (
         <div className="preview-status__icon" aria-hidden>
           <svg

--- a/src/components/DeviceMirror.tsx
+++ b/src/components/DeviceMirror.tsx
@@ -43,8 +43,9 @@ import { usePolling } from '../hooks/usePolling';
 import { checkDependenciesInstalled } from '../lib/project';
 import { attachPtySession, writePtySession } from '../lib/ptySession';
 import { getWindowLabel } from '../lib/window';
-import { SpinnerIcon, ResetIcon, ChevronIcon } from './icons';
+import { ResetIcon, ChevronIcon } from './icons';
 import { Button } from './primitives/Button';
+import { Spinner } from './primitives/Spinner';
 import { BuildTerminal } from './BuildTerminal';
 import { AndroidMirrorStage } from './AndroidMirrorStage';
 
@@ -657,7 +658,7 @@ export function DeviceMirror({ projectName, projectPath, onSendToAgent }: Device
                 onClick={() => setBuildOpen((o) => !o)}
                 aria-expanded={buildOpen}
               >
-                {launchStatus === 'building' && <SpinnerIcon size={12} />}
+                {launchStatus === 'building' && <Spinner size="sm" />}
                 <span className="device-mirror-build-title">{summary}</span>
               </button>
               {launchStatus === 'failed' && onSendToAgent && (
@@ -725,7 +726,7 @@ export function DeviceMirror({ projectName, projectPath, onSendToAgent }: Device
   // ---- Progress (starting) ----
   return (
     <div className="preview-loading">
-      <SpinnerIcon size={24} />
+      <Spinner />
       <span className="hint">{PLATFORM_COPY[platform ?? 'ios'].startHint}</span>
     </div>
   );

--- a/src/components/DiffModal.tsx
+++ b/src/components/DiffModal.tsx
@@ -16,6 +16,7 @@ import { FileIcon } from './icons';
 import { trackError } from '../lib/analytics';
 import { ModalFrame } from './primitives/ModalFrame';
 import { Button } from './primitives/Button';
+import { Spinner } from './primitives/Spinner';
 import { useAsyncState } from '../hooks/useAsyncState';
 
 // Image extensions to detect for preview
@@ -181,7 +182,7 @@ export function DiffModal({ projectPath, filePath, fileStatus, onClose }: DiffMo
         <div className="diff-body">
           {isLoading && (
             <div className="diff-loading">
-              <div className="diff-spinner" />
+              <Spinner size="lg" />
               <p>Loading diff...</p>
             </div>
           )}

--- a/src/components/EnvEditor.tsx
+++ b/src/components/EnvEditor.tsx
@@ -16,6 +16,7 @@
 import { useEnvEditor } from '../hooks/useEnvEditor';
 import { useOptionalToast } from '../contexts/ToastContext';
 import { useModal } from '../contexts/ModalContext';
+import { ModalFrame } from './primitives/ModalFrame';
 
 /** Props for the EnvEditor component */
 interface EnvEditorProps {
@@ -63,249 +64,88 @@ export function EnvEditor({ projectPath }: EnvEditorProps) {
   if (!isOpen) return null;
 
   return (
-    <div className="modal-overlay" onMouseDown={onClose}>
-      <div className="modal env-editor-modal" onMouseDown={(e) => e.stopPropagation()}>
-        <div className="env-editor-header">
-          <h3>Environment Variables</h3>
-          <button className="env-close-btn" onClick={onClose}>
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
+    <ModalFrame
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Environment Variables"
+      className="env-editor-modal"
+      // While the nested paste mini-modal is open, ESC / overlay-click must not
+      // tear down the whole editor (and the pasted content with it).
+      dismissable={!showPasteModal}
+    >
+      <div className="env-editor-content">
+        {/* File Tabs */}
+        <div className="env-file-tabs">
+          {envFiles.map((file) => (
+            <button
+              key={file.path}
+              className={`env-file-tab ${selectedFile?.path === file.path ? 'active' : ''}`}
+              onClick={() => setSelectedFile(file)}
             >
-              <line x1="18" y1="6" x2="6" y2="18" />
-              <line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </button>
+              {file.name}
+            </button>
+          ))}
+          {showNewFileInput ? (
+            <div className="env-new-file-input">
+              <input
+                type="text"
+                value={newFileName}
+                onChange={(e) => setNewFileName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void handleCreateFile();
+                  if (e.key === 'Escape') setShowNewFileInput(false);
+                }}
+                placeholder=".env.local"
+                autoFocus
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
+              />
+              <button onClick={() => void handleCreateFile()} title="Create">
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              </button>
+              <button onClick={() => setShowNewFileInput(false)} title="Cancel">
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+          ) : (
+            <button
+              className="env-file-tab env-add-file"
+              onClick={() => setShowNewFileInput(true)}
+              title="Create new env file"
+            >
+              +
+            </button>
+          )}
         </div>
 
-        <div className="env-editor-content">
-          {/* File Tabs */}
-          <div className="env-file-tabs">
-            {envFiles.map((file) => (
-              <button
-                key={file.path}
-                className={`env-file-tab ${selectedFile?.path === file.path ? 'active' : ''}`}
-                onClick={() => setSelectedFile(file)}
-              >
-                {file.name}
-              </button>
-            ))}
-            {showNewFileInput ? (
-              <div className="env-new-file-input">
-                <input
-                  type="text"
-                  value={newFileName}
-                  onChange={(e) => setNewFileName(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') void handleCreateFile();
-                    if (e.key === 'Escape') setShowNewFileInput(false);
-                  }}
-                  placeholder=".env.local"
-                  autoFocus
-                  autoComplete="off"
-                  autoCorrect="off"
-                  autoCapitalize="off"
-                  spellCheck={false}
-                />
-                <button onClick={() => void handleCreateFile()} title="Create">
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                  >
-                    <polyline points="20 6 9 17 4 12" />
-                  </svg>
-                </button>
-                <button onClick={() => setShowNewFileInput(false)} title="Cancel">
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                  >
-                    <line x1="18" y1="6" x2="6" y2="18" />
-                    <line x1="6" y1="6" x2="18" y2="18" />
-                  </svg>
-                </button>
-              </div>
-            ) : (
-              <button
-                className="env-file-tab env-add-file"
-                onClick={() => setShowNewFileInput(true)}
-                title="Create new env file"
-              >
-                +
-              </button>
-            )}
-          </div>
-
-          {/* Sync Warning */}
-          {syncStatus &&
-            (syncStatus.missingInExample.length > 0 || syncStatus.missingInLocal.length > 0) && (
-              <div className="env-sync-warning">
-                {syncStatus.missingInExample.length > 0 && (
-                  <div className="env-sync-item">
-                    <div className="env-sync-info">
-                      <svg
-                        width="14"
-                        height="14"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                      >
-                        <circle cx="12" cy="12" r="10" />
-                        <line x1="12" y1="8" x2="12" y2="12" />
-                        <line x1="12" y1="16" x2="12.01" y2="16" />
-                      </svg>
-                      <span>
-                        {syncStatus.missingInExample.length} key
-                        {syncStatus.missingInExample.length > 1 ? 's' : ''} in .env.local missing
-                        from .env.example
-                      </span>
-                    </div>
-                    <button className="env-sync-btn" onClick={() => void handleSyncToExample()}>
-                      Sync to .env.example
-                    </button>
-                  </div>
-                )}
-                {syncStatus.missingInLocal.length > 0 && (
-                  <div className="env-sync-item">
-                    <div className="env-sync-info">
-                      <svg
-                        width="14"
-                        height="14"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                      >
-                        <circle cx="12" cy="12" r="10" />
-                        <line x1="12" y1="8" x2="12" y2="12" />
-                        <line x1="12" y1="16" x2="12.01" y2="16" />
-                      </svg>
-                      <span>
-                        {syncStatus.missingInLocal.length} key
-                        {syncStatus.missingInLocal.length > 1 ? 's' : ''} in .env.example missing
-                        from .env.local
-                      </span>
-                    </div>
-                    <button className="env-sync-btn" onClick={() => void handleSyncToLocal()}>
-                      Add to .env.local
-                    </button>
-                  </div>
-                )}
-              </div>
-            )}
-
-          {/* Variables List */}
-          {isLoading ? (
-            <div className="env-loading">Loading...</div>
-          ) : selectedFile ? (
-            <div className="env-vars-container">
-              <div className="env-vars-list">
-                {vars.length === 0 ? (
-                  <div className="env-empty">
-                    No variables defined. Click "Add Variable" to get started.
-                  </div>
-                ) : (
-                  vars.map((v, index) => (
-                    <div key={index} className="env-var-row">
-                      <input
-                        type="text"
-                        className="env-var-key"
-                        value={v.key}
-                        onChange={(e) => handleUpdateVar(index, 'key', e.target.value)}
-                        placeholder="KEY"
-                        autoFocus={editingKey === v.key}
-                        onFocus={() => setEditingKey(v.key)}
-                        onBlur={() => setEditingKey(null)}
-                        autoComplete="off"
-                        autoCorrect="off"
-                        autoCapitalize="off"
-                        spellCheck={false}
-                      />
-                      <span className="env-var-equals">=</span>
-                      <input
-                        type={visibleValues.has(index) ? 'text' : 'password'}
-                        className="env-var-value"
-                        value={v.value}
-                        onChange={(e) => handleUpdateVar(index, 'value', e.target.value)}
-                        placeholder="value"
-                        autoComplete="off"
-                        autoCorrect="off"
-                        autoCapitalize="off"
-                        spellCheck={false}
-                      />
-                      <button
-                        className="env-var-visibility"
-                        onClick={() => toggleValueVisibility(index)}
-                        title={visibleValues.has(index) ? 'Hide value' : 'Show value'}
-                      >
-                        {visibleValues.has(index) ? (
-                          <svg
-                            width="14"
-                            height="14"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                          >
-                            <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
-                            <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
-                            <line x1="1" y1="1" x2="23" y2="23" />
-                          </svg>
-                        ) : (
-                          <svg
-                            width="14"
-                            height="14"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                          >
-                            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                            <circle cx="12" cy="12" r="3" />
-                          </svg>
-                        )}
-                      </button>
-                      <button
-                        className="env-var-delete"
-                        onClick={() => handleDeleteVar(index)}
-                        title="Delete variable"
-                      >
-                        <svg
-                          width="14"
-                          height="14"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        >
-                          <line x1="18" y1="6" x2="6" y2="18" />
-                          <line x1="6" y1="6" x2="18" y2="18" />
-                        </svg>
-                      </button>
-                    </div>
-                  ))
-                )}
-              </div>
-
-              <div className="env-actions">
-                <div className="env-actions-left">
-                  <button className="env-add-btn" onClick={handleAddVar}>
-                    + Add Variable
-                  </button>
-                  <button className="env-paste-btn" onClick={() => setShowPasteModal(true)}>
+        {/* Sync Warning */}
+        {syncStatus &&
+          (syncStatus.missingInExample.length > 0 || syncStatus.missingInLocal.length > 0) && (
+            <div className="env-sync-warning">
+              {syncStatus.missingInExample.length > 0 && (
+                <div className="env-sync-item">
+                  <div className="env-sync-info">
                     <svg
                       width="14"
                       height="14"
@@ -314,105 +154,255 @@ export function EnvEditor({ projectPath }: EnvEditorProps) {
                       stroke="currentColor"
                       strokeWidth="2"
                     >
-                      <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
-                      <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
+                      <circle cx="12" cy="12" r="10" />
+                      <line x1="12" y1="8" x2="12" y2="12" />
+                      <line x1="12" y1="16" x2="12.01" y2="16" />
                     </svg>
-                    Paste .env
+                    <span>
+                      {syncStatus.missingInExample.length} key
+                      {syncStatus.missingInExample.length > 1 ? 's' : ''} in .env.local missing from
+                      .env.example
+                    </span>
+                  </div>
+                  <button className="env-sync-btn" onClick={() => void handleSyncToExample()}>
+                    Sync to .env.example
                   </button>
                 </div>
-                <div className="env-actions-right">
-                  {selectedFile && (
-                    <button
-                      className="env-delete-file-btn"
-                      onClick={() => void handleDeleteFile()}
-                      title="Delete this file"
+              )}
+              {syncStatus.missingInLocal.length > 0 && (
+                <div className="env-sync-item">
+                  <div className="env-sync-info">
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
                     >
-                      Delete File
-                    </button>
-                  )}
-                  <button
-                    className="env-save-btn"
-                    onClick={() => void handleSave()}
-                    disabled={!hasChanges || isSaving || isLoading}
-                  >
-                    {isSaving ? 'Saving...' : 'Save'}
+                      <circle cx="12" cy="12" r="10" />
+                      <line x1="12" y1="8" x2="12" y2="12" />
+                      <line x1="12" y1="16" x2="12.01" y2="16" />
+                    </svg>
+                    <span>
+                      {syncStatus.missingInLocal.length} key
+                      {syncStatus.missingInLocal.length > 1 ? 's' : ''} in .env.example missing from
+                      .env.local
+                    </span>
+                  </div>
+                  <button className="env-sync-btn" onClick={() => void handleSyncToLocal()}>
+                    Add to .env.local
                   </button>
                 </div>
-              </div>
-            </div>
-          ) : (
-            <div className="env-empty-state">
-              <div className="env-empty-icon">$</div>
-              <h4>No environment files</h4>
-              <p>Create an .env file to store your API keys and secrets.</p>
-              <button className="env-create-btn" onClick={() => setShowNewFileInput(true)}>
-                Create .env.local
-              </button>
+              )}
             </div>
           )}
 
-          {error && <div className="env-error">{error}</div>}
-        </div>
+        {/* Variables List */}
+        {isLoading ? (
+          <div className="env-loading">Loading...</div>
+        ) : selectedFile ? (
+          <div className="env-vars-container">
+            <div className="env-vars-list">
+              {vars.length === 0 ? (
+                <div className="env-empty">
+                  No variables defined. Click "Add Variable" to get started.
+                </div>
+              ) : (
+                vars.map((v, index) => (
+                  <div key={index} className="env-var-row">
+                    <input
+                      type="text"
+                      className="env-var-key"
+                      value={v.key}
+                      onChange={(e) => handleUpdateVar(index, 'key', e.target.value)}
+                      placeholder="KEY"
+                      autoFocus={editingKey === v.key}
+                      onFocus={() => setEditingKey(v.key)}
+                      onBlur={() => setEditingKey(null)}
+                      autoComplete="off"
+                      autoCorrect="off"
+                      autoCapitalize="off"
+                      spellCheck={false}
+                    />
+                    <span className="env-var-equals">=</span>
+                    <input
+                      type={visibleValues.has(index) ? 'text' : 'password'}
+                      className="env-var-value"
+                      value={v.value}
+                      onChange={(e) => handleUpdateVar(index, 'value', e.target.value)}
+                      placeholder="value"
+                      autoComplete="off"
+                      autoCorrect="off"
+                      autoCapitalize="off"
+                      spellCheck={false}
+                    />
+                    <button
+                      className="env-var-visibility"
+                      onClick={() => toggleValueVisibility(index)}
+                      title={visibleValues.has(index) ? 'Hide value' : 'Show value'}
+                    >
+                      {visibleValues.has(index) ? (
+                        <svg
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                        >
+                          <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+                          <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+                          <line x1="1" y1="1" x2="23" y2="23" />
+                        </svg>
+                      ) : (
+                        <svg
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                        >
+                          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                          <circle cx="12" cy="12" r="3" />
+                        </svg>
+                      )}
+                    </button>
+                    <button
+                      className="env-var-delete"
+                      onClick={() => handleDeleteVar(index)}
+                      title="Delete variable"
+                    >
+                      <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                      >
+                        <line x1="18" y1="6" x2="6" y2="18" />
+                        <line x1="6" y1="6" x2="18" y2="18" />
+                      </svg>
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
 
-        {/* Paste Modal */}
-        {showPasteModal && (
-          <div className="env-paste-overlay" onMouseDown={() => setShowPasteModal(false)}>
-            <div className="env-paste-modal" onMouseDown={(e) => e.stopPropagation()}>
-              <div className="env-paste-header">
-                <h4>Paste .env Contents</h4>
-                <button
-                  className="env-close-btn"
-                  onClick={() => {
-                    setShowPasteModal(false);
-                    setPasteContent('');
-                  }}
-                >
+            <div className="env-actions">
+              <div className="env-actions-left">
+                <button className="env-add-btn" onClick={handleAddVar}>
+                  + Add Variable
+                </button>
+                <button className="env-paste-btn" onClick={() => setShowPasteModal(true)}>
                   <svg
-                    width="16"
-                    height="16"
+                    width="14"
+                    height="14"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
                     strokeWidth="2"
                   >
-                    <line x1="18" y1="6" x2="6" y2="18" />
-                    <line x1="6" y1="6" x2="18" y2="18" />
+                    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+                    <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
                   </svg>
+                  Paste .env
                 </button>
               </div>
-              <p className="env-paste-hint">
-                Paste your .env file contents below. Variables will be merged with existing ones.
-              </p>
-              <textarea
-                className="env-paste-textarea"
-                value={pasteContent}
-                onChange={(e) => setPasteContent(e.target.value)}
-                placeholder={`DATABASE_URL=postgres://...\nAPI_KEY=sk-...\nNODE_ENV=development`}
-                autoFocus
-                spellCheck={false}
-              />
-              <div className="env-paste-actions">
+              <div className="env-actions-right">
+                {selectedFile && (
+                  <button
+                    className="env-delete-file-btn"
+                    onClick={() => void handleDeleteFile()}
+                    title="Delete this file"
+                  >
+                    Delete File
+                  </button>
+                )}
                 <button
-                  className="env-paste-cancel"
-                  onClick={() => {
-                    setShowPasteModal(false);
-                    setPasteContent('');
-                  }}
+                  className="env-save-btn"
+                  onClick={() => void handleSave()}
+                  disabled={!hasChanges || isSaving || isLoading}
                 >
-                  Cancel
-                </button>
-                <button
-                  className="env-paste-confirm"
-                  onClick={handlePasteEnv}
-                  disabled={!pasteContent.trim()}
-                >
-                  Add Variables
+                  {isSaving ? 'Saving...' : 'Save'}
                 </button>
               </div>
             </div>
           </div>
+        ) : (
+          <div className="env-empty-state">
+            <div className="env-empty-icon">$</div>
+            <h4>No environment files</h4>
+            <p>Create an .env file to store your API keys and secrets.</p>
+            <button className="env-create-btn" onClick={() => setShowNewFileInput(true)}>
+              Create .env.local
+            </button>
+          </div>
         )}
+
+        {error && <div className="env-error">{error}</div>}
       </div>
-    </div>
+
+      {/* Paste Modal */}
+      {showPasteModal && (
+        <div className="env-paste-overlay" onMouseDown={() => setShowPasteModal(false)}>
+          <div className="env-paste-modal" onMouseDown={(e) => e.stopPropagation()}>
+            <div className="env-paste-header">
+              <h4>Paste .env Contents</h4>
+              <button
+                className="env-close-btn"
+                onClick={() => {
+                  setShowPasteModal(false);
+                  setPasteContent('');
+                }}
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+            <p className="env-paste-hint">
+              Paste your .env file contents below. Variables will be merged with existing ones.
+            </p>
+            <textarea
+              className="env-paste-textarea"
+              value={pasteContent}
+              onChange={(e) => setPasteContent(e.target.value)}
+              placeholder={`DATABASE_URL=postgres://...\nAPI_KEY=sk-...\nNODE_ENV=development`}
+              autoFocus
+              spellCheck={false}
+            />
+            <div className="env-paste-actions">
+              <button
+                className="env-paste-cancel"
+                onClick={() => {
+                  setShowPasteModal(false);
+                  setPasteContent('');
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                className="env-paste-confirm"
+                onClick={handlePasteEnv}
+                disabled={!pasteContent.trim()}
+              >
+                Add Variables
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </ModalFrame>
   );
 }

--- a/src/components/GitErrorHandler.tsx
+++ b/src/components/GitErrorHandler.tsx
@@ -8,6 +8,7 @@
  */
 
 import { WarningIcon, CopyIcon } from './icons';
+import { ModalFrame } from './primitives/ModalFrame';
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
 import { useOptionalToast } from '../contexts/ToastContext';
 
@@ -98,50 +99,48 @@ Please help me understand what went wrong and how to fix it.`,
   };
 
   return (
-    <div className="git-error-modal" onClick={onClose}>
-      <div className="git-error-content" onClick={(e) => e.stopPropagation()}>
-        <div className="git-error-header">
-          <div className="git-error-icon">
-            <WarningIcon size={24} />
-          </div>
-          <h2>{errorInfo.title}</h2>
+    <ModalFrame isOpen onClose={onClose} className="git-error-content" ariaLabel={errorInfo.title}>
+      <div className="git-error-header">
+        <div className="git-error-icon">
+          <WarningIcon size={24} />
         </div>
+        <h2>{errorInfo.title}</h2>
+      </div>
 
-        <div className="git-error-body">
-          <p className="git-error-description">{errorInfo.description}</p>
+      <div className="git-error-body">
+        <p className="git-error-description">{errorInfo.description}</p>
 
-          <div className="git-error-prompt-section">
-            <div className="git-error-prompt-label">Ask Claude to help:</div>
-            <div className="git-error-prompt">{errorInfo.claudePrompt}</div>
-          </div>
-        </div>
-
-        <div className="git-error-footer">
-          {errorType === 'merge_conflict' && onResolveConflicts ? (
-            <>
-              <button className="branch-card-action" onClick={handleCopyPrompt}>
-                <CopyIcon size={12} />
-                Copy Prompt
-              </button>
-              <button className="branch-card-action primary" onClick={onResolveConflicts}>
-                Resolve Conflicts
-              </button>
-            </>
-          ) : (
-            <>
-              <button className="branch-card-action" onClick={handleCopyPrompt}>
-                <CopyIcon size={12} />
-                Copy to Clipboard
-              </button>
-              {onSendToClaude && (
-                <button className="branch-card-action primary" onClick={handleSendToClaude}>
-                  Send to Claude
-                </button>
-              )}
-            </>
-          )}
+        <div className="git-error-prompt-section">
+          <div className="git-error-prompt-label">Ask Claude to help:</div>
+          <div className="git-error-prompt">{errorInfo.claudePrompt}</div>
         </div>
       </div>
-    </div>
+
+      <div className="git-error-footer">
+        {errorType === 'merge_conflict' && onResolveConflicts ? (
+          <>
+            <button className="branch-card-action" onClick={handleCopyPrompt}>
+              <CopyIcon size={12} />
+              Copy Prompt
+            </button>
+            <button className="branch-card-action primary" onClick={onResolveConflicts}>
+              Resolve Conflicts
+            </button>
+          </>
+        ) : (
+          <>
+            <button className="branch-card-action" onClick={handleCopyPrompt}>
+              <CopyIcon size={12} />
+              Copy to Clipboard
+            </button>
+            {onSendToClaude && (
+              <button className="branch-card-action primary" onClick={handleSendToClaude}>
+                Send to Claude
+              </button>
+            )}
+          </>
+        )}
+      </div>
+    </ModalFrame>
   );
 }

--- a/src/components/HealthTabPanel.tsx
+++ b/src/components/HealthTabPanel.tsx
@@ -29,7 +29,8 @@ import { useOptionalToast } from '../contexts/ToastContext';
 import { stripAnsi } from '../lib/ansi';
 import { Button } from './primitives/Button';
 import { ModalFrame } from './primitives/ModalFrame';
-import { SpinnerIcon, FileIcon, CopyIcon, ResetIcon } from './icons';
+import { Spinner } from './primitives/Spinner';
+import { FileIcon, CopyIcon, ResetIcon } from './icons';
 
 const CATEGORY_HINTS: Record<ScriptCategory, string> = {
   test: "Runs your project's test suite (vitest, jest, etc.) and reports pass/fail.",
@@ -167,7 +168,7 @@ export const HealthTabPanel = forwardRef<HealthTabPanelRef, HealthTabPanelProps>
             >
               {health.isRunningAll ? (
                 <>
-                  <SpinnerIcon size={12} /> Running…
+                  <Spinner size="sm" /> Running…
                 </>
               ) : (
                 'Run all'
@@ -195,7 +196,7 @@ export const HealthTabPanel = forwardRef<HealthTabPanelRef, HealthTabPanelProps>
               title="Re-detect scripts from package.json"
               aria-label="Refresh scripts"
             >
-              {health.isRefreshing ? <SpinnerIcon size={12} /> : <ResetIcon size={12} />}
+              {health.isRefreshing ? <Spinner size="sm" /> : <ResetIcon size={12} />}
             </button>
             <button
               type="button"
@@ -205,7 +206,7 @@ export const HealthTabPanel = forwardRef<HealthTabPanelRef, HealthTabPanelProps>
               title="View package.json"
               aria-label="View package.json"
             >
-              {health.isLoadingPackageJson ? <SpinnerIcon size={12} /> : <FileIcon size={12} />}
+              {health.isLoadingPackageJson ? <Spinner size="sm" /> : <FileIcon size={12} />}
             </button>
           </div>
         </div>
@@ -278,7 +279,7 @@ export const HealthTabPanel = forwardRef<HealthTabPanelRef, HealthTabPanelProps>
                     disabled={state.status === 'running' || health.isRunningAll}
                     title={state.result ? 'Re-run check' : 'Run check'}
                   >
-                    {state.status === 'running' ? <SpinnerIcon size={12} /> : 'Run'}
+                    {state.status === 'running' ? <Spinner size="sm" /> : 'Run'}
                   </Button>
                 </div>
               </li>
@@ -424,7 +425,8 @@ function HelpHint({ label }: { label: string }) {
 
 function StatusGlyph({ status }: { status: CheckStatus }) {
   if (status === 'missing') return null;
-  if (status === 'running') return <SpinnerIcon size={10} className="health-tab-glyph running" />;
+  if (status === 'running')
+    return <Spinner size="sm" className="health-tab-glyph running" label="Running" />;
   return <span className={`health-tab-glyph dot ${status}`} aria-hidden="true" />;
 }
 

--- a/src/components/ImportProject.tsx
+++ b/src/components/ImportProject.tsx
@@ -43,6 +43,7 @@ import {
   type WorkspacePick,
 } from './import-project/steps/Step3WorkspacePicker';
 import { logger } from '../lib/logger';
+import { Spinner } from './primitives/Spinner';
 
 /** Props for the ImportProject component */
 interface ImportProjectProps {
@@ -436,7 +437,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
     if (loadingAccounts) {
       return (
         <div className="create-modal-content creating">
-          <div className="create-spinner" />
+          <Spinner size="lg" className="create-spinner" />
           <p className="create-status">Loading GitHub accounts...</p>
         </div>
       );

--- a/src/components/IntegrationBar.tsx
+++ b/src/components/IntegrationBar.tsx
@@ -10,7 +10,8 @@
  */
 
 import { useState, useEffect } from 'react';
-import { CheckIcon, WarningIcon, ChevronIcon, ClaudeIcon, GitHubIcon, SpinnerIcon } from './icons';
+import { CheckIcon, WarningIcon, ChevronIcon, ClaudeIcon, GitHubIcon } from './icons';
+import { Spinner } from './primitives/Spinner';
 import { getFullSetupStatus, SetupItem, SETUP_ITEM_ORDER } from '../lib/setup';
 import { logger } from '../lib/logger';
 
@@ -80,7 +81,7 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
       : `${readyCount}/${totalCount} ready`;
 
   const statusIcon = isLoading ? (
-    <SpinnerIcon size={14} className="spinner-icon" />
+    <Spinner size="sm" />
   ) : allConnected ? (
     <CheckIcon size={14} className="integration-bar-status-icon success" />
   ) : (

--- a/src/components/LanguagesModal.tsx
+++ b/src/components/LanguagesModal.tsx
@@ -19,11 +19,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ModalFrame } from './primitives/ModalFrame';
 import { Button } from './primitives/Button';
+import { Spinner } from './primitives/Spinner';
 import { useModal } from '../contexts/ModalContext';
 import { useAsyncState } from '../hooks/useAsyncState';
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
 import { useOptionalToast } from '../contexts/ToastContext';
-import { GlobeIcon, SpinnerIcon, CloseIcon } from './icons';
+import { GlobeIcon, CloseIcon } from './icons';
 import { asCommandError, formatCommandError } from '../lib/errors';
 import { trackEvent } from '../lib/analytics';
 import {
@@ -387,7 +388,7 @@ export function LanguagesModal({ projectPath, onSendToClaude }: LanguagesModalPr
 
       {!promptReview && isLoading && (
         <div className="languages-loading">
-          <SpinnerIcon size={16} />
+          <Spinner />
           <span>Checking project…</span>
         </div>
       )}

--- a/src/components/McpModal.tsx
+++ b/src/components/McpModal.tsx
@@ -11,6 +11,7 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { SearchIcon } from './icons';
 import { ModalFrame } from './primitives/ModalFrame';
+import { Spinner } from './primitives/Spinner';
 import { type McpServer, listMcpServers, addMcpServer, removeMcpServer } from '../lib/mcp';
 import { trackEvent, trackSearch } from '../lib/analytics';
 import { logger } from '../lib/logger';
@@ -234,7 +235,7 @@ export function McpModal({
 
               {isLoadingServers && servers.length === 0 && (
                 <div className="mcp-loading">
-                  <div className="mcp-loading-spinner" />
+                  <Spinner className="mcp-loading-spinner" />
                   Loading MCP servers...
                 </div>
               )}

--- a/src/components/MoveFolderModal.tsx
+++ b/src/components/MoveFolderModal.tsx
@@ -12,6 +12,7 @@ import { FolderIcon, CheckIcon, PlusIcon } from './icons';
 import { logger } from '../lib/logger';
 import { ModalFrame } from './primitives/ModalFrame';
 import { Button } from './primitives/Button';
+import { Spinner } from './primitives/Spinner';
 
 /** Props for the MoveFolderModal component */
 interface MoveFolderModalProps {
@@ -113,7 +114,7 @@ export function MoveFolderModal({
 
         {loading ? (
           <div className="move-folder-loading">
-            <div className="spinner" />
+            <Spinner size="lg" style={{ color: 'var(--text-muted)' }} />
           </div>
         ) : (
           <div className="move-folder-list">

--- a/src/components/PluginManager.tsx
+++ b/src/components/PluginManager.tsx
@@ -27,6 +27,7 @@ import {
 import type { LoadedPlugin } from '../hooks/usePlugins';
 import { useModal } from '../contexts/ModalContext';
 import { PluginInstallForm } from './PluginInstallForm';
+import { Spinner } from './primitives/Spinner';
 import { PluginStatusGrid } from './PluginStatusGrid';
 
 type Tab = 'installed' | 'library';
@@ -427,7 +428,7 @@ export function PluginManager({
             <>
               {isLoading && plugins.length === 0 && (
                 <div className="plugins-loading">
-                  <div className="plugins-loading-spinner" />
+                  <Spinner style={{ color: 'var(--text-primary)' }} />
                   Loading plugins...
                 </div>
               )}
@@ -485,7 +486,7 @@ export function PluginManager({
 
               {isLoadingRegistry && registry.length === 0 && (
                 <div className="plugins-loading">
-                  <div className="plugins-loading-spinner" />
+                  <Spinner style={{ color: 'var(--text-primary)' }} />
                   Loading plugin library...
                 </div>
               )}

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -47,6 +47,7 @@ import { ElementTreePanel } from './edit/ElementTreePanel';
 import { useElementTree } from '../hooks/useElementTree';
 import { PreviewLocaleSwitcher, type PreviewLocaleConfig } from './PreviewLocaleSwitcher';
 import { CompactIcon, ExpandIcon, PanelLeftIcon, ResetIcon } from './icons';
+import { Spinner } from './primitives/Spinner';
 import { pathLocale, switchPathLocale } from '../lib/i18n';
 import type { ProjectType } from '../lib/static-server';
 
@@ -939,14 +940,14 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
             {/* Branch switching overlay */}
             {isBranchSwitching && (
               <div className="preview-branch-switching-overlay">
-                <div className="preview-branch-switching-spinner" />
+                <Spinner size="lg" style={{ color: 'var(--accent)' }} />
                 <span>Switching branch...</span>
               </div>
             )}
             {/* Dev server restarting overlay */}
             {isDevServerRestarting && (
               <div className="preview-branch-switching-overlay">
-                <div className="preview-branch-switching-spinner" />
+                <Spinner size="lg" style={{ color: 'var(--accent)' }} />
                 <span>Restarting dev server...</span>
               </div>
             )}

--- a/src/components/ProjectList.tsx
+++ b/src/components/ProjectList.tsx
@@ -51,6 +51,8 @@ import { SearchAndSort } from './SearchAndSort';
 import { FolderBreadcrumb } from './FolderBreadcrumb';
 import { MoveFolderModal } from './MoveFolderModal';
 import { SettingsModal } from './SettingsModal';
+import { ModalFrame } from './primitives/ModalFrame';
+import { Spinner } from './primitives/Spinner';
 import { GitHubCalendar } from './GitHubCalendar';
 import { useModal } from '../contexts/ModalContext';
 import {
@@ -497,7 +499,7 @@ export function ProjectList({
         />
         <div className="project-list dashboard">
           <div className="project-list-loading">
-            <div className="spinner" />
+            <Spinner size="lg" style={{ color: 'var(--text-muted)' }} />
             <p>Loading projects...</p>
             {cleanupStatus && <p className="project-list-cleanup-status">{cleanupStatus}</p>}
           </div>
@@ -716,9 +718,13 @@ export function ProjectList({
 
         {/* Delete Project Confirmation Modal */}
         {deleteConfirm && (
-          <div className="modal-overlay" onClick={() => setDeleteConfirm(null)}>
-            <div className="modal" onClick={(e) => e.stopPropagation()}>
-              <h3>Delete Project?</h3>
+          <ModalFrame
+            isOpen
+            onClose={() => setDeleteConfirm(null)}
+            title="Delete Project?"
+            showCloseButton={false}
+          >
+            <div style={{ padding: 'var(--spacing-xl)' }}>
               <p>
                 Are you sure you want to delete <strong>{deleteConfirm.name}</strong>?
               </p>
@@ -739,14 +745,18 @@ export function ProjectList({
                 </button>
               </div>
             </div>
-          </div>
+          </ModalFrame>
         )}
 
         {/* Delete Folder Confirmation Modal */}
         {deleteFolderConfirm && (
-          <div className="modal-overlay" onClick={() => setDeleteFolderConfirm(null)}>
-            <div className="modal" onClick={(e) => e.stopPropagation()}>
-              <h3>Delete Folder?</h3>
+          <ModalFrame
+            isOpen
+            onClose={() => setDeleteFolderConfirm(null)}
+            title="Delete Folder?"
+            showCloseButton={false}
+          >
+            <div style={{ padding: 'var(--spacing-xl)' }}>
               <p>
                 Are you sure you want to delete <strong>{deleteFolderConfirm.name}</strong>?
               </p>
@@ -766,7 +776,7 @@ export function ProjectList({
                 </button>
               </div>
             </div>
-          </div>
+          </ModalFrame>
         )}
 
         {/* Settings Modal */}

--- a/src/components/PublishBranchDropdown.tsx
+++ b/src/components/PublishBranchDropdown.tsx
@@ -10,7 +10,8 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { ProjectGitHubStatus } from '../lib/github';
 import { publishBranch } from '../lib/branches';
-import { ChevronIcon, BranchIcon, SuccessIcon, ErrorIcon, SpinnerIcon } from './icons';
+import { ChevronIcon, BranchIcon, SuccessIcon, ErrorIcon } from './icons';
+import { Spinner } from './primitives/Spinner';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { logger } from '../lib/logger';
 import { trackEvent, trackError } from '../lib/analytics';
@@ -320,7 +321,7 @@ export function PublishBranchDropdown({
           {publishState.status === 'publishing' && (
             <>
               <div className="publish-in-progress-header">
-                <SpinnerIcon />
+                <Spinner />
                 <span>{isMainBranch ? 'Publishing to production...' : 'Syncing changes...'}</span>
               </div>
               <div className="publish-actions">

--- a/src/components/PullRequestsTab.tsx
+++ b/src/components/PullRequestsTab.tsx
@@ -22,6 +22,7 @@ import { GitHubIcon, WarningIcon, BranchIcon } from './icons';
 import { trackEvent, trackError } from '../lib/analytics';
 import { ModalFrame } from './primitives/ModalFrame';
 import { Button } from './primitives/Button';
+import { Spinner } from './primitives/Spinner';
 import { useOptionalToast } from '../contexts/ToastContext';
 
 interface PullRequestsTabProps {
@@ -202,7 +203,7 @@ export function PullRequestsTab({
     return (
       <div className="prs-tab">
         <div className="prs-tab-loading">
-          <div className="branch-item-spinner" />
+          <Spinner size="lg" />
           <span>Loading pull requests...</span>
         </div>
       </div>

--- a/src/components/SkillsModal.tsx
+++ b/src/components/SkillsModal.tsx
@@ -11,6 +11,7 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { SearchIcon } from './icons';
 import { ModalFrame } from './primitives/ModalFrame';
+import { Spinner } from './primitives/Spinner';
 import {
   type AgentSkill,
   checkSkillsCli,
@@ -284,7 +285,7 @@ export function SkillsModal({
 
               {isLoadingSkills && skills.length === 0 && (
                 <div className="skills-loading">
-                  <div className="skills-loading-spinner" />
+                  <Spinner className="skills-loading-spinner" />
                   Loading skills...
                 </div>
               )}
@@ -387,7 +388,7 @@ export function SkillsModal({
 
                   {isSearching && (
                     <div className="skills-loading">
-                      <div className="skills-loading-spinner" />
+                      <Spinner className="skills-loading-spinner" />
                       Searching skills...
                     </div>
                   )}

--- a/src/components/SubmitReviewModal.tsx
+++ b/src/components/SubmitReviewModal.tsx
@@ -17,6 +17,7 @@ import { asCommandError, formatCommandError, isMergeConflictError } from '../lib
 import { logger } from '../lib/logger';
 import { ModalFrame } from './primitives/ModalFrame';
 import { Button } from './primitives/Button';
+import { Spinner } from './primitives/Spinner';
 import { GitHubIcon, WarningIcon } from './icons';
 import { useOptionalToast } from '../contexts/ToastContext';
 
@@ -419,7 +420,7 @@ export function SubmitReviewModal({
             >
               {isGenerating ? (
                 <>
-                  <span className="submit-review-spinner" />
+                  <Spinner size="sm" />
                   Generating with AI...
                 </>
               ) : (
@@ -456,7 +457,7 @@ export function SubmitReviewModal({
               >
                 {isGenerating ? (
                   <>
-                    <span className="submit-review-spinner" />
+                    <Spinner size="sm" />
                     Committing & generating...
                   </>
                 ) : (

--- a/src/components/WorkspaceModals.tsx
+++ b/src/components/WorkspaceModals.tsx
@@ -34,6 +34,7 @@ import type { AgentConfig } from '../lib/agent';
 import type { BranchInfo } from '../lib/branches';
 import type { AuthTerminalConfig, IntegrationState } from '../hooks/useIntegrationStatus';
 import type { LoadedPlugin } from '../hooks/usePlugins';
+import { Spinner } from './primitives/Spinner';
 
 export interface WorkspaceModalsProps {
   // Project context
@@ -325,7 +326,7 @@ export function WorkspaceModals({
               >
                 {pluginSuggestionInstalling ? (
                   <>
-                    <span className="plugin-suggestion-spinner" />
+                    <Spinner size="sm" />
                     Installing…
                   </>
                 ) : (

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -78,6 +78,7 @@ import type { PluginThemeData } from '../contexts/PluginContext';
 import type { PinnedProjectRow } from '../hooks/usePinnedProjects';
 import { useModal } from '../contexts/ModalContext';
 import { sessionRegistry } from '../lib/sessionRegistry';
+import { Spinner } from './primitives/Spinner';
 import '../styles/features/notifications.css';
 
 // ---------------------------------------------------------------------------
@@ -1335,7 +1336,7 @@ export const WorkspaceView = memo(function WorkspaceView({
                             data-education-id="screenshot-button"
                           >
                             {isCapturing ? (
-                              <div className="capture-spinner" />
+                              <Spinner size="sm" style={{ color: 'var(--accent)' }} />
                             ) : (
                               <CameraIcon size={14} />
                             )}
@@ -1351,7 +1352,7 @@ export const WorkspaceView = memo(function WorkspaceView({
                             data-education-id="crop-button"
                           >
                             {isCropCapturing ? (
-                              <div className="capture-spinner" />
+                              <Spinner size="sm" style={{ color: 'var(--accent)' }} />
                             ) : (
                               <CropIcon size={14} />
                             )}

--- a/src/components/icons/common.tsx
+++ b/src/components/icons/common.tsx
@@ -1,7 +1,7 @@
 /**
  * Navigation and UI chrome icons.
  *
- * Chevrons, check marks, warnings, close, info, spinner, search, arrows, and more/dots menus.
+ * Chevrons, check marks, warnings, close, info, search, arrows, and more/dots menus.
  */
 
 interface IconProps {
@@ -111,22 +111,6 @@ export function InfoIcon({ size = 16 }: IconProps) {
       <circle cx="12" cy="12" r="10" />
       <line x1="12" y1="8" x2="12" y2="12" />
       <line x1="12" y1="16" x2="12.01" y2="16" />
-    </svg>
-  );
-}
-
-export function SpinnerIcon({ size = 20, className }: IconProps) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      className={className || 'spinner-icon'}
-    >
-      <circle cx="12" cy="12" r="9" strokeDasharray="42 14" strokeLinecap="round" />
     </svg>
   );
 }

--- a/src/components/import-project/steps/Step2RepoSelection.tsx
+++ b/src/components/import-project/steps/Step2RepoSelection.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Button } from '../../primitives/Button';
+import { Spinner } from '../../primitives/Spinner';
 import type { GitHubRepo } from '../../../lib/github';
 
 export interface Step2RepoSelectionProps {
@@ -82,7 +83,7 @@ export function Step2RepoSelection({
       <div className="import-repo-list">
         {loadingRepos ? (
           <div className="import-repo-loading">
-            <div className="checklist-spinner" />
+            <Spinner style={{ color: 'var(--text-primary)' }} />
             <span>Loading repositories...</span>
           </div>
         ) : filteredRepos.length === 0 ? (

--- a/src/components/import-project/steps/Step3ImportProgress.tsx
+++ b/src/components/import-project/steps/Step3ImportProgress.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Button } from '../../primitives/Button';
+import { Spinner } from '../../primitives/Spinner';
 
 /** Import progress steps */
 export type Step = 'clone' | 'install' | 'setup' | 'done';
@@ -57,7 +58,7 @@ export function Step3ImportProgress({
     <div className="create-modal-content creating">
       <h2>Importing "{repoName}"</h2>
 
-      <div className="create-spinner" />
+      <Spinner size="lg" className="create-spinner" />
 
       <p className="create-status">{STATUS_MESSAGES[currentStep]}</p>
 
@@ -78,7 +79,7 @@ export function Step3ImportProgress({
                   <polyline points="20 6 9 17 4 12" />
                 </svg>
               ) : status === 'active' ? (
-                <div className="checklist-spinner" />
+                <Spinner />
               ) : (
                 <svg
                   width="18"

--- a/src/components/primitives/ModalFrame.tsx
+++ b/src/components/primitives/ModalFrame.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode, type MouseEvent } from 'react';
+import { useEffect, useRef, type ReactNode, type MouseEvent } from 'react';
 
 interface ModalFrameProps {
   isOpen: boolean;
@@ -34,10 +34,20 @@ export function ModalFrame({
     return () => window.removeEventListener('keydown', handler);
   }, [isOpen, dismissable, onClose]);
 
+  // Only dismiss when the press STARTED on the overlay. A click fires on the
+  // overlay when a text-selection drag begins inside the modal and the mouse
+  // releases outside it — closing then would throw away unsaved input.
+  const pressBeganOnOverlay = useRef(false);
+
   if (!isOpen) return null;
 
-  const handleOverlayClick = () => {
-    if (dismissable) onClose();
+  const handleOverlayMouseDown = (e: MouseEvent) => {
+    pressBeganOnOverlay.current = e.target === e.currentTarget;
+  };
+
+  const handleOverlayClick = (e: MouseEvent) => {
+    if (dismissable && pressBeganOnOverlay.current && e.target === e.currentTarget) onClose();
+    pressBeganOnOverlay.current = false;
   };
 
   const stop = (e: MouseEvent) => e.stopPropagation();
@@ -45,6 +55,7 @@ export function ModalFrame({
   return (
     <div
       className="modal-frame-overlay"
+      onMouseDown={handleOverlayMouseDown}
       onClick={handleOverlayClick}
       role="dialog"
       aria-modal="true"

--- a/src/components/primitives/Spinner.tsx
+++ b/src/components/primitives/Spinner.tsx
@@ -1,0 +1,23 @@
+import type { HTMLAttributes } from 'react';
+
+export type SpinnerSize = 'sm' | 'md' | 'lg';
+
+interface SpinnerProps extends HTMLAttributes<HTMLDivElement> {
+  /** sm = 14px (inline, inside buttons), md = 20px (default), lg = 32px (section loading). */
+  size?: SpinnerSize;
+  /** Accessible label announced to screen readers. */
+  label?: string;
+}
+
+/**
+ * Canonical loading spinner. The spinning arc uses `currentColor`, so tint it
+ * by setting `color` on the spinner itself or letting it inherit from the
+ * parent (e.g. inside a green action button the arc is automatically dark).
+ */
+export function Spinner({ size = 'md', label = 'Loading', className, ...rest }: SpinnerProps) {
+  const classes = ['ss-spinner', size !== 'md' ? `ss-spinner--${size}` : null, className]
+    .filter(Boolean)
+    .join(' ');
+
+  return <div className={classes} role="status" aria-label={label} {...rest} />;
+}

--- a/src/components/setup/OnboardingScreen.tsx
+++ b/src/components/setup/OnboardingScreen.tsx
@@ -20,6 +20,7 @@ import { CelebrationScreen } from './CelebrationScreen';
 import { OnboardingTerminal } from './OnboardingTerminal';
 import { trackEvent, trackPageview } from '../../lib/analytics';
 import { Button } from '../primitives/Button';
+import { Spinner } from '../primitives/Spinner';
 import { logger } from '../../lib/logger';
 import {
   SetupItem,
@@ -487,7 +488,7 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
   if (state === 'loading') {
     return (
       <div className="onboarding-screen onboarding-loading">
-        <div className="spinner" />
+        <Spinner size="lg" style={{ color: 'var(--text-muted)' }} />
         <p>Checking setup status...</p>
       </div>
     );

--- a/src/components/setup/SetupItem.test.tsx
+++ b/src/components/setup/SetupItem.test.tsx
@@ -95,7 +95,7 @@ describe('SetupItem', () => {
     render(<SetupItem item={item} />);
 
     expect(screen.getByText('Installing Node.js...')).toBeInTheDocument();
-    expect(document.querySelector('.setup-item-spinner')).toBeInTheDocument();
+    expect(document.querySelector('.ss-spinner')).toBeInTheDocument();
   });
 
   it('renders "in_progress" with brew hint for brew packages', () => {

--- a/src/components/setup/SetupItem.tsx
+++ b/src/components/setup/SetupItem.tsx
@@ -12,6 +12,7 @@ import {
   SETUP_TIME_ESTIMATES,
   BREW_PACKAGES,
 } from '../../lib/setup';
+import { Spinner } from '../primitives/Spinner';
 
 interface SetupItemProps {
   item: SetupItemType;
@@ -82,11 +83,6 @@ function EmptyCircleIcon() {
   );
 }
 
-/** Spinner for in-progress items */
-function SpinnerIcon() {
-  return <div className="setup-item-spinner" />;
-}
-
 /** Lock icon for blocked items */
 function BlockedIcon() {
   return (
@@ -117,7 +113,7 @@ function getStatusIcon(status: SetupItemStatus) {
     case 'error':
       return <ErrorIcon />;
     case 'in_progress':
-      return <SpinnerIcon />;
+      return <Spinner style={{ color: 'var(--accent)' }} />;
     case 'blocked':
       return <BlockedIcon />;
     default:

--- a/src/styles/components/modal.css
+++ b/src/styles/components/modal.css
@@ -4,8 +4,6 @@
   --modal-danger-hover: #ff5252;
   /* --action (#54e36e) as an rgb triplet for alpha tints (no global --action-rgb). */
   --modal-action-green-rgb: 84, 227, 110;
-  /* --action-text (#1e1e1e) as an rgb triplet for the spinner track tint. */
-  --modal-action-text-rgb: 30, 30, 30;
 }
 
 /* Hints */
@@ -203,13 +201,4 @@
 .plugin-suggestion-install:disabled {
   opacity: 0.7;
   cursor: wait;
-}
-
-.plugin-suggestion-spinner {
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgba(var(--modal-action-text-rgb), 0.3);
-  border-top-color: var(--action-text);
-  border-radius: var(--radius-full);
-  animation: spin 0.8s linear infinite;
 }

--- a/src/styles/features/agents-panel.css
+++ b/src/styles/features/agents-panel.css
@@ -144,9 +144,10 @@
   cursor: wait;
 }
 
-.agents-default-pill.switching .spinner-icon {
+.agents-default-pill.switching .ss-spinner {
   width: 10px;
   height: 10px;
+  border-width: 1.5px;
 }
 
 .agents-default-pill-radio {

--- a/src/styles/features/branches/branch-actions.css
+++ b/src/styles/features/branches/branch-actions.css
@@ -497,24 +497,15 @@
   flex-shrink: 0;
 }
 
-/* Git Error Handler */
-.git-error-modal {
-  position: fixed;
-  inset: 0;
-  background: var(--overlay-60);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-app-modal);
-}
+/* Git Error Handler (rendered inside ModalFrame; .git-error-content is the
+   className passed to it). The overlay/content chrome comes from
+   .modal-frame-overlay / .modal-frame-content in global/base.css. */
 
-.git-error-content {
-  width: 480px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-lg);
-  overflow: hidden;
+/* Git errors can pop while the publish dropdown (z: --z-modal-overlay) is
+   still open — keep them on the app-modal layer like the old hand-rolled
+   overlay did. */
+.modal-frame-overlay:has(.git-error-content) {
+  z-index: var(--z-app-modal);
 }
 
 .git-error-header {
@@ -657,16 +648,6 @@
   opacity: 0.7;
   cursor: not-allowed;
   background: var(--bg-secondary);
-}
-
-.submit-review-spinner {
-  display: inline-block;
-  width: 12px;
-  height: 12px;
-  border: 2px solid var(--border);
-  border-top-color: var(--text-primary);
-  border-radius: var(--radius-full);
-  animation: spin 0.6s linear infinite;
 }
 
 .submit-review-body {

--- a/src/styles/features/branches/main.css
+++ b/src/styles/features/branches/main.css
@@ -376,15 +376,6 @@
   color: var(--warning);
 }
 
-.branch-item-spinner {
-  width: 12px;
-  height: 12px;
-  border: 2px solid var(--border);
-  border-top-color: var(--text-muted);
-  border-radius: var(--radius-full);
-  animation: spin 1s linear infinite;
-}
-
 .branch-dropdown-footer {
   padding: 8px 0;
   border-top: 1px solid var(--border);

--- a/src/styles/features/branches/pr-list.css
+++ b/src/styles/features/branches/pr-list.css
@@ -292,12 +292,6 @@
   font-size: var(--font-size-lg);
 }
 
-.prs-tab-loading .branch-item-spinner {
-  width: 32px;
-  height: 32px;
-  border-width: 3px;
-}
-
 .prs-tab-error {
   height: 100%;
   display: flex;

--- a/src/styles/features/conflicts.css
+++ b/src/styles/features/conflicts.css
@@ -45,15 +45,6 @@
   text-align: center;
 }
 
-.conflict-spinner {
-  width: 32px;
-  height: 32px;
-  border: 3px solid var(--border);
-  border-top-color: var(--text-muted);
-  border-radius: var(--radius-full);
-  animation: spin 1s linear infinite;
-}
-
 .conflict-error {
   color: var(--warning);
 }

--- a/src/styles/features/create-project.css
+++ b/src/styles/features/create-project.css
@@ -262,14 +262,10 @@
   color: var(--text-primary);
 }
 
+/* Layout + tint for the create/import flow's <Spinner size="lg"> */
 .create-spinner {
-  width: 40px;
-  height: 40px;
   margin: 28px 0;
-  border: 3px solid var(--border);
-  border-top-color: var(--accent);
-  border-radius: var(--radius-full);
-  animation: spin 1s linear infinite;
+  color: var(--accent);
 }
 
 .create-status {
@@ -305,16 +301,6 @@
 }
 
 .checklist-item svg {
-  flex-shrink: 0;
-}
-
-.checklist-spinner {
-  width: 18px;
-  height: 18px;
-  border: 2px solid var(--border);
-  border-top-color: var(--text-primary);
-  border-radius: var(--radius-full);
-  animation: spin 1s linear infinite;
   flex-shrink: 0;
 }
 

--- a/src/styles/features/diff-modal.css
+++ b/src/styles/features/diff-modal.css
@@ -236,15 +236,6 @@
   color: var(--text-muted);
 }
 
-.diff-spinner {
-  width: 32px;
-  height: 32px;
-  border: 3px solid var(--border);
-  border-top-color: var(--text-muted);
-  border-radius: var(--radius-full);
-  animation: spin 1s linear infinite;
-}
-
 /* Error state */
 .diff-error {
   display: flex;

--- a/src/styles/features/env-editor.css
+++ b/src/styles/features/env-editor.css
@@ -1,25 +1,15 @@
-/* Environment Variables Editor */
+/* Environment Variables Editor (rendered inside ModalFrame;
+   .env-editor-modal is the className on .modal-frame-content). */
 .env-editor-modal {
   max-width: 600px;
   width: 90%;
   max-height: 80vh;
-  display: flex;
-  flex-direction: column;
+  /* The content frame must not scroll as a whole: the file tabs stay fixed
+     and .env-vars-list does its own scrolling. */
+  overflow: hidden;
 }
 
-.env-editor-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 16px;
-}
-
-.env-editor-header h3 {
-  font-size: var(--font-size-2xl);
-  font-weight: 600;
-  margin: 0;
-}
-
+/* Used by the nested paste mini-modal's close button. */
 .env-close-btn {
   padding: 4px;
   background: transparent;
@@ -43,6 +33,8 @@
   gap: 12px;
   flex: 1;
   min-height: 0;
+  /* ModalFrame's content has no body padding (it lives on the header). */
+  padding: var(--spacing-xl);
 }
 
 .env-file-tabs {

--- a/src/styles/features/health-tab.css
+++ b/src/styles/features/health-tab.css
@@ -318,6 +318,9 @@
 }
 
 .health-tab-glyph.running {
+  width: 10px;
+  height: 10px;
+  border-width: 1.5px;
   color: var(--warning);
 }
 

--- a/src/styles/features/mcp-modal.css
+++ b/src/styles/features/mcp-modal.css
@@ -431,14 +431,10 @@
   font-size: var(--font-size-md);
 }
 
+/* Layout + tint for the loading <Spinner> */
 .mcp-loading-spinner {
-  width: 20px;
-  height: 20px;
-  border: 2px solid var(--border);
-  border-top-color: var(--accent);
-  border-radius: var(--radius-full);
-  animation: spin 0.8s linear infinite;
   margin: 0 auto 12px;
+  color: var(--accent);
 }
 
 .mcp-error {

--- a/src/styles/features/plugins.css
+++ b/src/styles/features/plugins.css
@@ -142,15 +142,6 @@
   font-size: var(--font-size-md);
 }
 
-.plugins-loading-spinner {
-  width: 16px;
-  height: 16px;
-  border: 2px solid var(--border);
-  border-top-color: var(--text-primary);
-  border-radius: var(--radius-full);
-  animation: spin 0.6s linear infinite;
-}
-
 .plugins-empty {
   text-align: center;
   padding: 32px 0;

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -356,15 +356,6 @@
   color: var(--accent);
 }
 
-.capture-spinner {
-  width: 14px;
-  height: 14px;
-  border: 2px solid var(--border);
-  border-top-color: var(--accent);
-  border-radius: var(--radius-full);
-  animation: spin 0.8s linear infinite;
-}
-
 .preview-dimensions {
   margin-left: auto;
   padding: 2px 6px;
@@ -518,15 +509,6 @@
   z-index: var(--z-dropdown);
   color: var(--text-muted);
   font-size: var(--font-size-lg);
-}
-
-.preview-branch-switching-spinner {
-  width: 32px;
-  height: 32px;
-  border: 3px solid var(--border);
-  border-top-color: var(--accent);
-  border-radius: var(--radius-full);
-  animation: spin 0.8s linear infinite;
 }
 
 /* Preview Viewport */

--- a/src/styles/features/publish/dropdown.css
+++ b/src/styles/features/publish/dropdown.css
@@ -85,12 +85,3 @@
   color: var(--text-muted);
   font-size: var(--font-size-md);
 }
-
-.publish-loading-spinner {
-  width: 16px;
-  height: 16px;
-  border: 2px solid var(--border);
-  border-top-color: var(--text-muted);
-  border-radius: var(--radius-full);
-  animation: spin 1s linear infinite;
-}

--- a/src/styles/features/publish/states.css
+++ b/src/styles/features/publish/states.css
@@ -226,11 +226,3 @@
   font-size: 15px;
   font-weight: 500;
 }
-
-.publish-in-progress-header svg {
-  flex-shrink: 0;
-}
-
-.spinner-icon {
-  animation: spin 1s linear infinite;
-}

--- a/src/styles/features/setup.css
+++ b/src/styles/features/setup.css
@@ -134,15 +134,6 @@
   height: 20px;
 }
 
-.setup-item-spinner {
-  width: 20px;
-  height: 20px;
-  border: 2px solid var(--border);
-  border-top-color: var(--accent);
-  border-radius: var(--radius-full);
-  animation: spin 0.8s linear infinite;
-}
-
 .setup-item-name {
   font-weight: 500;
   font-size: var(--font-size-lg);

--- a/src/styles/features/skills-modal.css
+++ b/src/styles/features/skills-modal.css
@@ -472,14 +472,10 @@
   font-size: var(--font-size-md);
 }
 
+/* Layout + tint for the loading <Spinner> */
 .skills-loading-spinner {
-  width: 20px;
-  height: 20px;
-  border: 2px solid var(--border);
-  border-top-color: var(--accent);
-  border-radius: var(--radius-full);
-  animation: spin 0.8s linear infinite;
   margin: 0 auto 12px;
+  color: var(--accent);
 }
 
 .skills-error {

--- a/src/styles/global/base.css
+++ b/src/styles/global/base.css
@@ -688,6 +688,29 @@ button:hover {
   line-height: 1.5;
 }
 
+/* ===== Primitive: Spinner ===== */
+/* Arc color comes from currentColor — set `color` on the spinner or parent. */
+.ss-spinner {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  border: 2px solid var(--border);
+  border-top-color: currentColor;
+  border-radius: var(--radius-full);
+  animation: spin 0.8s linear infinite;
+}
+
+.ss-spinner--sm {
+  width: 14px;
+  height: 14px;
+}
+
+.ss-spinner--lg {
+  width: 32px;
+  height: 32px;
+  border-width: 3px;
+}
+
 /* ===== Primitive: Skeleton ===== */
 /* 0.4/0.7 (not the 0.5/0.85 once written here) — project-list.css carried a
    same-named duplicate that loaded later and won everywhere; these are the

--- a/src/styles/global/base.css
+++ b/src/styles/global/base.css
@@ -303,15 +303,6 @@ body.compact-mode-active html {
 }
 
 /* Spinner */
-.spinner {
-  width: 32px;
-  height: 32px;
-  border: 3px solid var(--border);
-  border-top-color: var(--text-muted);
-  border-radius: var(--radius-full);
-  animation: spin 1s linear infinite;
-}
-
 /* Shared keyframes — keyframe names are GLOBAL in CSS. Define shared ones
    here only; a feature-file duplicate silently overrides every consumer
    app-wide depending on import order. */


### PR DESCRIPTION
## What this is

Second PR of the design-system cleanup (follows #87).

## Changes

**New `Spinner` primitive** (`primitives/Spinner.tsx`): sm/md/lg, arc tinted via `currentColor`, `role=status`. Replaces ~16 per-feature spinner classes across 33 call sites; the `SpinnerIcon` SVG component is deleted (every usage was a loading state). Dead spinner CSS removed across 14 files. Spinner durations/track colors are intentionally normalized to one look — the one deliberate visual unification in this PR. Bonus fix found during migration: the AgentsPanel header spinner **never actually spun** (its class override dropped the animation class).

**Modal migrations to `ModalFrame`**: ProjectList's two delete confirms, GitErrorHandler, and EnvEditor (App's quit confirm already used it). Behavioral notes:
- All four gain ESC dismissal (they previously only closed via overlay click)
- GitErrorHandler keeps its app-modal z-tier (10000) via a `:has()` override so it still renders above the publish dropdown
- EnvEditor keeps fixed tabs + scrollable body, and dismissal is locked while its paste mini-modal is open (previously ESC was simply inert)

**ModalFrame dismissal hardening** (affects all 26+ modals): overlay dismissal now requires the mouse press to *start* on the overlay. Previously, selecting text inside a modal and releasing the mouse outside it fired a click on the overlay and closed the modal, discarding unsaved input — that latent flaw is why EnvEditor had hand-rolled `onMouseDown` close semantics.

**CLAUDE.md**: Spinner usage documented alongside the other primitives.

## Verification

- `pnpm check:all` green, 624 tests pass, production build clean
- Tests updated where they queried old spinner classes (SetupItem, AgentsPanel mocks)

## Still ahead (next PRs)

Dropdown/Tooltip primitives (6 + 5 hand-rolled copies), raw-button migration (350 sites), component folder reorg, docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)