### PR TITLE
Test backfill: lib utils, command palette, conflict/stitch parsers

### DIFF
--- a/src-tauri/src/commands/conflicts.rs
+++ b/src-tauri/src/commands/conflicts.rs
@@ -338,3 +338,79 @@ pub async fn complete_merge(project_path: String) -> Result<(), CommandError> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(content: &str) -> (Vec<ConflictBlock>, String, String) {
+        let all_lines: Vec<&str> = content.lines().collect();
+        parse_conflicts(content, &all_lines)
+    }
+
+    #[test]
+    fn no_markers_yields_no_conflicts() {
+        let (conflicts, ours, theirs) = parse("line one\nline two\nline three");
+        assert!(conflicts.is_empty());
+        assert_eq!(ours, "");
+        assert_eq!(theirs, "");
+    }
+
+    #[test]
+    fn single_conflict_extracts_branches_and_content() {
+        let content =
+            "a\nb\nc\n<<<<<<< HEAD\nours line\n=======\ntheirs line\n>>>>>>> feature\nd\ne";
+        let (conflicts, ours, theirs) = parse(content);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(ours, "HEAD");
+        assert_eq!(theirs, "feature");
+
+        let block = &conflicts[0];
+        assert_eq!(block.current_content, "ours line");
+        assert_eq!(block.incoming_content, "theirs line");
+        // Marker line is the 4th line (1-based).
+        assert_eq!(block.line_start, 4);
+        // Context excludes the conflict markers themselves.
+        assert!(block.context_before.contains('a'));
+        assert!(!block.context_before.contains("<<<<<<<"));
+        assert!(block.context_after.contains('d'));
+        assert!(!block.context_after.contains(">>>>>>>"));
+    }
+
+    #[test]
+    fn empty_marker_labels_fall_back_to_defaults() {
+        let content = "<<<<<<<\nfoo\n=======\nbar\n>>>>>>>";
+        let (conflicts, ours, theirs) = parse(content);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(ours, "current");
+        assert_eq!(theirs, "incoming");
+        assert_eq!(conflicts[0].current_content, "foo");
+        assert_eq!(conflicts[0].incoming_content, "bar");
+    }
+
+    #[test]
+    fn multiple_conflicts_are_all_parsed_with_first_branch_names() {
+        let content = "x\n<<<<<<< HEAD\na1\n=======\nb1\n>>>>>>> feat\ny\n\
+                       <<<<<<< HEAD\na2\n=======\nb2\n>>>>>>> feat\nz";
+        let (conflicts, ours, theirs) = parse(content);
+
+        assert_eq!(conflicts.len(), 2);
+        assert_eq!(ours, "HEAD");
+        assert_eq!(theirs, "feat");
+        assert_eq!(conflicts[0].current_content, "a1");
+        assert_eq!(conflicts[0].incoming_content, "b1");
+        assert_eq!(conflicts[1].current_content, "a2");
+        assert_eq!(conflicts[1].incoming_content, "b2");
+    }
+
+    #[test]
+    fn multiline_conflict_sides_join_with_newlines() {
+        let content = "<<<<<<< HEAD\nl1\nl2\n=======\nr1\nr2\nr3\n>>>>>>> other";
+        let (conflicts, _ours, _theirs) = parse(content);
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].current_content, "l1\nl2");
+        assert_eq!(conflicts[0].incoming_content, "r1\nr2\nr3");
+    }
+}

