### PR TITLE
Onboarding / setup-wizard overhaul

### DIFF
--- a/src-tauri/src/commands/setup/install.rs
+++ b/src-tauri/src/commands/setup/install.rs
@@ -61,7 +61,9 @@ pub async fn install_node_via_brew(app: tauri::AppHandle) -> Result<(), CommandE
         return Ok(());
     }
 
-    let brew = get_brew_command().ok_or("Homebrew not found")?;
+    let brew = get_brew_command().ok_or(
+        "Homebrew is needed to install this. Install Homebrew from the Package Manager step first, then try again.",
+    )?;
 
     let output = create_command(&brew)
         .args(["install", "node"])
@@ -95,7 +97,9 @@ pub async fn install_git_via_brew(app: tauri::AppHandle) -> Result<(), CommandEr
         return Ok(());
     }
 
-    let brew = get_brew_command().ok_or("Homebrew not found")?;
+    let brew = get_brew_command().ok_or(
+        "Homebrew is needed to install this. Install Homebrew from the Package Manager step first, then try again.",
+    )?;
 
     let output = create_command(&brew)
         .args(["install", "git"])
@@ -129,7 +133,9 @@ pub async fn install_gh_via_brew(app: tauri::AppHandle) -> Result<(), CommandErr
         return Ok(());
     }
 
-    let brew = get_brew_command().ok_or("Homebrew not found")?;
+    let brew = get_brew_command().ok_or(
+        "Homebrew is needed to install this. Install Homebrew from the Package Manager step first, then try again.",
+    )?;
 
     let output = create_command(&brew)
         .args(["install", "gh"])
@@ -180,7 +186,9 @@ pub async fn install_brew_packages(
         return Ok(());
     }
 
-    let brew = get_brew_command().ok_or("Homebrew not found")?;
+    let brew = get_brew_command().ok_or(
+        "Homebrew is needed to install this. Install Homebrew from the Package Manager step first, then try again.",
+    )?;
 
     let brew_packages: Vec<&str> = packages.iter().map(|p| p.as_str()).collect();
 

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -59,6 +59,70 @@ pub fn get_extended_path() -> String {
     result
 }
 
+/// Query the user's login shell for its PATH so we detect tools installed by
+/// any version manager (nvm, volta, fnm, asdf, …) exactly the way their terminal
+/// sees them. A macOS app launched from Finder does NOT inherit this PATH.
+/// Bounded by a short timeout so a slow shell rc can't hang detection; returns
+/// None on any failure.
+#[cfg(not(windows))]
+fn get_login_shell_path() -> Option<String> {
+    use std::io::Read;
+    use std::process::Stdio;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+
+    // -l (login) + -i (interactive) so the shell sources the rc files that set up
+    // version managers (nvm/fnm/asdf typically live in the interactive rc). A
+    // unique marker isolates the PATH from any banner/prompt a chatty rc prints;
+    // stdin is /dev/null so a prompting rc can't block on input. spawn() (not
+    // output()) keeps a handle so a slow rc can be killed, not just abandoned.
+    let mut child = create_command(&shell)
+        .args(["-lic", "echo \"__SHIPSTUDIO_PATH__${PATH}\""])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    // Read stdout on a worker thread so the wait is bounded. Take the handle so
+    // killing the child closes the pipe, which unblocks the reader and lets the
+    // thread exit (no leaked thread).
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+    };
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut stdout = stdout;
+        let mut buf = String::new();
+        let _ = stdout.read_to_string(&mut buf);
+        let _ = tx.send(buf);
+    });
+
+    let result = match rx.recv_timeout(Duration::from_secs(3)) {
+        Ok(buf) => buf
+            .lines()
+            .rev()
+            .find_map(|line| line.trim().strip_prefix("__SHIPSTUDIO_PATH__"))
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty()),
+        Err(_) => None,
+    };
+
+    // Always terminate + reap the child so a slow/interactive rc can't leave the
+    // shell process lingering. kill() is a harmless no-op if it already exited.
+    let _ = child.kill();
+    let _ = child.wait();
+
+    result
+}
+
 /// Computes the extended PATH (uncached). Called by `get_extended_path()`.
 fn build_extended_path() -> String {
     let current_path = std::env::var("PATH").unwrap_or_default();
@@ -186,6 +250,26 @@ fn build_extended_path() -> String {
         }
     }
 
