### PR TITLE
First-run terminal hint (type-to-dismiss)

### DIFF
--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -1054,10 +1054,10 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       {isReady && showFirstRunHint && (
         <div className="terminal-firstrun-hint">
           <div className="terminal-firstrun-hint-card" role="note">
-            <strong>This is your AI builder</strong>
+            <strong>This is your agent</strong>
             <span>
-              Type what you want to build in plain English (like "make me a landing page for a
-              coffee shop"), then press Enter.
+              Whether you use Claude Code, Codex, Opencode, or something else, your agent runs right
+              here. Tell it what you want to build in plain English, then press Enter.
             </span>
           </div>
         </div>

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -822,17 +822,25 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         });
         pushDisposable(unlistenExit);
 
+        // Dismiss the first-run hint on the user's first real keystroke — and
+        // broadcast so sibling terminals (split panes / tabs) clear theirs too.
+        // We gate on onKey (genuine keyboard input) rather than onData, because
+        // onData also fires for xterm's automatic replies to the program's
+        // terminal-capability queries (Device Attributes / cursor-position
+        // reports an agent's TUI sends on startup). Using onData would dismiss
+        // the hint a frame after it appears — before the user could read it.
+        const firstKeyDisposable = term.onKey(() => {
+          if (firstInputDoneRef.current) return;
+          firstInputDoneRef.current = true;
+          localStorage.setItem(FIRST_AGENT_INPUT_KEY, '1');
+          setShowFirstRunHint(false);
+          window.dispatchEvent(new Event(FIRST_AGENT_INPUT_EVENT));
+        });
+        ptyDisposablesRef.current.push(firstKeyDisposable);
+
         // Handle terminal input -> PTY. Resolves the session id lazily
         // from the ref so re-attach doesn't need a new listener.
         const inputDisposable = term.onData((data) => {
-          // Dismiss the first-run hint the moment the user types anything — and
-          // broadcast so sibling terminals (split panes / tabs) clear theirs too.
-          if (!firstInputDoneRef.current) {
-            firstInputDoneRef.current = true;
-            localStorage.setItem(FIRST_AGENT_INPUT_KEY, '1');
-            setShowFirstRunHint(false);
-            window.dispatchEvent(new Event(FIRST_AGENT_INPUT_EVENT));
-          }
           const sid = ptyRef.current?.sessionId;
           if (sid) void writePtySession(sid, data);
           // When user sends input to an agent without title-based status detection,

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -52,6 +52,12 @@ import '@xterm/xterm/css/xterm.css';
 /** Agent status based on terminal title */
 export type AgentStatus = 'thinking' | 'waiting' | 'idle';
 
+/** Set once the user sends their first input to any agent terminal. */
+const FIRST_AGENT_INPUT_KEY = 'shipstudio.sentFirstAgentMessage';
+/** In-process broadcast so every mounted terminal (split panes / tabs) clears
+ *  its first-run hint the moment the user types into ANY of them. */
+const FIRST_AGENT_INPUT_EVENT = 'shipstudio:first-agent-input';
+
 /** Props for the Terminal component */
 interface TerminalProps {
   /** Agent configuration to use for this terminal */
@@ -120,6 +126,24 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   const ptyDisposablesRef = useRef<Array<{ dispose(): void }>>([]);
   const [isReady, setIsReady] = useState(false);
   const [isFocused, setIsFocused] = useState(false); // Start unfocused to show overlay until user clicks
+
+  // First-run hint: show "this is your AI builder, type here" over the terminal
+  // until the user sends their first input, then never again (global flag, so it
+  // covers every agent terminal / tab / project, not just this one).
+  const [showFirstRunHint, setShowFirstRunHint] = useState(
+    () => localStorage.getItem(FIRST_AGENT_INPUT_KEY) !== '1'
+  );
+  const firstInputDoneRef = useRef(!showFirstRunHint);
+  // Clear this instance's hint when any sibling terminal reports first input.
+  useEffect(() => {
+    if (firstInputDoneRef.current) return;
+    const onFirstInput = () => {
+      firstInputDoneRef.current = true;
+      setShowFirstRunHint(false);
+    };
+    window.addEventListener(FIRST_AGENT_INPUT_EVENT, onFirstInput);
+    return () => window.removeEventListener(FIRST_AGENT_INPUT_EVENT, onFirstInput);
+  }, []);
 
   // Mirror `isActive` to a ref so non-effect closures (input handler,
   // resize observer) can read it without re-creating.
@@ -801,6 +825,14 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         // Handle terminal input -> PTY. Resolves the session id lazily
         // from the ref so re-attach doesn't need a new listener.
         const inputDisposable = term.onData((data) => {
+          // Dismiss the first-run hint the moment the user types anything — and
+          // broadcast so sibling terminals (split panes / tabs) clear theirs too.
+          if (!firstInputDoneRef.current) {
+            firstInputDoneRef.current = true;
+            localStorage.setItem(FIRST_AGENT_INPUT_KEY, '1');
+            setShowFirstRunHint(false);
+            window.dispatchEvent(new Event(FIRST_AGENT_INPUT_EVENT));
+          }
           const sid = ptyRef.current?.sessionId;
           if (sid) void writePtySession(sid, data);
           // When user sends input to an agent without title-based status detection,
@@ -1008,6 +1040,20 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           cursor: 'text',
         }}
       />
+      {/* First-run instruction so a non-developer knows this is a chat box, not
+          a scary console. pointer-events:none lets the click-to-focus below it
+          still work; it clears on the first keystroke. */}
+      {isReady && showFirstRunHint && (
+        <div className="terminal-firstrun-hint">
+          <div className="terminal-firstrun-hint-card" role="note">
+            <strong>This is your AI builder</strong>
+            <span>
+              Type what you want to build in plain English (like "make me a landing page for a
+              coffee shop"), then press Enter.
+            </span>
+          </div>
+        </div>
+      )}
     </div>
   );
 });

--- a/src/styles/features/workspace/terminal.css
+++ b/src/styles/features/workspace/terminal.css
@@ -643,11 +643,14 @@
   position: absolute;
   inset: 0;
   display: flex;
-  /* Anchor to the bottom so the card sits below the agent's startup banner
-     rather than over it; horizontally centered. */
-  align-items: flex-end;
-  justify-content: center;
-  padding: var(--spacing-md);
+  /* Bottom-anchored; the card fills the pane width with equal margins
+     (the padding below), centering only once it hits its max width. */
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  /* Left padding is 0: the terminal content already has a left offset, so a
+     left pad here would double it and push the card right. */
+  padding: var(--spacing-md) var(--spacing-md) var(--spacing-md) 0;
   pointer-events: none;
 }
 
@@ -655,8 +658,9 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-sm);
-  /* Cap the width but never wider than the (possibly split) pane. */
-  max-width: min(var(--hint-card-max-w), 100%);
+  /* Fill the (possibly split) pane, capping only on very wide panes. */
+  width: 100%;
+  max-width: var(--hint-card-max-w);
   padding: var(--spacing-lg);
   background: var(--bg-secondary);
   border: 1px solid var(--border);

