### PR TITLE
Backend hardening: tracing, network timeouts, port-eviction, CSP

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -16,6 +16,11 @@ const MAX_DIFF_SIZE: usize = 40_000;
 /// Timeout for the underlying AI agent CLI call. Claude can be slow, so 60s.
 const AGENT_CLI_TIMEOUT_SECS: u64 = 60;
 
+/// Timeout for the local git context-gathering ops (branch/log/diff). Bounds a
+/// pathological repo (a huge diff) and keeps the work off the blocking path —
+/// these run via async tokio process, not std `.output()` on the executor.
+const GIT_TIMEOUT_SECS: u64 = 60;
+
 /// Gather git context and generate a PR title and description using Claude CLI.
 #[tauri::command]
 #[tracing::instrument(skip(project_path), fields(project = %project_path, base = %base_branch))]
@@ -40,10 +45,10 @@ pub async fn generate_pr_description(
     );
 
     // Gather context in parallel-ish (all quick git commands)
-    let branch_name = get_branch_name(&validated_path)?;
-    let commits = get_commit_messages(&validated_path, &base_branch)?;
-    let diff_stat = get_diff_stat(&validated_path, &base_branch)?;
-    let diff = get_diff(&validated_path, &base_branch)?;
+    let branch_name = get_branch_name(&validated_path).await?;
+    let commits = get_commit_messages(&validated_path, &base_branch).await?;
+    let diff_stat = get_diff_stat(&validated_path, &base_branch).await?;
+    let diff = get_diff(&validated_path, &base_branch).await?;
 
     if commits.is_empty() && diff.is_empty() {
         return Err(
@@ -109,12 +114,16 @@ pub async fn generate_pr_description(
     parse_response(&response).map_err(CommandError::from)
 }
 
-fn get_branch_name(path: &std::path::Path) -> Result<String, CommandError> {
-    let output = create_command("git")
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(path)
-        .output()
-        .map_err(|e| e.to_string())?;
+async fn get_branch_name(path: &std::path::Path) -> Result<String, CommandError> {
+    let mut cmd = create_command("git");
+    cmd.args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(path);
+    let output = run_with_timeout(
+        tokio::process::Command::from(cmd),
+        "git rev-parse",
+        GIT_TIMEOUT_SECS,
+    )
+    .await?;
 
     if !output.status.success() {
         return Err(("Failed to get current branch name".to_string()).into());
@@ -123,39 +132,51 @@ fn get_branch_name(path: &std::path::Path) -> Result<String, CommandError> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-fn get_commit_messages(path: &std::path::Path, base: &str) -> Result<String, String> {
-    let output = create_command("git")
-        .args([
-            "--no-pager",
-            "log",
-            &format!("{base}..HEAD"),
-            "--pretty=format:%s",
-            "--no-merges",
-        ])
-        .current_dir(path)
-        .output()
-        .map_err(|e| e.to_string())?;
+async fn get_commit_messages(path: &std::path::Path, base: &str) -> Result<String, CommandError> {
+    let mut cmd = create_command("git");
+    cmd.args([
+        "--no-pager",
+        "log",
+        &format!("{base}..HEAD"),
+        "--pretty=format:%s",
+        "--no-merges",
+    ])
+    .current_dir(path);
+    let output = run_with_timeout(
+        tokio::process::Command::from(cmd),
+        "git log",
+        GIT_TIMEOUT_SECS,
+    )
+    .await?;
 
     // Not an error if there are no commits - diff might still exist
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-fn get_diff_stat(path: &std::path::Path, base: &str) -> Result<String, String> {
-    let output = create_command("git")
-        .args(["--no-pager", "diff", &format!("{base}...HEAD"), "--stat"])
-        .current_dir(path)
-        .output()
-        .map_err(|e| e.to_string())?;
+async fn get_diff_stat(path: &std::path::Path, base: &str) -> Result<String, CommandError> {
+    let mut cmd = create_command("git");
+    cmd.args(["--no-pager", "diff", &format!("{base}...HEAD"), "--stat"])
+        .current_dir(path);
+    let output = run_with_timeout(
+        tokio::process::Command::from(cmd),
+        "git diff --stat",
+        GIT_TIMEOUT_SECS,
+    )
+    .await?;
 
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-fn get_diff(path: &std::path::Path, base: &str) -> Result<String, String> {
-    let output = create_command("git")
-        .args(["--no-pager", "diff", &format!("{base}...HEAD")])
-        .current_dir(path)
-        .output()
-        .map_err(|e| e.to_string())?;
+async fn get_diff(path: &std::path::Path, base: &str) -> Result<String, CommandError> {
+    let mut cmd = create_command("git");
+    cmd.args(["--no-pager", "diff", &format!("{base}...HEAD")])
+        .current_dir(path);
+    let output = run_with_timeout(
+        tokio::process::Command::from(cmd),
+        "git diff",
+        GIT_TIMEOUT_SECS,
+    )
+    .await?;
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
@@ -272,5 +293,16 @@ mod tests {
         let response = "";
         let result = parse_response(response);
         assert!(result.is_err());
+    }
+
+    /// The git context helpers must run asynchronously through the timeout path
+    /// (they were blocking std `.output()` on the async executor). The repo root
+    /// is a git repo, so this is deterministic and guards the conversion wiring.
+    #[tokio::test]
+    async fn get_branch_name_runs_async_with_timeout() {
+        let out = get_branch_name(std::path::Path::new("."))
+            .await
+            .expect("git rev-parse should run within the timeout");
+        assert!(!out.is_empty());
     }
 }

--- a/src-tauri/src/commands/pty/mod.rs
+++ b/src-tauri/src/commands/pty/mod.rs
@@ -91,6 +91,7 @@ pub(super) fn kill_process(pid: u32) {
 /// Get the reserved port for a `(window, project)` pair, if any.
 /// Returns None if no port is reserved for this pair.
 #[tauri::command]
+#[tracing::instrument]
 pub fn get_reserved_port_for_window(window_label: String, project_path: String) -> Option<u16> {
     tracing::info!(
         "get_reserved_port_for_window called: window='{}', project='{}'",
@@ -113,6 +114,7 @@ pub fn get_reserved_port_for_window(window_label: String, project_path: String) 
 /// Also checks against reserved ports to avoid race conditions in multi-window scenarios.
 /// Returns the first available port found.
 #[tauri::command]
+#[tracing::instrument]
 pub fn find_available_port(preferred_port: u16) -> Result<u16, CommandError> {
     use std::net::TcpListener;
 
@@ -143,6 +145,7 @@ pub fn find_available_port(preferred_port: u16) -> Result<u16, CommandError> {
 /// returns it (idempotent) — different projects in the same window each get
 /// their own port independently.
 #[tauri::command]
+#[tracing::instrument]
 pub fn find_and_reserve_port(
     window_label: String,
     project_path: String,
@@ -204,6 +207,7 @@ pub fn find_and_reserve_port(
 /// is being torn down. For window-wide cleanup on close, the backend calls
 /// `release_port_for_window` directly.
 #[tauri::command]
+#[tracing::instrument]
 pub fn release_reserved_port(
     window_label: String,
     project_path: String,
@@ -221,6 +225,7 @@ pub fn release_reserved_port(
 ///
 /// This is needed for the frontend PTY spawn since macOS apps don't inherit shell PATH.
 #[tauri::command]
+#[tracing::instrument]
 pub fn get_shell_path() -> String {
     get_extended_path()
 }
@@ -232,6 +237,7 @@ pub fn get_shell_path() -> String {
 /// that Node.js and cmd.exe require to function.
 /// On macOS/Linux, returns an empty map (the Unix env vars are hardcoded in the frontend).
 #[tauri::command]
+#[tracing::instrument]
 pub fn get_system_env() -> std::collections::HashMap<String, String> {
     #[allow(unused_mut)]
     let mut env = std::collections::HashMap::new();

--- a/src-tauri/src/commands/pty/spawn.rs
+++ b/src-tauri/src/commands/pty/spawn.rs
@@ -25,6 +25,7 @@ use tauri::Emitter;
 /// The `window_label` parameter ensures events are only sent to the window that
 /// spawned the PTY, enabling multi-window isolation.
 #[tauri::command]
+#[tracing::instrument(skip(app, options))]
 pub async fn spawn_pty(
     app: tauri::AppHandle,
     options: SpawnPtyOptions,
@@ -163,6 +164,7 @@ pub async fn spawn_pty(
 ///
 /// The `pty_id` should be unique (e.g., the PTY ID from tauri-pty or a timestamp).
 #[tauri::command]
+#[tracing::instrument]
 pub fn register_external_pty(
     window_label: String,
     pid: u32,
@@ -197,6 +199,7 @@ pub fn register_external_pty(
 ///
 /// Called when the PTY exits normally (before window close) to keep the registry clean.
 #[tauri::command]
+#[tracing::instrument]
 pub fn unregister_external_pty(pty_id: u32) -> Result<(), CommandError> {
     if let Ok(mut registry) = PTY_REGISTRY.lock() {
         if let Some(info) = registry.remove(&pty_id) {

--- a/src-tauri/src/commands/pty/stream.rs
+++ b/src-tauri/src/commands/pty/stream.rs
@@ -12,6 +12,7 @@ use crate::utils::create_command;
 ///
 /// Uses SIGTERM first to allow graceful shutdown, then SIGKILL after a timeout.
 #[tauri::command]
+#[tracing::instrument]
 pub async fn kill_pty(id: u32) -> Result<bool, CommandError> {
     let pid = {
         let registry = PTY_REGISTRY.lock().map_err(|e| e.to_string())?;
@@ -83,6 +84,7 @@ pub fn kill_window_pty_sync(window_label: &str) -> u32 {
 /// This is the preferred method for cleanup when switching projects in a window.
 /// It only kills PTYs belonging to the specified window, leaving other windows' PTYs intact.
 #[tauri::command]
+#[tracing::instrument]
 pub async fn kill_window_pty(window_label: String) -> Result<u32, CommandError> {
     let pids_to_kill: Vec<(u32, u32)> = {
         let registry = PTY_REGISTRY.lock().map_err(|e| e.to_string())?;
@@ -190,6 +192,7 @@ pub fn get_project_pty_pids_internal(project_path: &str) -> Vec<u32> {
 ///
 /// Returns the number of PTYs killed.
 #[tauri::command]
+#[tracing::instrument]
 pub async fn kill_project_pty(project_path: String) -> Result<u32, CommandError> {
     Ok(kill_project_pty_internal(&project_path))
 }
@@ -197,6 +200,7 @@ pub async fn kill_project_pty(project_path: String) -> Result<u32, CommandError>
 /// Return the PIDs of all PTYs associated with a project. Used for memory
 /// queries and process-running checks. Returns an empty vec if no PTYs match.
 #[tauri::command]
+#[tracing::instrument]
 pub async fn get_project_pty_pids(project_path: String) -> Result<Vec<u32>, CommandError> {
     Ok(get_project_pty_pids_internal(&project_path))
 }
@@ -206,6 +210,7 @@ pub async fn get_project_pty_pids(project_path: String) -> Result<Vec<u32>, Comm
 /// WARNING: This kills PTYs across ALL windows. Use `kill_window_pty` instead
 /// for per-window cleanup. This should only be used during app shutdown.
 #[tauri::command]
+#[tracing::instrument]
 pub async fn kill_all_pty() -> Result<u32, CommandError> {
     let pids: Vec<(u32, u32)> = {
         let registry = PTY_REGISTRY.lock().map_err(|e| e.to_string())?;
@@ -244,6 +249,7 @@ pub async fn kill_all_pty() -> Result<u32, CommandError> {
 /// This kills any agent or next-server processes that have become orphaned
 /// (parent PID is 1, meaning their parent process died).
 #[tauri::command]
+#[tracing::instrument]
 pub async fn cleanup_orphaned_processes() -> Result<(), CommandError> {
     #[cfg(unix)]
     {
@@ -284,6 +290,7 @@ pub async fn cleanup_orphaned_processes() -> Result<(), CommandError> {
 
 /// Kill any process listening on a specific port
 #[tauri::command]
+#[tracing::instrument]
 pub async fn kill_port(port: u32) -> Result<(), CommandError> {
     #[cfg(unix)]
     {

--- a/src-tauri/src/commands/pty_session.rs
+++ b/src-tauri/src/commands/pty_session.rs
@@ -104,6 +104,7 @@ pub struct SessionListItem {
 /// and so the same id routes through write/attach/kill later.
 #[allow(clippy::too_many_arguments)]
 #[tauri::command]
+#[tracing::instrument(skip_all, fields(session_id = %session_id, command = %command))]
 pub async fn pty_session_open(
     app: AppHandle,
     session_id: String,
@@ -257,6 +258,7 @@ pub async fn pty_session_open(
 }
 
 #[tauri::command]
+#[tracing::instrument(skip(data))]
 pub fn pty_session_write(session_id: String, data: Vec<u8>) -> Result<(), CommandError> {
     let session = {
         let map = REGISTRY
@@ -276,6 +278,7 @@ pub fn pty_session_write(session_id: String, data: Vec<u8>) -> Result<(), Comman
 }
 
 #[tauri::command]
+#[tracing::instrument]
 pub fn pty_session_resize(session_id: String, cols: u16, rows: u16) -> Result<(), CommandError> {
     let session = {
         let map = REGISTRY
@@ -302,6 +305,7 @@ pub fn pty_session_resize(session_id: String, cols: u16, rows: u16) -> Result<()
 }
 
 #[tauri::command]
+#[tracing::instrument]
 pub fn pty_session_kill(session_id: String) -> Result<(), CommandError> {
     // Pop first so repeated kills are no-ops and the reader thread can exit
     // cleanly on its next read.
@@ -326,6 +330,7 @@ pub fn pty_session_kill(session_id: String) -> Result<(), CommandError> {
 }
 
 #[tauri::command]
+#[tracing::instrument]
 pub fn pty_session_attach(session_id: String) -> Result<AttachResult, CommandError> {
     let session = {
         let map = REGISTRY
@@ -357,6 +362,7 @@ pub fn pty_session_attach(session_id: String) -> Result<AttachResult, CommandErr
 }
 
 #[tauri::command]
+#[tracing::instrument]
 pub fn pty_session_list(
     project_path: Option<String>,
 ) -> Result<Vec<SessionListItem>, CommandError> {

--- a/src-tauri/src/commands/publishing.rs
+++ b/src-tauri/src/commands/publishing.rs
@@ -5,9 +5,30 @@
 use crate::commands::git::git_stage_and_commit;
 use crate::commands::github::ensure_git_identity;
 use crate::errors::CommandError;
+use crate::external_command::run_with_timeout;
 use crate::types::PublishResult;
 use crate::utils::{create_command, validate_project_path};
+use std::path::Path;
 use tracing::{debug, error, info, instrument, warn};
+
+/// Timeout for network-facing git operations (pull/push). Matches
+/// `git/branches.rs::GIT_NETWORK_TIMEOUT_SECS` — a hung remote must not freeze
+/// the publish command forever.
+const GIT_NETWORK_TIMEOUT_SECS: u64 = 60;
+
+/// Run a network-facing git command (pull/push) with a timeout. Mirrors
+/// `git/branches.rs::run_git_net`: local ops stay on blocking `create_command`,
+/// only the remote-touching ones route through `run_with_timeout`.
+async fn run_git_net(
+    args: &[&str],
+    cwd: &Path,
+    label: &str,
+) -> Result<std::process::Output, CommandError> {
+    let mut cmd = create_command("git");
+    cmd.args(args).current_dir(cwd);
+    let tokio_cmd = tokio::process::Command::from(cmd);
+    run_with_timeout(tokio_cmd, format!("git {label}"), GIT_NETWORK_TIMEOUT_SECS).await
+}
 
 #[tauri::command]
 #[instrument(name = "publish_to_github", skip(project_path, commit_message), fields(project = %project_path))]
@@ -36,10 +57,12 @@ pub async fn publish_to_github(
     };
 
     // Pull latest changes first (rebase to keep history clean)
-    let pull_output = create_command("git")
-        .args(["pull", "--rebase", "origin", &branch])
-        .current_dir(&validated_path)
-        .output();
+    let pull_output = run_git_net(
+        &["pull", "--rebase", "origin", &branch],
+        &validated_path,
+        "pull --rebase",
+    )
+    .await;
 
     // Handle pull errors - log unexpected ones but don't fail
     match pull_output {
@@ -108,11 +131,7 @@ pub async fn publish_to_github(
     }
 
     // Push to origin
-    let output = create_command("git")
-        .args(["push", "-u", "origin", &branch])
-        .current_dir(&validated_path)
-        .output()
-        .map_err(CommandError::from)?;
+    let output = run_git_net(&["push", "-u", "origin", &branch], &validated_path, "push").await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -148,11 +167,12 @@ pub async fn publish_to_staging(
 
     // Push to staging branch - Vercel auto-deploys via GitHub integration
     // Note: Using regular push instead of force push to avoid overwriting others' work
-    let push_output = create_command("git")
-        .args(["push", "-u", "origin", "HEAD:staging"])
-        .current_dir(&validated_path)
-        .output()
-        .map_err(CommandError::from)?;
+    let push_output = run_git_net(
+        &["push", "-u", "origin", "HEAD:staging"],
+        &validated_path,
+        "push staging",
+    )
+    .await?;
 
     if !push_output.status.success() {
         let stderr = String::from_utf8_lossy(&push_output.stderr);
@@ -198,11 +218,12 @@ pub async fn publish_to_production(
     let _ = git_stage_and_commit(&validated_path, &message);
 
     // Push to main branch - Vercel auto-deploys to production via GitHub integration
-    let push_output = create_command("git")
-        .args(["push", "-u", "origin", "HEAD:main"])
-        .current_dir(&validated_path)
-        .output()
-        .map_err(CommandError::from)?;
+    let push_output = run_git_net(
+        &["push", "-u", "origin", "HEAD:main"],
+        &validated_path,
+        "push main",
+    )
+    .await?;
 
     if !push_output.status.success() {
         let stderr = String::from_utf8_lossy(&push_output.stderr);
@@ -282,11 +303,8 @@ pub async fn publish_branch(
     }
 
     // Push to origin
-    let push_output = create_command("git")
-        .args(["push", "-u", "origin", &branch])
-        .current_dir(&validated_path)
-        .output()
-        .map_err(CommandError::from)?;
+    let push_output =
+        run_git_net(&["push", "-u", "origin", &branch], &validated_path, "push").await?;
 
     if !push_output.status.success() {
         let stderr = String::from_utf8_lossy(&push_output.stderr);
@@ -318,4 +336,23 @@ pub async fn publish_branch(
         url: String::new(),
         state: "QUEUED".to_string(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_git_net;
+    use std::path::Path;
+
+    /// The network git helper must actually execute git through the timeout path
+    /// (the whole point of A8 — replacing blocking `.output()` so a hung remote
+    /// can't freeze publishing). `--version` needs no repo or remote, so this is
+    /// deterministic and guards the `create_command` + `run_with_timeout` wiring.
+    #[tokio::test]
+    async fn run_git_net_executes_git_through_timeout() {
+        let out = run_git_net(&["--version"], Path::new("."), "--version")
+            .await
+            .expect("git --version should run within the timeout");
+        assert!(out.status.success());
+        assert!(String::from_utf8_lossy(&out.stdout).contains("git version"));
+    }
 }

--- a/src-tauri/src/commands/pull_requests.rs
+++ b/src-tauri/src/commands/pull_requests.rs
@@ -4,8 +4,27 @@
 
 use crate::commands::github::get_gh_command;
 use crate::errors::CommandError;
+use crate::external_command::run_with_timeout;
 use crate::types::PullRequestInfo;
 use crate::utils::{create_command, validate_project_path};
+
+/// Timeout for network-facing CLI ops (gh/git) so a hung remote can't freeze a
+/// PR command. Matches git/branches.rs.
+const NETWORK_TIMEOUT_SECS: u64 = 60;
+
+/// Run an already-configured network-facing command (gh/git) with a timeout,
+/// replacing blocking `.output()` so a stalled remote can't hang the UI.
+async fn run_net(
+    cmd: std::process::Command,
+    label: &str,
+) -> Result<std::process::Output, CommandError> {
+    run_with_timeout(
+        tokio::process::Command::from(cmd),
+        label.to_string(),
+        NETWORK_TIMEOUT_SECS,
+    )
+    .await
+}
 
 /// List pull requests for the repository
 #[tauri::command]
@@ -15,18 +34,17 @@ pub async fn list_pull_requests(
 ) -> Result<Vec<PullRequestInfo>, CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let output = get_gh_command()
-        .args([
-            "pr",
-            "list",
-            "--json",
-            "number,title,headRefName,baseRefName,author,state,mergeable,url,createdAt",
-            "--limit",
-            "20",
-        ])
-        .current_dir(&validated_path)
-        .output()
-        .map_err(|e| e.to_string())?;
+    let mut cmd = get_gh_command();
+    cmd.args([
+        "pr",
+        "list",
+        "--json",
+        "number,title,headRefName,baseRefName,author,state,mergeable,url,createdAt",
+        "--limit",
+        "20",
+    ])
+    .current_dir(&validated_path);
+    let output = run_net(cmd, "gh pr list").await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -76,11 +94,11 @@ pub async fn create_pull_request(
     let validated_path = validate_project_path(&project_path)?;
 
     // Push the branch to the remote first (gh pr create requires this)
-    let push_output = create_command("git")
+    let mut push_cmd = create_command("git");
+    push_cmd
         .args(["push", "-u", "origin", "HEAD"])
-        .current_dir(&validated_path)
-        .output()
-        .map_err(|e| format!("Failed to push branch: {e}"))?;
+        .current_dir(&validated_path);
+    let push_output = run_net(push_cmd, "git push").await?;
 
     if !push_output.status.success() {
         let stderr = String::from_utf8_lossy(&push_output.stderr);
@@ -95,11 +113,9 @@ pub async fn create_pull_request(
         "pr", "create", "--title", &title, "--body", &body_str, "--base", &base,
     ];
 
-    let output = get_gh_command()
-        .args(&args)
-        .current_dir(&validated_path)
-        .output()
-        .map_err(|e| e.to_string())?;
+    let mut cmd = get_gh_command();
+    cmd.args(&args).current_dir(&validated_path);
+    let output = run_net(cmd, "gh pr create").await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -119,11 +135,10 @@ pub async fn create_pull_request(
 pub async fn merge_pull_request(project_path: String, pr_number: i32) -> Result<(), CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let output = get_gh_command()
-        .args(["pr", "merge", &pr_number.to_string(), "--merge"])
-        .current_dir(&validated_path)
-        .output()
-        .map_err(|e| e.to_string())?;
+    let mut cmd = get_gh_command();
+    cmd.args(["pr", "merge", &pr_number.to_string(), "--merge"])
+        .current_dir(&validated_path);
+    let output = run_net(cmd, "gh pr merge").await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
@@ -154,11 +169,10 @@ pub async fn checkout_pull_request(
 ) -> Result<String, CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let output = get_gh_command()
-        .args(["pr", "checkout", &pr_number.to_string()])
-        .current_dir(&validated_path)
-        .output()
-        .map_err(|e| e.to_string())?;
+    let mut cmd = get_gh_command();
+    cmd.args(["pr", "checkout", &pr_number.to_string()])
+        .current_dir(&validated_path);
+    let output = run_net(cmd, "gh pr checkout").await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -184,11 +198,10 @@ pub async fn checkout_pull_request(
 pub async fn close_pull_request(project_path: String, pr_number: i32) -> Result<(), CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let output = get_gh_command()
-        .args(["pr", "close", &pr_number.to_string()])
-        .current_dir(&validated_path)
-        .output()
-        .map_err(|e| e.to_string())?;
+    let mut cmd = get_gh_command();
+    cmd.args(["pr", "close", &pr_number.to_string()])
+        .current_dir(&validated_path);
+    let output = run_net(cmd, "gh pr close").await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -196,4 +209,32 @@ pub async fn close_pull_request(project_path: String, pr_number: i32) -> Result<
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// run_net must execute a network-facing command through the timeout path
+    /// (the fix: blocking `.output()` replaced so a hung remote can't freeze PR
+    /// commands). `git --version` is deterministic and needs no repo or remote.
+    #[tokio::test]
+    async fn run_net_executes_command_through_timeout() {
+        let mut cmd = create_command("git");
+        cmd.args(["--version"]);
+        let out = run_net(cmd, "git --version")
+            .await
+            .expect("git --version should run within the timeout");
+        assert!(out.status.success());
+        assert!(String::from_utf8_lossy(&out.stdout).contains("git version"));
+    }
+
+    /// is_conflict_stderr gates the MergeConflict error path; keep its phrase
+    /// matching honest so unrelated failures don't masquerade as conflicts.
+    #[test]
+    fn is_conflict_stderr_matches_only_conflict_phrases() {
+        assert!(is_conflict_stderr("Pull request is not mergeable"));
+        assert!(is_conflict_stderr("merge commit cannot be cleanly created"));
+        assert!(!is_conflict_stderr("could not find pull request"));
+    }
 }

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -91,21 +91,41 @@ fn empty_body() -> ProxyBody {
         .boxed()
 }
 
-/// Remove the `frame-ancestors` directive from a CSP header value so the page
-/// can render inside the preview iframe. Returns the value untouched when no
-/// directive matched, and `None` when nothing remains (drop the header).
-fn strip_frame_ancestors(value: &hyper::header::HeaderValue) -> Option<hyper::header::HeaderValue> {
+/// Sanitize a CSP header value for the HTTP preview iframe. Removes two
+/// directives that are incompatible with serving the previewed app over plain
+/// HTTP inside an iframe:
+/// - `frame-ancestors` — so the page can be framed inside the preview at all.
+/// - `upgrade-insecure-requests` — the preview is served over `http://localhost`,
+///   but this directive makes the browser rewrite every subresource request to
+///   `https://`. WebKit (which the preview's WKWebView and Safari use) honors it
+///   even on localhost, so CSS/images 404 over https and the page renders blank
+///   or unstyled; Chromium exempts localhost, so the bug only shows in the
+///   WebKit preview. Stripping it only affects the local preview, never the
+///   user's deployed site.
+///
+/// Returns the value untouched when neither directive is present, and `None`
+/// when nothing remains (drop the header).
+fn sanitize_csp_for_preview(
+    value: &hyper::header::HeaderValue,
+) -> Option<hyper::header::HeaderValue> {
     let Ok(s) = value.to_str() else {
         // Unparseable CSP — drop it rather than risk it blanking the iframe.
         return None;
     };
-    if !s.to_ascii_lowercase().contains("frame-ancestors") {
+    let lower = s.to_ascii_lowercase();
+    if !lower.contains("frame-ancestors") && !lower.contains("upgrade-insecure-requests") {
         return Some(value.clone());
     }
     let kept: Vec<&str> = s
         .split(';')
         .map(str::trim)
-        .filter(|d| !d.is_empty() && !d.to_ascii_lowercase().starts_with("frame-ancestors"))
+        .filter(|d| {
+            if d.is_empty() {
+                return false;
+            }
+            let dl = d.to_ascii_lowercase();
+            !dl.starts_with("frame-ancestors") && dl != "upgrade-insecure-requests"
+        })
         .collect();
     if kept.is_empty() {
         return None;
@@ -366,7 +386,7 @@ async fn proxy_http_request(
                 continue;
             }
             if key == hyper::header::CONTENT_SECURITY_POLICY {
-                if let Some(v) = strip_frame_ancestors(value) {
+                if let Some(v) = sanitize_csp_for_preview(value) {
                     response = response.header(key, v);
                 }
                 continue;
@@ -386,7 +406,7 @@ async fn proxy_http_request(
                 continue;
             }
             if key == hyper::header::CONTENT_SECURITY_POLICY {
-                if let Some(v) = strip_frame_ancestors(value) {
+                if let Some(v) = sanitize_csp_for_preview(value) {
                     response = response.header(key, v);
                 }
                 continue;
@@ -547,20 +567,20 @@ async fn handle_websocket_upgrade(
 
 #[cfg(test)]
 mod tests {
-    use super::strip_frame_ancestors;
+    use super::sanitize_csp_for_preview;
     use hyper::header::HeaderValue;
 
     #[test]
-    fn csp_without_frame_ancestors_passes_through() {
+    fn csp_without_stripped_directives_passes_through() {
         let v = HeaderValue::from_static("default-src 'self'; img-src *");
-        assert_eq!(strip_frame_ancestors(&v).unwrap(), v);
+        assert_eq!(sanitize_csp_for_preview(&v).unwrap(), v);
     }
 
     #[test]
     fn frame_ancestors_directive_is_removed() {
         let v = HeaderValue::from_static("default-src 'self'; frame-ancestors 'none'; img-src *");
         assert_eq!(
-            strip_frame_ancestors(&v).unwrap(),
+            sanitize_csp_for_preview(&v).unwrap(),
             HeaderValue::from_static("default-src 'self'; img-src *")
         );
     }
@@ -568,12 +588,43 @@ mod tests {
     #[test]
     fn csp_that_is_only_frame_ancestors_is_dropped() {
         let v = HeaderValue::from_static("frame-ancestors 'none'");
-        assert!(strip_frame_ancestors(&v).is_none());
+        assert!(sanitize_csp_for_preview(&v).is_none());
     }
 
     #[test]
     fn frame_ancestors_match_is_case_insensitive() {
         let v = HeaderValue::from_static("Frame-Ancestors https://admin.shopify.com");
-        assert!(strip_frame_ancestors(&v).is_none());
+        assert!(sanitize_csp_for_preview(&v).is_none());
+    }
+
+    #[test]
+    fn upgrade_insecure_requests_directive_is_removed() {
+        // The preview is served over http://localhost; this directive makes WebKit
+        // rewrite subresources to https and blank them. It must be stripped while
+        // the rest of the policy is preserved.
+        let v = HeaderValue::from_static(
+            "default-src 'self'; img-src 'self'; upgrade-insecure-requests",
+        );
+        assert_eq!(
+            sanitize_csp_for_preview(&v).unwrap(),
+            HeaderValue::from_static("default-src 'self'; img-src 'self'")
+        );
+    }
+
+    #[test]
+    fn upgrade_insecure_requests_match_is_case_insensitive() {
+        let v = HeaderValue::from_static("Upgrade-Insecure-Requests");
+        assert!(sanitize_csp_for_preview(&v).is_none());
+    }
+
+    #[test]
+    fn frame_ancestors_and_upgrade_insecure_requests_removed_together() {
+        let v = HeaderValue::from_static(
+            "default-src 'self'; frame-ancestors 'none'; upgrade-insecure-requests; img-src *",
+        );
+        assert_eq!(
+            sanitize_csp_for_preview(&v).unwrap(),
+            HeaderValue::from_static("default-src 'self'; img-src *")
+        );
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -312,20 +312,19 @@ pub fn reserve_port_force(window_label: &str, project_path: &str, port: u16) -> 
         return false;
     };
     // Evict any stale holder of this exact port — serve-sim owns it now.
-    let stale: Vec<(String, String)> = ports
-        .iter()
-        .filter(|(_, &p)| p == port)
-        .map(|(k, _)| k.clone())
-        .collect();
-    for key in stale {
-        ports.remove(&key);
-        tracing::warn!(
-            "reserve_port_force: evicted stale reservation of port {} from ({}, {})",
-            port,
-            key.0,
-            key.1
-        );
-    }
+    ports.retain(|key, &mut p| {
+        if p == port {
+            tracing::warn!(
+                "reserve_port_force: evicted stale reservation of port {} from ({}, {})",
+                port,
+                key.0,
+                key.1
+            );
+            false
+        } else {
+            true
+        }
+    });
     port_set.insert(port);
     ports.insert((window_label.to_string(), project_path.to_string()), port);
     tracing::info!(

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -576,10 +576,6 @@ pub struct SpawnPtyOptions {
     pub cwd: String,
     pub command: String,
     pub args: Vec<String>,
-    #[allow(dead_code)]
-    pub rows: u32,
-    #[allow(dead_code)]
-    pub cols: u32,
 }
 
 // ============ Code Health ============


### PR DESCRIPTION
Split out of #93 per @julian-galluzzo's review (refactor sub-PR 1 of 5: backend-hardening).

Behavior-preserving backend cleanups from the loop-N passes:
- `#[tracing::instrument]` on the PTY / pty-session commands.
- `run_with_timeout` around network git/gh ops (`ai.rs`, `publishing.rs`, `pull_requests.rs`).
- `HashMap::retain` for stale-port eviction in `reserve_port_force`.
- Drop unused `rows`/`cols` from `SpawnPtyOptions`.
- Rename `strip_frame_ancestors` -> `sanitize_csp_for_preview` (also strips `upgrade-insecure-requests`).

Rust-only, based on `main`, file-disjoint from the other refactor sub-PRs. No agent-harness scaffolding.

Verified: `pnpm check:all`, `pnpm test:run`, `cargo test`, `pnpm tauri build`.