+    // Merge the user's login-shell PATH FIRST (covers nvm/volta/fnm/asdf/custom
+    // that a Finder-launched bundle wouldn't otherwise see). It must take
+    // precedence over the hard-coded fallbacks below so the active version-
+    // manager binary the user's terminal resolves wins over a stale system copy
+    // in /usr/local/bin etc. Non-Windows only.
+    #[cfg(not(windows))]
+    if let Some(shell_path) = get_login_shell_path() {
+        let shell_dirs: Vec<String> = shell_path
+            .split(':')
+            .filter(|dir| !dir.is_empty())
+            .map(|dir| dir.to_string())
+            .collect();
+        // Drop the fallbacks that the shell PATH already covers, then prepend
+        // the shell dirs so they are searched first.
+        paths.retain(|p| !shell_dirs.contains(p));
+        let mut merged = shell_dirs;
+        merged.append(&mut paths);
+        paths = merged;
+    }
+
     // Append existing PATH
     if !current_path.is_empty() {
         paths.push(current_path);
@@ -201,6 +285,27 @@ pub fn find_executable(cmd: &str) -> Option<std::path::PathBuf> {
     // First try which (works in dev and if PATH is set)
     if let Ok(path) = which::which(cmd) {
         return Some(path);
+    }
+
+    // Then search the extended PATH — which now includes the user's login-shell
+    // PATH, so we find tools installed by any version manager their terminal
+    // sees, even though a bundled app didn't inherit that PATH.
+    let separator = get_path_separator();
+    for dir in get_extended_path().split(separator) {
+        if dir.is_empty() {
+            continue;
+        }
+        let candidate = std::path::Path::new(dir).join(cmd);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        #[cfg(windows)]
+        for ext in ["exe", "cmd"] {
+            let win = std::path::Path::new(dir).join(format!("{cmd}.{ext}"));
+            if win.is_file() {
+                return Some(win);
+            }
+        }
     }
 
     #[cfg(windows)]
@@ -883,6 +988,16 @@ mod tests {
         fn test_nonexistent_command() {
             let result = find_executable("this-command-definitely-does-not-exist-12345");
             assert!(result.is_none());
+        }
+
+        /// The login-shell PATH query must never panic and, when it returns a
+        /// value, that value must be non-empty — regardless of the host shell.
+        #[test]
+        #[cfg(not(windows))]
+        fn test_get_login_shell_path_is_safe() {
+            if let Some(path) = get_login_shell_path() {
+                assert!(!path.is_empty());
+            }
         }
     }
 

--- a/src/components/setup/OnboardingScreen.test.tsx
+++ b/src/components/setup/OnboardingScreen.test.tsx
@@ -135,7 +135,9 @@ describe('OnboardingScreen', () => {
     render(<OnboardingScreen onComplete={onComplete} />);
 
     await waitFor(() => {
-      expect(screen.getByText('Set up version control and repository hosting')).toBeInTheDocument();
+      expect(
+        screen.getByText('Save your work safely and publish it online. Required.')
+      ).toBeInTheDocument();
     });
   });
 
@@ -155,7 +157,9 @@ describe('OnboardingScreen', () => {
     render(<OnboardingScreen onComplete={onComplete} />);
 
     await waitFor(() => {
-      expect(screen.getByText('Set up version control and repository hosting')).toBeInTheDocument();
+      expect(
+        screen.getByText('Save your work safely and publish it online. Required.')
+      ).toBeInTheDocument();
     });
   });
 
@@ -500,7 +504,7 @@ describe('OnboardingScreen', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('Set up version control and repository hosting')
+          screen.getByText('Save your work safely and publish it online. Required.')
         ).toBeInTheDocument();
       });
 
@@ -534,7 +538,7 @@ describe('OnboardingScreen', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('Set up version control and repository hosting')
+          screen.getByText('Save your work safely and publish it online. Required.')
         ).toBeInTheDocument();
       });
 
@@ -587,7 +591,9 @@ describe('OnboardingScreen', () => {
 
       // Should land on hosting step
       await waitFor(() => {
-        expect(screen.getByText('Deploy your projects to the web')).toBeInTheDocument();
+        expect(
+          screen.getByText('Optional. Connect later to put your site on the web.')
+        ).toBeInTheDocument();
       });
 
       // Skip for Now should be visible
@@ -610,7 +616,7 @@ describe('OnboardingScreen', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('Set up version control and repository hosting')
+          screen.getByText('Save your work safely and publish it online. Required.')
         ).toBeInTheDocument();
       });
 
