### PR TITLE
Let static sites with a package.json opt into static preview

### DIFF
--- a/src-tauri/src/commands/projects/dev_server.rs
+++ b/src-tauri/src/commands/projects/dev_server.rs
@@ -63,6 +63,60 @@ pub async fn set_custom_dev_command(
     Ok(())
 }
 
+/// Gets whether this project is forced to serve as a static site, overriding
+/// the `generic` classification a root `package.json` would otherwise trigger.
+/// Returns `false` when unset.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn get_force_static_serve(project_path: String) -> Result<bool, CommandError> {
+    let project = validate_project_path(&project_path)?;
+    let metadata_path = project.join(".shipstudio").join("project.json");
+
+    if !metadata_path.exists() {
+        return Ok(false);
+    }
+
+    let metadata = std::fs::read_to_string(&metadata_path)
+        .ok()
+        .and_then(|contents| serde_json::from_str::<ProjectMetadata>(&contents).ok())
+        .unwrap_or_default();
+
+    Ok(metadata.force_static_serve.unwrap_or(false))
+}
+
+/// Sets whether this project is forced to serve as a static site. Stores `None`
+/// (field omitted) when turned off, so the JSON stays clean.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn set_force_static_serve(project_path: String, force: bool) -> Result<(), CommandError> {
+    let project = validate_project_path(&project_path)?;
+    let shipstudio_dir = project.join(".shipstudio");
+    let metadata_path = shipstudio_dir.join("project.json");
+
+    let mut metadata = if metadata_path.exists() {
+        std::fs::read_to_string(&metadata_path)
+            .ok()
+            .and_then(|contents| serde_json::from_str::<ProjectMetadata>(&contents).ok())
+            .unwrap_or_default()
+    } else {
+        ProjectMetadata::default()
+    };
+
+    metadata.force_static_serve = if force { Some(true) } else { None };
+
+    if !shipstudio_dir.exists() {
+        std::fs::create_dir_all(&shipstudio_dir)
+            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
+    }
+
+    let contents = serde_json::to_string_pretty(&metadata)
+        .map_err(|e| format!("Failed to serialize project metadata: {e}"))?;
+    std::fs::write(&metadata_path, contents)
+        .map_err(|e| format!("Failed to write project metadata: {e}"))?;
+
+    Ok(())
+}
+
 /// Gets the dev server port for a project (returns None if not configured, meaning use default 3000)
 #[tauri::command]
 #[tracing::instrument(fields(project = %project_path))]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -370,6 +370,8 @@ pub fn run() {
             commands::projects::set_custom_dev_command,
             commands::projects::get_dev_server_port,
             commands::projects::set_dev_server_port,
+            commands::projects::get_force_static_serve,
+            commands::projects::set_force_static_serve,
             commands::projects::get_workspace_subpath,
             commands::projects::set_workspace_subpath,
             commands::projects::check_dependencies_installed,

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -198,6 +198,13 @@ pub struct ProjectMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub dev_server_port: Option<u16>,
+    /// When set, serve the project as a static site even though a `package.json`
+    /// is present (which would otherwise classify it as `generic` and start no
+    /// server). Lets a plain static site that carries build tooling (PostCSS,
+    /// autoprefixer, a CSS minifier) keep a working preview. `None` = respect
+    /// auto-detection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub force_static_serve: Option<bool>,
     /// Saved terminal tab state for session restoration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub terminal_state: Option<TerminalState>,
@@ -248,6 +255,7 @@ impl Default for ProjectMetadata {
             hide_main_branch_warning: None,
             custom_dev_command: None,
             dev_server_port: None,
+            force_static_serve: None,
             terminal_state: None,
             custom_thumbnail: None,
             workspace_subpath: None,
@@ -769,4 +777,42 @@ pub struct CompactModePreferences {
     pub always_on_top: bool,
     /// Whether the output area is currently expanded
     pub is_expanded: bool,
+}
+
+#[cfg(test)]
+mod metadata_tests {
+    use super::ProjectMetadata;
+
+    #[test]
+    fn force_static_serve_is_omitted_when_unset() {
+        let meta = ProjectMetadata::default();
+        assert_eq!(meta.force_static_serve, None);
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(
+            !json.contains("force_static_serve"),
+            "None should not serialize the field (skip_serializing_if), got: {json}"
+        );
+    }
+
+    #[test]
+    fn force_static_serve_round_trips_when_set() {
+        let mut meta = ProjectMetadata::default();
+        meta.force_static_serve = Some(true);
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(json.contains("\"force_static_serve\":true"));
+
+        let parsed: ProjectMetadata = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.force_static_serve, Some(true));
+    }
+
+    #[test]
+    fn legacy_files_without_the_field_default_to_none() {
+        // A project.json written by an older build omits the key entirely (the
+        // default already serializes without it). Deserializing must yield None,
+        // not an error.
+        let legacy_json = serde_json::to_string(&ProjectMetadata::default()).unwrap();
+        assert!(!legacy_json.contains("force_static_serve"));
+        let parsed: ProjectMetadata = serde_json::from_str(&legacy_json).unwrap();
+        assert_eq!(parsed.force_static_serve, None);
+    }
 }

