### PR TITLE
Route raw invoke() calls through typed lib wrappers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,7 @@ import { WorkspaceView } from './components/workspace/WorkspaceView';
 import { WorkspaceSidebar } from './components/workspace/WorkspaceSidebar';
 import { useProjectRail } from './hooks/useProjectRail';
 import { OnboardingScreen } from './components/setup';
-import { Project } from './lib/project';
+import { Project, setTerminalState } from './lib/project';
 import { markSetupComplete, getDefaultAgentId as fetchDefaultAgentId } from './lib/setup';
 import { initDefaultAgent } from './lib/agent';
 import { sessionRegistry } from './lib/sessionRegistry';
@@ -552,16 +552,13 @@ function AppContents({ initialProjectPath }: AppProps) {
         const idx = snap?.terminalTabs.findIndex((t) => t.sessionId === tabSessionId) ?? -1;
         if (snap && idx >= 0) {
           try {
-            await invoke('set_terminal_state', {
-              projectPath,
-              state: {
-                tabs: snap.terminalTabs.map((t) => ({
-                  agent_id: t.agentId,
-                  session_id: t.sessionId,
-                  custom_title: t.customTitle,
-                })),
-                active_tab_index: idx,
-              },
+            await setTerminalState(projectPath, {
+              tabs: snap.terminalTabs.map((t) => ({
+                agent_id: t.agentId,
+                session_id: t.sessionId,
+                custom_title: t.customTitle,
+              })),
+              active_tab_index: idx,
             });
           } catch (err) {
             logger.warn('[SelectProjectTab] Failed to persist active tab', {

--- a/src/components/preview/ScreenshotPreview.tsx
+++ b/src/components/preview/ScreenshotPreview.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { invoke } from '@tauri-apps/api/core';
+import { getScreenshotBase64 } from '../../lib/ide';
 import { CameraIcon, CloseIcon } from '../icons';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { logger } from '../../lib/logger';
@@ -36,7 +36,7 @@ export function ScreenshotToast({ filePath, onDismiss, onViewFull }: ScreenshotT
 
   // Load image as base64 on mount
   useEffect(() => {
-    invoke<string>('get_screenshot_base64', { filePath })
+    getScreenshotBase64(filePath)
       .then(setImageSrc)
       .catch((err) =>
         logger.error('Failed to load screenshot', {
@@ -113,7 +113,7 @@ export function ScreenshotPreviewModal({ filePath, onClose }: ScreenshotPreviewM
 
   // Load image as base64 on mount
   useEffect(() => {
-    invoke<string>('get_screenshot_base64', { filePath })
+    getScreenshotBase64(filePath)
       .then(setImageSrc)
       .catch((err) =>
         logger.error('Failed to load screenshot', {

--- a/src/components/setup/OnboardingTerminal.tsx
+++ b/src/components/setup/OnboardingTerminal.tsx
@@ -13,7 +13,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { spawn, IPty } from 'tauri-pty';
 import { homeDir } from '@tauri-apps/api/path';
-import { invoke } from '@tauri-apps/api/core';
+import { getSystemEnv } from '../../lib/project';
 import { readDir, exists } from '@tauri-apps/plugin-fs';
 import { loadNerdFonts } from '../../lib/fonts';
 import { isWindows } from '../../lib/setup';
@@ -162,7 +162,7 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
 
         if (isWin) {
           // Windows: get system env vars from backend and build Windows-compatible env
-          const systemEnv = await invoke<Record<string, string>>('get_system_env');
+          const systemEnv = await getSystemEnv();
 
           // Add extra tool installation paths to the front of PATH
           const programFiles = systemEnv['ProgramFiles'] || 'C:\\Program Files';

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -41,6 +41,7 @@ interface SessionHandle {
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { homeDir } from '@tauri-apps/api/path';
+import { getShellPath, getSystemEnv } from '../../lib/project';
 import { loadNerdFonts } from '../../lib/fonts';
 import { isWindows } from '../../lib/setup';
 import { logger } from '../../lib/logger';
@@ -529,14 +530,14 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         const isWin = isWindows();
         const sep = isWin ? '\\' : '/';
         const homeNormalized = home.endsWith(sep) ? home : `${home}${sep}`;
-        const fullPath = await invoke<string>('get_shell_path');
+        const fullPath = await getShellPath();
 
         // Build platform-appropriate env vars
         // Must pass all essential env vars since env replaces (not merges with) parent environment
         let env: Record<string, string>;
         if (isWin) {
           // Windows: get system env vars from backend and merge with PATH
-          const systemEnv = await invoke<Record<string, string>>('get_system_env');
+          const systemEnv = await getSystemEnv();
           env = {
             ...systemEnv,
             PATH: fullPath,

--- a/src/lib/ide.ts
+++ b/src/lib/ide.ts
@@ -48,3 +48,12 @@ export async function openInIde(
 export async function openInFinder(path: string): Promise<void> {
   return invoke<void>('open_in_finder', { path });
 }
+
+/**
+ * Read a saved screenshot file back as a base64 data string for inline display.
+ * @param filePath - Absolute path to the screenshot file
+ * @returns Base64-encoded image data
+ */
+export async function getScreenshotBase64(filePath: string): Promise<string> {
+  return invoke<string>('get_screenshot_base64', { filePath });
+}

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -265,6 +265,25 @@ function parseDevScriptForNpx(script: string, desiredPort: number): string[] | n
 }
 
 /**
+ * Get the extended shell PATH from the backend (includes nvm, Homebrew, the
+ * Claude desktop app, etc.) so spawned processes resolve the same tools the
+ * user's login shell would.
+ */
+export async function getShellPath(): Promise<string> {
+  return invoke<string>('get_shell_path');
+}
+
+/**
+ * Get the backend process's system environment variables. Needed on Windows,
+ * where a spawned process's env replaces (rather than merges with) the parent
+ * environment, so essential vars (SystemRoot, COMSPEC, PATHEXT, ...) must be
+ * passed through explicitly.
+ */
+export async function getSystemEnv(): Promise<Record<string, string>> {
+  return invoke<Record<string, string>>('get_system_env');
+}
+
+/**
  * Start the development server for a project.
  * Intelligently handles different frameworks (Vite, Next.js, etc.)
  * by parsing the dev script and ensuring the correct port is used.
@@ -288,7 +307,7 @@ export async function startDevServer(
   // Get extended PATH from backend (includes nvm, Homebrew, etc.)
   const home = await homeDir();
   const homeNormalized = home.endsWith('/') ? home : `${home}/`;
-  const fullPath = await invoke<string>('get_shell_path');
+  const fullPath = await getShellPath();
 
   let command = 'npm';
   let args: string[] = ['run', 'dev', '--', '--port', port.toString()];
@@ -363,7 +382,7 @@ export async function startDevServer(
   // Must pass all essential env vars since env replaces (not merges with) parent environment.
   // On Windows, many system env vars (SystemRoot, COMSPEC, PATHEXT, TEMP, etc.) are required
   // for Node.js and cmd.exe to function, so we fetch them from the backend.
-  const systemEnv = await invoke<Record<string, string>>('get_system_env');
+  const systemEnv = await getSystemEnv();
   const env: Record<string, string> = isWindows()
     ? {
         ...systemEnv,


### PR DESCRIPTION
Split out of #93 per @julian-galluzzo's review (refactor sub-PR 3 of 5: lib-wrappers).

Behavior-preserving: routes raw `invoke(...)` calls through typed `lib/project` + `lib/ide` wrappers (`getShellPath`, `getSystemEnv`, `getScreenshotBase64`, `setTerminalState`) across `Terminal`, `OnboardingTerminal`, `ScreenshotPreview`, and `App`.

Based on `main`. Heads-up: touches `Terminal.tsx` (shared with the file-tree PR #100) and `OnboardingTerminal.tsx` (left on `main` by the onboarding PR #101) — coordinate merge order; trivial rebase whichever lands first. No agent-harness scaffolding.

Verified: `pnpm check:all`, `pnpm test:run`, `pnpm build`.
