### PR TITLE
Vercel production-domain link, actionable Integrations panel, and auth logout

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -35,6 +35,7 @@ pub mod snapshots;
 pub mod static_server;
 pub mod support;
 pub mod templates;
+pub mod vercel;
 pub mod window;
 
 // Re-export all commands for easy access in lib.rs

--- a/src-tauri/src/commands/setup/auth.rs
+++ b/src-tauri/src/commands/setup/auth.rs
@@ -7,8 +7,12 @@ use super::{is_mock_installed, is_mock_mode, mock_install, AUTH_PIDS};
 use crate::agent::{get_active_agent, get_agent_by_id};
 use crate::commands::claude::find_binary_by_name;
 use crate::errors::CommandError;
+use crate::external_command::run_with_timeout;
 use crate::utils::{create_command, find_executable};
 use tauri::Emitter;
+
+/// Timeout for account sign-out CLI calls (they touch the network/keychain).
+const LOGOUT_TIMEOUT_SECS: u64 = 30;
 
 /// Start GitHub authentication (opens browser)
 #[tauri::command]
@@ -56,6 +60,73 @@ pub async fn start_github_auth(app: tauri::AppHandle) -> Result<String, CommandE
     });
 
     Ok("A code has been copied to your clipboard. Paste it in the browser to connect.".to_string())
+}
+
+/// Sign out of the GitHub CLI (`gh auth logout`). Idempotent: a "not logged in"
+/// result is treated as success so the Integrations panel's Disconnect always
+/// settles to a disconnected state.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn logout_github() -> Result<(), CommandError> {
+    if is_mock_mode() {
+        return Ok(());
+    }
+
+    let gh_path = find_executable("gh").ok_or("GitHub CLI not installed")?;
+    let mut cmd = create_command(&gh_path);
+    cmd.args(["auth", "logout", "--hostname", "github.com"]);
+    let output = run_with_timeout(
+        tokio::process::Command::from(cmd),
+        "gh auth logout",
+        LOGOUT_TIMEOUT_SECS,
+    )
+    .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+        if !stderr.contains("not logged in") && !stderr.contains("no accounts") {
+            return Err((format!(
+                "Failed to sign out of GitHub: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ))
+            .into());
+        }
+    }
+
+    crate::commands::github::invalidate_github_username_cache();
+    Ok(())
+}
+
+/// Sign out of the Vercel CLI (`vercel logout`). Idempotent like `logout_github`.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn logout_vercel() -> Result<(), CommandError> {
+    if is_mock_mode() {
+        return Ok(());
+    }
+
+    let vercel_path = find_executable("vercel").ok_or("Vercel CLI not installed")?;
+    let mut cmd = create_command(&vercel_path);
+    cmd.args(["logout"]);
+    let output = run_with_timeout(
+        tokio::process::Command::from(cmd),
+        "vercel logout",
+        LOGOUT_TIMEOUT_SECS,
+    )
+    .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+        if !stderr.contains("not logged in") {
+            return Err((format!(
+                "Failed to sign out of Vercel: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ))
+            .into());
+        }
+    }
+
+    Ok(())
 }
 
 /// Start agent authentication.

--- a/src-tauri/src/commands/vercel.rs
+++ b/src-tauri/src/commands/vercel.rs
@@ -30,9 +30,15 @@ const VERCEL_TIMEOUT_SECS: u64 = 15;
 #[derive(Serialize, Clone, Debug, Default, PartialEq)]
 pub struct VercelDomainInfo {
     /// The canonical production custom domain (e.g. "pop.bimbi.co"), if one exists.
+    /// Carried separately from `production_url` so the UI can show the bare host
+    /// as a label while opening the full URL.
     pub custom_domain: Option<String>,
     /// The system `*.vercel.app` URL Vercel returned, used as a fallback display.
     pub system_url: Option<String>,
+    /// The full `https://` address to open: `https://{custom_domain or system_url}`.
+    /// Built here once, authoritatively, so the frontend never constructs a URL
+    /// from a host fragment. `None` only when neither host exists.
+    pub production_url: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -117,9 +123,18 @@ fn select_production_domain(domains: &[DomainEntry]) -> VercelDomainInfo {
         pool.first().map(|d| d.name.clone())
     };
 
+    let custom_domain = pick(true).or_else(|| pick(false));
+    // The address to open: the custom domain if any, else the system url. Built
+    // here so callers receive an explicit `https://` URL, never a host fragment.
+    let production_url = custom_domain
+        .as_deref()
+        .or(system_url.as_deref())
+        .map(|host| format!("https://{host}"));
+
     VercelDomainInfo {
-        custom_domain: pick(true).or_else(|| pick(false)),
+        custom_domain,
         system_url,
+        production_url,
     }
 }
 
@@ -273,6 +288,8 @@ mod tests {
             info.system_url.as_deref(),
             Some("pop-sandy-five.vercel.app")
         );
+        // production_url is the canonical custom domain as a full https URL.
+        assert_eq!(info.production_url.as_deref(), Some("https://pop.bimbi.co"));
     }
 
     #[test]
@@ -300,6 +317,10 @@ mod tests {
         let info = select_production_domain(&domains);
         assert_eq!(info.custom_domain.as_deref(), Some("www.src.org.mx"));
         assert_eq!(info.system_url.as_deref(), Some("src-mx.vercel.app"));
+        assert_eq!(
+            info.production_url.as_deref(),
+            Some("https://www.src.org.mx")
+        );
     }
 
     #[test]
@@ -315,6 +336,11 @@ mod tests {
         assert_eq!(
             info.system_url.as_deref(),
             Some("creatormatch-v2.vercel.app")
+        );
+        // No custom domain: production_url falls back to the system host.
+        assert_eq!(
+            info.production_url.as_deref(),
+            Some("https://creatormatch-v2.vercel.app")
         );
     }
 