@@ -627,7 +633,9 @@ describe('OnboardingScreen', () => {
         fireEvent.click(screen.getByText('Next'));
       });
 
-      expect(screen.getByText('Set up version control and repository hosting')).toBeInTheDocument();
+      expect(
+        screen.getByText('Save your work safely and publish it online. Required.')
+      ).toBeInTheDocument();
     });
   });
 
@@ -807,7 +815,7 @@ describe('OnboardingScreen', () => {
       // Auto-advances to step 2
       await waitFor(() => {
         expect(
-          screen.getByText('Set up version control and repository hosting')
+          screen.getByText('Save your work safely and publish it online. Required.')
         ).toBeInTheDocument();
       });
 
@@ -825,7 +833,7 @@ describe('OnboardingScreen', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('Set up version control and repository hosting')
+          screen.getByText('Save your work safely and publish it online. Required.')
         ).toBeInTheDocument();
       });
 
@@ -1135,7 +1143,7 @@ describe('OnboardingScreen', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('Set up version control and repository hosting')
+          screen.getByText('Save your work safely and publish it online. Required.')
         ).toBeInTheDocument();
       });
 
@@ -1230,7 +1238,7 @@ describe('OnboardingScreen', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('Set up version control and repository hosting')
+          screen.getByText('Save your work safely and publish it online. Required.')
         ).toBeInTheDocument();
       });
 
@@ -1531,7 +1539,7 @@ describe('OnboardingScreen', () => {
       });
 
       // Node depends on homebrew — with homebrew not installed, node should show "Waiting for..."
-      expect(screen.getByText('Waiting for Package Manager')).toBeInTheDocument();
+      expect(screen.getByText('Unlocks after Package Manager')).toBeInTheDocument();
     });
 
     it('node becomes installable after homebrew is installed', async () => {
@@ -1549,7 +1557,7 @@ describe('OnboardingScreen', () => {
       });
 
       // Node should NOT show "Waiting for..." anymore
-      expect(screen.queryByText('Waiting for Package Manager')).not.toBeInTheDocument();
+      expect(screen.queryByText('Unlocks after Package Manager')).not.toBeInTheDocument();
 
       // Node should have an Install button
       const installButtons = screen.getAllByText('Install');
@@ -1563,12 +1571,12 @@ describe('OnboardingScreen', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('Set up version control and repository hosting')
+          screen.getByText('Save your work safely and publish it online. Required.')
         ).toBeInTheDocument();
       });
 
       // gh_auth depends on gh — with gh not installed, should show blocked
-      expect(screen.getByText('Waiting for GitHub CLI')).toBeInTheDocument();
+      expect(screen.getByText('Unlocks after GitHub CLI')).toBeInTheDocument();
     });
 
     it('claude_auth shows as blocked when claude is not installed (step 3)', async () => {
@@ -1581,7 +1589,7 @@ describe('OnboardingScreen', () => {
       });
 
       // claude_auth depends on claude — should show blocked
-      expect(screen.getByText('Waiting for Claude Code')).toBeInTheDocument();
+      expect(screen.getByText('Unlocks after Claude Code')).toBeInTheDocument();
     });
   });
 
@@ -1600,7 +1608,7 @@ describe('OnboardingScreen', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('Set up version control and repository hosting')
+          screen.getByText('Save your work safely and publish it online. Required.')
         ).toBeInTheDocument();
       });
 
@@ -1839,7 +1847,7 @@ describe('OnboardingScreen', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('Set up version control and repository hosting')
+          screen.getByText('Save your work safely and publish it online. Required.')
         ).toBeInTheDocument();
       });
 

--- a/src/components/setup/OnboardingScreen.tsx
+++ b/src/components/setup/OnboardingScreen.tsx
@@ -480,6 +480,27 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
     return isWizardStepComplete(currentStep, items);
   }, [currentStep, items, activeItemId, terminalConfig, selectedAgentId]);
 
