### PR TITLE
Single-header-row restructure (branch chip + tabs into WorkspaceHeader)

### DIFF
--- a/src/components/workspace/WorkspaceHeader.tsx
+++ b/src/components/workspace/WorkspaceHeader.tsx
@@ -51,6 +51,16 @@ export interface WorkspaceHeaderProps {
   // WorkspaceView. Omit to hide.
   headerExtras?: ReactNode;
 
+  // Branch chip rendered at the very end of the left cluster (after
+  // headerExtras). Pre-composed in WorkspaceView since it needs git/branch
+  // state. Omit to hide.
+  branchIndicator?: ReactNode;
+
+  // Workspace tabs (Preview/Focus/Code/Branches/PRs) rendered at the start of
+  // the right cluster (before the GitHub button). Pre-composed in WorkspaceView
+  // since they drive the right-pane tab state. Omit to hide.
+  tabs?: ReactNode;
+
   // Sidebar collapse — lives at the far-left of the header so the health
   // panel row below stays focused on health/logs. Omit `onToggleSidebar`
   // to hide the button entirely (e.g. compact mode or pinned layouts).
@@ -106,6 +116,8 @@ export function WorkspaceHeader({
   projectName,
   onOpenAssetsPanel,
   headerExtras,
+  branchIndicator,
+  tabs,
   isSidebarHidden,
   onToggleSidebar,
   integrations,
@@ -207,10 +219,12 @@ export function WorkspaceHeader({
           <span className="toolbar-btn-label">Support</span>
         </button>
         {headerExtras}
+        {branchIndicator}
       </div>
 
-      {/* Right side — GitHub, Publish slot, hosting plugin, Publish */}
+      {/* Right side — workspace tabs, GitHub, Publish slot, hosting plugin, Publish */}
       <div className="workspace-header-right">
+        {tabs}
         <span data-education-id="github-button">
           <GitHubButton
             githubState={integrations.github}

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -856,10 +856,101 @@ export const WorkspaceView = memo(function WorkspaceView({
     sessionRegistry.setTerminalTabAttention(currentProject.path, activeTerminalTab, false);
   }, [currentProject.path, activeTerminalTab, setAttentionTabs]);
 
+  // Branch chip + workspace tabs live in the single header row (left/right
+  // clusters of WorkspaceHeader). Composed here since they need git/branch +
+  // tab state, then passed in as nodes.
+  const branchIndicatorNode =
+    integrations.projectGithub?.status === 'connected' && currentBranch ? (
+      <BranchIndicator
+        currentBranch={currentBranch}
+        hasUncommittedChanges={hasUncommittedChanges}
+        changedFiles={changedFiles}
+        projectPath={currentProject.path}
+        isOnBranchesTab={workspaceTab === 'branches' || workspaceTab === 'prs'}
+        hasPreview={hasPreview}
+        onClick={() => {
+          if (workspaceTab === 'branches' || workspaceTab === 'prs') {
+            setWorkspaceTab(hasPreview ? 'preview' : 'code');
+          } else {
+            setWorkspaceTab('branches');
+          }
+        }}
+        onDiscard={() => {
+          void checkGitStatus(currentProject.path);
+        }}
+        onSave={() => setForcePublishOpen(true)}
+      />
+    ) : null;
+
+  const tabsNode = (
+    <div className="workspace-tabs">
+      {hasPreview && (
+        <button
+          className={`workspace-tab ${workspaceTab === 'preview' && !isPreviewHidden ? 'active' : ''}`}
+          onClick={() => {
+            setIsPreviewHidden(false);
+            setWorkspaceTab('preview');
+          }}
+        >
+          <EyeIcon size={14} />
+          <span>Preview</span>
+        </button>
+      )}
+      {/* Focus mode — collapses the preview pane so the agent terminal takes the
+          full workspace. Active whenever the preview is hidden. */}
+      <button
+        className={`workspace-tab ${isPreviewHidden ? 'active' : ''}`}
+        onClick={() => setIsPreviewHidden(!isPreviewHidden)}
+        title={isPreviewHidden ? 'Exit focus mode' : 'Hide preview — agent only'}
+      >
+        <EyeOffIcon size={14} />
+        <span>Focus</span>
+      </button>
+      <button
+        className={`workspace-tab ${workspaceTab === 'code' && !isPreviewHidden ? 'active' : ''}`}
+        onClick={() => {
+          setIsPreviewHidden(false);
+          setWorkspaceTab('code');
+        }}
+      >
+        <CodeIcon size={14} />
+        <span>Code</span>
+      </button>
+      {integrations.projectGithub?.status === 'connected' && (
+        <>
+          <button
+            className={`workspace-tab ${workspaceTab === 'branches' && !isPreviewHidden ? 'active' : ''}`}
+            onClick={() => {
+              setIsPreviewHidden(false);
+              setWorkspaceTab('branches');
+            }}
+            data-education-id="branches-tab"
+          >
+            <BranchIcon size={14} />
+            <span>Branches</span>
+          </button>
+          <button
+            className={`workspace-tab ${workspaceTab === 'prs' && !isPreviewHidden ? 'active' : ''}`}
+            onClick={() => {
+              setIsPreviewHidden(false);
+              setWorkspaceTab('prs');
+            }}
+            data-education-id="prs-tab"
+          >
+            <PullRequestIcon size={14} />
+            <span>PRs</span>
+          </button>
+        </>
+      )}
+    </div>
+  );
+
   const header = WorkspaceHeader({
     projectPath: currentProject.path,
     projectName: currentProject.name,
     onOpenAssetsPanel: assetsPanelModal.open,
+    branchIndicator: branchIndicatorNode,
+    tabs: tabsNode,
     headerExtras: (
       <PluginsDropdown
         plugins={loadedPlugins.filter((p) => !HOSTING_PLUGIN_IDS.includes(p.info.manifest.id))}
@@ -991,101 +1082,6 @@ export const WorkspaceView = memo(function WorkspaceView({
                   onCreateBranch={() => setWorkspaceTab('branches')}
                 />
               )}
-
-              {/* Full-width branch + tabs bar. Historically this lived inside
-                the right pane of the SplitPane, but it was lifted up here
-                so the branch chip + workspace tabs span the full workspace
-                width and stay visible even when the preview pane is
-                hidden. The tabs still only control what's rendered in the
-                right pane — clicking "Code" / "Branches" / "PRs" swaps
-                that content, identical to before. */}
-              <div className="preview-tabs-bar">
-                {integrations.projectGithub?.status === 'connected' && currentBranch && (
-                  <BranchIndicator
-                    currentBranch={currentBranch}
-                    hasUncommittedChanges={hasUncommittedChanges}
-                    changedFiles={changedFiles}
-                    projectPath={currentProject.path}
-                    isOnBranchesTab={workspaceTab === 'branches' || workspaceTab === 'prs'}
-                    hasPreview={hasPreview}
-                    onClick={() => {
-                      if (workspaceTab === 'branches' || workspaceTab === 'prs') {
-                        setWorkspaceTab(hasPreview ? 'preview' : 'code');
-                      } else {
-                        setWorkspaceTab('branches');
-                      }
-                    }}
-                    onDiscard={() => {
-                      void checkGitStatus(currentProject.path);
-                    }}
-                    onSave={() => setForcePublishOpen(true)}
-                  />
-                )}
-                <div style={{ flex: 1 }} />
-                <div className="workspace-tabs">
-                  {hasPreview && (
-                    <button
-                      className={`workspace-tab ${workspaceTab === 'preview' && !isPreviewHidden ? 'active' : ''}`}
-                      onClick={() => {
-                        setIsPreviewHidden(false);
-                        setWorkspaceTab('preview');
-                      }}
-                    >
-                      <EyeIcon size={14} />
-                      <span>Preview</span>
-                    </button>
-                  )}
-                  {/* Focus mode — collapses the preview pane so the agent
-                    terminal takes the full workspace. Useful when the user
-                    is running their own browser as the preview. Active
-                    whenever the preview is hidden, regardless of which
-                    tab underlies it. */}
-                  <button
-                    className={`workspace-tab ${isPreviewHidden ? 'active' : ''}`}
-                    onClick={() => setIsPreviewHidden(!isPreviewHidden)}
-                    title={isPreviewHidden ? 'Exit focus mode' : 'Hide preview — agent only'}
-                  >
-                    <EyeOffIcon size={14} />
-                    <span>Focus</span>
-                  </button>
-                  <button
-                    className={`workspace-tab ${workspaceTab === 'code' && !isPreviewHidden ? 'active' : ''}`}
-                    onClick={() => {
-                      setIsPreviewHidden(false);
-                      setWorkspaceTab('code');
-                    }}
-                  >
-                    <CodeIcon size={14} />
-                    <span>Code</span>
-                  </button>
-                  {integrations.projectGithub?.status === 'connected' && (
-                    <>
-                      <button
-                        className={`workspace-tab ${workspaceTab === 'branches' && !isPreviewHidden ? 'active' : ''}`}
-                        onClick={() => {
-                          setIsPreviewHidden(false);
-                          setWorkspaceTab('branches');
-                        }}
-                        data-education-id="branches-tab"
-                      >
-                        <BranchIcon size={14} />
-                        <span>Branches</span>
-                      </button>
-                      <button
-                        className={`workspace-tab ${workspaceTab === 'prs' && !isPreviewHidden ? 'active' : ''}`}
-                        onClick={() => {
-                          setIsPreviewHidden(false);
-                          setWorkspaceTab('prs');
-                        }}
-                        data-education-id="prs-tab"
-                      >
-                        <PullRequestIcon size={14} />
-                        <span>PRs</span>
-                      </button>
-                    </>
-                  )}
-                </div>
-              </div>
 
               <div className="workspace-content">
                 <SplitPane

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -891,6 +891,7 @@ export const WorkspaceView = memo(function WorkspaceView({
             setIsPreviewHidden(false);
             setWorkspaceTab('preview');
           }}
+          title="Preview"
         >
           <EyeIcon size={14} />
           <span>Preview</span>
@@ -912,6 +913,7 @@ export const WorkspaceView = memo(function WorkspaceView({
           setIsPreviewHidden(false);
           setWorkspaceTab('code');
         }}
+        title="Code"
       >
         <CodeIcon size={14} />
         <span>Code</span>
@@ -924,6 +926,7 @@ export const WorkspaceView = memo(function WorkspaceView({
               setIsPreviewHidden(false);
               setWorkspaceTab('branches');
             }}
+            title="Branches"
             data-education-id="branches-tab"
           >
             <BranchIcon size={14} />
@@ -935,6 +938,7 @@ export const WorkspaceView = memo(function WorkspaceView({
               setIsPreviewHidden(false);
               setWorkspaceTab('prs');
             }}
+            title="PRs"
             data-education-id="prs-tab"
           >
             <PullRequestIcon size={14} />

--- a/src/styles/features/branches/main.css
+++ b/src/styles/features/branches/main.css
@@ -20,8 +20,11 @@
     border-color var(--transition);
 }
 
-.preview-tabs-bar .branch-indicator {
-  margin-left: 4px;
+/* Match the branch chip's height to the toolbar buttons (.toolbar-icon-btn,
+   28px) now that it lives in the header row alongside them. */
+.workspace-header .branch-indicator-button {
+  height: 28px;
+  padding: 0 var(--spacing-md);
 }
 
 .branch-indicator-button:hover {

--- a/src/styles/features/branches/main.css
+++ b/src/styles/features/branches/main.css
@@ -27,6 +27,13 @@
   padding: 0 var(--spacing-md);
 }
 
+/* In the header the chip shares the row with the tabs and toolbar, so truncate
+   the branch name much sooner than the standalone chip's 280px to keep long
+   names from crowding out the tabs. */
+.workspace-header .branch-name {
+  max-width: 150px;
+}
+
 .branch-indicator-button:hover {
   background: var(--border);
   color: var(--text-primary);

--- a/src/styles/features/workspace/main.css
+++ b/src/styles/features/workspace/main.css
@@ -78,6 +78,23 @@
   border-bottom: 1px solid var(--border);
 }
 
+/* Narrow windows: collapse the header's text labels to icon-only so every
+   control stays visible (and reachable) instead of overflowing or scrolling
+   out of sight. The icons + tooltips carry the meaning. Keep this breakpoint in
+   sync with the terminal toolbar's (workspace/terminal.css) so every label
+   collapses in unison. */
+@media (max-width: 1300px) {
+  .workspace-header .toolbar-btn-label,
+  .workspace-header .workspace-tab > span {
+    display: none;
+  }
+
+  /* Tighter tab padding once they're icon-only. */
+  .workspace-header .workspace-tab {
+    padding: 0 var(--spacing-sm);
+  }
+}
+
 /* Two-column row below the titlebar: optional rail + main content. */
 .workspace-body {
   display: flex;

--- a/src/styles/features/workspace/tabs.css
+++ b/src/styles/features/workspace/tabs.css
@@ -9,7 +9,14 @@
   align-self: stretch;
   align-items: stretch;
   gap: 0;
-  margin-left: auto;
+}
+
+/* The tabs live in the single header row (right cluster). Cancel the header's
+   vertical padding so they span its full height and the active underline pins
+   flush to the header's bottom border, as the tab design intends. */
+.workspace-header .workspace-tabs {
+  margin-top: calc(var(--spacing-sm) * -1);
+  margin-bottom: calc(var(--spacing-sm) * -1);
 }
 
 .workspace-tab {
@@ -63,31 +70,6 @@
   display: flex;
   align-items: center;
   gap: 4px;
-}
-
-/* Preview Tabs Bar */
-.preview-tabs-bar {
-  display: flex;
-  align-items: center;
-  padding: 0 12px 0 8px;
-  min-height: 48px;
-  background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border);
-  flex-shrink: 0;
-  gap: 4px;
-  /* Establish stacking context so dropdowns appear above preview iframe */
-  position: relative;
-  z-index: 10;
-}
-
-.preview-tabs-bar-simple {
-  padding: 0 12px;
-}
-
-.preview-label {
-  font-size: var(--font-size-base);
-  font-weight: 500;
-  color: var(--text-muted);
 }
 
 /* Open in Browser Button */

--- a/src/styles/features/workspace/terminal.css
+++ b/src/styles/features/workspace/terminal.css
@@ -9,6 +9,19 @@
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
+  /* A floor gap so the left (undo/redo) and right (Split / Agent Settings)
+     clusters never butt up against each other once the flex:1 spacer between
+     them collapses on a narrow pane. */
+  gap: var(--spacing-sm);
+}
+
+/* Collapse "Agent Settings" to its gear icon at the SAME window width as the
+   header's label collapse (workspace/main.css) so every toolbar label drops to
+   icon-only in unison. Keep this breakpoint in sync with that one. */
+@media (max-width: 1300px) {
+  .terminal-tabs-bar .toolbar-btn-label {
+    display: none;
+  }
 }
 
 /* Right-side cluster — groups feature toggles + the Agent Settings


### PR DESCRIPTION
Split out of #93 per @julian-galluzzo's review (refactor sub-PR 5 of 5: single-header-row restructure).

Folds the branch indicator + workspace tabs into `WorkspaceHeader` (new `branchIndicator` / `tabs` slot props) and removes the separate `preview-tabs-bar` row, with the matching CSS re-targeting (`branches/main.css`, `workspace/tabs.css`).

Based on `main`. Heads-up: this restructures `WorkspaceView.tsx`, which the agent-indicator (#98) and workspace-tour (#99) PRs also touch (different slices) — coordinate merge order; trivial rebase whichever lands first. No agent-harness scaffolding.

Verified: `pnpm check:all`, `pnpm test:run`, `pnpm build`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Relocated branch indicator and workspace tabs to the workspace header row, improving layout organization and navigation flow.

* **Style**
  * Updated component spacing and alignment within the header for better visual hierarchy.
  * Enhanced responsive design: on narrower screens (≤1300px), toolbar and tab labels collapse to icon-only format to prevent overflow while maintaining full functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->