### PR TITLE
Static-project preview recovery + new analytics-event docs

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -93,9 +93,6 @@ Fired from `useIntegrationStatus` once GitHub auth resolves with a username.
 | `browser_tools_sent_to_agent` | `tab`, `entry_count` (null for elements), `had_data`, `char_count` |
 | `code_file_opened` | `file_extension` |
 | `code_tree_refreshed` | — |
-| `code_entry_moved` | — |
-| `code_paths_imported` | `count` |
-| `code_entry_deleted` | `is_dir` |
 | `code_snippet_sent_to_agent` | `file_extension`, `language`, `line_count`, `char_count`, `had_question` |
 | `code_snippet_copied` | `file_extension`, `line_count` |
 | `search_performed` (`code_files`) | Debounced |

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -85,6 +85,7 @@ Fired from `useIntegrationStatus` once GitHub auth resolves with a username.
 | `screenshot_captured` | `mode` (`viewport`/`fullpage`), `success`, `fell_back` |
 | `preview_refreshed` | `trigger: 'user'` |
 | `preview_page_selected` | `route_pattern` (id segments → `:id`, capped 200), `depth` |
+| `preview_fix_with_agent` | `has_logs`, `is_static` |
 | `logs_sent_to_agent` | `source` (`full_buffer`/`selection`), `char_count`, `line_count`, `had_question` |
 | `browser_tools_subtab_switched` | `from_tab`, `to_tab` |
 | `browser_tools_cleared` | `tab` |
@@ -92,6 +93,9 @@ Fired from `useIntegrationStatus` once GitHub auth resolves with a username.
 | `browser_tools_sent_to_agent` | `tab`, `entry_count` (null for elements), `had_data`, `char_count` |
 | `code_file_opened` | `file_extension` |
 | `code_tree_refreshed` | — |
+| `code_entry_moved` | — |
+| `code_paths_imported` | `count` |
+| `code_entry_deleted` | `is_dir` |
 | `code_snippet_sent_to_agent` | `file_extension`, `language`, `line_count`, `char_count`, `had_question` |
 | `code_snippet_copied` | `file_extension`, `line_count` |
 | `search_performed` (`code_files`) | Debounced |

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -641,14 +641,19 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
   }
 
   if (conn.isLoading || conn.isStopped || conn.hasError) {
-    // The agent handoff only makes sense for real dev servers (static projects
-    // have no server log to diagnose) and when a Claude terminal is wired up.
-    const handleFixWithAgent =
-      onSendToClaude && !isStaticProject
-        ? () => {
-            const logs = stripAnsi(devServerOutput).split('\n').slice(-200).join('\n').trim();
-            const prompt =
-              `My dev server isn't coming up — Ship Studio is waiting on ` +
+    // Keep the agent handoff available as the always-present recovery whenever a
+    // Claude terminal is wired up — for static projects too (a different prompt,
+    // since they have no server log to attach).
+    const handleFixWithAgent = onSendToClaude
+      ? () => {
+          const logs = isStaticProject
+            ? ''
+            : stripAnsi(devServerOutput).split('\n').slice(-200).join('\n').trim();
+          const prompt = isStaticProject
+            ? `My site preview isn't loading. Ship Studio is serving this project as static ` +
+              `files on http://localhost:${port} but nothing shows up. Please check the project ` +
+              `has an index.html at its root (and any files it references) so the preview renders.`
+            : `My dev server isn't coming up — Ship Studio is waiting on ` +
               `http://localhost:${port} but it never responds.\n\n` +
               (logs
                 ? `Recent dev-server output:\n\n\`\`\`\n${logs}\n\`\`\`\n\n`
@@ -656,10 +661,13 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
               `Please work out why it won't start — a busy port, a crash, a missing ` +
               `dependency, or a wrong or missing dev script — and fix it so it serves on ` +
               `port ${port}.`;
-            onSendToClaude(prompt);
-            void trackEvent('preview_fix_with_agent', { has_logs: !!logs });
-          }
-        : undefined;
+          onSendToClaude(prompt);
+          void trackEvent('preview_fix_with_agent', {
+            has_logs: !!logs,
+            is_static: isStaticProject,
+          });
+        }
+      : undefined;
 
     return (
       <DevServerStatus


### PR DESCRIPTION
Split out of #93 per @julian-galluzzo's review (the static-project recovery dropped from the core + the new-event analytics docs).

- Extends the "fix with agent" preview recovery to **static projects** — a tailored prompt (check for an `index.html`) instead of attaching dev-server logs.
- Documents the new analytics events in `docs/analytics.md` (`code_entry_moved/imported/deleted`, `preview_fix_with_agent` + `is_static`).

Based on `main`. Heads-up: the `Preview.tsx` hunk is in the dev-server-status branch (independent region), but shares the file with #93 / preview-scale — trivial rebase. No agent-harness scaffolding.

Verified: `pnpm check:all`, `pnpm test:run`, `pnpm build`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * "Fix with Agent" capability now extended to static projects, providing tailored assistance for verifying project structure and files.

* **Documentation**
  * Updated analytics documentation to track agent feature interactions across all project types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->