+  // Plain-language reason the Next button is disabled, so the user isn't left
+  // staring at a greyed-out button with no idea what's still required.
+  const nextBlockedReason = useMemo(() => {
+    if (isNextEnabled) return null;
+    if (activeItemId || terminalConfig) return null; // an action is mid-flight
+    if (currentStep === 'agent') {
+      if (!isAtLeastOneAgentReady(items)) return 'Connect at least one AI agent to continue';
+      if (getReadyAgentPairs(items).length > 1 && !selectedAgentId) {
+        return 'Choose your default agent to continue';
+      }
+    }
+    const stepDef = WIZARD_STEPS.find((s) => s.id === currentStep);
+    const blocker = stepDef?.itemIds
+      .map((id) => items.find((it) => it.id === id))
+      .find((it) => it !== undefined && it.status !== 'ready');
+    if (blocker) {
+      return `Finish setting up ${SETUP_FRIENDLY_NAMES[blocker.id] || blocker.id} to continue`;
+    }
+    return null;
+  }, [isNextEnabled, activeItemId, terminalConfig, currentStep, items, selectedAgentId]);
+
   // Get current step definition
   const currentStepDef = WIZARD_STEPS.find((s) => s.id === currentStep)!;
   const currentStepIndex = WIZARD_STEPS.findIndex((s) => s.id === currentStep);
@@ -599,6 +620,7 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
             </button>
           )}
           <div className="wizard-nav-spacer" />
+          {nextBlockedReason && <span className="wizard-nav-hint">{nextBlockedReason}</span>}
           <button
             className="wizard-nav-next"
             onClick={() => void handleNext()}

--- a/src/components/setup/SetupItem.test.tsx
+++ b/src/components/setup/SetupItem.test.tsx
@@ -135,7 +135,7 @@ describe('SetupItem', () => {
     const item = makeItem({ status: 'blocked' });
     render(<SetupItem item={item} blockedBy={['Package Manager']} />);
 
-    expect(screen.getByText('Waiting for Package Manager')).toBeInTheDocument();
+    expect(screen.getByText('Unlocks after Package Manager')).toBeInTheDocument();
   });
 
   // ============ Button disabled states ============

--- a/src/components/setup/SetupItem.tsx
+++ b/src/components/setup/SetupItem.tsx
@@ -138,9 +138,10 @@ function getActionButton(
     return null;
   }
 
-  // Blocked items show what they're waiting for
+  // Blocked items: frame as "becomes available", not "stuck". "Unlocks" reads
+  // correctly for both install items and connect/auth items (which don't install).
   if (item.status === 'blocked' && blockedBy && blockedBy.length > 0) {
-    return <span className="setup-item-blocked-text">Waiting for {blockedBy[0]}</span>;
+    return <span className="setup-item-blocked-text">Unlocks after {blockedBy[0]}</span>;
   }
 
   // In-progress items show the progress message

--- a/src/components/setup/steps/AgentStep.tsx
+++ b/src/components/setup/steps/AgentStep.tsx
@@ -17,6 +17,13 @@ import {
 } from '../../../lib/setup';
 import { ALL_AGENTS } from '../../../lib/agent';
 