--- a/src-tauri/src/commands/ide/screenshots/stitch.rs
+++ b/src-tauri/src/commands/ide/screenshots/stitch.rs
@@ -175,3 +175,51 @@ pub async fn stitch_screenshots(
 
     Ok(output_path_str)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::Rgba;
+
+    fn solid(w: u32, h: u32, rgba: [u8; 4]) -> DynamicImage {
+        DynamicImage::ImageRgba8(RgbaImage::from_pixel(w, h, Rgba(rgba)))
+    }
+
+    #[test]
+    fn different_dimensions_are_not_similar() {
+        let a = solid(100, 100, [0, 0, 0, 255]);
+        let b = solid(100, 50, [0, 0, 0, 255]);
+        assert!(!images_are_similar(&a, &b, 0));
+    }
+
+    #[test]
+    fn identical_images_are_similar() {
+        let a = solid(120, 120, [10, 20, 30, 255]);
+        let b = solid(120, 120, [10, 20, 30, 255]);
+        assert!(images_are_similar(&a, &b, 0));
+    }
+
+    #[test]
+    fn within_compression_tolerance_is_similar() {
+        // Each channel differs by 5 (< 10 threshold) -> still counts as matching.
+        let a = solid(120, 120, [100, 100, 100, 255]);
+        let b = solid(120, 120, [105, 105, 105, 255]);
+        assert!(images_are_similar(&a, &b, 0));
+    }
+
+    #[test]
+    fn beyond_tolerance_is_not_similar() {
+        // Solid black vs solid white -> no sampled pixel matches.
+        let a = solid(120, 120, [0, 0, 0, 255]);
+        let b = solid(120, 120, [255, 255, 255, 255]);
+        assert!(!images_are_similar(&a, &b, 0));
+    }
+
+    #[test]
+    fn skip_header_still_samples_bottom_region() {
+        // With a sticky-header skip, the comparison still runs over the bottom content region.
+        let a = solid(120, 120, [50, 60, 70, 255]);
+        let b = solid(120, 120, [50, 60, 70, 255]);
+        assert!(images_are_similar(&a, &b, 40));
+    }
+}

--- a/src/commands/frecency.test.ts
+++ b/src/commands/frecency.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { recordRun, frecencyBoost, _reset } from './frecency';
+
+describe('frecency', () => {
+  beforeEach(() => {
+    _reset();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns 0 for a command that was never run', () => {
+    expect(frecencyBoost('never.used')).toBe(0);
+  });
+
+  it('boosts a just-run command by its count (no recency penalty)', () => {
+    recordRun('cmd.a');
+    // days since last use ≈ 0 -> count / (1 + 0) === 1.
+    expect(frecencyBoost('cmd.a')).toBe(1);
+  });
+
+  it('increments the count on repeated runs', () => {
+    recordRun('cmd.a');
+    recordRun('cmd.a');
+    recordRun('cmd.a');
+    expect(frecencyBoost('cmd.a')).toBe(3);
+  });
+
+  it('decays the score as days pass since last use', () => {
+    recordRun('cmd.a'); // count 1, lastUsed = now
+    // Advance one full day -> count / (1 + 1) === 0.5.
+    vi.setSystemTime(new Date('2026-01-02T00:00:00Z'));
+    expect(frecencyBoost('cmd.a')).toBe(0.5);
+  });
+
+  it('_reset clears all recorded frecency', () => {
+    recordRun('cmd.a');
+    expect(frecencyBoost('cmd.a')).toBeGreaterThan(0);
+    _reset();
+    expect(frecencyBoost('cmd.a')).toBe(0);
+  });
+
+  it('falls back to an empty map when stored data is corrupt', async () => {
+    // The module caches in memory, so a fresh import is needed to exercise the
+    // JSON.parse failure path on first load.
+    vi.resetModules();
+    localStorage.setItem('ship-studio-palette-frecency', '{ not valid json');
+    const fresh = await import('./frecency');
+    expect(fresh.frecencyBoost('anything')).toBe(0);
+    localStorage.removeItem('ship-studio-palette-frecency');
+  });
+});

