### PR TITLE
Design system PR 4: action buttons → Button primitive; codify raw-button rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,16 @@ import { Button } from './primitives/Button';
 
 Variants: `primary | secondary | danger | ghost`. Sizes: `md | sm`. Use `block` for full-width.
 
+**When a raw `<button>` is fine** (don't force these into `<Button>`):
+
+- `toolbar-icon-btn` buttons — plugin-stable shared class for icon-only toolbar chrome
+- Icon-only buttons ≤ 28px (close ×, hover-reveal row actions, inline input confirm/cancel) — Button's padding would distort them
+- Toggle/switch UI (`aria-pressed` pills), segmented controls, tab buttons (`role="tab"`)
+- Dropdown triggers (the render-prop keeps the feature's own button) and anything inside a primitive
+- Brand-colored CTAs whose hue is intentional (connect overlay green, conflict yours/theirs pair) — changing them is a design decision, not a cleanup
+
+Everything else that's a standalone action button (CTA, submit, cancel, delete, confirm) uses `<Button variant>`.
+
 ### Async state in components → use `useAsyncState` or `useInvoke`
 
 Don't hand-roll `isLoading` + `error` + `data` state triples; they forget the mount guard, forget the `finally`, and drift.

--- a/src/components/AssetsPanel.tsx
+++ b/src/components/AssetsPanel.tsx
@@ -21,6 +21,7 @@ import { convertFileSrc } from '@tauri-apps/api/core';
 import { formatFileSize, isImageFile, type Asset } from '../lib/assets';
 import { useAssetManagement } from '../hooks/useAssetManagement';
 import { Dropdown, DropdownItem } from './primitives/Dropdown';
+import { Button } from './primitives/Button';
 import { useOptionalToast } from '../contexts/ToastContext';
 import { useModal } from '../contexts/ModalContext';
 import {
@@ -234,14 +235,14 @@ export function AssetsModal({ projectPath, isOpen, onClose, pick }: AssetsModalP
         <div className="assets-panel-content">
           {/* Toolbar */}
           <div className="assets-toolbar">
-            <button
-              className="assets-toolbar-btn"
+            <Button
+              variant="secondary"
+              leftIcon={<UploadIcon size={14} />}
               onClick={() => fileInputRef.current?.click()}
               disabled={isUploading}
             >
-              <UploadIcon size={14} />
               {isUploading ? 'Uploading...' : 'Upload'}
-            </button>
+            </Button>
             <input
               ref={fileInputRef}
               type="file"
@@ -249,10 +250,13 @@ export function AssetsModal({ projectPath, isOpen, onClose, pick }: AssetsModalP
               onChange={(e) => void handleUpload(e.target.files)}
               style={{ display: 'none' }}
             />
-            <button className="assets-toolbar-btn" onClick={() => setShowNewFolder(true)}>
-              <FolderPlusIcon size={14} />
+            <Button
+              variant="secondary"
+              leftIcon={<FolderPlusIcon size={14} />}
+              onClick={() => setShowNewFolder(true)}
+            >
               New Folder
-            </button>
+            </Button>
             <div className="assets-toolbar-spacer" />
             <div className="assets-view-toggle">
               <button

--- a/src/components/BranchesTab.tsx
+++ b/src/components/BranchesTab.tsx
@@ -247,30 +247,33 @@ export function BranchesTab({
                 (() => {
                   const existingPR = openPRs.find((pr) => pr.headRef === currentBranchInfo.name);
                   return existingPR ? (
-                    <button
-                      className="branch-card-action"
+                    <Button
+                      variant="secondary"
+                      size="sm"
                       onClick={() => onViewPR?.()}
                       title={`PR #${existingPR.number}: ${existingPR.title}`}
                     >
                       View PR #{existingPR.number}
-                    </button>
+                    </Button>
                   ) : (
-                    <button
-                      className="branch-card-action primary"
+                    <Button
+                      variant="primary"
+                      size="sm"
                       onClick={() => onSubmitForReview(currentBranchInfo.name)}
                     >
                       Submit for Review
-                    </button>
+                    </Button>
                   );
                 })()}
-              <button
-                className="branch-card-action danger-outline"
+              <Button
+                variant="danger"
+                size="sm"
                 onClick={() => setShowRevertConfirm(true)}
                 disabled={isReverting}
                 title="Discard local changes and pull from GitHub"
               >
                 {isReverting ? 'Reverting...' : 'Revert to GitHub'}
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -321,22 +324,24 @@ export function BranchesTab({
                 </label>
               )}
               <div className="branches-new-branch-actions">
-                <button
-                  className="branch-card-action"
+                <Button
+                  variant="secondary"
+                  size="sm"
                   onClick={() => {
                     setShowNewBranch(false);
                     setNewBranchName('');
                   }}
                 >
                   Cancel
-                </button>
-                <button
-                  className="branch-card-action primary"
+                </Button>
+                <Button
+                  variant="primary"
+                  size="sm"
                   onClick={() => void handleCreateBranch()}
                   disabled={!newBranchName.trim() || isCreatingBranch}
                 >
                   {isCreatingBranch ? 'Creating...' : 'Create'}
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -545,19 +550,19 @@ function BranchCard({
 
       <div className="branch-card-actions">
         {isCurrent && showSubmitForReview && (
-          <button className="branch-card-action primary" onClick={onSubmitForReview}>
+          <Button variant="primary" size="sm" onClick={onSubmitForReview}>
             Submit for Review
-          </button>
+          </Button>
         )}
         {!isCurrent && (
-          <button className="branch-card-action" onClick={onSwitch} disabled={isSwitching}>
+          <Button variant="secondary" size="sm" onClick={onSwitch} disabled={isSwitching}>
             {isSwitching ? 'Switching...' : 'Switch'}
-          </button>
+          </Button>
         )}
         {showDelete && (
-          <button className="branch-card-action danger" onClick={onDelete} disabled={isDeleting}>
+          <Button variant="danger" size="sm" onClick={onDelete} disabled={isDeleting}>
             {isDeleting ? 'Deleting...' : 'Delete'}
-          </button>
+          </Button>
         )}
       </div>
     </div>

--- a/src/components/CodeTab.tsx
+++ b/src/components/CodeTab.tsx
@@ -10,6 +10,7 @@ import { useFileTree } from '../hooks/useFileTree';
 import { FileTree } from './FileTree';
 import { CodeViewer } from './CodeViewer';
 import { Spinner } from './primitives/Spinner';
+import { Button } from './primitives/Button';
 import { ResetIcon, SearchIcon } from './icons';
 import { type FileTreeNode, fileExtensionForAnalytics } from '../lib/code';
 import { trackEvent, trackSearch } from '../lib/analytics';
@@ -147,9 +148,9 @@ export function CodeTab({ projectPath, onSendToAgent, revealTarget }: CodeTabPro
           ) : treeError ? (
             <div className="code-tab-sidebar-error">
               <span>Failed to load files</span>
-              <button className="code-tab-retry-btn" onClick={refreshTree}>
+              <Button variant="secondary" size="sm" onClick={refreshTree}>
                 Retry
-              </button>
+              </Button>
             </div>
           ) : filteredTree.length === 0 ? (
             <div className="code-tab-sidebar-empty">

--- a/src/components/EnvEditor.tsx
+++ b/src/components/EnvEditor.tsx
@@ -17,6 +17,7 @@ import { useEnvEditor } from '../hooks/useEnvEditor';
 import { useOptionalToast } from '../contexts/ToastContext';
 import { useModal } from '../contexts/ModalContext';
 import { ModalFrame } from './primitives/ModalFrame';
+import { Button } from './primitives/Button';
 
 /** Props for the EnvEditor component */
 interface EnvEditorProps {
@@ -164,9 +165,9 @@ export function EnvEditor({ projectPath }: EnvEditorProps) {
                       .env.example
                     </span>
                   </div>
-                  <button className="env-sync-btn" onClick={() => void handleSyncToExample()}>
+                  <Button variant="secondary" size="sm" onClick={() => void handleSyncToExample()}>
                     Sync to .env.example
-                  </button>
+                  </Button>
                 </div>
               )}
               {syncStatus.missingInLocal.length > 0 && (
@@ -190,9 +191,9 @@ export function EnvEditor({ projectPath }: EnvEditorProps) {
                       .env.local
                     </span>
                   </div>
-                  <button className="env-sync-btn" onClick={() => void handleSyncToLocal()}>
+                  <Button variant="secondary" size="sm" onClick={() => void handleSyncToLocal()}>
                     Add to .env.local
-                  </button>
+                  </Button>
                 </div>
               )}
             </div>
@@ -293,41 +294,46 @@ export function EnvEditor({ projectPath }: EnvEditorProps) {
 
             <div className="env-actions">
               <div className="env-actions-left">
-                <button className="env-add-btn" onClick={handleAddVar}>
+                <Button variant="secondary" onClick={handleAddVar}>
                   + Add Variable
-                </button>
-                <button className="env-paste-btn" onClick={() => setShowPasteModal(true)}>
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                  >
-                    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
-                    <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
-                  </svg>
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={() => setShowPasteModal(true)}
+                  leftIcon={
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
+                      <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+                      <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
+                    </svg>
+                  }
+                >
                   Paste .env
-                </button>
+                </Button>
               </div>
               <div className="env-actions-right">
                 {selectedFile && (
-                  <button
-                    className="env-delete-file-btn"
+                  <Button
+                    variant="danger"
                     onClick={() => void handleDeleteFile()}
                     title="Delete this file"
                   >
                     Delete File
-                  </button>
+                  </Button>
                 )}
-                <button
-                  className="env-save-btn"
+                <Button
+                  variant="primary"
                   onClick={() => void handleSave()}
                   disabled={!hasChanges || isSaving || isLoading}
                 >
                   {isSaving ? 'Saving...' : 'Save'}
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -336,9 +342,9 @@ export function EnvEditor({ projectPath }: EnvEditorProps) {
             <div className="env-empty-icon">$</div>
             <h4>No environment files</h4>
             <p>Create an .env file to store your API keys and secrets.</p>
-            <button className="env-create-btn" onClick={() => setShowNewFileInput(true)}>
+            <Button variant="primary" onClick={() => setShowNewFileInput(true)}>
               Create .env.local
-            </button>
+            </Button>
           </div>
         )}
 
@@ -383,22 +389,18 @@ export function EnvEditor({ projectPath }: EnvEditorProps) {
               spellCheck={false}
             />
             <div className="env-paste-actions">
-              <button
-                className="env-paste-cancel"
+              <Button
+                variant="secondary"
                 onClick={() => {
                   setShowPasteModal(false);
                   setPasteContent('');
                 }}
               >
                 Cancel
-              </button>
-              <button
-                className="env-paste-confirm"
-                onClick={handlePasteEnv}
-                disabled={!pasteContent.trim()}
-              >
+              </Button>
+              <Button variant="primary" onClick={handlePasteEnv} disabled={!pasteContent.trim()}>
                 Add Variables
-              </button>
+              </Button>
             </div>
           </div>
         </div>

--- a/src/components/GitErrorHandler.tsx
+++ b/src/components/GitErrorHandler.tsx
@@ -9,6 +9,7 @@
 
 import { WarningIcon, CopyIcon } from './icons';
 import { ModalFrame } from './primitives/ModalFrame';
+import { Button } from './primitives/Button';
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
 import { useOptionalToast } from '../contexts/ToastContext';
 
@@ -119,24 +120,32 @@ Please help me understand what went wrong and how to fix it.`,
       <div className="git-error-footer">
         {errorType === 'merge_conflict' && onResolveConflicts ? (
           <>
-            <button className="branch-card-action" onClick={handleCopyPrompt}>
-              <CopyIcon size={12} />
+            <Button
+              variant="secondary"
+              size="sm"
+              leftIcon={<CopyIcon size={12} />}
+              onClick={handleCopyPrompt}
+            >
               Copy Prompt
-            </button>
-            <button className="branch-card-action primary" onClick={onResolveConflicts}>
+            </Button>
+            <Button variant="primary" size="sm" onClick={onResolveConflicts}>
               Resolve Conflicts
-            </button>
+            </Button>
           </>
         ) : (
           <>
-            <button className="branch-card-action" onClick={handleCopyPrompt}>
-              <CopyIcon size={12} />
+            <Button
+              variant="secondary"
+              size="sm"
+              leftIcon={<CopyIcon size={12} />}
+              onClick={handleCopyPrompt}
+            >
               Copy to Clipboard
-            </button>
+            </Button>
             {onSendToClaude && (
-              <button className="branch-card-action primary" onClick={handleSendToClaude}>
+              <Button variant="primary" size="sm" onClick={handleSendToClaude}>
                 Send to Claude
-              </button>
+              </Button>
             )}
           </>
         )}

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -47,6 +47,7 @@ import { ElementTreePanel } from './edit/ElementTreePanel';
 import { useElementTree } from '../hooks/useElementTree';
 import { PreviewLocaleSwitcher, type PreviewLocaleConfig } from './PreviewLocaleSwitcher';
 import { CompactIcon, ExpandIcon, PanelLeftIcon, ResetIcon } from './icons';
+import { Button } from './primitives/Button';
 import { Spinner } from './primitives/Spinner';
 import { pathLocale, switchPathLocale } from '../lib/i18n';
 import type { ProjectType } from '../lib/static-server';
@@ -632,9 +633,9 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
         <p className="hint">
           This project hasn't run <code>{needsInstall.packageManager} install</code> yet.
         </p>
-        <button className="btn-primary" onClick={onRunInstall} disabled={!onRunInstall}>
+        <Button variant="primary" onClick={onRunInstall} disabled={!onRunInstall}>
           Install with {needsInstall.packageManager}
-        </button>
+        </Button>
       </div>
     );
   }

--- a/src/components/ProjectList.tsx
+++ b/src/components/ProjectList.tsx
@@ -52,6 +52,7 @@ import { FolderBreadcrumb } from './FolderBreadcrumb';
 import { MoveFolderModal } from './MoveFolderModal';
 import { SettingsModal } from './SettingsModal';
 import { ModalFrame } from './primitives/ModalFrame';
+import { Button } from './primitives/Button';
 import { Spinner } from './primitives/Spinner';
 import { GitHubCalendar } from './GitHubCalendar';
 import { useModal } from '../contexts/ModalContext';
@@ -715,65 +716,26 @@ export function ProjectList({
 
         {/* Delete Project Confirmation Modal */}
         {deleteConfirm && (
-          <ModalFrame
-            isOpen
-            onClose={() => setDeleteConfirm(null)}
+          <DeleteConfirmModal
             title="Delete Project?"
-            showCloseButton={false}
-          >
-            <div style={{ padding: 'var(--spacing-xl)' }}>
-              <p>
-                Are you sure you want to delete <strong>{deleteConfirm.name}</strong>?
-              </p>
-              <p className="hint">
-                This will delete the local copy from your computer. If this project is connected to
-                GitHub, your code will remain there and you can reimport it at any time.
-              </p>
-              <div className="modal-actions">
-                <button onClick={() => setDeleteConfirm(null)} disabled={deleting}>
-                  Cancel
-                </button>
-                <button
-                  className="btn-danger"
-                  onClick={() => void handleDelete(deleteConfirm)}
-                  disabled={deleting}
-                >
-                  {deleting ? 'Deleting...' : 'Delete'}
-                </button>
-              </div>
-            </div>
-          </ModalFrame>
+            name={deleteConfirm.name}
+            hint="This will delete the local copy from your computer. If this project is connected to GitHub, your code will remain there and you can reimport it at any time."
+            deleting={deleting}
+            onCancel={() => setDeleteConfirm(null)}
+            onDelete={() => void handleDelete(deleteConfirm)}
+          />
         )}
 
         {/* Delete Folder Confirmation Modal */}
         {deleteFolderConfirm && (
-          <ModalFrame
-            isOpen
-            onClose={() => setDeleteFolderConfirm(null)}
+          <DeleteConfirmModal
             title="Delete Folder?"
-            showCloseButton={false}
-          >
-            <div style={{ padding: 'var(--spacing-xl)' }}>
-              <p>
-                Are you sure you want to delete <strong>{deleteFolderConfirm.name}</strong>?
-              </p>
-              <p className="hint">
-                Projects in this folder will not be deleted. They will appear at the root level.
-              </p>
-              <div className="modal-actions">
-                <button onClick={() => setDeleteFolderConfirm(null)} disabled={deletingFolder}>
-                  Cancel
-                </button>
-                <button
-                  className="btn-danger"
-                  onClick={() => void handleDeleteFolder(deleteFolderConfirm)}
-                  disabled={deletingFolder}
-                >
-                  {deletingFolder ? 'Deleting...' : 'Delete'}
-                </button>
-              </div>
-            </div>
-          </ModalFrame>
+            name={deleteFolderConfirm.name}
+            hint="Projects in this folder will not be deleted. They will appear at the root level."
+            deleting={deletingFolder}
+            onCancel={() => setDeleteFolderConfirm(null)}
+            onDelete={() => void handleDeleteFolder(deleteFolderConfirm)}
+          />
         )}
 
         {/* Settings Modal */}
@@ -788,5 +750,41 @@ export function ProjectList({
         {/* ChangelogModal is mounted globally in <AppGlobalModals>. */}
       </div>
     </div>
+  );
+}
+
+/** Shared delete-confirmation dialog for projects and folders. */
+function DeleteConfirmModal({
+  title,
+  name,
+  hint,
+  deleting,
+  onCancel,
+  onDelete,
+}: {
+  title: string;
+  name: string;
+  hint: string;
+  deleting: boolean;
+  onCancel: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <ModalFrame isOpen onClose={onCancel} title={title} showCloseButton={false}>
+      <div style={{ padding: 'var(--spacing-xl)' }}>
+        <p>
+          Are you sure you want to delete <strong>{name}</strong>?
+        </p>
+        <p className="hint">{hint}</p>
+        <div className="modal-actions">
+          <Button variant="secondary" onClick={onCancel} disabled={deleting}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={onDelete} disabled={deleting}>
+            {deleting ? 'Deleting...' : 'Delete'}
+          </Button>
+        </div>
+      </div>
+    </ModalFrame>
   );
 }

--- a/src/components/PullRequestsTab.tsx
+++ b/src/components/PullRequestsTab.tsx
@@ -522,32 +522,34 @@ function PrCard({
             <GitHubIcon size={16} />
           </button>
           {onCheckout && !isCheckedOut && (
-            <button className="branch-card-action" onClick={onCheckout} disabled={isCheckingOut}>
+            <Button variant="secondary" size="sm" onClick={onCheckout} disabled={isCheckingOut}>
               {isCheckingOut ? 'Pulling...' : 'Pull'}
-            </button>
+            </Button>
           )}
           {hasConflicts && onResolveConflicts ? (
-            <button
-              className="branch-card-action primary"
+            <Button
+              variant="primary"
+              size="sm"
               onClick={() => onResolveConflicts(pr.headRef, pr.baseRef)}
             >
               Resolve
-            </button>
+            </Button>
           ) : (
             onMerge && (
-              <button
-                className={`branch-card-action ${canMerge ? 'primary' : ''}`}
+              <Button
+                variant={canMerge ? 'primary' : 'secondary'}
+                size="sm"
                 onClick={onMerge}
                 disabled={isMerging || !canMerge}
               >
                 {isMerging ? 'Merging...' : 'Merge'}
-              </button>
+              </Button>
             )
           )}
           {onClose && (
-            <button className="branch-card-action danger" onClick={onClose} disabled={isClosing}>
+            <Button variant="danger" size="sm" onClick={onClose} disabled={isClosing}>
               {isClosing ? 'Closing...' : 'Close'}
-            </button>
+            </Button>
           )}
         </div>
       )}

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -18,6 +18,7 @@ import { Update } from '@tauri-apps/plugin-updater';
 import { checkForUpdate, downloadAndInstall, restartApp, UpdateInfo } from '../lib/updater';
 import { trackEvent, trackError } from '../lib/analytics';
 import { logger } from '../lib/logger';
+import { Button } from './primitives/Button';
 import '../styles/features/update-banner.css';
 
 /** How often to check for updates (1 hour) */
@@ -168,12 +169,12 @@ export function UpdateBanner() {
         </div>
         {status === 'idle' && (
           <div className="update-banner-actions">
-            <button className="update-banner-btn secondary" onClick={handleLater}>
+            <Button variant="secondary" size="sm" onClick={handleLater}>
               Later
-            </button>
-            <button className="update-banner-btn primary" onClick={() => void handleUpdate()}>
+            </Button>
+            <Button variant="primary" size="sm" onClick={() => void handleUpdate()}>
               Update Now
-            </button>
+            </Button>
           </div>
         )}
         {status === 'downloading' && (
@@ -185,16 +186,16 @@ export function UpdateBanner() {
           </div>
         )}
         {status === 'ready' && (
-          <button className="update-banner-btn primary" onClick={() => void handleRestart()}>
+          <Button variant="primary" size="sm" onClick={() => void handleRestart()}>
             Restart to Apply
-          </button>
+          </Button>
         )}
         {status === 'error' && (
           <div className="update-banner-actions">
             <span className="update-banner-error">{error}</span>
-            <button className="update-banner-btn secondary" onClick={() => void handleUpdate()}>
+            <Button variant="secondary" size="sm" onClick={() => void handleUpdate()}>
               Retry
-            </button>
+            </Button>
           </div>
         )}
       </div>

--- a/src/components/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { SearchIcon, ChevronIcon, ResetIcon } from './icons';
+import { Button } from './primitives/Button';
 import { BrowserDropdown } from './BrowserDropdown';
 import { useOpenPalette } from './CommandPalette/paletteContext';
 import { ALL_AGENTS, TERMINAL, getAgentById, type AgentConfig } from '../lib/agent';
@@ -621,15 +622,16 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
       </div>
 
       <div className="workspace-sidebar-footer">
-        <button
-          type="button"
+        <Button
+          variant="ghost"
+          block
           className="workspace-sidebar-add-project"
           onClick={onOpenProjectPicker}
           title="Open a project"
         >
           <span className="workspace-sidebar-add-icon">+</span>
           <span>Open project</span>
-        </button>
+        </Button>
       </div>
     </aside>
   );

--- a/src/components/support/NewTicketForm.tsx
+++ b/src/components/support/NewTicketForm.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useState, useEffect } from 'react';
+import { Button } from '../primitives/Button';
 import { createTicket } from '../../lib/support';
 import type { Conversation } from '../../lib/support';
 import { trackEvent } from '../../lib/analytics';
@@ -239,16 +240,12 @@ export function NewTicketForm({
 
       {/* Actions */}
       <div className="support-form-actions">
-        <button className="support-cancel-btn" onClick={onCancel} disabled={submitting}>
+        <Button variant="secondary" onClick={onCancel} disabled={submitting}>
           Cancel
-        </button>
-        <button
-          className="support-submit-btn"
-          onClick={() => void handleSubmit()}
-          disabled={!canSubmit}
-        >
+        </Button>
+        <Button variant="primary" onClick={() => void handleSubmit()} disabled={!canSubmit}>
           {submitting ? 'Submitting...' : 'Submit'}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/styles/components/modal.css
+++ b/src/styles/components/modal.css
@@ -1,7 +1,5 @@
 /* Modal-local colors — intentional one-offs, not part of the global scale. */
 :root {
-  /* Hover state for .btn-danger — lighter step of --error. */
-  --modal-danger-hover: #ff5252;
   /* --action (#54e36e) as an rgb triplet for alpha tints (no global --action-rgb). */
   --modal-action-green-rgb: 84, 227, 110;
 }
@@ -50,21 +48,6 @@
   justify-content: flex-end;
   gap: 12px;
   margin-top: 24px;
-}
-
-.btn-danger {
-  background: var(--error);
-  color: var(--text-bright);
-  font-weight: 600;
-}
-
-.btn-danger:hover {
-  background: var(--modal-danger-hover);
-}
-
-.btn-danger:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
 }
 
 /* Quit Confirmation Modal */

--- a/src/styles/features/assets-panel.css
+++ b/src/styles/features/assets-panel.css
@@ -202,33 +202,6 @@
   align-items: center;
 }
 
-.assets-toolbar-btn {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 12px;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  color: var(--text-secondary);
-  font-size: var(--font-size-md);
-  cursor: pointer;
-  transition:
-    background-color var(--transition),
-    color var(--transition),
-    border-color var(--transition);
-}
-
-.assets-toolbar-btn:hover:not(:disabled) {
-  background: var(--border);
-  color: var(--text-primary);
-}
-
-.assets-toolbar-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
 .assets-toolbar-spacer {
   flex: 1;
 }

--- a/src/styles/features/branches/pr-list.css
+++ b/src/styles/features/branches/pr-list.css
@@ -217,6 +217,8 @@
   flex-shrink: 0;
 }
 
+/* Text actions on branch/PR cards now use the <Button> primitive; this class
+   remains only for the icon-only GitHub link (.pr-card-icon-btn). */
 .branch-card-action {
   display: flex;
   align-items: center;
@@ -237,41 +239,6 @@
 .branch-card-action:hover {
   background: var(--border);
   color: var(--text-primary);
-}
-
-.branch-card-action.primary {
-  background: var(--action);
-  border-color: var(--action);
-  color: var(--action-text);
-}
-
-.branch-card-action.primary:hover {
-  background: var(--action-hover);
-}
-
-.branch-card-action.danger {
-  color: var(--error-light);
-}
-
-.branch-card-action.danger:hover {
-  background: rgba(var(--error-light-rgb), 0.1);
-  border-color: rgba(var(--error-light-rgb), 0.3);
-}
-
-.branch-card-action.danger-outline {
-  background: transparent;
-  border: 1px solid rgba(var(--error-light-rgb), 0.3);
-  color: var(--error-light);
-}
-
-.branch-card-action.danger-outline:hover {
-  background: rgba(var(--error-light-rgb), 0.1);
-  border-color: rgba(var(--error-light-rgb), 0.5);
-}
-
-.branch-card-action.danger-outline:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 
 /* Pull Requests Tab */

--- a/src/styles/features/env-editor.css
+++ b/src/styles/features/env-editor.css
@@ -231,70 +231,6 @@
   gap: 8px;
 }
 
-.env-add-btn {
-  padding: 8px 12px;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  color: var(--text-secondary);
-  font-size: var(--font-size-md);
-  cursor: pointer;
-  transition:
-    background-color var(--transition),
-    color var(--transition),
-    border-color var(--transition);
-}
-
-.env-add-btn:hover {
-  background: var(--border);
-  color: var(--text-primary);
-}
-
-.env-save-btn {
-  padding: 8px 16px;
-  background: var(--accent);
-  border: none;
-  border-radius: var(--radius);
-  color: var(--bg-primary);
-  font-size: var(--font-size-md);
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    background-color var(--transition),
-    color var(--transition),
-    border-color var(--transition);
-}
-
-.env-save-btn:hover:not(:disabled) {
-  background: var(--accent-hover);
-}
-
-.env-save-btn:disabled {
-  background: var(--bg-tertiary);
-  color: var(--text-muted);
-  cursor: not-allowed;
-}
-
-.env-delete-file-btn {
-  padding: 8px 12px;
-  background: transparent;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  color: var(--text-muted);
-  font-size: var(--font-size-md);
-  cursor: pointer;
-  transition:
-    background-color var(--transition),
-    color var(--transition),
-    border-color var(--transition);
-}
-
-.env-delete-file-btn:hover {
-  background: rgba(var(--error-rgb), 0.1);
-  border-color: var(--error);
-  color: var(--error);
-}
-
 .env-empty {
   padding: 40px 20px;
   text-align: center;
@@ -341,25 +277,6 @@
   max-width: 260px;
 }
 
-.env-create-btn {
-  padding: 10px 20px;
-  background: var(--accent);
-  border: none;
-  border-radius: var(--radius);
-  color: var(--bg-primary);
-  font-size: var(--font-size-md);
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    background-color var(--transition),
-    color var(--transition),
-    border-color var(--transition);
-}
-
-.env-create-btn:hover {
-  background: var(--accent-hover);
-}
-
 .env-loading {
   padding: 40px 20px;
   text-align: center;
@@ -403,54 +320,6 @@
 }
 
 .env-sync-info svg {
-  flex-shrink: 0;
-}
-
-.env-sync-btn {
-  padding: 6px 12px;
-  background: rgba(var(--warning-light-rgb), 0.2);
-  border: 1px solid rgba(var(--warning-light-rgb), 0.4);
-  border-radius: var(--radius);
-  color: var(--warning-light);
-  font-size: var(--font-size-base);
-  font-weight: 500;
-  cursor: pointer;
-  white-space: nowrap;
-  transition:
-    background-color var(--transition),
-    color var(--transition),
-    border-color var(--transition);
-}
-
-.env-sync-btn:hover {
-  background: rgba(var(--warning-light-rgb), 0.3);
-  border-color: var(--warning-light);
-}
-
-/* Paste .env Button */
-.env-paste-btn {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 12px;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  color: var(--text-secondary);
-  font-size: var(--font-size-md);
-  cursor: pointer;
-  transition:
-    background-color var(--transition),
-    color var(--transition),
-    border-color var(--transition);
-}
-
-.env-paste-btn:hover {
-  background: var(--border);
-  color: var(--text-primary);
-}
-
-.env-paste-btn svg {
   flex-shrink: 0;
 }
 
@@ -526,48 +395,4 @@
   justify-content: flex-end;
   gap: 8px;
   margin-top: 4px;
-}
-
-.env-paste-cancel {
-  padding: 8px 16px;
-  background: transparent;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  color: var(--text-secondary);
-  font-size: var(--font-size-md);
-  cursor: pointer;
-  transition:
-    background-color var(--transition),
-    color var(--transition),
-    border-color var(--transition);
-}
-
-.env-paste-cancel:hover {
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
-}
-
-.env-paste-confirm {
-  padding: 8px 16px;
-  background: var(--accent);
-  border: none;
-  border-radius: var(--radius);
-  color: var(--bg-primary);
-  font-size: var(--font-size-md);
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    background-color var(--transition),
-    color var(--transition),
-    border-color var(--transition);
-}
-
-.env-paste-confirm:hover:not(:disabled) {
-  background: var(--accent-hover);
-}
-
-.env-paste-confirm:disabled {
-  background: var(--bg-tertiary);
-  color: var(--text-muted);
-  cursor: not-allowed;
 }

--- a/src/styles/features/publish/sites.css
+++ b/src/styles/features/publish/sites.css
@@ -167,35 +167,3 @@
   gap: 8px;
   padding: 0 16px 16px;
 }
-
-.publish-link-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 12px;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  color: var(--text-secondary);
-  font-size: var(--font-size-base);
-  cursor: pointer;
-  transition:
-    background-color var(--transition),
-    color var(--transition),
-    border-color var(--transition);
-}
-
-.publish-link-button:hover {
-  background: var(--border);
-  color: var(--text-primary);
-}
-
-.publish-link-button.publish-link-loading {
-  color: var(--text-muted);
-  cursor: default;
-}
-
-.publish-link-button.publish-link-loading:hover {
-  background: var(--bg-tertiary);
-  color: var(--text-muted);
-}

--- a/src/styles/features/publish/states.css
+++ b/src/styles/features/publish/states.css
@@ -159,10 +159,6 @@
   padding: 0 16px 16px;
 }
 
-.publish-success-sites .publish-link-button {
-  justify-content: center;
-}
-
 .publish-actions-center {
   display: flex;
   justify-content: center;

--- a/src/styles/features/support-panel.css
+++ b/src/styles/features/support-panel.css
@@ -11,8 +11,7 @@
   --support-ticket-resolved: #4ade80;
   --support-ticket-closed: #9ca3af;
   --support-ticket-closed-rgb: 107, 114, 128;
-  /* Form submit hover + soft error banner */
-  --support-submit-hover: #16a34a;
+  /* Soft error banner */
   --support-error-soft: #f87171;
   --support-error-soft-rgb: 255, 77, 77;
 }
@@ -514,40 +513,6 @@
   justify-content: flex-end;
   gap: 8px;
   padding-top: 8px;
-}
-
-.support-form-actions button {
-  padding: 8px 16px;
-  border-radius: var(--radius);
-  font-size: var(--font-size-md);
-  font-weight: 500;
-  cursor: pointer;
-}
-
-.support-form-actions .support-cancel-btn {
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
-  color: var(--text-secondary);
-}
-
-.support-form-actions .support-cancel-btn:hover:not(:disabled) {
-  background: var(--border);
-  color: var(--text-primary);
-}
-
-.support-form-actions .support-submit-btn {
-  background: var(--success-light);
-  border: none;
-  color: var(--text-bright);
-}
-
-.support-form-actions .support-submit-btn:hover:not(:disabled) {
-  background: var(--support-submit-hover);
-}
-
-.support-form-actions button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 
 /* ─── Share Project Info Toggle ────────────────────────────────────────────── */

--- a/src/styles/features/update-banner.css
+++ b/src/styles/features/update-banner.css
@@ -45,38 +45,6 @@
   gap: 8px;
 }
 
-.update-banner-btn {
-  padding: 6px 12px;
-  border-radius: var(--radius);
-  font-size: var(--font-size-md);
-  font-weight: 500;
-  cursor: pointer;
-  border: none;
-  transition:
-    background-color 0.15s ease,
-    color 0.15s ease,
-    border-color 0.15s ease;
-}
-
-.update-banner-btn.secondary {
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-}
-
-.update-banner-btn.secondary:hover {
-  background: var(--border);
-  color: var(--text-primary);
-}
-
-.update-banner-btn.primary {
-  background: var(--action);
-  color: var(--action-text);
-}
-
-.update-banner-btn.primary:hover {
-  background: var(--action-hover);
-}
-
 .update-banner-progress-container {
   display: flex;
   align-items: center;

--- a/src/styles/features/workspace/sidebar.css
+++ b/src/styles/features/workspace/sidebar.css
@@ -838,29 +838,13 @@
   overflow-x: hidden;
 }
 
+/* Layout-only — colors/hover/cursor come from the Button primitive (ghost).
+ * Full-bleed: fixed height; flush corners via the sidebar-wide
+ * border-radius reset above. Font pinned to the sidebar's base size so the
+ * footer matches the rows above it. */
 .workspace-sidebar-add-project {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--spacing-sm);
-  width: 100%;
   height: 44px;
-  padding: 0 var(--spacing-md);
-  background: var(--bg-secondary);
-  border: none;
-  color: var(--text-muted);
-  font: inherit;
   font-size: var(--font-size-base);
-  font-weight: 500;
-  cursor: pointer;
-  transition:
-    background var(--transition-fast),
-    color var(--transition-fast);
-}
-
-.workspace-sidebar-add-project:hover {
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
 }
 
 .workspace-sidebar-add-icon {

--- a/src/styles/modes/code-mode.css
+++ b/src/styles/modes/code-mode.css
@@ -111,21 +111,6 @@
   font-size: var(--font-size-base);
 }
 
-.code-tab-retry-btn {
-  padding: 4px 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-  font-size: var(--font-size-base);
-  cursor: pointer;
-}
-
-.code-tab-retry-btn:hover {
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-}
-
 /* Divider */
 .code-tab-divider {
   width: 1px;


### PR DESCRIPTION
## What this is

Fourth PR of the design-system cleanup (follows #87, #88, #89).

## Changes

**~25 action buttons across 11 components** migrated to `<Button variant>`: AssetsPanel, EnvEditor, Preview, WorkspaceSidebar, ProjectList (the two delete confirms are extracted into a shared local `DeleteConfirmModal` — also kept the file under its LOC ceiling), BranchesTab, PullRequestsTab, GitErrorHandler, UpdateBanner, support/NewTicketForm, CodeTab. ~230 lines of per-domain button CSS deleted, including the entirely-dead `publish-link-button` family.

**CLAUDE.md now codifies when a raw `<button>` is legitimate** — the audit's '350 raw buttons' turned out to be mostly icon-only chrome, toggles, tabs, segmented controls, and dropdown triggers, which deliberately stay raw. The doc makes the Button rule enforceable by review without false positives.

**Deliberately skipped** (each listed in-code or below): brand-colored CTAs (connect-overlay green, conflict yours/theirs pair, info-blue branch controls), `github-button` toolbar chrome needing pixel alignment, `btn-warning` (no warning variant exists), tightly-paired plugin-suggestion buttons.

## Visual deltas to eyeball (intentional normalization)

- Delete confirms: filled-red → outlined-red `danger`; Cancel → outlined secondary
- Branch/PR card actions: slightly more compact, plain actions transparent-bg
- Env editor Save/Create: `--accent` white → `--action` green fill
- Env sync buttons lost their amber tint (now neutral secondary inside the amber banner)
- Update banner buttons normalized to sm sizing
- Support ticket Submit: `--success-light` → `--action` green

## Verification

`pnpm check:all` green, 624 tests pass. Rebased onto main post-#89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)