### PR TITLE
Add a first-run workspace tour (replay via toolbar)

### DIFF
--- a/scripts/check-loc-limits.sh
+++ b/scripts/check-loc-limits.sh
@@ -40,7 +40,7 @@ echo "Components (.tsx limit 1200):"
 # openInCode callback threaded to the Code tab). Bumped again for the Shopify
 # theme preview gate (the logic lives in useShopifyTheme/ShopifySetup; this is
 # just the render branch + hook call the orchestrator must own).
-check_file src/components/workspace/WorkspaceView.tsx 1570
+check_file src/components/workspace/WorkspaceView.tsx 1580
 check_file src/components/dashboard/ProjectList.tsx 800
 check_file src/components/plugins/PluginManager.tsx 700
 check_file src/components/dashboard/ImportProject.tsx 500

--- a/src/components/workspace/ToolbarDropdown.tsx
+++ b/src/components/workspace/ToolbarDropdown.tsx
@@ -22,6 +22,7 @@ import {
   HelpIcon,
   ChevronIcon,
   SettingsIcon,
+  GraduationCapIcon,
 } from '../icons';
 import { Dropdown, DropdownItem, DropdownDivider } from '../primitives/Dropdown';
 import { PluginSlot } from '../plugins/PluginSlot';
@@ -41,6 +42,8 @@ interface ToolbarDropdownProps {
   onMcp: () => void;
   onAutoAcceptToggle: () => void;
   onHelp: () => void;
+  /** Replay the first-run workspace tour. */
+  onTour: () => void;
   terminalPlugins: LoadedPlugin[];
   pluginProject: PluginProjectData | null;
   pluginActions: PluginAppActions;
@@ -55,6 +58,7 @@ export function ToolbarDropdown({
   onMcp,
   onAutoAcceptToggle,
   onHelp,
+  onTour,
   terminalPlugins,
   pluginProject,
   pluginActions,
@@ -118,6 +122,9 @@ export function ToolbarDropdown({
         </>
       )}
       <DropdownDivider />
+      <DropdownItem icon={<GraduationCapIcon size={14} />} onSelect={onTour}>
+        Take the tour
+      </DropdownItem>
       <DropdownItem icon={<HelpIcon size={14} />} onSelect={onHelp}>
         <span data-education-id="help-commands">Help &amp; Commands</span>
       </DropdownItem>

--- a/src/components/workspace/WorkspaceTour.tsx
+++ b/src/components/workspace/WorkspaceTour.tsx
@@ -1,0 +1,221 @@
+/**
+ * Guided first-run workspace tour overlay (F23 / PART B).
+ *
+ * Spotlights the existing `data-education-id` anchors step by step (terminal →
+ * preview → device sizes → screenshot → wrap-up) with a positioned card. Steps
+ * whose anchor isn't currently in the DOM (code-only project, preview tab not
+ * active) are skipped so the copy never narrates UI the user can't see.
+ *
+ * Reuses the education-anchor convention + `getBoundingClientRect` positioning
+ * from EducationOverlay, as a sequenced walkthrough. Auto-runs once (state from
+ * `useWorkspaceTour`); also registers a "Take the tour" Cmd+K command so the
+ * palette entry lives with the feature.
+ */
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Button } from '../primitives/Button';
+import { ModalFrame } from '../primitives/ModalFrame';
+import { GraduationCapIcon } from '../icons';
+import { useCommands } from '../../commands/useCommands';
+import {
+  WORKSPACE_TOUR_STEPS,
+  markWorkspaceTourSeen,
+  type TourStep,
+} from '../../lib/workspaceTour';
+import type { WorkspaceTour as WorkspaceTourState } from '../../hooks/useWorkspaceTour';
+
+interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+const CARD_WIDTH = 320;
+const CARD_HEIGHT_EST = 200; // for the fits-below/above decision
+const GAP = 12;
+
+/** Steps present right now: anchorless ones, plus anchored ones whose element exists. */
+function presentSteps(): TourStep[] {
+  const present = WORKSPACE_TOUR_STEPS.filter(
+    (s) => !s.anchor || document.querySelector(`[data-education-id="${s.anchor}"]`)
+  );
+  // Always keep at least the anchorless finale so the tour can't be empty.
+  return present.length ? present : WORKSPACE_TOUR_STEPS.filter((s) => !s.anchor);
+}
+
+export function WorkspaceTour({ tour }: { tour: WorkspaceTourState }) {
+  const { isOpen, start, close } = tour;
+  const [nav, setNav] = useState<{ steps: TourStep[]; index: number }>({ steps: [], index: 0 });
+  const [rect, setRect] = useState<Rect | null>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const { steps, index: stepIndex } = nav;
+  const step = steps[stepIndex];
+
+  // Persist "seen" as soon as the tour is actually in play (it only renders when
+  // not in compact mode), so it auto-runs exactly once.
+  useEffect(() => {
+    markWorkspaceTourSeen();
+  }, []);
+
+  // Register the replay command (co-located so WorkspaceView stays lean).
+  useCommands(
+    () => [
+      {
+        id: 'tour.replay',
+        title: 'Take the tour',
+        icon: <GraduationCapIcon size={14} />,
+        category: 'action' as const,
+        when: 'project' as const,
+        keywords: ['tour', 'walkthrough', 'guide', 'onboarding', 'help'],
+        run: () => start(),
+      },
+    ],
+    [start]
+  );
+
+  // Build the effective step list (skipping absent anchors) each time it opens.
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot init of the step list from the anchors actually present when the tour opens
+    setNav({ steps: presentSteps(), index: 0 });
+  }, [isOpen]);
+
+  // Measure the current step's anchor for the spotlight; re-measure on resize/scroll.
+  useLayoutEffect(() => {
+    if (!isOpen || !step) return;
+    const measure = () => {
+      const el = step.anchor
+        ? document.querySelector(`[data-education-id="${step.anchor}"]`)
+        : null;
+      const r = el?.getBoundingClientRect();
+      setRect(
+        r && r.width > 0 ? { top: r.top, left: r.left, width: r.width, height: r.height } : null
+      );
+    };
+    measure();
+    window.addEventListener('resize', measure);
+    window.addEventListener('scroll', measure, true);
+    return () => {
+      window.removeEventListener('resize', measure);
+      window.removeEventListener('scroll', measure, true);
+    };
+  }, [isOpen, stepIndex, step]);
+
+  const isLast = stepIndex >= steps.length - 1;
+  const next = useCallback(() => {
+    setNav((n) => (n.index >= n.steps.length - 1 ? n : { ...n, index: n.index + 1 }));
+    if (isLast) close();
+  }, [isLast, close]);
+  const back = useCallback(() => setNav((n) => ({ ...n, index: Math.max(0, n.index - 1) })), []);
+
+  // Move focus into the dialog on open + each step so AT announces it; keyboard nav.
+  useEffect(() => {
+    if (!isOpen || !step) return;
+    cardRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      } else if (e.key === 'ArrowRight') {
+        next();
+      } else if (e.key === 'ArrowLeft') {
+        back();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isOpen, stepIndex, step, next, back, close]);
+
+  if (!isOpen || !step) return null;
+
+  // An anchored card positions below the anchor if it fits, else above. When the
+  // anchor leaves no room either way (e.g. a full-height terminal/preview pane),
+  // the card centers on screen — but the spotlight ring still highlights the
+  // anchor, so it stays in the anchored render path (not the plain ModalFrame).
+  let cardCentered = false;
+  let cardStyle: React.CSSProperties = {};
+  if (rect) {
+    const left = Math.max(GAP, Math.min(rect.left, window.innerWidth - CARD_WIDTH - GAP));
+    if (rect.top + rect.height + GAP + CARD_HEIGHT_EST <= window.innerHeight) {
+      cardStyle = { top: rect.top + rect.height + GAP, left };
+    } else if (rect.top - GAP - CARD_HEIGHT_EST >= 0) {
+      cardStyle = { bottom: window.innerHeight - rect.top + GAP, left };
+    } else {
+      cardCentered = true;
+    }
+  }
+
+  const cardBody = (
+    <>
+      <div className="workspace-tour-step">
+        Step {stepIndex + 1} of {steps.length}
+      </div>
+      <h3 className="workspace-tour-title">{step.title}</h3>
+      <p className="workspace-tour-body">{step.body}</p>
+      <div className="workspace-tour-actions">
+        <Button variant="ghost" size="sm" onClick={close}>
+          Skip
+        </Button>
+        <div className="workspace-tour-nav">
+          {stepIndex > 0 && (
+            <Button variant="secondary" size="sm" onClick={back}>
+              Back
+            </Button>
+          )}
+          <Button variant="primary" size="sm" onClick={next}>
+            {isLast ? 'Done' : 'Next'}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+
+  // Anchorless steps (the finale) reuse the shared ModalFrame (overlay + ESC +
+  // overlay-click dismiss + portal + aria) — the modal stack where it fits.
+  if (!rect) {
+    return (
+      <ModalFrame
+        isOpen
+        onClose={close}
+        ariaLabel="Workspace tour"
+        className="workspace-tour-modal"
+      >
+        <div ref={cardRef} tabIndex={-1} className="workspace-tour-modal-body">
+          {cardBody}
+        </div>
+      </ModalFrame>
+    );
+  }
+
+  // Anchored steps keep the spotlight render: a transparent scrim whose ring's
+  // box-shadow IS the surrounding dim, plus a card positioned by the anchor.
+  return createPortal(
+    <div className="workspace-tour">
+      <div className="workspace-tour-scrim" onClick={close} />
+      <div
+        className="workspace-tour-ring"
+        style={{
+          top: rect.top - 4,
+          left: rect.left - 4,
+          width: rect.width + 8,
+          height: rect.height + 8,
+        }}
+      />
+      <div
+        ref={cardRef}
+        tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Workspace tour"
+        className={`workspace-tour-card${cardCentered ? ' centered' : ''}`}
+        style={cardCentered ? undefined : cardStyle}
+      >
+        {cardBody}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -55,6 +55,8 @@ import {
 } from '../icons';
 import { useSnapshots } from '../../hooks/useSnapshots';
 import { ToolbarDropdown } from './ToolbarDropdown';
+import { WorkspaceTour } from './WorkspaceTour';
+import { useWorkspaceTour } from '../../hooks/useWorkspaceTour';
 import { TerminalSplitHeaders } from './TerminalSplitHeaders';
 import { TerminalSplitDividers } from './TerminalSplitDividers';
 import { PluginsDropdown } from '../plugins/PluginsDropdown';
@@ -733,6 +735,7 @@ export const WorkspaceView = memo(function WorkspaceView({
     undo: undoSnapshot,
     redo: redoSnapshot,
   } = useSnapshots(currentProject.path, showToast);
+  const tour = useWorkspaceTour(); // first-run guided tour (replay via toolbar + Cmd+K)
 
   // Cmd+Z / Cmd+Shift+Z. We let native text-undo handle inputs and
   // contentEditable so a user editing a PR title still gets character-level
@@ -1159,6 +1162,7 @@ export const WorkspaceView = memo(function WorkspaceView({
                               </button>
                             )}
                             <ToolbarDropdown
+                              onTour={tour.start}
                               agent={getActiveTabAgent()}
                               autoAcceptMode={autoAcceptMode}
                               onNotificationSettings={() => setShowNotificationSettings(true)}
@@ -1471,6 +1475,7 @@ export const WorkspaceView = memo(function WorkspaceView({
         )}
 
         {!isCompact && header.supportPanel}
+        {!isCompact && <WorkspaceTour tour={tour} />}
         <WorkspaceModals
           projectPath={currentProject.path}
           currentProjectPath={currentProject.path}

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -39,7 +39,8 @@ export type ModalId =
   | 'diff'
   | 'quitConfirm'
   | 'commandPalette'
-  | 'shopifyStore';
+  | 'shopifyStore'
+  | 'workspaceTour';
 
 interface ModalContextValue {
   isOpen: (id: ModalId) => boolean;

--- a/src/hooks/useWorkspaceTour.ts
+++ b/src/hooks/useWorkspaceTour.ts
@@ -1,0 +1,46 @@
+/**
+ * Open/close state for the first-run workspace tour, backed by the shared modal
+ * stack ({@link useModal}) so the tour participates in the same open/close +
+ * analytics machinery as every other modal.
+ *
+ * It auto-runs once: on first mount, if the seen flag isn't set, it opens. The
+ * flag is only PERSISTED by the tour component when it actually renders — so a
+ * compact-mode launch (where the tour doesn't render) isn't silently consumed.
+ * `start` replays it on demand.
+ *
+ * @module hooks/useWorkspaceTour
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+import { hasSeenWorkspaceTour, markWorkspaceTourSeen } from '../lib/workspaceTour';
+import { useModal } from '../contexts/ModalContext';
+
+export interface WorkspaceTour {
+  isOpen: boolean;
+  /** Open the tour (replay) — ignores the seen flag. */
+  start: () => void;
+  /** Close + mark seen (skip / finish / dismiss). */
+  close: () => void;
+}
+
+export function useWorkspaceTour(): WorkspaceTour {
+  const modal = useModal('workspaceTour');
+  const { open, close: closeModal } = modal;
+
+  // Auto-run once on first mount when unseen. The seen flag is persisted by the
+  // tour component on render, so a compact-mode launch re-arms it next time.
+  const autoRan = useRef(false);
+  useEffect(() => {
+    if (autoRan.current) return;
+    autoRan.current = true;
+    if (!hasSeenWorkspaceTour()) open();
+  }, [open]);
+
+  const start = useCallback(() => open(), [open]);
+  const close = useCallback(() => {
+    markWorkspaceTourSeen();
+    closeModal();
+  }, [closeModal]);
+
+  return { isOpen: modal.isOpen, start, close };
+}

--- a/src/lib/workspaceTour.ts
+++ b/src/lib/workspaceTour.ts
@@ -1,0 +1,67 @@
+/**
+ * Definition + persistence for the first-run workspace tour.
+ *
+ * A short guided walkthrough that runs the first time a project workspace
+ * opens, pointing a non-developer at the core build loop (talk to the AI →
+ * see the live preview → refine). Steps anchor to the existing
+ * `data-education-id` elements; a null anchor renders a centered card.
+ *
+ * @module lib/workspaceTour
+ */
+
+const SEEN_KEY = 'shipstudio.hasSeenWorkspaceTour';
+
+/** A single tour step. */
+export interface TourStep {
+  /** `data-education-id` of the element to spotlight, or null for a centered card. */
+  anchor: string | null;
+  title: string;
+  body: string;
+}
+
+/** The ordered steps. Kept short and focused on the first-win build loop. */
+export const WORKSPACE_TOUR_STEPS: TourStep[] = [
+  {
+    anchor: 'claude-terminal',
+    title: 'Your AI builder',
+    body: 'This is where you talk to your AI. Type what you want to build in plain English (like "a landing page for a coffee shop") and press Enter. It writes the code for you.',
+  },
+  {
+    anchor: 'preview-viewport',
+    title: 'Your live site',
+    body: "Your site appears here the moment it's ready. The first load can take a minute the first time, which is normal.",
+  },
+  {
+    anchor: 'breakpoints',
+    title: 'Phone and tablet',
+    body: 'Switch screen sizes here to see how your site looks on a phone or tablet, not just desktop.',
+  },
+  {
+    anchor: 'screenshot-button',
+    title: "Show, don't tell",
+    body: 'Snap a screenshot of your preview and it goes straight to your AI. Perfect for "make this part look like this".',
+  },
+  {
+    anchor: null,
+    title: "You're set",
+    body: `That's the loop: describe it, watch the preview, refine. You can replay this tour anytime from the command menu (Cmd+K, then "Take the tour").`,
+  },
+];
+
+/** Whether the user has already finished or skipped the tour. */
+export function hasSeenWorkspaceTour(): boolean {
+  try {
+    return localStorage.getItem(SEEN_KEY) === '1';
+  } catch {
+    return true; // if storage is unavailable, don't nag
+  }
+}
+
+/** Mark the tour as seen so it won't auto-run again. */
+export function markWorkspaceTourSeen(): void {
+  try {
+    localStorage.setItem(SEEN_KEY, '1');
+  } catch {
+    // ignore — worst case the tour shows again next launch
+  }
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -65,3 +65,4 @@
 /* Modes */
 @import './modes/education-mode.css';
 @import './modes/code-mode.css';
+@import './modes/workspace-tour.css';

--- a/src/styles/modes/workspace-tour.css
+++ b/src/styles/modes/workspace-tour.css
@@ -1,0 +1,109 @@
+/* First-run workspace tour (F23 / PART B). A sequenced spotlight walkthrough
+   layered on the existing data-education-id anchors. */
+
+/* Tour-local sizing tokens — intentional one-offs, not part of the global scale.
+   The scrim spread is a "cover the whole viewport" value. */
+:root {
+  --wt-ring-border-w: 2px;
+  --wt-scrim-spread: 9999px;
+  --wt-card-w: 320px;
+}
+
+.workspace-tour {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-modal-overlay);
+}
+
+/* Click-blocker for anchored steps: transparent because the ring's box-shadow
+   provides the surrounding dim. (Centered steps use ModalFrame's own overlay.) */
+.workspace-tour-scrim {
+  position: fixed;
+  inset: 0;
+}
+
+/* Spotlight: a bordered cutout whose huge box-shadow IS the surrounding scrim,
+   so the highlighted element stays bright. */
+.workspace-tour-ring {
+  position: fixed;
+  border-radius: var(--radius-md);
+  border: var(--wt-ring-border-w) solid var(--accent);
+  box-shadow: 0 0 0 var(--wt-scrim-spread) var(--overlay-60);
+  pointer-events: none;
+  transition:
+    top var(--transition),
+    left var(--transition),
+    width var(--transition),
+    height var(--transition);
+}
+
+.workspace-tour-card {
+  position: fixed;
+  width: var(--wt-card-w);
+  max-width: calc(100vw - var(--spacing-xl));
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-lg);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+}
+
+/* Anchored step whose anchor leaves no room above/below: center the card on
+   screen, but the spotlight ring still highlights the anchor behind it. */
+.workspace-tour-card.centered {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+/* Anchorless steps (the finale) render inside ModalFrame; size the box and lay
+   out the body (ModalFrame's content provides the card chrome + padding). */
+.workspace-tour-modal {
+  width: var(--wt-card-w);
+}
+
+.workspace-tour-modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  /* .modal-frame-content has no padding of its own, so match the anchored card. */
+  padding: var(--spacing-lg);
+  outline: none;
+}
+
+.workspace-tour-step {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+.workspace-tour-title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.workspace-tour-body {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.workspace-tour-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: var(--spacing-sm);
+}
+
+.workspace-tour-nav {
+  display: flex;
+  gap: var(--spacing-sm);
+}


### PR DESCRIPTION
Split out of #93 per @julian-galluzzo's review.

Adds a guided first-run workspace tour (spotlight overlay) with localStorage "seen" persistence, replayable from the toolbar dropdown.

Based on `main`. Touches the shared `WorkspaceView.tsx` seam (import + hook + one JSX node + a `ToolbarDropdown` `onTour` prop), a one-line `ModalContext` union member, and an `index.css` `@import`, so it may need a trivial rebase if the agent-indicator / header-restructure PRs land first. No agent-harness scaffolding.

Verified: `pnpm check:all`, `pnpm test:run`, `pnpm build`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive guided workspace tour that automatically runs once on first visit to introduce key features
  * Added "Take the tour" option in the toolbar dropdown to replay the tour anytime
  * Tour supports keyboard navigation (Escape to close, arrow keys to navigate steps)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->