--- a/src/commands/registry.test.ts
+++ b/src/commands/registry.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Command } from './types';
+import { setBucket, getSnapshot, subscribe, _reset } from './registry';
+
+const cmd = (id: string): Command => ({
+  id,
+  title: id,
+  category: 'action',
+  run: () => undefined,
+});
+
+describe('command registry', () => {
+  beforeEach(() => {
+    _reset();
+  });
+
+  it('merges commands from multiple buckets into the snapshot', () => {
+    setBucket('a', [cmd('a.one')]);
+    setBucket('b', [cmd('b.one'), cmd('b.two')]);
+    expect(
+      getSnapshot()
+        .map((c) => c.id)
+        .sort()
+    ).toEqual(['a.one', 'b.one', 'b.two']);
+  });
+
+  it('clears a bucket when set to an empty array', () => {
+    setBucket('a', [cmd('a.one')]);
+    setBucket('b', [cmd('b.one')]);
+    setBucket('a', []);
+    expect(getSnapshot().map((c) => c.id)).toEqual(['b.one']);
+  });
+
+  it('is a no-op (no new snapshot) when clearing an absent bucket', () => {
+    setBucket('a', [cmd('a.one')]);
+    const before = getSnapshot();
+    setBucket('ghost', []);
+    expect(getSnapshot()).toBe(before);
+  });
+
+  it('keeps a stable snapshot reference until the next mutation', () => {
+    setBucket('a', [cmd('a.one')]);
+    const snap = getSnapshot();
+    expect(getSnapshot()).toBe(snap);
+    setBucket('b', [cmd('b.one')]);
+    expect(getSnapshot()).not.toBe(snap);
+  });
+
+  it('notifies subscribers on change and stops after unsubscribe', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribe(listener);
+    setBucket('a', [cmd('a.one')]);
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsubscribe();
+    setBucket('b', [cmd('b.one')]);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/commands/score.test.ts
+++ b/src/commands/score.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { scoreMatch } from './score';
+
+describe('scoreMatch', () => {
+  it('returns the neutral 0.5 for an empty or whitespace query', () => {
+    expect(scoreMatch('', 'home')).toBe(0.5);
+    expect(scoreMatch('   ', 'home')).toBe(0.5);
+  });
+
+  it('scores an exact title match as 1.0', () => {
+    expect(scoreMatch('home', 'home')).toBe(1);
+    expect(scoreMatch('HOME', 'Home')).toBe(1); // case-insensitive
+  });
+
+  it('scores a prefix match as 0.95', () => {
+    expect(scoreMatch('hom', 'home')).toBe(0.95);
+  });
+
+  it('scores a word-boundary match as 0.85', () => {
+    expect(scoreMatch('serv', 'Restart dev server')).toBe(0.85);
+  });
+
+  it('scores an initials / acronym match as 0.75', () => {
+    expect(scoreMatch('rds', 'Restart Dev Server')).toBe(0.75);
+  });
+
+  it('requires at least 2 chars for the initials path', () => {
+    // Single-char query never reaches the initials branch; "d" matches the
+    // "Dev" word boundary instead of the "rds" acronym.
+    expect(scoreMatch('d', 'Restart Dev Server')).toBe(0.85);
+  });
+
+  it('scores a bare substring hit as 0.6', () => {
+    expect(scoreMatch('est', 'test')).toBe(0.6);
+  });
+
+  it('caps keyword-only matches at 0.5 so the title always wins', () => {
+    // No hit on the title, but the keyword prefixes -> would be 0.95, capped.
+    expect(scoreMatch('foo', 'Unrelated title', ['foobar'])).toBe(0.5);
+    // Even an exact keyword match is capped.
+    expect(scoreMatch('deploy', 'Unrelated title', ['deploy'])).toBe(0.5);
+  });
+
+  it('returns 0 when nothing matches', () => {
+    expect(scoreMatch('zzz', 'home')).toBe(0);
+    expect(scoreMatch('zzz', 'home', ['nope', 'never'])).toBe(0);
+  });
+});

--- a/src/lib/ansi.test.ts
+++ b/src/lib/ansi.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { stripAnsi } from './ansi';
+
+describe('stripAnsi', () => {
+  it('removes SGR color codes', () => {
+    expect(stripAnsi('\x1b[32mfoo\x1b[0m')).toBe('foo');
+  });
+
+  it('removes cursor-move / erase CSI sequences', () => {
+    expect(stripAnsi('a\x1b[2Kb')).toBe('ab');
+  });
+
+  it('removes BEL-terminated OSC window-title sequences', () => {
+    expect(stripAnsi('\x1b]0;my title\x07rest')).toBe('rest');
+  });
+
+  it('removes interleaved CSI and OSC families', () => {
+    expect(stripAnsi('\x1b[31mred\x1b[0m \x1b]0;title\x07plain')).toBe('red plain');
+  });
+
+  it('passes a plain string through unchanged', () => {
+    expect(stripAnsi('hello world')).toBe('hello world');
+  });
+});

--- a/src/lib/color.test.ts
+++ b/src/lib/color.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { toHex, visibleHex, toRgba, rgbaToCss, toCss, toFormat } from './color';
+
+describe('toHex', () => {
+  it('normalizes named / rgb colors to 6-digit hex', () => {
+    expect(toHex('#ff0000')).toBe('#ff0000');
+    expect(toHex('red')).toBe('#ff0000');
+    expect(toHex('rgb(0, 255, 0)')).toBe('#00ff00');
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(toHex('var(--brand)')).toBeNull();
+  });
+});
+
+describe('visibleHex', () => {
+  it('returns hex for an opaque color', () => {
+    expect(visibleHex('#3366ff')).toBe('#3366ff');
+  });
+
+  it('returns null for fully transparent or unparseable colors', () => {
+    expect(visibleHex('transparent')).toBeNull();
+    expect(visibleHex('rgba(0, 0, 0, 0)')).toBeNull();
+    expect(visibleHex('var(--x)')).toBeNull();
+  });
+});
+
+describe('toRgba', () => {
+  it('converts a hex color to clamped 0-255 channels', () => {
+    expect(toRgba('#ff0000')).toEqual({ r: 255, g: 0, b: 0, a: 1 });
+  });
+
+  it('preserves alpha from an rgba color', () => {
+    expect(toRgba('rgba(0, 128, 255, 0.5)')).toEqual({ r: 0, g: 128, b: 255, a: 0.5 });
+  });
+
+  it('falls back to opaque black for unparseable input', () => {
+    expect(toRgba('not-a-color')).toEqual({ r: 0, g: 0, b: 0, a: 1 });
+  });
+});
+
+describe('rgbaToCss', () => {
+  it('emits rgb() when fully opaque', () => {
+    expect(rgbaToCss({ r: 1, g: 2, b: 3, a: 1 })).toBe('rgb(1, 2, 3)');
+  });
+
+  it('emits rgba() with 3dp-rounded alpha when translucent', () => {
+    expect(rgbaToCss({ r: 1, g: 2, b: 3, a: 0.5 })).toBe('rgba(1, 2, 3, 0.5)');
+    expect(rgbaToCss({ r: 1, g: 2, b: 3, a: 0.123456 })).toBe('rgba(1, 2, 3, 0.123)');
+  });
+});
+
+describe('toCss', () => {
+  it('round-trips a parseable color to a canonical rgb()/rgba() string', () => {
+    expect(toCss('#ff0000')).toBe('rgb(255, 0, 0)');
+    expect(toCss('rgba(255, 0, 0, 0.5)')).toBe('rgba(255, 0, 0, 0.5)');
+  });
+
+  it('returns null when the color cannot be parsed', () => {
+    expect(toCss('var(--x)')).toBeNull();
+  });
+});
+
+describe('toFormat', () => {
+  it('returns the input unchanged when unparseable (partial typing is preserved)', () => {
+    expect(toFormat('var(--brand', 'hex')).toBe('var(--brand');
+  });
+
+  it('uses 8-digit hex only when alpha < 1', () => {
+    expect(toFormat('#ff0000', 'hex')).toBe('#ff0000');
+    expect(toFormat('rgba(255, 0, 0, 0.5)', 'hex')).toMatch(/^#ff0000[0-9a-f]{2}$/);
+  });
+
+  it('dispatches to the requested format family', () => {
+    expect(toFormat('#ff0000', 'rgb')).toBe('rgb(255, 0, 0)');
+    expect(toFormat('#ff0000', 'hsl')).toMatch(/^hsl\(/);
+    expect(toFormat('#ff0000', 'oklch')).toMatch(/^oklch\([\d.]+ [\d.]+ [\d.]+\)$/);
+  });
+
+  it('appends rounded alpha in oklch when translucent', () => {
+    expect(toFormat('rgba(255, 0, 0, 0.5)', 'oklch')).toContain(' / 0.5)');
+  });
+});

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import {
+  asCommandError,
+  formatCommandError,
+  isMergeConflictError,
+  type CommandError,
+} from './errors';
+
+describe('asCommandError', () => {
+  it('passes through an already-tagged CommandError', () => {
+    const err: CommandError = { type: 'Timeout', cmd: 'git', secs: 5 };
+    expect(asCommandError(err)).toBe(err);
+  });
+
+  it('wraps a plain string as Other', () => {
+    expect(asCommandError('boom')).toEqual({ type: 'Other', message: 'boom' });
+  });
+
+  it('wraps an Error instance using its message', () => {
+    expect(asCommandError(new Error('kaboom'))).toEqual({ type: 'Other', message: 'kaboom' });
+  });
+
+  it('coerces an arbitrary unknown via String()', () => {
+    expect(asCommandError(42)).toEqual({ type: 'Other', message: '42' });
+    expect(asCommandError(null)).toEqual({ type: 'Other', message: 'null' });
+  });
+});
+
+describe('formatCommandError', () => {
+  it('renders every variant to a user-facing string', () => {
+    expect(formatCommandError({ type: 'Timeout', cmd: 'git', secs: 5 })).toBe(
+      '`git` timed out after 5s'
+    );
+    expect(formatCommandError({ type: 'Process', cmd: 'git', exit_code: 1, stderr: 'bad' })).toBe(
+      '`git` exited with status 1: bad'
+    );
+    expect(formatCommandError({ type: 'Validation', field: 'path', reason: 'empty' })).toBe(
+      'Validation failed for `path`: empty'
+    );
+    expect(formatCommandError({ type: 'NotAuthenticated', service: 'GitHub' })).toBe(
+      'Not authenticated with GitHub'
+    );
+    expect(formatCommandError({ type: 'Io', message: 'disk full' })).toBe('I/O error: disk full');
+    expect(formatCommandError({ type: 'MergeConflict', pr_number: 7, stderr: 'conflict' })).toBe(
+      "Pull request #7 can't be merged cleanly: conflict"
+    );
+    expect(formatCommandError({ type: 'Other', message: 'just a message' })).toBe('just a message');
+  });
+});
+
+describe('isMergeConflictError', () => {
+  it('is true only for the MergeConflict variant', () => {
+    expect(isMergeConflictError({ type: 'MergeConflict', pr_number: 1, stderr: '' })).toBe(true);
+    expect(isMergeConflictError({ type: 'Timeout', cmd: 'git', secs: 1 })).toBe(false);
+    expect(isMergeConflictError('plain string error')).toBe(false);
+  });
+});

--- a/src/lib/projectIdentity.test.ts
+++ b/src/lib/projectIdentity.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { getProjectId } from './projectIdentity';
+
+describe('getProjectId', () => {
+  it('is deterministic for the same path', () => {
+    expect(getProjectId('/Users/me/ShipStudio/acme')).toBe(
+      getProjectId('/Users/me/ShipStudio/acme')
+    );
+  });
+
+  it('always returns exactly 8 lowercase hex chars', () => {
+    expect(getProjectId('/a/b/c')).toMatch(/^[0-9a-f]{8}$/);
+    expect(getProjectId('/some/other/path')).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('produces the FNV-1a offset basis for the empty string', () => {
+    // No bytes mixed in -> hash stays at the 2166136261 offset basis (0x811c9dc5).
+    expect(getProjectId('')).toBe('811c9dc5');
+  });
+
+  it('maps distinct paths to distinct ids', () => {
+    expect(getProjectId('/project/a')).not.toBe(getProjectId('/project/b'));
+  });
+});

--- a/src/lib/static-server.test.ts
+++ b/src/lib/static-server.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { isMobileProjectType } from './static-server';
+
+describe('isMobileProjectType', () => {
+  it('is true for native mobile project types', () => {
+    expect(isMobileProjectType('reactnative')).toBe(true);
+    expect(isMobileProjectType('flutter')).toBe(true);
+  });
+
+  it('is false for web and unknown project types', () => {
+    expect(isMobileProjectType('vite')).toBe(false);
+    expect(isMobileProjectType('nextjs')).toBe(false);
+    expect(isMobileProjectType('statichtml')).toBe(false);
+    expect(isMobileProjectType('unknown')).toBe(false);
+  });
+});


### PR DESCRIPTION
Split out of #93 per @julian-galluzzo's review (refactor sub-PR 2 of 5: test-backfill).

Pure test additions, no source changes:
- Frontend unit tests: `ansi`, `errors`, `projectIdentity`, `static-server`, `color`, and the command-palette `frecency` / `registry` / `scorer`.
- Rust `#[cfg(test)]` modules: `parse_conflicts` and `images_are_similar`.

Based on `main`, file-disjoint from the other refactor sub-PRs. No agent-harness scaffolding.

Verified: `pnpm check:all`, `pnpm test:run`, `cargo test`, `pnpm tauri build`.