--- a/src/styles/features/workspace/terminal.css
+++ b/src/styles/features/workspace/terminal.css
@@ -637,3 +637,42 @@
   background: rgba(var(--warning-rgb), 0.2);
   color: var(--warning);
 }
+
+/* First-run hint shown over a fresh agent terminal until the user types. */
+.terminal-firstrun-hint {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  /* Anchor to the bottom so the card sits below the agent's startup banner
+     rather than over it; horizontally centered. */
+  align-items: flex-end;
+  justify-content: center;
+  padding: var(--spacing-md);
+  pointer-events: none;
+}
+
+.terminal-firstrun-hint-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  /* Cap the width but never wider than the (possibly split) pane. */
+  max-width: min(var(--hint-card-max-w), 100%);
+  padding: var(--spacing-lg);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  text-align: center;
+}
+
+.terminal-firstrun-hint-card strong {
+  color: var(--text-primary);
+  font-size: var(--font-size-md);
+  font-weight: 600;
+}
+
+.terminal-firstrun-hint-card span {
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+}

--- a/src/styles/global/base.css
+++ b/src/styles/global/base.css
@@ -178,7 +178,7 @@
   --tree-panel-w: 240px;
   --tree-code-w: 420px;
   /* Max width for the terminal first-run hint card. */
-  --hint-card-max-w: 360px;
+  --hint-card-max-w: 720px;
   --z-modal-overlay: 1000;
   --z-modal: 1001;
   --z-tooltip: 1100;

--- a/src/styles/global/base.css
+++ b/src/styles/global/base.css
@@ -177,6 +177,8 @@
      so hand-editing HTML isn't cramped. */
   --tree-panel-w: 240px;
   --tree-code-w: 420px;
+  /* Max width for the terminal first-run hint card. */
+  --hint-card-max-w: 360px;
   --z-modal-overlay: 1000;
   --z-modal: 1001;
   --z-tooltip: 1100;


### PR DESCRIPTION
Split out of #93 per @julian-galluzzo's review (the deferred onboarding first-run hint).

Adds a "this is your AI builder, type here" hint over a fresh agent terminal, dismissed on the user's first input — a global flag broadcast across split panes / tabs so it clears everywhere at once.

Based on `main`. Heads-up: touches `Terminal.tsx` (shared with #100 / #104) and `base.css` / `terminal.css` — coordinate merge order; trivial rebase. No agent-harness scaffolding.

Verified: `pnpm check:all`, `pnpm test:run`, `pnpm build`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a first-run instruction hint overlay for agent terminals to help new users get started
  * The hint persists across sessions and dismisses across all mounted terminals when typing begins in any terminal
  * Added new terminal hint overlay styling, including a dedicated hint card layout and supporting design token for consistent sizing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->