+/** One-line plain descriptions so "Codex"/"Opencode" aren't opaque brand names. */
+const AGENT_DESCRIPTIONS: Record<string, string> = {
+  claude: "Anthropic's coding agent",
+  codex: "OpenAI's coding agent",
+  opencode: 'Open-source coding agent',
+};
+
 interface AgentStepProps {
   items: SetupItemType[];
   onItemAction: (itemId: string) => void;
@@ -98,6 +105,9 @@ export function AgentStep({
                 </div>
               )}
             </div>
+            {AGENT_DESCRIPTIONS[pair.binaryId] && (
+              <p className="wizard-agent-card-desc">{AGENT_DESCRIPTIONS[pair.binaryId]}</p>
+            )}
 
             <div className="wizard-agent-card-items">
               {[binaryItem, authItem].map((item) => {

--- a/src/components/terminal/DevServerStatus.test.tsx
+++ b/src/components/terminal/DevServerStatus.test.tsx
@@ -20,12 +20,18 @@ function renderStatus(overrides: Partial<React.ComponentProps<typeof DevServerSt
 }
 
 describe('DevServerStatus', () => {
-  it('shows Stop + the attempt counter while loading', () => {
-    const props = renderStatus({ phase: 'loading' });
-    expect(screen.getByText('Attempt 24/60')).toBeInTheDocument();
+  it('shows Stop + the attempt counter once past warm-up', () => {
+    const props = renderStatus({ phase: 'loading', retryCount: 24 });
+    expect(screen.getByText('Still trying… (attempt 24 of 60)')).toBeInTheDocument();
     fireEvent.click(screen.getByText('Stop'));
     expect(props.onStop).toHaveBeenCalledOnce();
     expect(screen.queryByText('Retry')).not.toBeInTheDocument();
+  });
+
+  it('shows a calm warm-up message early, before the raw attempt counter', () => {
+    renderStatus({ phase: 'loading', retryCount: 5 });
+    expect(screen.getByText('This can take a minute the first time…')).toBeInTheDocument();
+    expect(screen.queryByText(/attempt 5 of 60/)).not.toBeInTheDocument();
   });
 
   it('swaps Stop for Retry once stopped, without showing an attempt counter', () => {

--- a/src/components/terminal/DevServerStatus.tsx
+++ b/src/components/terminal/DevServerStatus.tsx
@@ -18,6 +18,11 @@ import { stripAnsi } from '../../lib/ansi';
  *  EADDRINUSE, small enough to stay readable in the cramped preview pane. */
 const LOG_TAIL_LINES = 60;
 
+/** Below this many attempts the wait is treated as normal first-time warm-up
+ *  (a reassuring message); only past it do we show the raw attempt counter,
+ *  which otherwise reads as "broken" to a non-developer well before it is. */
+const WARMUP_ATTEMPTS = 15;
+
 export type DevServerPhase = 'loading' | 'stopped' | 'error';
 
 interface DevServerStatusProps {
@@ -150,7 +155,9 @@ export function DevServerStatus({
 
       {phase === 'loading' && retryCount > 0 && (
         <p className="preview-status__attempt">
-          Attempt {retryCount}/{maxRetries}
+          {retryCount <= WARMUP_ATTEMPTS
+            ? 'This can take a minute the first time…'
+            : `Still trying… (attempt ${retryCount} of ${maxRetries})`}
         </p>
       )}
 

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -317,7 +317,7 @@ export const WIZARD_STEPS: WizardStepDef[] = [
   {
     id: 'git-github',
     title: 'Git & GitHub',
-    subtitle: 'Set up version control and repository hosting',
+    subtitle: 'Save your work safely and publish it online. Required.',
     itemIds: ['git', 'gh', 'gh_auth'],
     skippable: false,
   },
@@ -331,7 +331,7 @@ export const WIZARD_STEPS: WizardStepDef[] = [
   {
     id: 'hosting',
     title: 'Hosting Provider',
-    subtitle: 'Deploy your projects to the web',
+    subtitle: 'Optional. Connect later to put your site on the web.',
     itemIds: ['vercel', 'vercel_auth'],
     skippable: true,
   },

--- a/src/styles/features/setup.css
+++ b/src/styles/features/setup.css
@@ -405,6 +405,14 @@
   flex: 1;
 }
 
+.wizard-nav-hint {
+  margin-right: var(--spacing-md);
+  align-self: center;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  text-align: right;
+}
+
 .wizard-nav-back {
   padding: 8px 18px;
   font-size: var(--font-size-lg);
@@ -507,6 +515,12 @@
 .wizard-agent-card-name {
   font-size: 15px;
   font-weight: 600;
+}
+
+.wizard-agent-card-desc {
+  margin: var(--spacing-xs) 0 0;
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
 }
 
 .wizard-agent-card-badge {


### PR DESCRIPTION
Split out of #93 per @julian-galluzzo's review.

Overhauls the first-run setup wizard: friendlier tool names, a browser sign-in flow, "unlocks after" wording, optional-Homebrew / Node-present step-complete logic, npm permission repair, and calmer dev-server status messaging.

Based on `main`. Scoping notes:
- The GitHub/Vercel **logout wrappers** ship in the Vercel PR (#95), not here.
- `OnboardingTerminal.tsx` is left on `main` (its only branch change was a lib-wrapper swap that belongs to the refactor PR).
- The terminal **first-run hint** is deferred to a small follow-up (it touches the shared `Terminal.tsx` seam alongside other PRs).

No agent-harness scaffolding. Verified: `pnpm check:all`, `pnpm test:run`, `cargo test`, `pnpm tauri build`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a browser-based authentication flow for GitHub and Claude sign-in.
  * Added agent descriptions to the setup wizard.

* **Improvements**
  * Package Manager is now optional once Node.js is detected.
  * Enhanced tool discovery to better match what your terminal finds (including version-manager installs).
  * Updated setup labels and statuses (e.g., GitHub connector, Vercel (hosting), Repair file access).
  * Clearer “Next” blocker explanations and “Unlocks after …” messaging.
  * Improved dev server loading messaging and Homebrew-missing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->