### PR TITLE
Design system PR 6: documentation — token/primitive reference, structure guide, mega-hook JSDoc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,6 +408,8 @@ usePolling(async () => refreshStatus(path), { intervalMs: 3000, enabled: isFocus
 
 ### CSS values → always use design tokens
 
+Full token + primitive reference: [docs/design-system.md](docs/design-system.md)
+
 The tokens live at the top of [src/styles/global/base.css](src/styles/global/base.css) under a documented block. Never use raw hex colors, raw spacing px, raw z-index numbers, or raw durations.
 
 ```css

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,10 +451,10 @@ CSS lives under this folder structure:
 
 ```
 src/styles/
-├── global/      base.css, typography, utility classes
-├── features/    branches/, plugins/, dashboard/, publish/
-├── modes/       compact-mode, education-mode
-└── components/  modal, tooltip, button
+├── global/      base.css (tokens, primitives' styles, shared keyframes)
+├── features/    branches/, plugins/, dashboard/, publish/, workspace/, …
+├── modes/       compact-mode, education-mode, code-mode
+└── components/  modal, command-palette
 ```
 
 Don't dump new files into `src/styles/` root unless they're genuinely cross-cutting.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,202 @@
+# Ship Studio Design System
+
+The reference for tokens and UI primitives. Audience: you're about to build a feature and need
+the right token or component in under a minute. Canonical sources (always trust these over docs):
+
+- Tokens: the `:root` block at the top of [src/styles/global/base.css](../src/styles/global/base.css)
+- Primitives: [src/components/primitives/](../src/components/primitives/)
+- The rules and rationale: [CLAUDE.md → How to Do Things in Ship Studio](../CLAUDE.md#how-to-do-things-in-ship-studio)
+  and [docs/CONTRIBUTING_PATTERNS.md](CONTRIBUTING_PATTERNS.md)
+
+## Design tokens
+
+All defined in the `:root` block of `base.css`. Never write raw hex colors, raw spacing px, raw
+z-index numbers, or raw durations in CSS — use a token (CI enforces colors; review enforces the rest).
+
+| Group | Tokens | When to use |
+| --- | --- | --- |
+| Surfaces | `--bg-primary` / `--bg-secondary` / `--bg-tertiary`, `--bg-deep` | App background → panels → raised elements; `--bg-deep` for recessed wells (terminals, log output, code editors). |
+| Text | `--text-primary` / `--text-secondary` / `--text-muted`, `--text-bright` | Default → secondary labels → disabled/hints; `--text-bright` (pure white) only for high-emphasis text/icons. |
+| Brand / interactive | `--accent(-hover)`, `--action(-hover)`, `--action-text` | `--accent` is the white brand accent (active/selected); `--action` is the green CTA color, always paired with `--action-text` for legible dark text on it. |
+| Status | `--success(-light)`, `--warning(-light)`, `--error(-light)`, `--error-deep`, `--modified-yellow` | Semantic states. `-light` variants for tinted backgrounds/pills, `--error-deep` for armed destructive states, `--modified-yellow` for git-modified badges. |
+| Info blue | `--info(-hover/-light/-dark)` | Links, info banners, "open" PR state, focus accents. |
+| Purple | `--purple`, `--purple-light`, `--purple-deep-rgb` | AI / agent surfaces only (skills, MCP, plugin marketplace). |
+| Slack | `--slack-pink`, `--slack-lavender(-bright)` | Slack community CTA branding only (dashboard, setup, support panel). |
+| RGB triplets | `--*-rgb` (e.g. `--error-rgb: 244, 71, 71`) | For alpha tints only: `rgba(var(--error-rgb), 0.1)`. Each must stay in sync with its solid token. |
+| Tints | `--tint-subtle` / `--tint` / `--tint-strong` | White hover/selection washes on dark surfaces (5/8/10% white). |
+| Overlays | `--overlay-30` … `--overlay-80` | Black scrims behind modals, image dimming. Suffix = alpha %. |
+| ANSI palette | `--ansi-green/red/yellow/blue(-dark)` (+ `-rgb`) | Terminal-flavored output: health diagnostics, browser tools, log rendering. Not for general UI status — that's the status group. |
+| Code syntax | `--code-keyword/string/property/comment` | VS Code dark syntax colors for code mode and diff rendering. |
+| Structure / hover | `--border`, `--bg-hover`, `--border-hover` | Borders and the standard hover pair for list rows / tabs / bordered cards. |
+| Spacing | `--spacing-xs` … `--spacing-2xl` (4–32px) | All padding, margin, gap. |
+| Radius | `--radius-sm` (4) / `--radius` (6) / `--radius-md` (8) / `--radius-lg` (12) / `--radius-full` | Corner rounding; `--radius-full` for circles. |
+| Z-index tiers | `--z-dropdown` (100) → `--z-preview-fullscreen` (900) → `--z-modal-overlay/-modal` (1000/1001) → `--z-tooltip` (1100) → `--z-notification` (1200) → `--z-app-*` / `--z-toast*` (9999–10010) | Pick the tier, not a number: floating menus < fullscreen preview < modals < tooltips < toasts < global app overlays. (`--z-changelog-sentinel` is the deliberate ceiling.) |
+| Layout dims | `--editor-panel-w`, `--preview-toolbar-h`, `--tree-panel-w` | Shared panel dimensions that must agree across files (and with `PANEL_WIDTH` in `VisualEditorPanel.tsx`). |
+| Shadows | `--shadow-sm` / `--shadow` / `--shadow-md` / `--shadow-lg` | Elevation: small popovers → dropdowns → modals → fullscreen layers. |
+| Transitions | `--transition-fast` (0.1s) / `--transition` (0.15s) / `--transition-slow` (0.3s) | Duration + easing bundled: `transition: background var(--transition)`. |
+| Type scale | `--font-size-xs` (10) … `--font-size-3xl` (24); `--font-mono` | Dense desktop UI, 1px steps at the small end. Off-scale sizes (9/15/17px…) are migration debt — round to the nearest token when touching that code. `--font-mono` for terminal/code. |
+
+Need a value that doesn't exist? Add the token to `:root` in `base.css` first, then use it.
+
+### The three escape hatches
+
+1. **File-local tokens** — intentional one-off colors (brand hues, feature accents) go in a `:root`
+   block at the top of that feature's CSS file, prefixed with the feature name
+   (e.g. `--github-publish-hover-teal` in `features/github.css`).
+2. **`css-ok` tag** — a raw value that genuinely must stay (e.g. backgrounds matching xterm's
+   theme) gets a `/* css-ok: reason */` comment on the same line; CI skips tagged lines.
+3. **Small local z-index** — within the "content" tier (content-on-content stacking), raw `1`,
+   `2`, `5`, `10` are fine. Anything that floats over other UI uses a `--z-*` token.
+
+### Plugin-stable API
+
+`--bg-*`, `--text-*`, `--accent`, `--action`, `--border`, `--warning`, `--success`, `--error`,
+`--font-mono`, plus the `toolbar-icon-btn` / `btn-primary` / `btn-secondary` classes, are public
+API for plugins. Renaming any of them is a breaking change (see CLAUDE.md "Shared CSS Classes").
+
+## Primitives
+
+All in [src/components/primitives/](../src/components/primitives/), styled in `base.css` under
+`/* ===== Primitive: … ===== */` sections. Hooks that pair with them: `useModalState`,
+`useInvoke` / `useAsyncState`, `useCopyToClipboard`, `usePolling` (see CLAUDE.md).
+
+### ModalFrame — [ModalFrame.tsx](../src/components/primitives/ModalFrame.tsx)
+
+Overlay + content container + optional header with close button. ESC and click-outside built in.
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `isOpen` | `boolean` | — | Renders `null` when false. |
+| `onClose` | `() => void` | — | Called on ESC / overlay click / close button. |
+| `title` | `ReactNode?` | — | Omit entirely to render headerless. |
+| `dismissable` | `boolean` | `true` | `false` disables ESC + overlay dismissal (in-flight destructive ops). |
+| `className` | `string?` | — | Appended to the content container for width/tone overrides. |
+| `showCloseButton` | `boolean` | `true` | Ignored when no `title`. |
+| `ariaLabel` | `string?` | falls back to string `title` | Accessible dialog label. |
+
+```tsx
+<ModalFrame isOpen={isOpen} onClose={close} title="Rename project">
+  {/* body */}
+</ModalFrame>
+```
+
+Gotchas:
+
+- **Dismissal requires the press to start on the overlay.** A text-selection drag that begins
+  inside the modal and releases outside does not close it — don't "fix" this, it protects
+  unsaved input.
+- CI checks that every `*Modal.tsx` file imports `ModalFrame` (`check-patterns.sh` rule 5).
+- Open/close state: `useModalState()` for local toggles, `useModal('id')` from `ModalContext`
+  for app-registered modals.
+
+### Button — [Button.tsx](../src/components/primitives/Button.tsx)
+
+The standalone action button. Extends `ButtonHTMLAttributes` (so `onClick`, `disabled`, `title`,
+… all pass through), forwards its ref, defaults `type="button"`.
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `variant` | `'primary' \| 'secondary' \| 'danger' \| 'ghost'` | `'secondary'` | primary = green CTA (one per view); secondary = outlined neutral; danger = red-tinted destructive; ghost = borderless low-emphasis. |
+| `size` | `'sm' \| 'md'` | `'md'` | `sm` for dense rows/toolbars. |
+| `block` | `boolean?` | — | Full width. |
+| `leftIcon` / `rightIcon` | `ReactNode?` | — | Rendered beside children with the standard gap. |
+
+```tsx
+<Button variant="primary" leftIcon={<PlusIcon size={14} />} onClick={create}>
+  Create project
+</Button>
+```
+
+When a raw `<button>` is legitimate — the canonical list lives in
+[CLAUDE.md → "When a raw `<button>` is fine"](../CLAUDE.md#new-button--use-button-variant-from-srccomponentsprimitivesbuttontsx).
+Summary: `toolbar-icon-btn` chrome, icon-only buttons ≤ 28px, toggles/segmented controls/tabs,
+dropdown triggers, internals of other primitives, and intentionally brand-colored CTAs.
+
+### Spinner — [Spinner.tsx](../src/components/primitives/Spinner.tsx)
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | sm = 14px (inline / inside buttons), md = 20px, lg = 32px (section loading). |
+| `label` | `string` | `'Loading'` | Screen-reader announcement (`role="status"`). |
+
+```tsx
+<Spinner size="sm" />
+```
+
+Gotcha: the spinning arc uses `currentColor` — tint it by setting `color` on the spinner
+(`style={{ color: 'var(--accent)' }}`) or let it inherit; inside a green action button it's
+automatically dark. The track stays `var(--border)`.
+
+### Dropdown — [Dropdown.tsx](../src/components/primitives/Dropdown.tsx)
+
+Menu with open/close state, click-outside, ESC, alignment, and optional portal positioning.
+Exports `Dropdown`, `DropdownItem`, `DropdownDivider`.
+
+| Prop (Dropdown) | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `trigger` | `(props: DropdownTriggerProps) => ReactNode` | — | Spread the props onto your button — they wire toggle, anchor ref, and aria state. |
+| `align` | `'left' \| 'right'` | `'left'` | Which trigger edge the menu aligns to. |
+| `portal` | `boolean` | `false` | Body portal + fixed positioning. **Use when an ancestor has `overflow: hidden`** (terminal panes, editor panels) that would clip the menu; re-anchors on scroll/resize. |
+| `menuClassName` | `string?` | — | Width/feature tweaks on the menu. |
+| `onOpenChange` | `(open: boolean) => void?` | — | E.g. lazy-load menu data. |
+
+`DropdownItem`: `onSelect` (menu auto-closes after, unless `keepOpen`), `icon` (size 14 is the
+house convention), `variant: 'default' | 'danger'`, `active`, `disabled`.
+
+```tsx
+<Dropdown align="right" trigger={(p) => <button className="toolbar-icon-btn" {...p}>•••</button>}>
+  <DropdownItem icon={<EditIcon size={14} />} onSelect={rename}>Rename</DropdownItem>
+  <DropdownDivider />
+  <DropdownItem variant="danger" onSelect={remove}>Delete</DropdownItem>
+</Dropdown>
+```
+
+Gotcha: the trigger click already calls `stopPropagation()` (triggers often sit inside clickable
+cards), so don't add your own.
+
+### EmptyState — [EmptyState.tsx](../src/components/primitives/EmptyState.tsx)
+
+Centered icon / title / description / action stack for empty lists and zero-data panels.
+
+| Prop | Type | Notes |
+| --- | --- | --- |
+| `title` | `ReactNode` | Required; the headline. |
+| `icon` / `description` / `action` | `ReactNode?` | `action` is typically a `<Button>`. |
+| `className` | `string?` | Appended for feature spacing tweaks. |
+
+```tsx
+<EmptyState icon={<BranchIcon size={24} />} title="No branches yet" action={<Button>New branch</Button>} />
+```
+
+### Skeleton — [Skeleton.tsx](../src/components/primitives/Skeleton.tsx)
+
+Pulsing placeholder while content loads.
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `variant` | `'text' \| 'card' \| 'grid'` | `'text'` | text = 12px line, card = 96px block, grid = auto-fill grid of cards. |
+| `count` | `number` | `1` | Renders that many siblings (or grid cells). |
+| `width` / `height` | `number \| string?` | — | Inline size overrides; ignored by `grid`. |
+| `className` / `style` | — | — | Pass-through. |
+
+```tsx
+<Skeleton variant="grid" count={6} />
+```
+
+Gotcha: the `skeleton-pulse` keyframes live in `base.css` only — keyframe names are global in
+CSS, and a feature-file duplicate silently overrides every consumer (this happened; CI now fails
+duplicates).
+
+## Enforcement
+
+[`scripts/check-patterns.sh`](../scripts/check-patterns.sh) (run via `pnpm check:patterns`, part of
+`pnpm check:all` in CI) is a deliberately simple grep-based gate against pre-refactor patterns.
+It **fails** on: raw color literals in `src/styles` (unless the line is a `--token:` definition or
+carries a `/* css-ok: reason */` tag), `var()` references to custom properties defined nowhere
+(an undefined var invalidates the declaration and the style silently doesn't apply — this shipped
+invisible hover states for months), duplicate `@keyframes` names (global namespace, import-order
+roulette), new `onToast?:` prop interfaces (use `useOptionalToast`), and `*Modal.tsx` files that
+don't import `ModalFrame`. It also prints informational counts for remaining `Result<T, String>`
+Rust signatures and raw `navigator.clipboard` calls. `pnpm check:loc`
+([check-loc-limits.sh](../scripts/check-loc-limits.sh)) separately caps file sizes. The full list
+of in/out patterns is in [CLAUDE.md → Patterns That Are "Out"](../CLAUDE.md#patterns-that-are-out).

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1,0 +1,39 @@
+# src/components — Structure Guide
+
+One folder per feature domain. Token + primitive reference: [docs/design-system.md](../../docs/design-system.md).
+
+## Folders
+
+- **`primitives/`** — The design-system building blocks (`ModalFrame`, `Button`, `Spinner`, `Dropdown`, `EmptyState`, `Skeleton`). Generic, feature-agnostic, styled in `src/styles/global/base.css`. Nothing in here may import from feature folders.
+- **`icons/`** — Shared SVG icon components, grouped by domain (`brand`, `common`, `editor`, `layout`, `status`, `utility`) and re-exported from `index.tsx`. Add new icons here, not inline in features.
+- **`dashboard/`** — The home screen: project grid/list and cards, folders, search/sort, project rail, create-project and template gallery, settings modal, changelog, agents panel, integration bar.
+- **`workspace/`** — The open-project shell: header, sidebar, split panes, compact mode, and workspace-scoped modals (env editor, languages, backups, project settings, notifications).
+- **`branches/`** — Git branch and PR UI: branches/PR tabs, branch indicator, diff modal, conflict resolution, submit-for-review, publish dropdown, GitHub button.
+- **`preview/`** — The live preview pane: browser tools, breakpoint/zoom toolbar pieces, locale switcher, screenshots, and the mobile device mirror (iOS/Android).
+- **`terminal/`** — Embedded terminals: the agent PTY terminal, build terminal, dev-server status/logs, dev-command modal.
+- **`code/`** — Code mode: file tree, read-only code viewer, and the project health tab panel.
+- **`edit/`** — Visual editor internals: the editor panel, element tree, and the property controls (color, length, spacing, enum, opacity, image…).
+- **`plugins/`** — Plugin system UI plus the agent-extension modals: plugin manager/slots, skills modal, MCP modal.
+- **`setup/`** — First-run onboarding wizard: orchestrator, step indicator, per-step components under `steps/`, onboarding terminal, celebration screen.
+- **`shopify/`** — Shopify theme experience: theme setup flow and store-connection modal.
+- **`support/`** — In-app support panel: ticket list/form, conversation view, help articles.
+- **`CommandPalette/`** — The Cmd+K palette UI, its host, and the palette context. Command *registration* lives in `src/commands/`, not here.
+- **`import-project/`** — The GitHub import wizard's `steps/` (account selection, repo selection, workspace picker, progress). The `ImportProject` orchestrator lives in `dashboard/` because it's launched from the dashboard.
+
+## Root-level files
+
+Cross-cutting components mounted at the app level (by `App.tsx` or global hosts), not owned by any single feature view:
+
+- `AppGlobalModals.tsx` — globally-mounted modals that palette commands can open from any view
+- `ConnectOverlay.tsx` — full-tab "connect GitHub" gate shown when a feature needs auth
+- `EducationOverlay.tsx` — Education Mode x-ray overlay (hover any UI element to learn it)
+- `ErrorBoundary.tsx` — top-level crash recovery, including plugin-crash attribution/uninstall
+- `HelpModal.tsx` — slash-command glossary, shortcuts, and tips (openable from anywhere)
+- `UpdateBanner.tsx` — auto-update available/progress banner
+
+## Where does my new component go?
+
+Owned by one feature view → that feature's folder. Generic and reusable across features →
+`primitives/` (and document it in `docs/design-system.md`). An SVG icon → `icons/`. Mounted
+globally across views → root level (rare; think twice). A modal → the folder of the feature
+that opens it, built on `<ModalFrame>`.

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -25,6 +25,8 @@ One folder per feature domain. Token + primitive reference: [docs/design-system.
 Cross-cutting components mounted at the app level (by `App.tsx` or global hosts), not owned by any single feature view:
 
 - `AppGlobalModals.tsx` — globally-mounted modals that palette commands can open from any view
+  (mounts `HelpModal` and `dashboard/ChangelogModal` — a modal can live in a feature folder and
+  still be globally mounted here)
 - `ConnectOverlay.tsx` — full-tab "connect GitHub" gate shown when a feature needs auth
 - `EducationOverlay.tsx` — Education Mode x-ray overlay (hover any UI element to learn it)
 - `ErrorBoundary.tsx` — top-level crash recovery, including plugin-crash attribution/uninstall

--- a/src/components/primitives/Button.tsx
+++ b/src/components/primitives/Button.tsx
@@ -2,6 +2,19 @@ import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost';
 
+/**
+ * Props for the canonical action button. Extends the native button attributes
+ * (`onClick`, `disabled`, `title`, …) and forwards its ref; `type` defaults to
+ * `"button"` so forms don't submit by accident.
+ *
+ * - `variant` — visual emphasis. `primary` = green CTA (the one main action of
+ *   a view), `secondary` (default) = outlined neutral action, `danger` =
+ *   red-tinted destructive action, `ghost` = borderless low-emphasis action.
+ * - `size` — `md` (default) or `sm` for dense rows and toolbars.
+ * - `block` — stretch to the full width of the container.
+ * - `leftIcon` / `rightIcon` — icon nodes rendered beside the label with the
+ *   standard gap (size 14 is the house convention).
+ */
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   size?: 'sm' | 'md';

--- a/src/components/primitives/EmptyState.tsx
+++ b/src/components/primitives/EmptyState.tsx
@@ -1,13 +1,22 @@
 import type { ReactNode } from 'react';
 
 interface EmptyStateProps {
+  /** Leading icon node, rendered muted above the title. */
   icon?: ReactNode;
+  /** The headline (required). */
   title: ReactNode;
+  /** Supporting copy under the title; wraps at a readable max-width. */
   description?: ReactNode;
+  /** Call-to-action rendered below — typically a `<Button>`. */
   action?: ReactNode;
+  /** Extra class on the container for feature-specific spacing tweaks. */
   className?: string;
 }
 
+/**
+ * Canonical empty state: a centered icon / title / description / action stack
+ * for empty lists and zero-data panels.
+ */
 export function EmptyState({ icon, title, description, action, className }: EmptyStateProps) {
   return (
     <div className={`empty-state${className ? ` ${className}` : ''}`}>

--- a/src/components/primitives/Skeleton.tsx
+++ b/src/components/primitives/Skeleton.tsx
@@ -1,14 +1,25 @@
 import type { CSSProperties } from 'react';
 
 interface SkeletonProps {
+  /** text = 12px line (default), card = 96px block, grid = auto-fill grid of cards. */
   variant?: 'text' | 'card' | 'grid';
+  /** How many placeholders to render (siblings, or cells for `grid`). Default 1. */
   count?: number;
+  /** Inline width override (px number or CSS string). Ignored by `grid`. */
   width?: number | string;
+  /** Inline height override (px number or CSS string). Ignored by `grid`. */
   height?: number | string;
+  /** Extra class on each placeholder (or the grid container). */
   className?: string;
+  /** Extra inline styles merged before width/height. Ignored by `grid`. */
   style?: CSSProperties;
 }
 
+/**
+ * Canonical loading placeholder. Pulses via the shared `skeleton-pulse`
+ * keyframes in base.css — keyframe names are global in CSS, so never redefine
+ * them in a feature file (a duplicate silently overrides every consumer).
+ */
 export function Skeleton({
   variant = 'text',
   count = 1,

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -1,11 +1,37 @@
 /**
- * Hook for dev server lifecycle management.
+ * Hook for dev server lifecycle management — owns one dev-server handle per
+ * project path so hot (pinned) projects keep their servers running across
+ * project switches.
  *
- * Tracks one dev-server handle per project path so that pinned projects can
- * keep their servers running across project switches. External callers still
- * see a single "current project" scalar API — `devServerPort`, `projectType`,
- * `customDevCommand`, output buffers, etc. — which is derived from the map
- * keyed by the `currentProjectPath` argument.
+ * `startServerForProject` phases: resolve workspace cwd (monorepo subpath) →
+ * detect project type → dependency gate (`node_modules` missing sets
+ * `needsInstall` and defers the spawn; Preview renders an install CTA) →
+ * spawn per type: custom command for `generic`, static file server for
+ * `statichtml`, skip entirely for mobile, `shopify theme dev` behind a
+ * store-connected gate, plain `startDevServer` PTY otherwise → wire an exit
+ * watcher that nulls the handle when the process dies externally (otherwise
+ * `isServerRunning` lies and the next open "reuses" a dead server).
+ *
+ * Output pipeline: probe-line filter (liveness `GET /` pings, with a pending-
+ * line buffer because PTY chunks aren't line-aligned) → 100KB ring buffer →
+ * 300ms-throttled version bump that only re-renders for the active project.
+ *
+ * External callers see a single "current project" scalar API — `devServerPort`,
+ * `projectType`, `customDevCommand`, `needsInstall`, output versions, plus
+ * synthetic refs (`devServerRef`, `devServerOutputRef`) whose `.current`
+ * getters read the map slot live — derived from the map keyed by the
+ * `currentProjectPath` argument. Consumed by App.tsx, which feeds Preview,
+ * the dev-logs pane, and useProjectLifecycle's reuse/restart decisions.
+ *
+ * Boundaries: lib/project (`startDevServer` PTY), lib/static-server,
+ * lib/shopify, and `kill_port` / `clear_project_cache` invokes.
+ *
+ * Gotchas: `stopServer` sets `suppressed` BEFORE stopping so leaked PTY
+ * onData listeners can't write into a buffer consumers believe is cleared;
+ * the exit watcher only clears state when the map still points at the handle
+ * it watched (a restart swaps handles under it); `currentPathRef` is synced
+ * during render so handlers firing between `setCurrentProject` and the next
+ * commit still target the right project.
  */
 
 import { useState, useRef, useCallback, useMemo } from 'react';

--- a/src/hooks/useProjectCreation.ts
+++ b/src/hooks/useProjectCreation.ts
@@ -1,8 +1,32 @@
 /**
- * Hook that encapsulates all project creation logic for the CreateProject wizard.
+ * Hook that owns all project-creation logic for the CreateProject wizard —
+ * state, side effects, and handlers — so the component only renders.
  *
- * Extracts state management, side effects, and handlers from CreateProject
- * so the component only handles rendering.
+ * Two-step form (`formStep`): pick a source ('select-template': a built-in
+ * `TEMPLATES` entry, or a .zip via browser file picker / Tauri drag-drop) →
+ * 'enter-name'. Then the creation pipeline (`currentStep`, mirrored by the
+ * progress UI via `getStepStatus`): clone (`git clone` through a `spawn_pty`
+ * PTY; zips go through `extract_template_zip`; blank uses
+ * `create_blank_project`) → init (`remove_git_history` so the project
+ * detaches from the template repo, gitignore `.shipstudio/`, fire-and-forget
+ * Vercel plugin install) → install (`npm install` via PTY, gated on an npm
+ * cache-permission pre-check) → done → `onComplete(projectPath)`, which the
+ * caller turns into a project open. `retryInstall` re-runs just the install
+ * step against `createdProjectPath`.
+ *
+ * Consumed solely by `components/dashboard/CreateProject.tsx`.
+ *
+ * Boundaries: `spawn_pty` + the `pty-output`/`pty-exit` events (exit codes
+ * mapped to friendly errors: 243 npm cache, 128 git auth, 69 Xcode license),
+ * `list_projects` (duplicate-name check), `ensure_shipstudio_dir`,
+ * lib/setup (`checkNpmCachePermissions`), lib/plugins.
+ *
+ * Gotchas: `waitForPtyExit` treats a `null` exit code (process killed) as
+ * SUCCESS, so a killed clone/install proceeds to the next step. The two zip
+ * sources are mutually exclusive (`zipFile` from the browser vs `zipPath`
+ * from Tauri drag-drop — selecting one clears the other), and the native
+ * drag-drop listeners are only attached on the select-template step while
+ * not creating.
  *
  * @module hooks/useProjectCreation
  */

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -1,9 +1,33 @@
 /**
- * Hook for project lifecycle operations.
+ * Hook for project lifecycle operations — owns the dashboard ⇄ workspace
+ * navigation, orchestrating every other subsystem on project open/close.
  *
- * Manages: project selection/opening, back-to-projects, project creation/import,
- * dev server restart, compact mode entry, GitHub status refresh,
- * preview readiness, terminal interactions, and auto-accept mode.
+ * `handleSelectProject` phases: monorepo workspace gate (pauses for picker) →
+ * claim navigation version + duplicate-open guard → save outgoing project's
+ * terminal state + read auto-accept → show workspace IMMEDIATELY (server spins
+ * up in background) → restore/seed terminal tabs → duplicate-window check +
+ * session registration (backend authority, `sessionRegistry` mirror) → kill +
+ * reserve dev port → fetch branch info → start dev server via
+ * `startServerForProject` (skipped when a hot session's server is reused) →
+ * background GitHub status / screenshots / plugin suggestion.
+ *
+ * `handleBackToProjects` is a *view switch*, not a teardown: dev server, PTYs,
+ * and session-registry entry stay alive (hot-session contract); only the
+ * sidebar close button or app quit stops a session.
+ *
+ * Exposes auto-accept mode, create/import modal state, the monorepo picker,
+ * the install-overlay terminal config, and publishing flags — all consumed by
+ * App.tsx, which threads them into WorkspaceView and the dashboard.
+ *
+ * Boundaries: lib/projectSessions + sessionRegistry, lib/window (port
+ * reservation, window registry), and direct invokes (`get/set_terminal_state`,
+ * `kill_port`, `mark_project_opened`, `register_project_for_window`, …).
+ *
+ * Gotchas: every await inside `handleSelectProject` is followed by a
+ * `navigationVersionRef` check — a newer navigation supersedes the in-flight
+ * one, which must then stop touching view state. And `installTerminalConfig.
+ * args` lives in state purely for reference stability: a fresh array literal
+ * per render would tear down + respawn the install PTY in a loop.
  *
  * @module hooks/useProjectLifecycle
  */

--- a/src/hooks/useTerminalManagement.ts
+++ b/src/hooks/useTerminalManagement.ts
@@ -1,14 +1,32 @@
 /**
- * Terminal tab state — per project.
+ * Terminal tab state — per project. Owns the agent-terminal tab lists (and
+ * split-pane layout) for every open session, keyed by project path.
  *
- * Slice 4: each project that's been opened keeps its own tab list alive
- * until the session is explicitly closed. `useTerminalManagement` now
- * stores `Map<projectPath, ProjectTerminalState>` and exposes the CURRENT
- * project's slice through the same scalar API consumers already use.
- * Terminal React components are rendered for every active session; the
- * non-current ones get `display: none` from WorkspaceView so their xterm
- * instances (and the PTY processes they drive) keep running in the
- * background for multitasking.
+ * Lifecycle of a project's slice: seed (`ensureProjectSeeded` creates one
+ * default tab, or `restoreTerminalTabs` rebuilds from persisted backend state
+ * with `shouldResume: true`) → mutate (add/close tabs up to 5, switch agent —
+ * which kills the PTY and mints a fresh session ID, split-pane enable/resize/
+ * remove) → teardown (`closeAllTerminalsForProject` on explicit session close,
+ * `killAllTerminals` on window close). Each project keeps its tabs alive until
+ * explicitly closed (Slice 4 hot sessions): Terminal components are rendered
+ * for every session in `allSessions`, with non-current ones hidden via
+ * `display: none` by WorkspaceView so xterm + PTYs keep running.
+ *
+ * State lives in a `Map<projectPath, ProjectTerminalState>` ref; the CURRENT
+ * project's slice is exposed through scalars (`terminalTabs`,
+ * `activeTerminalTab`, `splitPaneTabIds`, …) re-derived via an epoch counter.
+ * Consumed by App.tsx, which threads it into WorkspaceView,
+ * TerminalSplitHeaders, and useProjectLifecycle (tab save/restore on switch).
+ *
+ * Boundaries: no Tauri calls of its own — PTYs are driven through
+ * `TerminalHandle` refs (`terminalRefsMap`, keyed `${projectPath}::${tabId}`);
+ * persistence (`get/set_terminal_state`) is the caller's job.
+ *
+ * Gotchas: `restoreTerminalTabs` is deliberately idempotent — if the project
+ * already has in-memory state, restoring would clobber live hot-session PTYs,
+ * so it no-ops. Split-pane sizes always re-sum to 100: closing/removing a pane
+ * redistributes its share across survivors, and `setSplitPaneSizes` clamps to
+ * a 12% minimum then renormalizes.
  *
  * @module hooks/useTerminalManagement
  */

--- a/src/hooks/useVisualEditor.ts
+++ b/src/hooks/useVisualEditor.ts
@@ -1,15 +1,34 @@
 /**
- * Visual editor controller.
+ * Visual editor controller — owns edit-mode state and the postMessage bridge
+ * to the in-iframe selection script (`SELECT_SCRIPT` in
+ * `src-tauri/src/proxy/mod.rs`).
  *
- * Owns edit-mode state and the message bridge to the in-iframe selection script
- * (`SELECT_SCRIPT` in `src-tauri/src/proxy/mod.rs`):
- *  - toggling edit mode posts `ss:activate` / `ss:deactivate`
- *  - incoming `ss:select` messages are resolved to a source location
- *  - `previewClass` posts `ss:mutate` for instant DOM feedback (no write)
- *  - `commit` writes the merged className back to source via the backend
+ * Lifecycle: toggle on → post `ss:activate` (re-posted on every iframe `load`,
+ * since the script re-initializes inert on each HMR reload) → an `ss:select`
+ * click resolves to source via the backend (class resolution, plus parallel
+ * text/image resolutions guarded by a staleness token) → edits (`applyToken`,
+ * `setBoxSide`, `stepSpacing`, `reset`) twMerge the live class and post
+ * `ss:mutate` with breakpoint-scoped preview rules (instant DOM feedback, no
+ * write) → `commit` writes the merged className back to source and advances
+ * the drift baseline so consecutive edits keep working. Text and image edits
+ * (`ss:textCommit`, `replaceImage`) write immediately on confirm.
  *
- * The selection script re-initializes inert on every (HMR) reload, so we
- * re-post `ss:activate` on each iframe `load` while edit mode is on.
+ * Exposes `editMode`, `selection`, `currentClass`, text/image resolutions,
+ * `multiTarget`, auto-save, and the edit/commit callbacks — consumed by
+ * Preview.tsx, which threads them into VisualEditorPanel.
+ *
+ * Boundaries: lib/edit wrappers (`resolveClassnameSource`, `applyClassnameEdit
+ * [Multi]`, `resolveTextSource`/`applyTextEdit`, `resolveImageSource`/
+ * `applySrcEdit`, `findComponentUsage`) over the Rust edit backend; the iframe
+ * `ss:*` message protocol; localStorage for the auto-save opt-in.
+ *
+ * Gotchas: incoming messages are trusted only when `e.source` is the preview
+ * iframe's contentWindow — the iframe hosts untrusted project content, and a
+ * forged `ss:textCommit` would otherwise write to the user's files. Every
+ * write arms `ss:suppressReload` BEFORE touching disk: Astro's full reload can
+ * beat the post-write `ss:commit`, briefly reverting the preview. Live values
+ * (`currentClass`, text/image targets) are mirrored into refs so the commit
+ * callbacks read fresh state without re-subscribing the message handler.
  */
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';


### PR DESCRIPTION
## What this is

Final PR of the design-system cleanup (#87–#91).

## Changes

- **`docs/design-system.md`** — single source of truth: every token group with when-to-use, props + examples + learned gotchas for all six primitives (ModalFrame, Button, Spinner, Dropdown, EmptyState, Skeleton), the three escape hatches (file-local tokens, `css-ok`, local z-index), and what CI enforces.
- **`src/components/README.md`** — the new folder structure: what belongs in each of the 15 folders, why 6 files stay at root, and a 5-line 'where does my new component go' guide.
- **JSDoc on Button, EmptyState, Skeleton** (matching ModalFrame's existing style — every primitive is now documented).
- **Orientation JSDoc on the 5 largest hooks** (useProjectLifecycle, useDevServer, useVisualEditor, useProjectCreation, useTerminalManagement): phases, key state + consumers, external boundaries, and the genuinely-present gotchas (navigation supersession guard, suppressed-set-before-stop, forged-postMessage check, ss:suppressReload arming order…).
- CLAUDE.md: pointer to the design-system doc + fixed stale CSS folder diagram.

## Found while documenting (flagged, NOT fixed here — bug-fix material for a normal PR)

1. `useProjectCreation` treats a null PTY exit code (killed process) as **success**; `useProjectLifecycle` treats the same event as failure — opposite policies for the same signal.
2. `useProjectCreation.isCreating` never resets on error (no path back to the form).
3. `useProjectLifecycle` has write-only `setCurrentPreviewPage` state.
4. `useDevServer`'s restart path can orphan a PTY that resolves after its 10s spawn timeout.

## Verification

typecheck + 624 tests + check:all green. Comments/docs only — zero behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive design-system reference covering tokens, usage rules, primitives, and enforcement guidance
  * Added a components structure guide clarifying folder layout and placement rules for shared pieces and feature folders
  * Expanded inline/docs for primitives and hooks with detailed prop descriptions, lifecycle/behavior notes, and usage gotchas
<!-- end of auto-generated comment: release notes by coderabbit.ai -->