### PR TITLE
Group the create-project template gallery (web / mobile / other)

### DIFF
--- a/src/components/dashboard/CreateProject.tsx
+++ b/src/components/dashboard/CreateProject.tsx
@@ -21,10 +21,12 @@ import { Spinner } from '../primitives/Spinner';
 import {
   useProjectCreation,
   TEMPLATES,
+  TEMPLATE_GROUPS,
   STEPS,
   STATUS_MESSAGES,
 } from '../../hooks/useProjectCreation';
 import { TemplateGallery, type CommunityTemplate } from './TemplateGallery';
+import { TemplateCard } from './TemplateCard';
 
 /** Props for the CreateProject component */
 interface CreateProjectProps {
@@ -64,6 +66,7 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
     handleRemoveZip,
     setZipPath,
     setZipFileName,
+    setError,
     saveDefaultTemplate,
     defaultTemplateId,
   } = useProjectCreation({ onComplete, onCancel });
@@ -141,8 +144,10 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
         setZipFileName(selectedCommunityTemplate.name + '.zip');
         rawHandleContinue();
       } catch (err) {
-        // Show error inline — don't block the modal
+        // Surface the failure (don't block the modal) — a silent catch left the
+        // button snapping back to "Continue" with no explanation.
         logger.error('Failed to download community template', { error: err });
+        setError("Couldn't download that template. Check your connection and try again.");
       } finally {
         setDownloading(false);
       }
