### PR TITLE
Design-system: a11y tooltip sweep + ModalFrame/Button migrations

### DIFF
--- a/src/components/branches/GitHubButton.tsx
+++ b/src/components/branches/GitHubButton.tsx
@@ -17,6 +17,7 @@ import { GitHubState } from '../../hooks/useIntegrationStatus';
 import { ProjectGitHubStatus, pushToGitHub, getGitHubOrgs } from '../../lib/github';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { Button } from '../primitives/Button';
+import { ModalFrame } from '../primitives/ModalFrame';
 import { useOptionalToast } from '../../contexts/ToastContext';
 
 /** Props for the GitHubButton component */
@@ -59,6 +60,11 @@ export function GitHubButton({
   const createRepoTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { cliStatus, username } = githubState;
+
+  const closeCreateModal = () => {
+    setShowCreateModal(false);
+    onModalClose?.();
+  };
 
   // Clear fallback timeout on unmount
   useEffect(() => {
@@ -166,142 +172,130 @@ export function GitHubButton({
       </button>
 
       {/* Create Repo Modal */}
-      {showCreateModal && (
-        <div
-          className="modal-overlay"
-          onClick={() => {
-            setShowCreateModal(false);
-            onModalClose?.();
-          }}
-        >
-          <div className="modal github-modal" onClick={(e) => e.stopPropagation()}>
-            <h3>Create GitHub Repository</h3>
-            <p>Create a new GitHub repository for this project.</p>
+      <ModalFrame
+        isOpen={showCreateModal}
+        onClose={closeCreateModal}
+        title="Create GitHub Repository"
+        className="github-modal"
+        dismissable={!isLoading}
+      >
+        <p>Create a new GitHub repository for this project.</p>
 
-            <div className="github-form">
-              <label>
-                Owner
-                <select
-                  className="owner-select"
-                  value={selectedOwner || username || ''}
-                  onChange={(e) => setSelectedOwner(e.target.value)}
-                >
-                  {username && <option value={username}>{username}</option>}
-                  {orgs.map((org) => (
-                    <option key={org} value={org}>
-                      {org}
-                    </option>
-                  ))}
-                </select>
-              </label>
+        <div className="github-form">
+          <label>
+            Owner
+            <select
+              className="owner-select"
+              value={selectedOwner || username || ''}
+              onChange={(e) => setSelectedOwner(e.target.value)}
+            >
+              {username && <option value={username}>{username}</option>}
+              {orgs.map((org) => (
+                <option key={org} value={org}>
+                  {org}
+                </option>
+              ))}
+            </select>
+          </label>
 
-              <label>
-                Repository name
-                <div className="repo-name-input">
-                  <span className="repo-prefix">{selectedOwner || username}/</span>
-                  <input
-                    type="text"
-                    value={repoName}
-                    onChange={(e) => setRepoName(e.target.value.replace(/[^a-zA-Z0-9-_]/g, '-'))}
-                    placeholder="my-project"
-                    autoFocus
-                    autoComplete="off"
-                    autoCorrect="off"
-                    autoCapitalize="off"
-                    spellCheck={false}
-                  />
-                </div>
-              </label>
-
-              <label className="visibility-option">
-                <input
-                  type="radio"
-                  name="visibility"
-                  checked={isPrivate}
-                  onChange={() => setIsPrivate(true)}
-                />
-                <div>
-                  <strong>Private</strong>
-                  <span>Only you can see this repository</span>
-                </div>
-              </label>
-
-              <label className="visibility-option">
-                <input
-                  type="radio"
-                  name="visibility"
-                  checked={!isPrivate}
-                  onChange={() => setIsPrivate(false)}
-                />
-                <div>
-                  <strong>Public</strong>
-                  <span>Anyone can see this repository</span>
-                </div>
-              </label>
-
-              {error && <p className="github-error">{error}</p>}
+          <label>
+            Repository name
+            <div className="repo-name-input">
+              <span className="repo-prefix">{selectedOwner || username}/</span>
+              <input
+                type="text"
+                value={repoName}
+                onChange={(e) => setRepoName(e.target.value.replace(/[^a-zA-Z0-9-_]/g, '-'))}
+                placeholder="my-project"
+                autoFocus
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
+              />
             </div>
+          </label>
 
-            <div className="modal-actions">
-              <Button
-                variant="secondary"
-                onClick={() => {
-                  setShowCreateModal(false);
-                  onModalClose?.();
-                }}
-                disabled={isLoading}
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="primary"
-                onClick={() => {
-                  if (!repoName.trim()) return;
-
-                  const handleCreate = async () => {
-                    setIsLoading(true);
-                    setIsCreatingRepo(true);
-                    setError(null);
-                    try {
-                      const owner = selectedOwner || username;
-                      const fullRepoName = `${owner}/${repoName}`;
-                      await pushToGitHub({
-                        projectPath,
-                        repoName: fullRepoName,
-                        isPrivate,
-                      });
-
-                      // Close modal immediately after GitHub repo is created
-                      setShowCreateModal(false);
-                      setIsLoading(false);
-                      onModalClose?.();
-
-                      // Refresh status - this will clear isCreatingRepo when status updates
-                      await onStatusChange();
-                      onToast?.('Repository created!', 'success');
-
-                      // Fallback: clear isCreatingRepo after a delay if status doesn't update
-                      createRepoTimeoutRef.current = setTimeout(() => {
-                        setIsCreatingRepo(false);
-                      }, 3000);
-                    } catch (e) {
-                      setError(String(e));
-                      onToast?.('Failed to create repository', 'error');
-                      setIsLoading(false);
-                      setIsCreatingRepo(false);
-                    }
-                  };
-
-                  void handleCreate();
-                }}
-                disabled={isLoading || !repoName.trim()}
-              >
-                {isLoading ? 'Creating...' : 'Create Repository'}
-              </Button>
+          <label className="visibility-option">
+            <input
+              type="radio"
+              name="visibility"
+              checked={isPrivate}
+              onChange={() => setIsPrivate(true)}
+            />
+            <div>
+              <strong>Private</strong>
+              <span>Only you can see this repository</span>
             </div>
-          </div>
+          </label>
+
+          <label className="visibility-option">
+            <input
+              type="radio"
+              name="visibility"
+              checked={!isPrivate}
+              onChange={() => setIsPrivate(false)}
+            />
+            <div>
+              <strong>Public</strong>
+              <span>Anyone can see this repository</span>
+            </div>
+          </label>
+
+          {error && <p className="github-error">{error}</p>}
         </div>
-      )}
+
+        <div className="modal-actions">
+          <Button variant="secondary" onClick={closeCreateModal} disabled={isLoading}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => {
+              if (!repoName.trim()) return;
+
+              const handleCreate = async () => {
+                setIsLoading(true);
+                setIsCreatingRepo(true);
+                setError(null);
+                try {
+                  const owner = selectedOwner || username;
+                  const fullRepoName = `${owner}/${repoName}`;
+                  await pushToGitHub({
+                    projectPath,
+                    repoName: fullRepoName,
+                    isPrivate,
+                  });
+
+                  // Close modal immediately after GitHub repo is created
+                  setShowCreateModal(false);
+                  setIsLoading(false);
+                  onModalClose?.();
+
+                  // Refresh status - this will clear isCreatingRepo when status updates
+                  await onStatusChange();
+                  onToast?.('Repository created!', 'success');
+
+                  // Fallback: clear isCreatingRepo after a delay if status doesn't update
+                  createRepoTimeoutRef.current = setTimeout(() => {
+                    setIsCreatingRepo(false);
+                  }, 3000);
+                } catch (e) {
+                  setError(String(e));
+                  onToast?.('Failed to create repository', 'error');
+                  setIsLoading(false);
+                  setIsCreatingRepo(false);
+                }
+              };
+
+              void handleCreate();
+            }}
+            disabled={isLoading || !repoName.trim()}
+          >
+            {isLoading ? 'Creating...' : 'Create Repository'}
+          </Button>
+        </div>
+      </ModalFrame>
     </>
   );
 }

--- a/src/components/dashboard/AgentsPanel.tsx
+++ b/src/components/dashboard/AgentsPanel.tsx
@@ -322,6 +322,7 @@ export function AgentsPanel() {
                       type="button"
                       className="agents-panel-kebab"
                       onClick={() => setOpenMenuId(menuOpen ? null : agent.id)}
+                      title={`More actions for ${agent.displayName}`}
                       aria-label={`More actions for ${agent.displayName}`}
                       aria-haspopup="menu"
                       aria-expanded={menuOpen}

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -36,6 +36,7 @@ export function DashboardHeader({
         className="dashboard-search"
         data-education-id="search-projects"
         onClick={() => palette.open()}
+        title="Open command palette"
         aria-label="Open command palette"
       >
         <SearchIcon />

--- a/src/components/dashboard/ImportTypePicker.tsx
+++ b/src/components/dashboard/ImportTypePicker.tsx
@@ -8,7 +8,8 @@
  * @module components/ImportTypePicker
  */
 
-import { GitHubIcon, FolderIcon, CloseIcon } from '../icons';
+import { GitHubIcon, FolderIcon } from '../icons';
+import { ModalFrame } from '../primitives/ModalFrame';
 
 interface ImportTypePickerProps {
   /** Callback when user selects GitHub import */
@@ -25,37 +26,29 @@ export function ImportTypePicker({
   onClose,
 }: ImportTypePickerProps) {
   return (
-    <div className="create-modal-overlay" onClick={onClose}>
-      <div className="create-modal import-picker-modal" onClick={(e) => e.stopPropagation()}>
-        <div className="import-picker-header">
-          <h2>Import Project</h2>
-          <button className="import-picker-close" onClick={onClose}>
-            <CloseIcon size={18} />
-          </button>
-        </div>
-        <div className="import-picker-options">
-          <button className="import-picker-card" onClick={onSelectGitHub}>
-            <div className="import-picker-icon">
-              <GitHubIcon size={28} />
-            </div>
-            <div className="import-picker-text">
-              <span className="import-picker-title">GitHub Repository</span>
-              <span className="import-picker-subtitle">Clone from GitHub</span>
-            </div>
-          </button>
-          <button className="import-picker-card" onClick={onSelectLocalFolder}>
-            <div className="import-picker-icon">
-              <FolderIcon size={28} />
-            </div>
-            <div className="import-picker-text">
-              <span className="import-picker-title">Local Folder</span>
-              <span className="import-picker-subtitle">
-                Open an existing project from your computer
-              </span>
-            </div>
-          </button>
-        </div>
+    <ModalFrame isOpen onClose={onClose} title="Import Project" className="import-picker-modal">
+      <div className="import-picker-options">
+        <button className="import-picker-card" onClick={onSelectGitHub}>
+          <div className="import-picker-icon">
+            <GitHubIcon size={28} />
+          </div>
+          <div className="import-picker-text">
+            <span className="import-picker-title">GitHub Repository</span>
+            <span className="import-picker-subtitle">Clone from GitHub</span>
+          </div>
+        </button>
+        <button className="import-picker-card" onClick={onSelectLocalFolder}>
+          <div className="import-picker-icon">
+            <FolderIcon size={28} />
+          </div>
+          <div className="import-picker-text">
+            <span className="import-picker-title">Local Folder</span>
+            <span className="import-picker-subtitle">
+              Open an existing project from your computer
+            </span>
+          </div>
+        </button>
       </div>
-    </div>
+    </ModalFrame>
   );
 }

--- a/src/components/dashboard/ProjectRail.tsx
+++ b/src/components/dashboard/ProjectRail.tsx
@@ -26,6 +26,7 @@ import { useEffect, useRef, useState, useLayoutEffect, useCallback } from 'react
 import type { PinnedProjectRow } from '../../hooks/usePinnedProjects';
 import { getProjectThumbnail, listProjects } from '../../lib/project';
 import { logger } from '../../lib/logger';
+import { Button } from '../primitives/Button';
 
 interface ProjectRailProps {
   /** Joined pin + session rows from `usePinnedProjects`. */
@@ -433,8 +434,10 @@ export function ProjectRail({
           onClick={(e) => e.stopPropagation()}
           role="menu"
         >
-          <button
+          <Button
+            variant="ghost"
             className="project-rail-menu-item danger"
+            role="menuitem"
             onClick={() => {
               const path = contextMenu.projectPath;
               setContextMenu(null);
@@ -442,7 +445,7 @@ export function ProjectRail({
             }}
           >
             Unpin from sidebar
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/src/components/dashboard/TemplateGallery.tsx
+++ b/src/components/dashboard/TemplateGallery.tsx
@@ -165,7 +165,13 @@ export function TemplateGallery({
           spellCheck={false}
         />
         {searchQuery && (
-          <button type="button" className="tg-search-clear" onClick={() => onSearchChange('')}>
+          <button
+            type="button"
+            className="tg-search-clear"
+            title="Clear search"
+            aria-label="Clear search"
+            onClick={() => onSearchChange('')}
+          >
             <svg
               width="14"
               height="14"
@@ -186,6 +192,8 @@ export function TemplateGallery({
           <button
             type="button"
             className="tg-scroll-btn tg-scroll-left"
+            title="Scroll left"
+            aria-label="Scroll left"
             onClick={() => scroll('left')}
           >
             <svg
@@ -231,6 +239,8 @@ export function TemplateGallery({
           <button
             type="button"
             className="tg-scroll-btn tg-scroll-right"
+            title="Scroll right"
+            aria-label="Scroll right"
             onClick={() => scroll('right')}
           >
             <svg

--- a/src/components/edit/ColorControls.tsx
+++ b/src/components/edit/ColorControls.tsx
@@ -136,6 +136,7 @@ export function ColorField({
         ref={triggerRef}
         type="button"
         className="ss-color-swatch"
+        title={`${label} color`}
         aria-label={`${label} color`}
         aria-haspopup="dialog"
         aria-expanded={open}

--- a/src/components/edit/CustomCssBox.tsx
+++ b/src/components/edit/CustomCssBox.tsx
@@ -53,6 +53,7 @@ export function CustomCssBox({ currentClass, layer, onApplyEnum, onReset }: Prop
               <button
                 type="button"
                 className="ss-custom-css__chip-x"
+                title={`Remove ${p.prop}`}
                 aria-label={`Remove ${p.prop}`}
                 onClick={() => onReset({ match: (t) => t === p.token, cssProps: [p.prop] })}
               >

--- a/src/components/edit/EnumDropdown.tsx
+++ b/src/components/edit/EnumDropdown.tsx
@@ -75,6 +75,7 @@ export function EnumDropdown({ label, options, value, onChange }: Props) {
         ref={triggerRef}
         type="button"
         className="ss-enum__trigger"
+        title={label}
         aria-label={label}
         aria-haspopup="listbox"
         aria-expanded={open}

--- a/src/components/import-project/steps/Step1AccountSelection.tsx
+++ b/src/components/import-project/steps/Step1AccountSelection.tsx
@@ -30,7 +30,13 @@ export function Step1AccountSelection({
           <h2>Import Project</h2>
           <p>Select a GitHub account</p>
         </div>
-        <button className="create-modal-close" onClick={onCancel} type="button">
+        <button
+          className="create-modal-close"
+          onClick={onCancel}
+          type="button"
+          title="Close"
+          aria-label="Close"
+        >
           <svg
             width="20"
             height="20"

--- a/src/components/import-project/steps/Step2RepoSelection.tsx
+++ b/src/components/import-project/steps/Step2RepoSelection.tsx
@@ -51,7 +51,13 @@ export function Step2RepoSelection({
             )}
           </p>
         </div>
-        <button className="create-modal-close" onClick={onCancel} type="button">
+        <button
+          className="create-modal-close"
+          onClick={onCancel}
+          type="button"
+          title="Close"
+          aria-label="Close"
+        >
           <svg
             width="20"
             height="20"

--- a/src/components/plugins/PluginManager.tsx
+++ b/src/components/plugins/PluginManager.tsx
@@ -382,7 +382,7 @@ export function PluginManager({
       <div className="modal plugins-modal" onMouseDown={(e) => e.stopPropagation()}>
         <div className="plugins-modal-header">
           <h3>Plugins</h3>
-          <button className="plugins-close-btn" onClick={onClose}>
+          <button className="plugins-close-btn" onClick={onClose} title="Close" aria-label="Close">
             <CloseIcon size={16} />
           </button>
         </div>

--- a/src/components/preview/DeviceMirror.tsx
+++ b/src/components/preview/DeviceMirror.tsx
@@ -675,6 +675,7 @@ export function DeviceMirror({ projectName, projectPath, onSendToAgent }: Device
                 type="button"
                 className={`device-mirror-build-chevron${buildOpen ? ' open' : ''}`}
                 onClick={() => setBuildOpen((o) => !o)}
+                title={buildOpen ? 'Collapse build log' : 'Expand build log'}
                 aria-label={buildOpen ? 'Collapse build log' : 'Expand build log'}
               >
                 <ChevronIcon size={14} />

--- a/src/components/primitives/ModalFrame.tsx
+++ b/src/components/primitives/ModalFrame.tsx
@@ -70,6 +70,7 @@ export function ModalFrame({
                 type="button"
                 className="modal-frame-close"
                 onClick={onClose}
+                title="Close dialog"
                 aria-label="Close dialog"
               >
                 <svg

--- a/src/components/support/SupportPanel.tsx
+++ b/src/components/support/SupportPanel.tsx
@@ -86,12 +86,22 @@ export function SupportPanel({ isOpen, onClose, projectPath, projectName }: Supp
       <div className={`support-panel ${isOpen ? 'open' : ''}`}>
         <div className="support-panel-header">
           {showBack && (
-            <button className="support-back-btn" onClick={goBack}>
+            <button
+              className="support-back-btn"
+              onClick={goBack}
+              title="Go back"
+              aria-label="Go back"
+            >
               ←
             </button>
           )}
           <h2>{headerTitle}</h2>
-          <button className="support-close-btn" onClick={handleClose}>
+          <button
+            className="support-close-btn"
+            onClick={handleClose}
+            title="Close"
+            aria-label="Close"
+          >
             ×
           </button>
         </div>

--- a/src/components/workspace/CompactTopbar.tsx
+++ b/src/components/workspace/CompactTopbar.tsx
@@ -173,6 +173,7 @@ export function CompactTopbar({
           style={pinStyle}
           onClick={togglePin}
           aria-pressed={isPinned}
+          title={isPinned ? 'Unpin window' : 'Pin window on top'}
           aria-label={isPinned ? 'Unpin window' : 'Pin window on top'}
         >
           <PinIcon size={12} />
@@ -181,6 +182,7 @@ export function CompactTopbar({
           type="button"
           style={paletteBtnStyle}
           onClick={openAllPalette}
+          title="Open command palette"
           aria-label="Open command palette"
         >
           ⌘K
@@ -194,6 +196,7 @@ export function CompactTopbar({
             type="button"
             style={projectBtnStyle}
             onClick={openProjectPalette}
+            title={`Switch project (currently ${projectLabel})`}
             aria-label={`Switch project (currently ${projectLabel})`}
           >
             <span

--- a/src/components/workspace/WorkspaceSidebar.tsx
+++ b/src/components/workspace/WorkspaceSidebar.tsx
@@ -585,6 +585,7 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
         type="button"
         className="workspace-sidebar-filter"
         onClick={() => openPalette()}
+        title="Open command palette"
         aria-label="Open command palette"
       >
         <SearchIcon size={12} />
@@ -810,6 +811,7 @@ function ProjectGroup({
             onToggleExpand();
           }}
           aria-expanded={isExpanded}
+          title={isExpanded ? 'Collapse project' : 'Expand project'}
           aria-label={isExpanded ? 'Collapse project' : 'Expand project'}
         >
           <ChevronIcon

--- a/src/styles/features/github.css
+++ b/src/styles/features/github.css
@@ -157,13 +157,6 @@
   overflow: hidden;
 }
 
-.github-modal h3 {
-  padding: 20px 20px 0;
-  font-size: var(--font-size-xl);
-  font-weight: 600;
-  margin: 0;
-}
-
 .github-modal > p {
   padding: 6px 20px 0;
   font-size: var(--font-size-md);

--- a/src/styles/features/import-picker.css
+++ b/src/styles/features/import-picker.css
@@ -2,37 +2,11 @@
 
 .import-picker-modal {
   max-width: 460px;
-}
-
-.import-picker-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 20px 24px 0;
-}
-
-.import-picker-header h2 {
-  margin: 0;
-  font-size: 17px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.import-picker-close {
-  background: none;
-  border: none;
-  color: var(--text-secondary);
-  cursor: pointer;
-  padding: 4px;
-  border-radius: var(--radius);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.import-picker-close:hover {
-  color: var(--text-primary);
-  background: var(--bg-tertiary);
+  /* Override ModalFrame's --bg-secondary panel back to --bg-primary so the
+     nested surface hierarchy reads correctly: panel (primary) < cards
+     (secondary) < icon tiles (tertiary). Without this the cards share the
+     panel fill and lose their raised cue. */
+  background: var(--bg-primary);
 }
 
 .import-picker-options {


### PR DESCRIPTION
Split out of #93 per @julian-galluzzo's review (refactor sub-PR 4 of 5: design-system + a11y).

- a11y tooltip sweep: `title` attributes matching existing `aria-label`s across ~14 components.
- Migrate the create-repo (`GitHubButton`) and import-type (`ImportTypePicker`) modals to the `ModalFrame` primitive (dropping their hand-rolled overlay/close markup + the `import-picker.css` / `github.css` rules `ModalFrame` now owns).
- Migrate the `ProjectRail` Unpin action to the `Button` primitive.

Based on `main`. No agent-harness scaffolding. Verified: `pnpm check:all`, `pnpm test:run`, `pnpm build`.