--- a/src/components/workspace/ProjectSettingsModal.tsx
+++ b/src/components/workspace/ProjectSettingsModal.tsx
@@ -5,7 +5,7 @@
  * The parent component handles persistence via Tauri commands.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import '../../styles/features/notifications.css';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
@@ -40,14 +40,23 @@ export function ProjectSettingsModal({
   // — a detected framework already serves itself.
   const showForceStatic = !isWebProject && !!projectPath;
   const [forceStatic, setForceStatic] = useState(false);
+  // The on-disk value once loaded for the current project, or null while the
+  // load is still in flight. Persisting is gated on this so a Save before the
+  // load resolves (or right after switching projects) can't clobber the real
+  // value with the stale default. A ref (not state) — it's only read at save
+  // time and must not trigger a render.
+  const loadedForceStatic = useRef<boolean | null>(null);
 
-  // Load the persisted override whenever the modal opens.
+  // Load the persisted override whenever the modal opens (or the project changes).
   useEffect(() => {
     if (!isOpen || !showForceStatic || !projectPath) return;
     let cancelled = false;
+    loadedForceStatic.current = null;
     getForceStaticServe(projectPath)
       .then((value) => {
-        if (!cancelled) setForceStatic(value);
+        if (cancelled) return;
+        setForceStatic(value);
+        loadedForceStatic.current = value;
       })
       .catch((err) => {
         logger.warn('[ProjectSettings] Failed to load force_static_serve', {
@@ -68,7 +77,14 @@ export function ProjectSettingsModal({
         const trimmed = devCommand.trim();
         onSaveDevCommand(trimmed || null);
       }
-      if (showForceStatic && projectPath) {
+      // Only persist when the current value has loaded and the user actually
+      // changed it — never write the stale default over an unread value.
+      if (
+        showForceStatic &&
+        projectPath &&
+        loadedForceStatic.current !== null &&
+        forceStatic !== loadedForceStatic.current
+      ) {
         void setForceStaticServe(projectPath, forceStatic).catch((err) => {
           logger.error('[ProjectSettings] Failed to save force_static_serve', {
             error: err instanceof Error ? err.message : String(err),
@@ -207,7 +223,7 @@ export function ProjectSettingsModal({
                   >
                     Serve files directly even though a <code>package.json</code> is present. Use
                     this for plain HTML/CSS sites that keep a <code>package.json</code> only for
-                    build tooling. Restart the dev server (or reopen the project) to apply.
+                    build tooling. Reopen the project to apply.
                   </span>
                 </span>
               </label>

--- a/src/components/workspace/ProjectSettingsModal.tsx
+++ b/src/components/workspace/ProjectSettingsModal.tsx
@@ -5,11 +5,13 @@
  * The parent component handles persistence via Tauri commands.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import '../../styles/features/notifications.css';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { useModal } from '../../contexts/ModalContext';
+import { getForceStaticServe, setForceStaticServe } from '../../lib/project';
+import { logger } from '../../lib/logger';
 
 interface ProjectSettingsModalProps {
   currentPort: number;
@@ -18,6 +20,8 @@ interface ProjectSettingsModalProps {
   customDevCommand?: string | null;
   onSaveDevCommand?: (command: string | null) => void;
   isWebProject?: boolean;
+  /** Absolute project path — enables the "serve as static site" override. */
+  projectPath?: string;
 }
 
 export function ProjectSettingsModal({
@@ -26,11 +30,34 @@ export function ProjectSettingsModal({
   customDevCommand,
   onSaveDevCommand,
   isWebProject,
+  projectPath,
 }: ProjectSettingsModalProps) {
   const { isOpen, close: onClose } = useModal('projectSettings');
   const [port, setPort] = useState(currentPort);
   const [devCommand, setDevCommand] = useState(customDevCommand ?? '');
   const showDevCommand = !isWebProject && onSaveDevCommand;
+  // The static-serve override is only meaningful for non-web (generic) projects
+  // — a detected framework already serves itself.
+  const showForceStatic = !isWebProject && !!projectPath;
+  const [forceStatic, setForceStatic] = useState(false);
+
+  // Load the persisted override whenever the modal opens.
+  useEffect(() => {
+    if (!isOpen || !showForceStatic || !projectPath) return;
+    let cancelled = false;
+    getForceStaticServe(projectPath)
+      .then((value) => {
+        if (!cancelled) setForceStatic(value);
+      })
+      .catch((err) => {
+        logger.warn('[ProjectSettings] Failed to load force_static_serve', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, showForceStatic, projectPath]);
 
   const isValid = Number.isInteger(port) && port >= 1 && port <= 65535;
 
@@ -40,6 +67,13 @@ export function ProjectSettingsModal({
       if (showDevCommand) {
         const trimmed = devCommand.trim();
         onSaveDevCommand(trimmed || null);
+      }
+      if (showForceStatic && projectPath) {
+        void setForceStaticServe(projectPath, forceStatic).catch((err) => {
+          logger.error('[ProjectSettings] Failed to save force_static_serve', {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
       }
       onClose();
     }
@@ -134,6 +168,49 @@ export function ProjectSettingsModal({
                   toolbar. Leave blank to manage the dev server yourself in the terminal.
                 </span>
               </div>
+            </div>
+          )}
+          {showForceStatic && (
+            <div className="notification-setting-section">
+              <label
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: 'var(--spacing-sm)',
+                  cursor: 'pointer',
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={forceStatic}
+                  onChange={(e) => setForceStatic(e.target.checked)}
+                  style={{ marginTop: 2 }}
+                />
+                <span
+                  style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-xs)' }}
+                >
+                  <span
+                    style={{
+                      fontSize: 'var(--font-size-sm)',
+                      fontWeight: 500,
+                      color: 'var(--text-primary)',
+                    }}
+                  >
+                    Serve as a static site
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 'var(--font-size-xs)',
+                      color: 'var(--text-muted)',
+                      lineHeight: 1.4,
+                    }}
+                  >
+                    Serve files directly even though a <code>package.json</code> is present. Use
+                    this for plain HTML/CSS sites that keep a <code>package.json</code> only for
+                    build tooling. Restart the dev server (or reopen the project) to apply.
+                  </span>
+                </span>
+              </label>
             </div>
           )}
         </div>

--- a/src/components/workspace/WorkspaceModals.tsx
+++ b/src/components/workspace/WorkspaceModals.tsx
@@ -467,6 +467,7 @@ export function WorkspaceModals({
         customDevCommand={customDevCommand}
         onSaveDevCommand={onSaveDevCommand}
         isWebProject={isWebProject}
+        projectPath={projectPath}
       />
 
       {/* Plugin terminal modal — reuses OnboardingTerminal for interactive CLI commands */}

--- a/src/hooks/useDevServer.test.ts
+++ b/src/hooks/useDevServer.test.ts
@@ -10,6 +10,7 @@ vi.mock('../lib/project', () => ({
   }),
   getCustomDevCommand: vi.fn().mockResolvedValue(null),
   setCustomDevCommand: vi.fn().mockResolvedValue(undefined),
+  getForceStaticServe: vi.fn().mockResolvedValue(false),
   getWorkspaceSubpath: vi.fn().mockResolvedValue(null),
   resolveWorkspacePath: (path: string, subpath: string | null) =>
     subpath ? `${path}/${subpath}` : path,
@@ -54,6 +55,7 @@ describe('useDevServer', () => {
       stop: vi.fn().mockResolvedValue(undefined),
     } as never);
     vi.mocked(project.getCustomDevCommand).mockResolvedValue(null);
+    vi.mocked(project.getForceStaticServe).mockResolvedValue(false);
     vi.mocked(project.getWorkspaceSubpath).mockResolvedValue(null);
   });
 
@@ -172,6 +174,50 @@ describe('useDevServer', () => {
       expect(result.current.projectType).toBe('statichtml');
       expect(result.current.devServerPort).toBe(9090);
       expect(startStaticServer).toHaveBeenCalledWith('main', '/path/to/project');
+    });
+
+    it('serves a generic project statically when force_static_serve is set', async () => {
+      // A static site with a package.json detects as `generic`, which would
+      // otherwise start no server. force_static_serve overrides it to static.
+      const { detectProjectType, startStaticServer } = await import('../lib/static-server');
+      const { getForceStaticServe, startDevServer } = await import('../lib/project');
+      vi.mocked(detectProjectType).mockResolvedValue('generic');
+      vi.mocked(getForceStaticServe).mockResolvedValue(true);
+      vi.mocked(startStaticServer).mockResolvedValue(9091);
+
+      const { result } = renderHook(() => useDevServer('/path/to/project'));
+
+      let detectedType: string | undefined;
+      await act(async () => {
+        detectedType = await result.current.startServerForProject(
+          '/path/to/project',
+          'my-project',
+          3000,
+          'main'
+        );
+      });
+
+      expect(detectedType).toBe('statichtml');
+      expect(result.current.projectType).toBe('statichtml');
+      expect(startStaticServer).toHaveBeenCalledWith('main', '/path/to/project');
+      // It must NOT fall into the generic/no-command branch that starts nothing.
+      expect(startDevServer).not.toHaveBeenCalled();
+    });
+
+    it('leaves a generic project as-is when force_static_serve is off', async () => {
+      const { detectProjectType, startStaticServer } = await import('../lib/static-server');
+      const { getForceStaticServe } = await import('../lib/project');
+      vi.mocked(detectProjectType).mockResolvedValue('generic');
+      vi.mocked(getForceStaticServe).mockResolvedValue(false);
+
+      const { result } = renderHook(() => useDevServer('/path/to/project'));
+
+      await act(async () => {
+        await result.current.startServerForProject('/path/to/project', 'my-project', 3000, 'main');
+      });
+
+      expect(result.current.projectType).toBe('generic');
+      expect(startStaticServer).not.toHaveBeenCalled();
     });
 
     it('starts dev server for non-static projects', async () => {

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -43,6 +43,7 @@ import {
   getWorkspaceSubpath,
   resolveWorkspacePath,
   checkDependenciesInstalled,
+  getForceStaticServe,
 } from '../lib/project';
 import { detectPackageManager } from '../lib/github';
 
@@ -517,6 +518,27 @@ export function useDevServer(currentProjectPath: string | null) {
       } catch {
         logger.warn('[OpenProject] Failed to detect project type, defaulting to unknown');
       }
+
+      // A plain static site that carries a root `package.json` only for build
+      // tooling (PostCSS, autoprefixer, a CSS minifier) is detected as `generic`
+      // and would start no server. The user can opt into static serving via
+      // `.shipstudio/project.json` → `force_static_serve`; when set, treat it as
+      // a static-HTML project so it serves over the static server and the
+      // Preview pane renders (it gates out `generic`/`unknown`).
+      let forceStatic = false;
+      try {
+        forceStatic = await getForceStaticServe(projectPath);
+      } catch {
+        /* default: respect detection */
+      }
+      if (forceStatic && (detectedType === 'generic' || detectedType === 'unknown')) {
+        logger.info('[OpenProject] force_static_serve set; serving as static HTML', {
+          projectPath,
+          detectedType,
+        });
+        detectedType = 'statichtml';
+      }
+
       s.type = detectedType;
       bump();
 
@@ -527,8 +549,11 @@ export function useDevServer(currentProjectPath: string | null) {
       // and a theme's optional package.json (Tailwind tooling, or one an
       // agent added) must not block the preview behind an install gate.
       try {
+        // Shopify themes and force-static projects don't need an npm install to
+        // preview: the theme runs via `shopify theme dev`, and a force-static
+        // site is served straight off disk regardless of its build tooling.
         const depStatus =
-          detectedType === 'shopifytheme'
+          detectedType === 'shopifytheme' || forceStatic
             ? { installed: true, hasPackageJson: false }
             : await checkDependenciesInstalled(projectPath);
         if (!depStatus.installed && depStatus.hasPackageJson) {

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -524,14 +524,15 @@ export function useDevServer(currentProjectPath: string | null) {
       // and would start no server. The user can opt into static serving via
       // `.shipstudio/project.json` → `force_static_serve`; when set, treat it as
       // a static-HTML project so it serves over the static server and the
-      // Preview pane renders (it gates out `generic`/`unknown`).
+      // Preview pane renders (it gates out `generic`). Scoped to `generic` —
+      // the override is specifically for the package.json-present case.
       let forceStatic = false;
       try {
         forceStatic = await getForceStaticServe(projectPath);
       } catch {
         /* default: respect detection */
       }
-      if (forceStatic && (detectedType === 'generic' || detectedType === 'unknown')) {
+      if (forceStatic && detectedType === 'generic') {
         logger.info('[OpenProject] force_static_serve set; serving as static HTML', {
           projectPath,
           detectedType,

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -633,6 +633,24 @@ export async function setCustomDevCommand(
   return invoke<void>('set_custom_dev_command', { projectPath, command });
 }
 
+/**
+ * Get whether the project is forced to serve as a static site (overriding the
+ * `generic` classification a root `package.json` would otherwise trigger).
+ * @param projectPath - Absolute path to the project directory
+ */
+export async function getForceStaticServe(projectPath: string): Promise<boolean> {
+  return invoke<boolean>('get_force_static_serve', { projectPath });
+}
+
+/**
+ * Set whether the project is forced to serve as a static site.
+ * @param projectPath - Absolute path to the project directory
+ * @param force - true to always serve statically; false to respect detection
+ */
+export async function setForceStaticServe(projectPath: string, force: boolean): Promise<void> {
+  return invoke<void>('set_force_static_serve', { projectPath, force });
+}
+
 /** A runnable app discovered inside a monorepo at import time. */
 export interface WorkspaceInfo {
   /** Package name from the workspace's `package.json`. */


### PR DESCRIPTION
## Problem

A plain HTML/CSS site that adds a root `package.json` — for build tooling like PostCSS, autoprefixer, or a CSS minifier — was detected as `ProjectType::Generic`. Generic projects start no dev server unless a custom dev command is configured, so the **preview went blank**. The static-serve path (`detection.rs`) is only reached when there's *no* `package.json`, so it was unreachable the moment any Node tooling was introduced. Removing `package.json` fixed it; that was the only workaround.

Reported by a user running a static site with PostCSS.

## Fix

Add an opt-in `force_static_serve` flag to `.shipstudio/project.json`. When set, a `generic`/`unknown` project is served over the existing static server instead of waiting for a dev command. This matches the codebase's "explicit over implicit" philosophy — no detection guessing, the user declares intent.

- **`types.rs`** — `ProjectMetadata.force_static_serve: Option<bool>` (omitted from JSON when off, so legacy files and the "off" state stay clean)
- **`dev_server.rs`** — `get_force_static_serve` / `set_force_static_serve` commands (path-validated, `#[tracing::instrument]`, `Result<_, CommandError>`)
- **`useDevServer.ts`** — after detection, if the flag is set and the type is `generic`/`unknown`, override to `statichtml` so it serves over the static server *and* the Preview pane renders (it gates out `generic`). Force-static projects are also exempt from the npm-install gate, since serving off disk needs no `node_modules`.
- **`ProjectSettingsModal`** — a "Serve as a static site" checkbox, shown only for non-web projects. Takes effect on the next dev-server start (helper text says so).

## Test plan

- [x] `cargo test` — 3 new serde round-trip tests (round-trips when set, omitted when None, legacy files default to None)
- [x] `pnpm test:run` — full suite (626 passed / 4 skipped), incl. 2 new `useDevServer` tests proving the serve decision: *generic + flag → static server starts, `startDevServer` not called*; *flag off → stays generic, no static server*
- [x] `pnpm typecheck`, `pnpm lint:strict` (0 warnings), `pnpm check:patterns`, `pnpm format:check`
- [x] `cargo fmt --check`, `cargo clippy` (no new warnings)
- [ ] Manual desktop smoke: open a static site that carries a `package.json`, toggle "Serve as a static site" in Project Settings, restart the dev server, confirm the preview serves

## Patterns checklist

- [x] New buttons/inputs follow existing modal patterns; toggle uses design tokens for new styles
- [x] New `#[tauri::command]`s return `Result<T, CommandError>`, have `#[tracing::instrument]`, validate paths with `validate_project_path`
- [x] Frontend calls go through `src/lib/project.ts` wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Serve as a static site" setting in the Project Settings Modal to override how generic projects are served.
  * Projects configured with this setting will be served as static HTML sites instead of attempting dynamic serving.
  * Per-project configuration is persisted automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->