@@ -266,40 +271,34 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
 
           {activeTab === 'scratch' && (
             <>
-              <div className="stack-grid">
-                {TEMPLATES.map((template) => (
-                  <button
-                    key={template.id}
-                    type="button"
-                    className={`stack-card ${selectedTemplate?.id === template.id && !hasZipTemplate ? 'stack-card-selected' : ''}`}
-                    onClick={() => {
-                      handleTemplateSelect(template);
-                      void trackEvent('template_selected', {
-                        template_id: template.id,
-                        $screen_name: 'Create Project',
-                      });
-                      setSetAsDefaultChecked(false);
-                    }}
-                  >
-                    <span className="stack-card-name">{template.name}</span>
-                    <span className="stack-card-desc">{template.description}</span>
-                    {selectedTemplate?.id === template.id && !hasZipTemplate && (
-                      <div className="stack-card-check">
-                        <svg
-                          width="14"
-                          height="14"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="3"
-                        >
-                          <polyline points="20 6 9 17 4 12" />
-                        </svg>
-                      </div>
-                    )}
-                  </button>
-                ))}
-              </div>
+              {TEMPLATE_GROUPS.map((group) => {
+                const groupTemplates = TEMPLATES.filter((t) => t.category === group.id);
+                if (groupTemplates.length === 0) return null;
+                return (
+                  <div key={group.id} className="stack-group">
+                    <h3 className="stack-group-title">{group.label}</h3>
+                    <div className="stack-grid">
+                      {groupTemplates.map((template) => (
+                        <TemplateCard
+                          key={template.id}
+                          name={template.name}
+                          description={template.description}
+                          selected={selectedTemplate?.id === template.id && !hasZipTemplate}
+                          recommended={template.id === defaultTemplateId}
+                          onSelect={() => {
+                            handleTemplateSelect(template);
+                            void trackEvent('template_selected', {
+                              template_id: template.id,
+                              $screen_name: 'Create Project',
+                            });
+                            setSetAsDefaultChecked(false);
+                          }}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
 
               {selectedTemplate && selectedTemplate.id !== defaultTemplateId && !hasZipTemplate && (
                 <button

--- a/src/components/dashboard/TemplateCard.tsx
+++ b/src/components/dashboard/TemplateCard.tsx
@@ -1,0 +1,60 @@
+/**
+ * Selectable template card for the "Start from Scratch" grid in Create Project.
+ *
+ * Wraps the shared {@link Button} primitive (ghost variant) so the grid card
+ * participates in the design-system button system, while keeping its grid-card
+ * layout via the `stack-card` classes (which override the base button box model;
+ * feature CSS loads after base.css). Renders the template name, an optional
+ * "Recommended" badge, the description, and a check mark when selected.
+ *
+ * @module components/dashboard/TemplateCard
+ */
+
+import { Button } from '../primitives/Button';
+
+interface TemplateCardProps {
+  name: string;
+  description: string;
+  /** Whether this card is the active selection (drives the ring + check). */
+  selected: boolean;
+  /** Whether to show the neutral "Recommended" badge. */
+  recommended: boolean;
+  onSelect: () => void;
+}
+
+export function TemplateCard({
+  name,
+  description,
+  selected,
+  recommended,
+  onSelect,
+}: TemplateCardProps) {
+  return (
+    <Button
+      variant="ghost"
+      className={`stack-card${selected ? ' stack-card-selected' : ''}`}
+      aria-pressed={selected}
+      onClick={onSelect}
+    >
+      <span className="stack-card-name">
+        {name}
+        {recommended && <span className="stack-card-badge">Recommended</span>}
+      </span>
+      <span className="stack-card-desc">{description}</span>
+      {selected && (
+        <div className="stack-card-check">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </div>
+      )}
+    </Button>
+  );
+}

--- a/src/components/dashboard/TemplateCard.tsx
+++ b/src/components/dashboard/TemplateCard.tsx
@@ -38,7 +38,20 @@ export function TemplateCard({
     >
       <span className="stack-card-name">
         {name}
-        {recommended && <span className="stack-card-badge">Recommended</span>}
+        {recommended && (
+          <svg
+            className="stack-card-star"
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            role="img"
+            aria-label="Recommended"
+          >
+            <title>Recommended</title>
+            <path d="M11.48 3.5a.562.562 0 011.04 0l2.125 5.11a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.562.562 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z" />
+          </svg>
+        )}
       </span>
       <span className="stack-card-desc">{description}</span>
       {selected && (

--- a/src/components/dashboard/TemplateCard.tsx
+++ b/src/components/dashboard/TemplateCard.tsx
@@ -55,8 +55,10 @@ export function TemplateCard({
       </span>
       <span className="stack-card-desc">{description}</span>
       {selected && (
-        <div className="stack-card-check">
+        <div className="stack-card-check" aria-hidden="true">
           <svg
+            aria-hidden="true"
+            focusable="false"
             width="14"
             height="14"
             viewBox="0 0 24 24"

--- a/src/hooks/useProjectCreation.ts
+++ b/src/hooks/useProjectCreation.ts
@@ -43,6 +43,9 @@ import { installPlugin, VERCEL_PLUGIN_REPO } from '../lib/plugins';
 // Types & Constants
 // ---------------------------------------------------------------------------
 
+/** Grouping for the template picker, so the grid isn't an undifferentiated list. */
+export type TemplateCategory = 'web' | 'mobile' | 'other';
+
 /** Template definition for project scaffolding */
 export interface Template {
   /** Unique identifier for the template */
@@ -53,6 +56,8 @@ export interface Template {
   description: string;
   /** GitHub repository URL to clone */
   repo: string;
+  /** Which section of the picker this template appears under */
+  category: TemplateCategory;
   /** Skip the npm install step (templates with no package.json, e.g. HTML/Flutter) */
   skipInstall?: boolean;
 }
@@ -73,66 +78,83 @@ export const TEMPLATES: Template[] = [
   {
     id: 'nextjs-basic',
     name: 'Next.js',
-    description: 'A minimal Next.js starter with Tailwind CSS',
+    description: 'A modern website. A great default if you are not sure.',
     repo: 'https://github.com/ship-studio/static-marketing-site-starter',
+    category: 'web',
   },
   {
     id: 'sveltekit-basic',
     name: 'SvelteKit',
-    description: 'A minimal SvelteKit starter with Tailwind CSS',
+    description: 'A fast, lightweight website.',
     repo: 'https://github.com/ship-studio/sveltekit-static-marketing-site-starter',
+    category: 'web',
   },
   {
     id: 'astro-basic',
     name: 'Astro',
-    description: 'A minimal Astro starter with Tailwind CSS',
+    description: 'A content or marketing site that loads fast.',
     repo: 'https://github.com/ship-studio/astro-static-marketing-site-starter',
+    category: 'web',
   },
   {
     id: 'nuxt-basic',
     name: 'Nuxt',
-    description: 'A minimal Nuxt starter with Tailwind CSS',
+    description: 'A website built on Vue.',
     repo: 'https://github.com/ship-studio/nuxt-static-marketing-site-starter',
+    category: 'web',
   },
   {
     id: 'html-basic',
     name: 'HTML/CSS/JS',
-    description: 'A plain HTML starter — no framework, no build step',
+    description: 'A plain website with no framework or build step.',
     repo: 'https://github.com/ship-studio/html-starter',
-    skipInstall: true,
-  },
-  {
-    id: 'shopify-theme',
-    name: 'Shopify Theme',
-    description: 'An Online Store 2.0 theme — previews against your real store',
-    repo: 'https://github.com/ship-studio/shopify-theme-starter',
+    category: 'web',
     skipInstall: true,
   },
   {
     id: 'expo-mobile',
     name: 'Expo',
-    description: 'An iOS & Android app — the easiest mobile path',
+    description: 'An iOS and Android app. The easiest mobile path.',
     repo: 'https://github.com/ship-studio/expo-starter',
+    category: 'mobile',
   },
   {
     id: 'react-native-mobile',
     name: 'React Native',
-    description: 'An iOS & Android app with full native control',
+    description: 'An iOS and Android app with full native control.',
     repo: 'https://github.com/ship-studio/react-native-starter',
+    category: 'mobile',
   },
   {
     id: 'flutter-mobile',
     name: 'Flutter',
-    description: 'An iOS & Android app built with Flutter and Material 3',
+    description: 'An iOS and Android app built with Flutter.',
     repo: 'https://github.com/ship-studio/flutter-starter',
+    category: 'mobile',
+    skipInstall: true,
+  },
+  {
+    id: 'shopify-theme',
+    name: 'Shopify Theme',
+    description: 'An online store theme that previews against your real store.',
+    repo: 'https://github.com/ship-studio/shopify-theme-starter',
+    category: 'other',
     skipInstall: true,
   },
   {
     id: 'blank',
     name: 'Blank Project',
-    description: 'An empty folder — start from scratch',
+    description: 'An empty folder. Start completely from scratch.',
     repo: '',
+    category: 'other',
   },
+];
+
+/** Picker sections, in display order. */
+export const TEMPLATE_GROUPS: { id: TemplateCategory; label: string }[] = [
+  { id: 'web', label: 'Websites' },
+  { id: 'mobile', label: 'Mobile apps' },
+  { id: 'other', label: 'Other' },
 ];
 
 /** Form wizard steps before creation starts */
@@ -682,6 +704,7 @@ export function useProjectCreation({ onComplete, onCancel }: UseProjectCreationP
     // Zip state setters (for community template download flow)
     setZipPath,
     setZipFileName,
+    setError,
 
     // Default template
     saveDefaultTemplate,

--- a/src/hooks/useProjectCreation.ts
+++ b/src/hooks/useProjectCreation.ts
@@ -152,7 +152,7 @@ export const TEMPLATES: Template[] = [
 
 /** Picker sections, in display order. */
 export const TEMPLATE_GROUPS: { id: TemplateCategory; label: string }[] = [
-  { id: 'web', label: 'Websites' },
+  { id: 'web', label: 'Websites & web apps' },
   { id: 'mobile', label: 'Mobile apps' },
   { id: 'other', label: 'Other' },
 ];

--- a/src/styles/features/create-project.css
+++ b/src/styles/features/create-project.css
@@ -1,9 +1,13 @@
 /* Create Project Modal */
 
-/* Create-project-local colors — intentional one-offs, not part of the global scale. */
+/* Create-project-local colors + sizing — intentional one-offs, off the global scale. */
 :root {
   --create-default-green: #34c759;
   --create-default-green-rgb: 52, 199, 89;
+  --create-group-gap: 18px;
+  --create-grid-gap: 10px;
+  --create-card-pad-y: 14px;
+  --create-card-radius: 10px;
 }
 
 .create-modal-overlay {
@@ -132,10 +136,23 @@
 }
 
 /* Stack Grid (Start from Scratch) */
+.stack-group {
+  margin-bottom: var(--create-group-gap);
+}
+
+.stack-group-title {
+  margin: 0 0 var(--spacing-sm);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
 .stack-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 10px;
+  gap: var(--create-grid-gap);
 }
 
 .stack-card {
@@ -143,11 +160,15 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 4px;
-  padding: 14px 12px;
+  /* The card renders through the <Button> primitive, which sets
+     white-space: nowrap; reset it here so the multi-line descriptions wrap
+     within the card instead of overflowing on a single line and clipping. */
+  white-space: normal;
+  gap: var(--spacing-xs);
+  padding: var(--create-card-pad-y) var(--spacing-md);
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--create-card-radius);
   cursor: pointer;
   text-align: left;
   transition:
@@ -166,9 +187,26 @@
 }
 
 .stack-card-name {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
   font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--text-primary);
+}
+
+/* Neutral chip — deliberately NOT the accent green used for selection, so on
+   the pre-selected default tile "Recommended" reads as a separate signal from
+   the green selected border/check rather than blurring into one. */
+.stack-card-badge {
+  padding: 1px var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
 }
 
 .stack-card-desc {

--- a/src/styles/features/create-project.css
+++ b/src/styles/features/create-project.css
@@ -8,6 +8,9 @@
   --create-grid-gap: 10px;
   --create-card-pad-y: 14px;
   --create-card-radius: 10px;
+  /* "Recommended" star — a neutral grey so it reads as a quiet marker and
+     stays distinct from the green selected-state ring/check. */
+  --create-recommended-star: var(--text-muted);
 }
 
 .create-modal-overlay {
@@ -190,23 +193,21 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  flex-wrap: wrap;
+  /* nowrap keeps the "Recommended" tag on the title line; if it wrapped it
+     would add a row to only the recommended card and push that card's
+     description below the others in the row, breaking alignment. */
+  flex-wrap: nowrap;
   font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--text-primary);
 }
 
-/* Neutral chip — deliberately NOT the accent green used for selection, so on
-   the pre-selected default tile "Recommended" reads as a separate signal from
-   the green selected border/check rather than blurring into one. */
-.stack-card-badge {
-  padding: 1px var(--spacing-sm);
-  border-radius: var(--radius-sm);
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
-  color: var(--text-secondary);
-  font-size: var(--font-size-xs);
-  font-weight: 600;
+/* "Recommended" star — a quiet grey marker, deliberately NOT the accent green
+   used for selection, so on the pre-selected default tile it stays a separate
+   signal from the green selected border/check. */
+.stack-card-star {
+  flex-shrink: 0;
+  color: var(--create-recommended-star);
 }
 
 .stack-card-desc {


### PR DESCRIPTION
Split out of #93 per @julian-galluzzo's review.

Groups the create-project template picker into **web / mobile / other** stacks, with a Recommended badge and selectable template categories (new `TemplateCard` + `TEMPLATE_GROUPS` in `useProjectCreation`).

4 files, based on `main`. Fully self-contained, no shared-file changes. No agent-harness scaffolding.

Verified: `pnpm check:all`, `pnpm test:run`, `cargo test`, `pnpm tauri build`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Templates are now organized by category (Web, Mobile, Other) for easier discovery and selection.
  * Added "Recommended" badges to highlight featured templates.

* **Bug Fixes**
  * Enhanced error handling with user-friendly messaging when template downloads fail.

* **Style**
  * Improved template card layout, spacing, and visual presentation for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->