### PR TITLE
Surface branch-switch stash state in the toast

### DIFF
--- a/src/components/branches/BranchesTab.tsx
+++ b/src/components/branches/BranchesTab.tsx
@@ -129,7 +129,12 @@ export function BranchesTab({
       if (result.success) {
         onBranchSwitch(branchName);
         void trackEvent('branch_switched', { $screen_name: 'Workspace' });
-        onToast?.(`Switched to ${branchName}`, 'success');
+        onToast?.(
+          result.stashApplied
+            ? `Switched to ${branchName} and restored your stashed changes`
+            : `Switched to ${branchName}`,
+          'success'
+        );
       } else if (result.error?.includes('Uncommitted changes')) {
         // Show the unsaved changes modal
         setPendingSwitch(branchName);

--- a/src/lib/branches.ts
+++ b/src/lib/branches.ts
@@ -39,6 +39,10 @@ export interface SwitchResult {
   success: boolean;
   /** Whether changes were stashed */
   stashedChanges: boolean;
+  /** When switching to a branch that has a pending stash, the source branch name */
+  pendingStashFrom: string | null;
+  /** Whether a stash was automatically applied during the switch */
+  stashApplied: boolean;
   /** Error message if switch failed */
   error: string | null;
 }
@@ -107,12 +111,16 @@ export async function switchBranch(
   const result = await invoke<{
     success: boolean;
     stashed_changes: boolean;
+    pending_stash_from: string | null;
+    stash_applied: boolean;
     error: string | null;
   }>('switch_branch', { projectPath, branchName, autoStash });
 
   return {
     success: result.success,
     stashedChanges: result.stashed_changes,
+    pendingStashFrom: result.pending_stash_from,
+    stashApplied: result.stash_applied,
     error: result.error,
   };
 }


### PR DESCRIPTION
Split out of #93 per @julian-galluzzo's review (final refactor leftover).

Surfaces `pending_stash_from` / `stash_applied` through `SwitchResult` so the branch-switch toast tells the user when a stash was auto-applied (loop #6).

Based on `main`, independent. No agent-harness scaffolding. Verified: `pnpm check:all`, `pnpm test:run`, `pnpm build`.
