### PR TITLE
Add a dashboard empty-state CTA (create your first project)

### DIFF
--- a/src/components/dashboard/ProjectGridView.tsx
+++ b/src/components/dashboard/ProjectGridView.tsx
@@ -8,6 +8,7 @@
 import { FolderCard } from './FolderCard';
 import { ProjectCard } from './ProjectCard';
 import { EmptyState } from '../primitives/EmptyState';
+import { Button } from '../primitives/Button';
 import type { DashboardProject } from '../../lib/project';
 import type { FolderInfo } from '../../lib/folders';
 
@@ -39,6 +40,8 @@ export interface ProjectGridViewProps {
   pinnedSet?: ReadonlySet<string>;
   /** Toggle pin state for a project. */
   onTogglePin?: (projectPath: string, pinned: boolean) => void;
+  /** Start the create-project flow (drives the zero-projects empty-state CTA). */
+  onCreateProject?: () => void;
 }
 
 export function ProjectGridView({
@@ -60,6 +63,7 @@ export function ProjectGridView({
   onDeleteFolder,
   pinnedSet,
   onTogglePin,
+  onCreateProject,
 }: ProjectGridViewProps) {
   if (totalCount === 0) {
     return (
@@ -74,7 +78,14 @@ export function ProjectGridView({
         ) : (
           <EmptyState
             title="No projects yet"
-            description="Create your first project to get started"
+            description="You don't need a repo or any code to start — pick a template and your AI agent builds it."
+            action={
+              onCreateProject ? (
+                <Button variant="primary" onClick={onCreateProject}>
+                  + Create your first project
+                </Button>
+              ) : undefined
+            }
           />
         )}
       </div>

--- a/src/components/dashboard/ProjectList.tsx
+++ b/src/components/dashboard/ProjectList.tsx
@@ -173,10 +173,11 @@ export function ProjectList({
   }, []);
 
   // Search and sort state
-  // NOTE: search filtering now flows through the Cmd+K palette; the
-  // state is kept here only because downstream grid/folder filters still
-  // key off an empty string. It's effectively a constant for now.
-  const [searchQuery] = useState('');
+  // NOTE: search filtering now flows through the Cmd+K palette; this is kept
+  // only because downstream grid/folder filters still key off a query string.
+  // It's a constant for now (no setter), so it's a plain const rather than
+  // dead useState.
+  const searchQuery: string = '';
   const [sortBy, setSortBy] = useState<SortOption>('last_opened');
 
   const loadProjects = async () => {
@@ -603,6 +604,7 @@ export function ProjectList({
           onDeleteFolder={(folder) => setDeleteFolderConfirm(folder)}
           pinnedSet={pinnedSet}
           onTogglePin={onTogglePin}
+          onCreateProject={onCreateProject}
         />
 
         <AgentsPanel />


### PR DESCRIPTION
Split out of #93 per @julian-galluzzo's review.

Adds a "create your first project" CTA to the dashboard's zero-projects empty state (`ProjectGridView` + `ProjectList`).

2 files, based on `main`. (Minor: `ProjectList.tsx` also carries a tiny colocated `searchQuery` cleanup that sits in the same file.) No agent-harness scaffolding.

Verified: `pnpm check:all`, `pnpm test:run`, `pnpm build`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the empty state display when no projects exist with a call-to-action button to create a new project
  * Updated empty state messaging to mention template selection and AI agent project building

<!-- end of auto-generated comment: release notes by coderabbit.ai -->