--- a/src-tauri/src/commands/vercel.rs
+++ b/src-tauri/src/commands/vercel.rs
@@ -1,0 +1,342 @@
+//! # Vercel domain lookup
+//!
+//! Reads the production custom domain for a project so the UI can show the real
+//! site address (e.g. `pop.bimbi.co`) instead of nothing. Ship Studio publishes
+//! through Vercel's GitHub integration and never knew the deployed domain.
+//!
+//! Projects deployed that way usually have **no** local `.vercel/project.json`
+//! (nobody ran `vercel link`), and they often live under a Vercel **team**
+//! rather than the personal scope — so we can't rely on a project id on disk.
+//! Instead we match the Vercel project by its linked **GitHub repo**
+//! (`owner/name`), searching the personal scope and every team to find the
+//! project id, then read its production domains and pick the **canonical** one
+//! (the domain Vercel does not redirect away from — every other custom host on
+//! the project redirects to it).
+//!
+//! Auth: the app authenticates Vercel through the `vercel` CLI, so we reuse the
+//! token that CLI already stored on disk. The token stays in the backend — it is
+//! never logged, never returned to the frontend, and only sent to api.vercel.com.
+
+use crate::errors::CommandError;
+use crate::utils::validate_project_path;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+const VERCEL_API: &str = "https://api.vercel.com";
+const VERCEL_TIMEOUT_SECS: u64 = 15;
+
+/// The production domains Vercel knows about for a project.
+#[derive(Serialize, Clone, Debug, Default, PartialEq)]
+pub struct VercelDomainInfo {
+    /// The canonical production custom domain (e.g. "pop.bimbi.co"), if one exists.
+    pub custom_domain: Option<String>,
+    /// The system `*.vercel.app` URL Vercel returned, used as a fallback display.
+    pub system_url: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ProjectLink {
+    org: Option<String>,
+    repo: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct VercelProject {
+    id: String,
+    link: Option<ProjectLink>,
+}
+
+#[derive(Deserialize)]
+struct ProjectsResponse {
+    projects: Vec<VercelProject>,
+}
+
+#[derive(Deserialize)]
+struct Team {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct TeamsResponse {
+    teams: Vec<Team>,
+}
+
+/// One entry from `GET /v9/projects/{id}/domains`.
+#[derive(Deserialize, Debug)]
+struct DomainEntry {
+    name: String,
+    #[serde(rename = "apexName")]
+    apex_name: Option<String>,
+    #[serde(default)]
+    verified: bool,
+    /// When set, this host redirects to another — so it is NOT the canonical domain.
+    #[serde(default)]
+    redirect: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct DomainsResponse {
+    domains: Vec<DomainEntry>,
+}
+
+fn is_system_domain(d: &DomainEntry) -> bool {
+    d.apex_name.as_deref() == Some("vercel.app") || d.name.ends_with(".vercel.app")
+}
+
+/// Pick the canonical production custom domain (and the system `*.vercel.app`
+/// fallback). Pure filtering — never constructs a host.
+///
+/// The canonical domain is one Vercel does NOT redirect (`redirect == null`):
+/// for src-mx, `src.mx`/`src.org.mx`/... all redirect to `www.src.org.mx`, which
+/// is the only non-redirect host and therefore the real site address. Among
+/// non-redirect custom domains, prefer a verified one, then the apex
+/// (name == apexName), then a `www.` host, then the first Vercel listed.
+fn select_production_domain(domains: &[DomainEntry]) -> VercelDomainInfo {
+    let system_url = domains
+        .iter()
+        .find(|d| is_system_domain(d))
+        .map(|d| d.name.clone());
+
+    let pick = |verified_only: bool| -> Option<String> {
+        let mut pool: Vec<&DomainEntry> = domains
+            .iter()
+            .filter(|d| {
+                !is_system_domain(d) && d.redirect.is_none() && (!verified_only || d.verified)
+            })
+            .collect();
+        pool.sort_by_key(|d| {
+            if d.apex_name.as_deref() == Some(d.name.as_str()) {
+                0
+            } else if d.name.starts_with("www.") {
+                1
+            } else {
+                2
+            }
+        });
+        pool.first().map(|d| d.name.clone())
+    };
+
+    VercelDomainInfo {
+        custom_domain: pick(true).or_else(|| pick(false)),
+        system_url,
+    }
+}
+
+async fn read_vercel_token() -> Option<String> {
+    let path = dirs::data_dir()?.join("com.vercel.cli").join("auth.json");
+    let raw = tokio::fs::read_to_string(&path).await.ok()?;
+    let json: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    json.get("token")
+        .and_then(|t| t.as_str())
+        .filter(|t| !t.is_empty())
+        .map(|t| t.to_string())
+}
+
+/// GET a Vercel API path and parse JSON. Returns `None` on timeout, transport
+/// error, non-2xx, or parse failure — the domain lookup is best-effort.
+async fn get_json<T: DeserializeOwned>(
+    client: &reqwest::Client,
+    url: &str,
+    token: &str,
+) -> Option<T> {
+    let req = client.get(url).bearer_auth(token).send();
+    let resp = tokio::time::timeout(Duration::from_secs(VERCEL_TIMEOUT_SECS), req)
+        .await
+        .ok()?
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    resp.json::<T>().await.ok()
+}
+
+/// Find the id of the project linked to `owner/repo` in one scope (personal when
+/// `team_id` is `None`).
+async fn find_project_id(
+    client: &reqwest::Client,
+    token: &str,
+    team_id: Option<&str>,
+    owner: &str,
+    repo: &str,
+) -> Option<String> {
+    let mut url = format!("{VERCEL_API}/v9/projects?limit=100");
+    if let Some(team) = team_id {
+        url.push_str("&teamId=");
+        url.push_str(team);
+    }
+    let list: ProjectsResponse = get_json(client, &url, token).await?;
+    list.projects.into_iter().find_map(|p| {
+        let link = p.link?;
+        if link.org.as_deref() == Some(owner) && link.repo.as_deref() == Some(repo) {
+            Some(p.id)
+        } else {
+            None
+        }
+    })
+}
+
+/// Fetch the production custom domain for a project, matched by its GitHub repo.
+///
+/// `github_repo` is the `owner/name` Ship Studio already resolved from the git
+/// remote. Returns `Ok(None)` (never an error) when there's no repo, the Vercel
+/// CLI isn't authenticated, no Vercel project is linked to that repo, or there's
+/// no domain to report — so callers show the affordance only when a real value
+/// exists. Never constructs a host.
+#[tauri::command]
+#[tracing::instrument(skip(project_path), fields(project = %project_path, repo = ?github_repo))]
+pub async fn get_vercel_production_domain(
+    project_path: String,
+    github_repo: Option<String>,
+) -> Result<Option<VercelDomainInfo>, CommandError> {
+    let _ = validate_project_path(&project_path)?;
+
+    let Some(repo) = github_repo.filter(|r| !r.trim().is_empty()) else {
+        return Ok(None);
+    };
+    let Some((owner, name)) = repo.split_once('/') else {
+        return Ok(None);
+    };
+    let name = name.trim_end_matches(".git");
+
+    let Some(token) = read_vercel_token().await else {
+        return Ok(None); // Vercel CLI not authenticated
+    };
+
+    let client = reqwest::Client::new();
+
+    // Find the project + the scope (team) it lives in: personal first, then teams.
+    let mut found: Option<(String, Option<String>)> =
+        find_project_id(&client, &token, None, owner, name)
+            .await
+            .map(|id| (id, None));
+    if found.is_none() {
+        let teams_url = format!("{VERCEL_API}/v2/teams?limit=100");
+        if let Some(teams) = get_json::<TeamsResponse>(&client, &teams_url, &token).await {
+            for team in teams.teams {
+                if let Some(id) =
+                    find_project_id(&client, &token, Some(&team.id), owner, name).await
+                {
+                    found = Some((id, Some(team.id)));
+                    break;
+                }
+            }
+        }
+    }
+
+    let Some((project_id, team_id)) = found else {
+        return Ok(None); // no Vercel project linked to this repo in any scope
+    };
+
+    // Fetch the project's production domains (with redirect/verified metadata) in
+    // the same scope, and pick the canonical one.
+    let mut url =
+        format!("{VERCEL_API}/v9/projects/{project_id}/domains?production=true&limit=100");
+    if let Some(team) = team_id.as_deref() {
+        url.push_str("&teamId=");
+        url.push_str(team);
+    }
+    let Some(data) = get_json::<DomainsResponse>(&client, &url, &token).await else {
+        return Ok(None);
+    };
+
+    let info = select_production_domain(&data.domains);
+    if info.custom_domain.is_none() && info.system_url.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(info))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(name: &str, apex: &str, verified: bool, redirect: Option<&str>) -> DomainEntry {
+        DomainEntry {
+            name: name.to_string(),
+            apex_name: Some(apex.to_string()),
+            verified,
+            redirect: redirect.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn picks_verified_custom_domain_over_system() {
+        // Real `pop` /domains shape.
+        let domains = vec![
+            entry("pop.bimbi.co", "bimbi.co", true, None),
+            entry("pop-sandy-five.vercel.app", "vercel.app", true, None),
+        ];
+        let info = select_production_domain(&domains);
+        assert_eq!(info.custom_domain.as_deref(), Some("pop.bimbi.co"));
+        assert_eq!(
+            info.system_url.as_deref(),
+            Some("pop-sandy-five.vercel.app")
+        );
+    }
+
+    #[test]
+    fn picks_the_non_redirect_canonical_among_many() {
+        // Real `src-mx` /domains shape: only www.src.org.mx has redirect: null.
+        let domains = vec![
+            entry(
+                "statisticalresearch.org",
+                "statisticalresearch.org",
+                true,
+                Some("www.src.org.mx"),
+            ),
+            entry(
+                "www.statisticalresearch.org",
+                "statisticalresearch.org",
+                true,
+                Some("www.src.org.mx"),
+            ),
+            entry("src.org.mx", "src.org.mx", true, Some("www.src.org.mx")),
+            entry("www.src.org.mx", "src.org.mx", true, None),
+            entry("src.mx", "src.mx", true, Some("www.src.org.mx")),
+            entry("www.src.mx", "src.mx", true, Some("www.src.org.mx")),
+            entry("src-mx.vercel.app", "vercel.app", true, None),
+        ];
+        let info = select_production_domain(&domains);
+        assert_eq!(info.custom_domain.as_deref(), Some("www.src.org.mx"));
+        assert_eq!(info.system_url.as_deref(), Some("src-mx.vercel.app"));
+    }
+
+    #[test]
+    fn no_custom_domain_falls_back_to_system() {
+        let domains = vec![entry(
+            "creatormatch-v2.vercel.app",
+            "vercel.app",
+            true,
+            None,
+        )];
+        let info = select_production_domain(&domains);
+        assert_eq!(info.custom_domain, None);
+        assert_eq!(
+            info.system_url.as_deref(),
+            Some("creatormatch-v2.vercel.app")
+        );
+    }
+
+    #[test]
+    fn prefers_apex_over_www_when_both_are_canonical() {
+        let domains = vec![
+            entry("www.example.com", "example.com", true, None),
+            entry("example.com", "example.com", true, None),
+        ];
+        let info = select_production_domain(&domains);
+        assert_eq!(info.custom_domain.as_deref(), Some("example.com"));
+    }
+
+    #[test]
+    fn uses_unverified_only_when_no_verified_canonical_exists() {
+        let domains = vec![entry("pending.example.com", "example.com", false, None)];
+        let info = select_production_domain(&domains);
+        assert_eq!(info.custom_domain.as_deref(), Some("pending.example.com"));
+    }
+
+    #[test]
+    fn empty_yields_nothing() {
+        assert_eq!(select_production_domain(&[]), VercelDomainInfo::default());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -502,6 +502,7 @@ pub fn run() {
             commands::publishing::publish_to_staging,
             commands::publishing::publish_to_production,
             commands::publishing::publish_branch,
+            commands::vercel::get_vercel_production_domain,
             // Pull requests
             commands::pull_requests::list_pull_requests,
             commands::pull_requests::create_pull_request,
@@ -568,6 +569,8 @@ pub fn run() {
             commands::setup::install_brew_packages,
             commands::setup::install_winget_packages,
             commands::setup::start_github_auth,
+            commands::setup::logout_github,
+            commands::setup::logout_vercel,
             commands::setup::start_claude_auth,
             commands::setup::check_claude_auth_status,
             commands::setup::check_npm_cache_permissions,

--- a/src/components/branches/PublishBranchDropdown.test.tsx
+++ b/src/components/branches/PublishBranchDropdown.test.tsx
@@ -7,19 +7,13 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { liveSiteHost } from '../../lib/vercel';
+import { mockInvokeResponse } from '../../test/setup';
 
-const invokeResults = new Map<string, unknown>();
-vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn((cmd: string) => Promise.resolve(invokeResults.get(cmd))),
-}));
-
-const openUrlMock = vi.fn<(u: string) => void>();
-vi.mock('@tauri-apps/plugin-opener', () => ({
-  openUrl: (u: string) => {
-    openUrlMock(u);
-  },
-}));
+// @tauri-apps/api/core and @tauri-apps/plugin-opener are mocked centrally in
+// src/test/setup.ts; openUrl is a vi.fn() we read back via vi.mocked below.
+const openUrlMock = vi.mocked(openUrl);
 
 import { PublishBranchDropdown } from './PublishBranchDropdown';
 
@@ -37,27 +31,41 @@ const baseProps = {
   setIsPublishing: vi.fn(),
 };
 
+// The centralized IPC + opener mocks are cleared between tests by the global
+// beforeEach/afterEach in src/test/setup.ts.
 beforeEach(() => {
-  invokeResults.clear();
   openUrlMock.mockClear();
 });
 
 describe('liveSiteHost', () => {
   it('prefers the custom domain, falls back to the system url, else null', () => {
-    expect(liveSiteHost({ custom_domain: 'pop.bimbi.co', system_url: 'x.vercel.app' })).toBe(
-      'pop.bimbi.co'
-    );
-    expect(liveSiteHost({ custom_domain: null, system_url: 'x.vercel.app' })).toBe('x.vercel.app');
-    expect(liveSiteHost({ custom_domain: null, system_url: null })).toBeNull();
+    expect(
+      liveSiteHost({
+        custom_domain: 'pop.bimbi.co',
+        system_url: 'x.vercel.app',
+        production_url: 'https://pop.bimbi.co',
+      })
+    ).toBe('pop.bimbi.co');
+    expect(
+      liveSiteHost({
+        custom_domain: null,
+        system_url: 'x.vercel.app',
+        production_url: 'https://x.vercel.app',
+      })
+    ).toBe('x.vercel.app');
+    expect(
+      liveSiteHost({ custom_domain: null, system_url: null, production_url: null })
+    ).toBeNull();
     expect(liveSiteHost(null)).toBeNull();
   });
 });
 
 describe('PublishBranchDropdown live domain', () => {
   it('shows the Vercel custom domain on the main branch and opens it on click', async () => {
-    invokeResults.set('get_vercel_production_domain', {
+    mockInvokeResponse('get_vercel_production_domain', {
       custom_domain: 'pop.bimbi.co',
       system_url: 'pop-sandy-five.vercel.app',
+      production_url: 'https://pop.bimbi.co',
     });
     render(<PublishBranchDropdown {...baseProps} />);
     fireEvent.click(screen.getByRole('button', { name: /Publish/ }));
@@ -68,9 +76,10 @@ describe('PublishBranchDropdown live domain', () => {
   });
 
   it('does not show a domain on a feature branch', async () => {
-    invokeResults.set('get_vercel_production_domain', {
+    mockInvokeResponse('get_vercel_production_domain', {
       custom_domain: 'pop.bimbi.co',
       system_url: null,
+      production_url: 'https://pop.bimbi.co',
     });
     render(<PublishBranchDropdown {...baseProps} currentBranch="feature/x" />);
     fireEvent.click(screen.getByRole('button', { name: /Sync/ }));

--- a/src/components/branches/PublishBranchDropdown.test.tsx
+++ b/src/components/branches/PublishBranchDropdown.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Tests for PublishBranchDropdown's Vercel live-domain surface.
+ *   - liveSiteHost picks custom domain → system url → null
+ *   - on the main branch, the fetched custom domain renders and opens on click
+ *   - on a feature branch, no domain is fetched or shown (production only)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { liveSiteHost } from '../../lib/vercel';
+
+const invokeResults = new Map<string, unknown>();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn((cmd: string) => Promise.resolve(invokeResults.get(cmd))),
+}));
+
+const openUrlMock = vi.fn<(u: string) => void>();
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openUrl: (u: string) => {
+    openUrlMock(u);
+  },
+}));
+
+import { PublishBranchDropdown } from './PublishBranchDropdown';
+
+const baseProps = {
+  currentBranch: 'main',
+  projectGithubStatus: {
+    status: 'connected' as const,
+    github_repo: 'user/repo',
+    github_url: 'https://github.com/user/repo',
+  },
+  projectPath: '/p',
+  hasChangesToSync: true,
+  onStatusChange: vi.fn(),
+  isPublishing: false,
+  setIsPublishing: vi.fn(),
+};
+
+beforeEach(() => {
+  invokeResults.clear();
+  openUrlMock.mockClear();
+});
+
+describe('liveSiteHost', () => {
+  it('prefers the custom domain, falls back to the system url, else null', () => {
+    expect(liveSiteHost({ custom_domain: 'pop.bimbi.co', system_url: 'x.vercel.app' })).toBe(
+      'pop.bimbi.co'
+    );
+    expect(liveSiteHost({ custom_domain: null, system_url: 'x.vercel.app' })).toBe('x.vercel.app');
+    expect(liveSiteHost({ custom_domain: null, system_url: null })).toBeNull();
+    expect(liveSiteHost(null)).toBeNull();
+  });
+});
+
+describe('PublishBranchDropdown live domain', () => {
+  it('shows the Vercel custom domain on the main branch and opens it on click', async () => {
+    invokeResults.set('get_vercel_production_domain', {
+      custom_domain: 'pop.bimbi.co',
+      system_url: 'pop-sandy-five.vercel.app',
+    });
+    render(<PublishBranchDropdown {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /Publish/ }));
+
+    const link = await screen.findByRole('button', { name: /pop\.bimbi\.co/ });
+    fireEvent.click(link);
+    expect(openUrlMock).toHaveBeenCalledWith('https://pop.bimbi.co');
+  });
+
+  it('does not show a domain on a feature branch', async () => {
+    invokeResults.set('get_vercel_production_domain', {
+      custom_domain: 'pop.bimbi.co',
+      system_url: null,
+    });
+    render(<PublishBranchDropdown {...baseProps} currentBranch="feature/x" />);
+    fireEvent.click(screen.getByRole('button', { name: /Sync/ }));
+
+    await waitFor(() => screen.getByText(/Sync your changes/));
+    expect(screen.queryByText('pop.bimbi.co')).toBeNull();
+  });
+});

--- a/src/components/branches/PublishBranchDropdown.tsx
+++ b/src/components/branches/PublishBranchDropdown.tsx
@@ -102,8 +102,13 @@ export function PublishBranchDropdown({
   // failure — it's an optional enhancement, never a constructed URL (the backend
   // returns null when there's nothing real).
   useEffect(() => {
-    if (!isOpen || !isMainBranch || !githubRepo) return;
+    if (!isMainBranch || !githubRepo) {
+      setVercelDomain(null);
+      return;
+    }
+    if (!isOpen) return;
     let cancelled = false;
+    setVercelDomain(null);
     void getVercelProductionDomain(projectPath, githubRepo)
       .then((d) => {
         if (!cancelled) setVercelDomain(d);

--- a/src/components/branches/PublishBranchDropdown.tsx
+++ b/src/components/branches/PublishBranchDropdown.tsx
@@ -8,8 +8,10 @@
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { ProjectGitHubStatus } from '../../lib/github';
 import { publishBranch } from '../../lib/branches';
+import { getVercelProductionDomain, liveSiteHost, type VercelDomainInfo } from '../../lib/vercel';
 import { ChevronIcon, BranchIcon, SuccessIcon, ErrorIcon } from '../icons';
 import { Spinner } from '../primitives/Spinner';
 import { useClickOutside } from '../../hooks/useClickOutside';
@@ -85,11 +87,56 @@ export function PublishBranchDropdown({
   const onToast = (message: string, type?: 'success' | 'error') => showToast(message, type);
   const [isOpen, setIsOpen] = useState(false);
   const [publishState, setPublishState] = useState<PublishState>({ status: 'idle' });
+  const [vercelDomain, setVercelDomain] = useState<VercelDomainInfo | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const hasGitHubRepo =
     projectGithubStatus?.status === 'connected' && projectGithubStatus?.github_repo;
   const isMainBranch = currentBranch === 'main' || currentBranch === 'master';
+  const githubRepo =
+    projectGithubStatus?.status === 'connected' ? (projectGithubStatus.github_repo ?? null) : null;
+
+  // The production custom domain is static Vercel project config (not tied to a
+  // deploy completing), so we can fetch + show it as soon as the dropdown opens
+  // on the main branch. We look the project up by its GitHub repo. Silent on
+  // failure — it's an optional enhancement, never a constructed URL (the backend
+  // returns null when there's nothing real).
+  useEffect(() => {
+    if (!isOpen || !isMainBranch || !githubRepo) return;
+    let cancelled = false;
+    void getVercelProductionDomain(projectPath, githubRepo)
+      .then((d) => {
+        if (!cancelled) setVercelDomain(d);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, isMainBranch, githubRepo, projectPath]);
+
+  const liveHost = liveSiteHost(vercelDomain);
+  const liveDomainLink = liveHost ? (
+    <div className="publish-live-domain-row">
+      <span className="publish-live-domain-label">Live at</span>
+      <button
+        type="button"
+        className="publish-live-domain"
+        onClick={() => void openUrl(`https://${liveHost}`)}
+        title={`Open https://${liveHost}`}
+      >
+        {liveHost}
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path
+            d="M7 17 17 7M17 7H8M17 7v9"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+    </div>
+  ) : null;
 
   // Track previous forceOpen value to detect true→false transitions
   const prevForceOpenRef = useRef<boolean | undefined>(undefined);
@@ -260,6 +307,7 @@ export function PublishBranchDropdown({
                 <SuccessIcon />
                 <span>{isMainBranch ? 'Published!' : 'Changes synced'}</span>
               </div>
+              {liveDomainLink}
               {!isMainBranch && (
                 <div className="publish-branch-hint">
                   This change has been synced to the <strong>{currentBranch}</strong> branch.
@@ -352,6 +400,8 @@ export function PublishBranchDropdown({
                   </div>
                 )}
 
+                {liveDomainLink}
+
                 {!isMainBranch && (
                   <div className="publish-branch-description">
                     This will save your work to GitHub so others can see it.
@@ -381,6 +431,7 @@ export function PublishBranchDropdown({
                 <SuccessIcon />
                 <span>All changes synced</span>
               </div>
+              {liveDomainLink}
               <div className="publish-actions publish-actions-center">
                 <button className="publish-done" onClick={handleDone}>
                   Done

--- a/src/components/branches/PublishBranchDropdown.tsx
+++ b/src/components/branches/PublishBranchDropdown.tsx
@@ -11,7 +11,12 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { ProjectGitHubStatus } from '../../lib/github';
 import { publishBranch } from '../../lib/branches';
-import { getVercelProductionDomain, liveSiteHost, type VercelDomainInfo } from '../../lib/vercel';
+import {
+  getVercelProductionDomain,
+  liveSiteHost,
+  liveSiteUrl,
+  type VercelDomainInfo,
+} from '../../lib/vercel';
 import { ChevronIcon, BranchIcon, SuccessIcon, ErrorIcon } from '../icons';
 import { Spinner } from '../primitives/Spinner';
 import { useClickOutside } from '../../hooks/useClickOutside';
@@ -120,28 +125,30 @@ export function PublishBranchDropdown({
   }, [isOpen, isMainBranch, githubRepo, projectPath]);
 
   const liveHost = liveSiteHost(vercelDomain);
-  const liveDomainLink = liveHost ? (
-    <div className="publish-live-domain-row">
-      <span className="publish-live-domain-label">Live at</span>
-      <button
-        type="button"
-        className="publish-live-domain"
-        onClick={() => void openUrl(`https://${liveHost}`)}
-        title={`Open https://${liveHost}`}
-      >
-        {liveHost}
-        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <path
-            d="M7 17 17 7M17 7H8M17 7v9"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      </button>
-    </div>
-  ) : null;
+  const liveUrl = liveSiteUrl(vercelDomain);
+  const liveDomainLink =
+    liveHost && liveUrl ? (
+      <div className="publish-live-domain-row">
+        <span className="publish-live-domain-label">Live at</span>
+        <button
+          type="button"
+          className="publish-live-domain"
+          onClick={() => void openUrl(liveUrl)}
+          title={`Open ${liveUrl}`}
+        >
+          {liveHost}
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path
+              d="M7 17 17 7M17 7H8M17 7v9"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+    ) : null;
 
   // Track previous forceOpen value to detect true→false transitions
   const prevForceOpenRef = useRef<boolean | undefined>(undefined);

--- a/src/components/dashboard/IntegrationBar.test.tsx
+++ b/src/components/dashboard/IntegrationBar.test.tsx
@@ -10,26 +10,10 @@
  * plus a couple of behaviors (Disconnect invokes logout; Connect opens a terminal).
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import type { SetupItem } from '../../lib/setup';
-
-const invokeResults = new Map<string, { value?: unknown; error?: Error }>();
-const invokeCalls: Array<{ cmd: string; args?: unknown }> = [];
-
-function mockInvoke(cmd: string, value: unknown) {
-  invokeResults.set(cmd, { value });
-}
-
-vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn((cmd: string, args?: unknown) => {
-    invokeCalls.push({ cmd, args });
-    const result = invokeResults.get(cmd);
-    if (result?.error) return Promise.reject(result.error);
-    if (result) return Promise.resolve(result.value);
-    return Promise.resolve(undefined);
-  }),
-}));
+import { mockInvokeResponse } from '../../test/setup';
 
 // Avoid pulling xterm / tauri-pty into jsdom.
 vi.mock('../setup/OnboardingTerminal', () => ({
@@ -55,7 +39,7 @@ function item(overrides: Partial<SetupItem> & Pick<SetupItem, 'id'>): SetupItem 
 }
 
 function setItems(items: SetupItem[]) {
-  mockInvoke('get_full_setup_status', {
+  mockInvokeResponse('get_full_setup_status', {
     allReady: false,
     items,
     optionalAuths: { githubAuthenticated: false },
@@ -71,10 +55,8 @@ async function renderExpanded(items: SetupItem[]) {
   fireEvent.click(screen.getByRole('button', { name: /integrations/i }));
 }
 
-beforeEach(() => {
-  invokeResults.clear();
-  invokeCalls.length = 0;
-});
+// The centralized IPC mock (src/test/setup.ts) is cleared between tests by the
+// global beforeEach/afterEach, so no local reset is needed here.
 
 describe('IntegrationBar action gating', () => {
   it('shows Install for a not-installed tool and Connect for a not-authenticated account', async () => {
@@ -97,6 +79,13 @@ describe('IntegrationBar action gating', () => {
   });
 
   it('shows Reconnect + Disconnect in a ready account kebab, and Disconnect logs out', async () => {
+    // Record the logout call via a function-valued IPC mock.
+    let loggedOut = false;
+    mockInvokeResponse('logout_github', () => {
+      loggedOut = true;
+      return undefined;
+    });
+
     await renderExpanded([
       item({ id: 'gh_auth', friendlyName: 'GitHub Account', status: 'ready', username: 'octocat' }),
     ]);
@@ -109,7 +98,7 @@ describe('IntegrationBar action gating', () => {
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'Disconnect' }));
 
     await waitFor(() => {
-      expect(invokeCalls.some((c) => c.cmd === 'logout_github')).toBe(true);
+      expect(loggedOut).toBe(true);
     });
   });
 

--- a/src/components/dashboard/IntegrationBar.test.tsx
+++ b/src/components/dashboard/IntegrationBar.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Tests for IntegrationBar — the actionable dashboard integrations card.
+ *
+ * Covers the per-row action gating:
+ *   - not-installed tool        → Install button
+ *   - not-authenticated account → Connect button
+ *   - ready account             → kebab with Reconnect + Disconnect (no Install/Connect)
+ *   - ready coding-agent binary → kebab with Update + Uninstall
+ *   - ready system tool         → no action affordance
+ * plus a couple of behaviors (Disconnect invokes logout; Connect opens a terminal).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import type { SetupItem } from '../../lib/setup';
+
+const invokeResults = new Map<string, { value?: unknown; error?: Error }>();
+const invokeCalls: Array<{ cmd: string; args?: unknown }> = [];
+
+function mockInvoke(cmd: string, value: unknown) {
+  invokeResults.set(cmd, { value });
+}
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn((cmd: string, args?: unknown) => {
+    invokeCalls.push({ cmd, args });
+    const result = invokeResults.get(cmd);
+    if (result?.error) return Promise.reject(result.error);
+    if (result) return Promise.resolve(result.value);
+    return Promise.resolve(undefined);
+  }),
+}));
+
+// Avoid pulling xterm / tauri-pty into jsdom.
+vi.mock('../setup/OnboardingTerminal', () => ({
+  OnboardingTerminal: () => <div data-testid="mock-terminal" />,
+}));
+
+vi.mock('../icons', () => ({
+  CheckIcon: () => <span data-testid="check-icon" />,
+  WarningIcon: () => <span data-testid="warning-icon" />,
+  ChevronIcon: () => <span data-testid="chevron-icon" />,
+  ClaudeIcon: () => <span data-testid="claude-icon" />,
+  GitHubIcon: () => <span data-testid="github-icon" />,
+}));
+
+import { IntegrationBar } from './IntegrationBar';
+
+function item(overrides: Partial<SetupItem> & Pick<SetupItem, 'id'>): SetupItem {
+  return {
+    friendlyName: overrides.id,
+    status: 'ready',
+    ...overrides,
+  } as SetupItem;
+}
+
+function setItems(items: SetupItem[]) {
+  mockInvoke('get_full_setup_status', {
+    allReady: false,
+    items,
+    optionalAuths: { githubAuthenticated: false },
+    detectedAgents: [],
+  });
+}
+
+async function renderExpanded(items: SetupItem[]) {
+  setItems(items);
+  render(<IntegrationBar />);
+  // expand the card so the rows render
+  await waitFor(() => screen.getByText('Integrations'));
+  fireEvent.click(screen.getByRole('button', { name: /integrations/i }));
+}
+
+beforeEach(() => {
+  invokeResults.clear();
+  invokeCalls.length = 0;
+});
+
+describe('IntegrationBar action gating', () => {
+  it('shows Install for a not-installed tool and Connect for a not-authenticated account', async () => {
+    await renderExpanded([
+      item({ id: 'gh', friendlyName: 'GitHub connector', status: 'not_installed' }),
+      item({ id: 'vercel_auth', friendlyName: 'Vercel Account', status: 'not_authenticated' }),
+    ]);
+    await waitFor(() => screen.getByText('GitHub connector'));
+    expect(screen.getByRole('button', { name: 'Install' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Connect' })).toBeTruthy();
+  });
+
+  it('offers no action affordance for a ready system tool', async () => {
+    await renderExpanded([
+      item({ id: 'homebrew', friendlyName: 'Package Manager', status: 'ready', version: '6.0.1' }),
+    ]);
+    await waitFor(() => screen.getByText('Package Manager'));
+    expect(screen.queryByRole('button', { name: 'Install' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /More actions/ })).toBeNull();
+  });
+
+  it('shows Reconnect + Disconnect in a ready account kebab, and Disconnect logs out', async () => {
+    await renderExpanded([
+      item({ id: 'gh_auth', friendlyName: 'GitHub Account', status: 'ready', username: 'octocat' }),
+    ]);
+    await waitFor(() => screen.getByText('GitHub Account'));
+    expect(screen.queryByRole('button', { name: 'Connect' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /More actions for GitHub Account/ }));
+    const menu = screen.getByRole('menu');
+    expect(within(menu).getByRole('menuitem', { name: 'Reconnect' })).toBeTruthy();
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Disconnect' }));
+
+    await waitFor(() => {
+      expect(invokeCalls.some((c) => c.cmd === 'logout_github')).toBe(true);
+    });
+  });
+
+  it('shows Update + Uninstall in a ready coding-agent kebab', async () => {
+    await renderExpanded([
+      item({ id: 'claude', friendlyName: 'Claude Code', status: 'ready', version: '2.1.0' }),
+    ]);
+    await waitFor(() => screen.getByText('Claude Code'));
+    fireEvent.click(screen.getByRole('button', { name: /More actions for Claude Code/ }));
+    const menu = screen.getByRole('menu');
+    expect(within(menu).getByRole('menuitem', { name: 'Update' })).toBeTruthy();
+    expect(within(menu).getByRole('menuitem', { name: 'Uninstall' })).toBeTruthy();
+  });
+
+  it('opens a terminal when connecting an agent account', async () => {
+    await renderExpanded([
+      item({ id: 'codex_auth', friendlyName: 'Codex Account', status: 'not_authenticated' }),
+    ]);
+    await waitFor(() => screen.getByText('Codex Account'));
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+    await waitFor(() => expect(screen.getByTestId('mock-terminal')).toBeTruthy());
+  });
+});

--- a/src/components/dashboard/IntegrationBar.tsx
+++ b/src/components/dashboard/IntegrationBar.tsx
@@ -6,44 +6,232 @@
  * summary line ("All integrations connected" or "X/Y ready") sits inside
  * the card header, and the individual integration rows reveal on expand.
  *
+ * Each row is actionable:
+ *  - tools (Homebrew, Node, Git, GitHub CLI, Vercel CLI, agents) — Install when
+ *    missing; coding agents additionally offer Update / Uninstall.
+ *  - accounts (the *_auth rows) — Connect when signed out; Reconnect / Disconnect
+ *    when signed in. System tools are never offered an uninstall (removing them
+ *    would break the app), per the chosen "disconnect accounts, uninstall agents
+ *    only" policy.
+ *
  * @module components/IntegrationBar
  */
 
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { CheckIcon, WarningIcon, ChevronIcon, ClaudeIcon, GitHubIcon } from '../icons';
 import { Spinner } from '../primitives/Spinner';
-import { getFullSetupStatus, SetupItem, SETUP_ITEM_ORDER } from '../../lib/setup';
+import { Button } from '../primitives/Button';
+import { ModalFrame } from '../primitives/ModalFrame';
+import { OnboardingTerminal } from '../setup/OnboardingTerminal';
+import {
+  getFullSetupStatus,
+  installPackages,
+  logoutGithub,
+  logoutVercel,
+  SetupItem,
+  SETUP_ITEM_ORDER,
+  TERMINAL_COMMANDS,
+} from '../../lib/setup';
+import { signOutAgent, uninstallAgent } from '../../lib/agents-management';
+import { useOptionalToast } from '../../contexts/ToastContext';
 import { logger } from '../../lib/logger';
 
+/** Setup item id → coding-agent id (covers the binary row and its `_auth` row). */
+const AGENT_ID_BY_ITEM: Record<string, string> = {
+  claude: 'claude-code',
+  claude_auth: 'claude-code',
+  codex: 'codex',
+  codex_auth: 'codex',
+  opencode: 'opencode',
+  opencode_auth: 'opencode',
+};
+
+/** The coding-agent binary rows — the only items eligible for uninstall. */
+const AGENT_BINARY_ITEMS = new Set(['claude', 'codex', 'opencode']);
+
+/** Tools installed via the package manager (direct invoke) rather than a terminal. */
+const PKG_MGR_ITEMS = new Set(['node', 'git', 'gh']);
+
+const isAccountItem = (id: string) => id.endsWith('_auth');
+
+function KebabGlyph() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+      <circle cx="2.5" cy="7" r="1.3" fill="currentColor" />
+      <circle cx="7" cy="7" r="1.3" fill="currentColor" />
+      <circle cx="11.5" cy="7" r="1.3" fill="currentColor" />
+    </svg>
+  );
+}
+
 interface IntegrationBarProps {
-  /** Callback to connect GitHub account */
+  /** Optional friendly browser GitHub-connect flow (falls back to the terminal). */
   onGitHubConnect?: () => void;
+}
+
+interface TerminalTask {
+  itemId: string;
+  title: string;
+  command: string;
+  args: string[];
+}
+
+interface UninstallConfirm {
+  itemId: string;
+  agentId: string;
+  name: string;
 }
 
 export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [setupItems, setSetupItems] = useState<SetupItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [terminalTask, setTerminalTask] = useState<TerminalTask | null>(null);
+  const [confirmUninstall, setConfirmUninstall] = useState<UninstallConfirm | null>(null);
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const panelRef = useRef<HTMLElement>(null);
+  const { showToast } = useOptionalToast();
+
+  // Stable showToast identity so refresh() doesn't re-fire the mount effect when
+  // there's no ToastProvider (useOptionalToast returns a fresh object per render).
+  const showToastRef = useRef(showToast);
+  useEffect(() => {
+    showToastRef.current = showToast;
+  }, [showToast]);
+
+  const refresh = useCallback(async () => {
+    try {
+      const status = await getFullSetupStatus();
+      const sorted = [...status.items].sort(
+        (a, b) => SETUP_ITEM_ORDER.indexOf(a.id) - SETUP_ITEM_ORDER.indexOf(b.id)
+      );
+      setSetupItems(sorted);
+    } catch (error) {
+      logger.error('Failed to load setup status', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    const load = async () => {
-      setIsLoading(true);
-      try {
-        const status = await getFullSetupStatus();
-        const sorted = [...status.items].sort((a, b) => {
-          return SETUP_ITEM_ORDER.indexOf(a.id) - SETUP_ITEM_ORDER.indexOf(b.id);
-        });
-        setSetupItems(sorted);
-      } catch (error) {
-        logger.error('Failed to load setup status', {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      } finally {
-        setIsLoading(false);
+    void refresh();
+  }, [refresh]);
+
+  // Close the kebab menu on outside click.
+  useEffect(() => {
+    if (!openMenuId) return;
+    const handler = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpenMenuId(null);
       }
     };
-    void load();
+    window.addEventListener('mousedown', handler);
+    return () => window.removeEventListener('mousedown', handler);
+  }, [openMenuId]);
+
+  // Auth/install files (and newly-installed binaries) can land a beat after the
+  // action finishes — refresh now and retry a few times so the row settles.
+  const scheduleRefresh = useCallback(() => {
+    void refresh();
+    [600, 1500, 3000].forEach((delay) => setTimeout(() => void refresh(), delay));
+  }, [refresh]);
+
+  const openTerminal = useCallback((item: SetupItem) => {
+    setOpenMenuId(null);
+    const cmd = TERMINAL_COMMANDS[item.id];
+    if (!cmd) return;
+    setTerminalTask({
+      itemId: item.id,
+      title: item.friendlyName,
+      command: cmd.command,
+      args: cmd.args,
+    });
   }, []);
+
+  const handleTerminalExit = useCallback(() => {
+    setTerminalTask(null);
+    scheduleRefresh();
+  }, [scheduleRefresh]);
+
+  const runInstall = useCallback(
+    async (item: SetupItem) => {
+      setOpenMenuId(null);
+      if (!PKG_MGR_ITEMS.has(item.id)) {
+        openTerminal(item); // homebrew, agents, vercel, npm_fix
+        return;
+      }
+      if (busy) return;
+      setBusy(item.id);
+      try {
+        await installPackages([item.id]);
+        showToast(`Installed ${item.friendlyName}`, 'success');
+        scheduleRefresh();
+      } catch (err) {
+        showToast(`Install failed: ${String(err)}`, 'error');
+      } finally {
+        setBusy(null);
+      }
+    },
+    [busy, openTerminal, scheduleRefresh, showToast]
+  );
+
+  const runConnect = useCallback(
+    (item: SetupItem) => {
+      setOpenMenuId(null);
+      if (item.id === 'gh_auth' && onGitHubConnect) {
+        onGitHubConnect();
+        scheduleRefresh();
+        return;
+      }
+      openTerminal(item); // claude_auth / codex_auth / opencode_auth / vercel_auth (gh_auth fallback)
+    },
+    [onGitHubConnect, openTerminal, scheduleRefresh]
+  );
+
+  const runDisconnect = useCallback(
+    async (item: SetupItem) => {
+      setOpenMenuId(null);
+      if (busy) return;
+      setBusy(item.id);
+      try {
+        if (item.id === 'gh_auth') {
+          await logoutGithub();
+        } else if (item.id === 'vercel_auth') {
+          await logoutVercel();
+        } else {
+          const agentId = AGENT_ID_BY_ITEM[item.id];
+          if (agentId) await signOutAgent(agentId);
+        }
+        showToast(`Disconnected ${item.friendlyName}`, 'success');
+        scheduleRefresh();
+      } catch (err) {
+        showToast(`Disconnect failed: ${String(err)}`, 'error');
+      } finally {
+        setBusy(null);
+      }
+    },
+    [busy, scheduleRefresh, showToast]
+  );
+
+  const runUninstall = useCallback(
+    async ({ itemId, agentId, name }: UninstallConfirm) => {
+      setConfirmUninstall(null);
+      setBusy(itemId);
+      try {
+        await uninstallAgent(agentId);
+        showToast(`Uninstalled ${name}`, 'success');
+        scheduleRefresh();
+      } catch (err) {
+        showToast(`Uninstall failed: ${String(err)}`, 'error');
+      } finally {
+        setBusy(null);
+      }
+    },
+    [scheduleRefresh, showToast]
+  );
 
   const readyCount = setupItems.filter((item) => item.status === 'ready').length;
   const totalCount = setupItems.length;
@@ -66,12 +254,9 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
     if (item.status === 'ready') {
       return item.username || item.version || 'Ready';
     }
+    if (item.status === 'in_progress') return 'Working…';
+    if (item.status === 'error') return item.errorMessage || 'Error';
     return item.status === 'not_installed' ? 'Not installed' : 'Not connected';
-  };
-
-  const getConnectHandler = (itemId: string) => {
-    if (itemId === 'gh_auth') return onGitHubConnect;
-    return undefined;
   };
 
   const subtitle = isLoading
@@ -90,6 +275,7 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
 
   return (
     <section
+      ref={panelRef}
       className={`dashboard-card integration-bar ${isExpanded ? 'is-expanded' : ''}`}
       data-education-id="integration-bar"
     >
@@ -101,10 +287,10 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
       >
         <div>
           <h3 className="dashboard-card-title">Integrations</h3>
-          <p className="dashboard-card-subtitle integration-bar-subtitle">
+          <div className="dashboard-card-subtitle integration-bar-subtitle">
             {statusIcon}
             <span>{subtitle}</span>
-          </p>
+          </div>
         </div>
         <ChevronIcon
           size={14}
@@ -115,36 +301,151 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
       {isExpanded && (
         <div className="dashboard-card-rows">
           {setupItems.map((item) => {
-            const connectHandler = getConnectHandler(item.id);
-            const showConnectButton = item.status !== 'ready' && connectHandler;
-            const isReady = item.status === 'ready';
+            const account = isAccountItem(item.id);
+            const ready = item.status === 'ready';
+            const isBusy = busy === item.id;
+            const inProgress = item.status === 'in_progress' || isBusy;
+            const isAgentBinary = AGENT_BINARY_ITEMS.has(item.id);
+            const needsInstall =
+              !account && (item.status === 'not_installed' || item.status === 'error');
+            const needsConnect =
+              account && (item.status === 'not_authenticated' || item.status === 'error');
+            const showMenu = ready && (account || isAgentBinary);
+            const menuOpen = openMenuId === item.id;
 
             return (
-              <div key={item.id} className="dashboard-card-row is-static">
-                <div className={`dashboard-card-row-icon ${isReady ? 'success' : ''}`}>
+              <div key={item.id} className="dashboard-card-row">
+                <div className={`dashboard-card-row-icon ${ready ? 'success' : ''}`}>
                   {getItemIcon(item.id)}
                 </div>
                 <div className="dashboard-card-row-main">
                   <span className="dashboard-card-row-name">{item.friendlyName}</span>
-                  <span className={`dashboard-card-row-status ${isReady ? 'success' : ''}`}>
+                  <span className={`dashboard-card-row-status ${ready ? 'success' : ''}`}>
                     {getStatusText(item)}
                   </span>
                 </div>
-                {showConnectButton && (
-                  <button
-                    className="integration-bar-item-connect"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      connectHandler();
-                    }}
-                  >
-                    Connect
-                  </button>
-                )}
+
+                <div className="agents-panel-row-actions">
+                  {inProgress && <Spinner size="sm" />}
+
+                  {!inProgress && needsInstall && (
+                    <Button variant="primary" size="sm" onClick={() => void runInstall(item)}>
+                      Install
+                    </Button>
+                  )}
+
+                  {!inProgress && needsConnect && (
+                    <Button variant="primary" size="sm" onClick={() => runConnect(item)}>
+                      Connect
+                    </Button>
+                  )}
+
+                  {!inProgress && showMenu && (
+                    <div className="agents-panel-menu-wrap">
+                      <button
+                        type="button"
+                        className="agents-panel-kebab"
+                        onClick={() => setOpenMenuId(menuOpen ? null : item.id)}
+                        title={`More actions for ${item.friendlyName}`}
+                        aria-label={`More actions for ${item.friendlyName}`}
+                        aria-haspopup="menu"
+                        aria-expanded={menuOpen}
+                      >
+                        <KebabGlyph />
+                      </button>
+                      {menuOpen && (
+                        <div className="agents-panel-menu" role="menu">
+                          {account && (
+                            <button type="button" role="menuitem" onClick={() => runConnect(item)}>
+                              Reconnect
+                            </button>
+                          )}
+                          {account && (
+                            <button
+                              type="button"
+                              role="menuitem"
+                              className="agents-panel-menu-danger"
+                              onClick={() => void runDisconnect(item)}
+                            >
+                              Disconnect
+                            </button>
+                          )}
+                          {isAgentBinary && (
+                            <button
+                              type="button"
+                              role="menuitem"
+                              onClick={() => openTerminal(item)}
+                            >
+                              Update
+                            </button>
+                          )}
+                          {isAgentBinary && (
+                            <button
+                              type="button"
+                              role="menuitem"
+                              className="agents-panel-menu-danger"
+                              onClick={() => {
+                                setOpenMenuId(null);
+                                setConfirmUninstall({
+                                  itemId: item.id,
+                                  agentId: AGENT_ID_BY_ITEM[item.id],
+                                  name: item.friendlyName,
+                                });
+                              }}
+                            >
+                              Uninstall
+                            </button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
               </div>
             );
           })}
         </div>
+      )}
+
+      {terminalTask && (
+        <ModalFrame
+          isOpen
+          onClose={handleTerminalExit}
+          title={terminalTask.title}
+          className="agents-panel-terminal-modal"
+        >
+          <div className="agents-panel-terminal-body">
+            <OnboardingTerminal
+              command={terminalTask.command}
+              args={terminalTask.args}
+              onExit={handleTerminalExit}
+            />
+          </div>
+        </ModalFrame>
+      )}
+
+      {confirmUninstall && (
+        <ModalFrame
+          isOpen
+          onClose={() => setConfirmUninstall(null)}
+          title={`Uninstall ${confirmUninstall.name}?`}
+          className="agents-panel-confirm-modal"
+        >
+          <div className="agents-panel-confirm-body">
+            <p>
+              This removes the {confirmUninstall.name} CLI from your machine. You can reinstall it
+              any time from this panel.
+            </p>
+            <div className="agents-panel-confirm-actions">
+              <Button variant="secondary" onClick={() => setConfirmUninstall(null)}>
+                Cancel
+              </Button>
+              <Button variant="danger" onClick={() => void runUninstall(confirmUninstall)}>
+                Uninstall
+              </Button>
+            </div>
+          </div>
+        </ModalFrame>
       )}
     </section>
   );

--- a/src/components/dashboard/IntegrationBar.tsx
+++ b/src/components/dashboard/IntegrationBar.tsx
@@ -33,6 +33,7 @@ import {
   TERMINAL_COMMANDS,
 } from '../../lib/setup';
 import { signOutAgent, uninstallAgent } from '../../lib/agents-management';
+import { useAsyncState } from '../../hooks/useAsyncState';
 import { useOptionalToast } from '../../contexts/ToastContext';
 import { logger } from '../../lib/logger';
 
@@ -84,8 +85,6 @@ interface UninstallConfirm {
 
 export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [setupItems, setSetupItems] = useState<SetupItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [busy, setBusy] = useState<string | null>(null);
   const [terminalTask, setTerminalTask] = useState<TerminalTask | null>(null);
   const [confirmUninstall, setConfirmUninstall] = useState<UninstallConfirm | null>(null);
@@ -93,32 +92,33 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
   const panelRef = useRef<HTMLElement>(null);
   const { showToast } = useOptionalToast();
 
-  // Stable showToast identity so refresh() doesn't re-fire the mount effect when
-  // there's no ToastProvider (useOptionalToast returns a fresh object per render).
-  const showToastRef = useRef(showToast);
-  useEffect(() => {
-    showToastRef.current = showToast;
-  }, [showToast]);
-
-  const refresh = useCallback(async () => {
-    try {
+  // Setup status via the shared async-state hook — gives us the mount guard,
+  // the try/finally loading flag, and a stable `execute` for free. The fetcher
+  // sorts into the canonical row order so `data` is render-ready. A failed load
+  // is logged and surfaces as an empty list (no crash, no spinner stuck on).
+  // Show "Checking…" only until the first load settles — not on the silent
+  // background refreshes that follow an install/connect. Mirrors the prior
+  // behavior, where isLoading was set true once and only flipped to false.
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const { data: setupItems, execute: refresh } = useAsyncState<SetupItem[]>(
+    useCallback(async () => {
       const status = await getFullSetupStatus();
-      const sorted = [...status.items].sort(
+      return [...status.items].sort(
         (a, b) => SETUP_ITEM_ORDER.indexOf(a.id) - SETUP_ITEM_ORDER.indexOf(b.id)
       );
-      setSetupItems(sorted);
-    } catch (error) {
-      logger.error('Failed to load setup status', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-    } finally {
-      setIsLoading(false);
+    }, []),
+    {
+      initial: [],
+      immediate: true,
+      onSuccess: () => setHasLoaded(true),
+      onError: (error) => {
+        setHasLoaded(true);
+        logger.error('Failed to load setup status', { error: error.message });
+      },
     }
-  }, []);
-
-  useEffect(() => {
-    void refresh();
-  }, [refresh]);
+  );
+  const isChecking = !hasLoaded;
+  const items = setupItems ?? [];
 
   // Close the kebab menu on outside click.
   useEffect(() => {
@@ -234,8 +234,8 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
     [busy, scheduleRefresh, showToast]
   );
 
-  const readyCount = setupItems.filter((item) => item.status === 'ready').length;
-  const totalCount = setupItems.length;
+  const readyCount = items.filter((item) => item.status === 'ready').length;
+  const totalCount = items.length;
   const allConnected = totalCount > 0 && readyCount === totalCount;
 
   const getItemIcon = (itemId: string) => {
@@ -260,13 +260,13 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
     return item.status === 'not_installed' ? 'Not installed' : 'Not connected';
   };
 
-  const subtitle = isLoading
+  const subtitle = isChecking
     ? 'Checking…'
     : allConnected
       ? 'All integrations connected'
       : `${readyCount}/${totalCount} ready`;
 
-  const statusIcon = isLoading ? (
+  const statusIcon = isChecking ? (
     <Spinner size="sm" />
   ) : allConnected ? (
     <CheckIcon size={14} className="integration-bar-status-icon success" />
@@ -301,7 +301,7 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
 
       {isExpanded && (
         <div className="dashboard-card-rows">
-          {setupItems.map((item) => {
+          {items.map((item) => {
             const account = isAccountItem(item.id);
             const ready = item.status === 'ready';
             const isBusy = busy === item.id;

--- a/src/components/dashboard/IntegrationBar.tsx
+++ b/src/components/dashboard/IntegrationBar.tsx
@@ -218,6 +218,7 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
 
   const runUninstall = useCallback(
     async ({ itemId, agentId, name }: UninstallConfirm) => {
+      if (busy) return;
       setConfirmUninstall(null);
       setBusy(itemId);
       try {
@@ -230,7 +231,7 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
         setBusy(null);
       }
     },
-    [scheduleRefresh, showToast]
+    [busy, scheduleRefresh, showToast]
   );
 
   const readyCount = setupItems.filter((item) => item.status === 'ready').length;

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -389,6 +389,16 @@ export async function startGitHubAuth(): Promise<string> {
   return invoke<string>('start_github_auth');
 }
 
+/** Sign out of the GitHub CLI (`gh auth logout`). Idempotent. */
+export async function logoutGithub(): Promise<void> {
+  return invoke<void>('logout_github');
+}
+
+/** Sign out of the Vercel CLI (`vercel logout`). Idempotent. */
+export async function logoutVercel(): Promise<void> {
+  return invoke<void>('logout_vercel');
+}
+
 /**
  * Install Claude Code CLI.
  */

--- a/src/lib/vercel.ts
+++ b/src/lib/vercel.ts
@@ -1,0 +1,40 @@
+/**
+ * Vercel project domain lookup.
+ *
+ * Ship Studio publishes via Vercel's GitHub integration and only ever knew the
+ * git push — never the deployed domain. This reads the production custom domain
+ * Vercel actually has configured so the UI can show the real site address.
+ *
+ * @module lib/vercel
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+
+/** Production domains Vercel reports for a linked project (snake_case from Rust). */
+export interface VercelDomainInfo {
+  /** Verified production custom domain (e.g. "pop.bimbi.co"), or null. */
+  custom_domain: string | null;
+  /** System `*.vercel.app` URL, used as a fallback display, or null. */
+  system_url: string | null;
+}
+
+/**
+ * Fetch a project's production custom domain, matched by its GitHub repo
+ * (`owner/name`) across the user's personal scope and every Vercel team. Returns
+ * null when there's no repo, the CLI isn't authenticated, no Vercel project is
+ * linked to the repo, or there's no domain to report — never a constructed URL.
+ */
+export async function getVercelProductionDomain(
+  projectPath: string,
+  githubRepo: string | null
+): Promise<VercelDomainInfo | null> {
+  return invoke<VercelDomainInfo | null>('get_vercel_production_domain', {
+    projectPath,
+    githubRepo,
+  });
+}
+
+/** The single address to show/open: the custom domain if any, else the system url. */
+export function liveSiteHost(domain: VercelDomainInfo | null): string | null {
+  return domain?.custom_domain ?? domain?.system_url ?? null;
+}

--- a/src/lib/vercel.ts
+++ b/src/lib/vercel.ts
@@ -16,6 +16,12 @@ export interface VercelDomainInfo {
   custom_domain: string | null;
   /** System `*.vercel.app` URL, used as a fallback display, or null. */
   system_url: string | null;
+  /**
+   * Full `https://` address to open (e.g. "https://pop.bimbi.co"), built by the
+   * backend from the canonical host. Consumers open this directly — they never
+   * construct a URL from a host fragment. Null only when no host exists.
+   */
+  production_url: string | null;
 }
 
 /**
@@ -34,7 +40,16 @@ export async function getVercelProductionDomain(
   });
 }
 
-/** The single address to show/open: the custom domain if any, else the system url. */
+/** The bare host to display as a label: the custom domain if any, else the system url. */
 export function liveSiteHost(domain: VercelDomainInfo | null): string | null {
   return domain?.custom_domain ?? domain?.system_url ?? null;
+}
+
+/**
+ * The full `https://` URL to open — surfaced straight from the backend's
+ * `production_url`, never built from a host fragment here. Null when there's no
+ * live site to open.
+ */
+export function liveSiteUrl(domain: VercelDomainInfo | null): string | null {
+  return domain?.production_url ?? null;
 }

--- a/src/styles/features/publish/states.css
+++ b/src/styles/features/publish/states.css
@@ -42,6 +42,38 @@
   color: var(--accent);
 }
 
+/* Live production domain (from Vercel) shown in the publish dropdown. */
+.publish-live-domain-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+  font-size: var(--font-size-md);
+}
+
+.publish-live-domain-label {
+  color: var(--text-muted);
+}
+
+.publish-live-domain {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--action);
+  cursor: pointer;
+}
+
+.publish-live-domain:hover {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 .publish-elapsed {
   margin-left: auto;
   font-size: var(--font-size-md);

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -53,12 +53,13 @@ export function clearInvokeMocks() {
   invokeErrors.clear();
 }
 
-// Set up Tauri mocks before all tests
-beforeAll(() => {
-  // Mock windows
+// (Re)install the official Tauri IPC mock. `clearMocks()` in afterEach deletes
+// `window.__TAURI_INTERNALS__.invoke`, so registering this only once in
+// beforeAll would leave every test after the first with no IPC handler. We call
+// it from beforeAll *and* beforeEach so every test gets a live mock.
+function installTauriIpcMock() {
   mockWindows('main');
 
-  // Set up IPC mock handler
   mockIPC((cmd, args) => {
     // Check for error first
     const error = invokeErrors.get(cmd);
@@ -115,6 +116,11 @@ beforeAll(() => {
         return undefined;
     }
   });
+}
+
+// Set up Tauri mocks before all tests
+beforeAll(() => {
+  installTauriIpcMock();
 });
 
 // Mock tauri-pty (native module)
@@ -148,6 +154,9 @@ vi.mock('@tauri-apps/plugin-process', () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   clearInvokeMocks();
+  // The prior afterEach's clearMocks() removed the IPC handler — reinstall it
+  // so each test starts with a working invoke mock.
+  installTauriIpcMock();
 });
 
 // Cleanup after each test


### PR DESCRIPTION
Split out of #93 per @julian-galluzzo's review (second of the scoped PRs; the first is the re-scoped #93 core).

**What this adds**
- `get_vercel_production_domain`: reads the canonical Vercel custom domain via the Vercel API, and surfaces a live-site link in the publish dropdown.
- An actionable dashboard Integrations panel: install / connect / reconnect / disconnect for GitHub and Vercel.
- `logout_github` / `logout_vercel` commands backing the panel's Disconnect.

**Scope**: 11 files, based on `main`. No agent-harness scaffolding. The two GitHub/Vercel logout wrappers are split in here (they back the Integrations panel); the onboarding-wizard rewording stays in its own upcoming PR.

**Verified**: `pnpm check:all`, `pnpm test:run`, `cargo test`, `pnpm tauri build`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* Show and quick-link to your Vercel production domain in the publish dropdown (main branch only).
* Add GitHub and Vercel sign-out from the dashboard integrations panel (via disconnect actions).
* Upgrade the dashboard integrations panel with interactive install/connect/disconnect/uninstall flows and per-row action menus.

**Tests**
* Added coverage for Vercel live-domain display and publish dropdown behavior, plus dashboard integrations panel action gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->