### PR TITLE
Auto-generate commit messages on publish

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -16,6 +16,13 @@ const MAX_DIFF_SIZE: usize = 40_000;
 /// Timeout for the underlying AI agent CLI call. Claude can be slow, so 60s.
 const AGENT_CLI_TIMEOUT_SECS: u64 = 60;
 
+/// Timeout for commit-message generation. Shorter than PR generation since this
+/// runs on every publish and a commit subject is a small, fast request.
+const COMMIT_MSG_CLI_TIMEOUT_SECS: u64 = 30;
+
+/// Fallback commit message used when AI generation is unavailable or fails.
+pub const DEFAULT_COMMIT_MESSAGE: &str = "Update from Ship Studio";
+
 /// Gather git context and generate a PR title and description using Claude CLI.
 #[tauri::command]
 #[tracing::instrument(skip(project_path), fields(project = %project_path, base = %base_branch))]
@@ -51,26 +58,7 @@ pub async fn generate_pr_description(
         );
     }
 
-    // Truncate diff if too large
-    let truncated_diff = if diff.len() > MAX_DIFF_SIZE {
-        warn!(
-            "Diff is {} bytes, truncating to {}",
-            diff.len(),
-            MAX_DIFF_SIZE
-        );
-        let truncated = &diff[..MAX_DIFF_SIZE];
-        // Try to cut at a newline boundary
-        match truncated.rfind('\n') {
-            Some(pos) => format!(
-                "{}\n\n[... diff truncated, {} more bytes ...]",
-                &truncated[..pos],
-                diff.len() - pos
-            ),
-            None => format!("{truncated}\n\n[... diff truncated ...]"),
-        }
-    } else {
-        diff
-    };
+    let truncated_diff = truncate_diff(&diff);
 
     let prompt = build_prompt(
         &branch_name,
@@ -160,6 +148,35 @@ fn get_diff(path: &std::path::Path, base: &str) -> Result<String, String> {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+/// Truncate a diff to [`MAX_DIFF_SIZE`] at a newline boundary, appending a
+/// marker noting how many bytes were dropped. Returns the diff unchanged when
+/// it already fits. The cut is floored to a UTF-8 char boundary so slicing a
+/// multi-byte sequence can never panic.
+fn truncate_diff(diff: &str) -> String {
+    if diff.len() <= MAX_DIFF_SIZE {
+        return diff.to_string();
+    }
+    warn!(
+        "Diff is {} bytes, truncating to {}",
+        diff.len(),
+        MAX_DIFF_SIZE
+    );
+    let mut end = MAX_DIFF_SIZE;
+    while end > 0 && !diff.is_char_boundary(end) {
+        end -= 1;
+    }
+    let truncated = &diff[..end];
+    // Try to cut at a newline boundary for cleaner output
+    match truncated.rfind('\n') {
+        Some(pos) => format!(
+            "{}\n\n[... diff truncated, {} more bytes ...]",
+            &truncated[..pos],
+            diff.len() - pos
+        ),
+        None => format!("{truncated}\n\n[... diff truncated ...]"),
+    }
+}
+
 fn build_prompt(
     branch_name: &str,
     base_branch: &str,
@@ -238,6 +255,204 @@ fn parse_response(response: &str) -> Result<GeneratedPR, String> {
     Ok(GeneratedPR { title, description })
 }
 
+// ---------------------------------------------------------------------------
+// Commit message generation
+// ---------------------------------------------------------------------------
+
+/// Generate a commit message for the project's current uncommitted changes.
+///
+/// Exposed as a command for potential UI use (e.g. a "regenerate" button); the
+/// publish flow generates messages internally via [`resolve_commit_message`].
+#[tauri::command]
+#[tracing::instrument(skip(project_path), fields(project = %project_path))]
+pub async fn generate_commit_message(project_path: String) -> Result<String, CommandError> {
+    let validated_path = validate_project_path(&project_path)?;
+    generate_commit_message_for_path(&validated_path).await
+}
+
+/// Resolve the commit message for a publish action: use the caller-provided
+/// message when present and non-empty, otherwise auto-generate one from the
+/// working tree, falling back to [`DEFAULT_COMMIT_MESSAGE`] if generation is
+/// unavailable (no headless agent, agent not installed, nothing to summarize,
+/// CLI failure/timeout). This never errors so publishing always proceeds.
+pub async fn resolve_commit_message(path: &std::path::Path, provided: Option<String>) -> String {
+    if let Some(message) = provided {
+        let trimmed = message.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    match generate_commit_message_for_path(path).await {
+        Ok(message) => {
+            info!(message = %message, "Auto-generated commit message");
+            message
+        }
+        Err(e) => {
+            debug!(error = %e, "Falling back to default commit message");
+            DEFAULT_COMMIT_MESSAGE.to_string()
+        }
+    }
+}
+
+/// Generate a concise, single-line commit subject from the project's current
+/// uncommitted changes using the active agent CLI in print mode.
+///
+/// Returns an error (so callers fall back to a static default) when the active
+/// agent has no headless print mode (only Claude does today), the agent CLI
+/// isn't installed, there's nothing to summarize, or the CLI fails/times out.
+pub async fn generate_commit_message_for_path(
+    path: &std::path::Path,
+) -> Result<String, CommandError> {
+    let agent = get_active_agent();
+
+    // Only agents with a real headless print mode can run non-interactively.
+    // Codex/Opencode have no print flag today, so we don't risk launching an
+    // interactive session that would just hang until the timeout.
+    if agent.print_mode_flags.is_empty() {
+        return Err(format!(
+            "{} has no headless print mode; cannot auto-generate commit message",
+            agent.display_name
+        )
+        .into());
+    }
+
+    let agent_path = find_agent_binary()
+        .ok_or_else(|| format!("{} CLI is not installed", agent.display_name))?;
+
+    // Cheap guard: if nothing changed, skip the agent call entirely.
+    let status = git_status_porcelain(path)?;
+    if status.trim().is_empty() {
+        return Err("No changes to summarize".to_string().into());
+    }
+    let diff = truncate_diff(&git_working_diff(path));
+    let prompt = build_commit_prompt(&status, &diff);
+
+    debug!("Calling {} CLI for commit message", agent.display_name);
+
+    let mut args: Vec<&str> = agent.print_mode_flags.to_vec();
+    args.push(&prompt);
+
+    let mut cmd = create_command(&agent_path);
+    cmd.args(&args)
+        .env("PATH", get_extended_path())
+        .current_dir(path);
+    let tokio_cmd = tokio::process::Command::from(cmd);
+    let output = run_with_timeout(
+        tokio_cmd,
+        format!("{} CLI", agent.display_name),
+        COMMIT_MSG_CLI_TIMEOUT_SECS,
+    )
+    .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!("{} CLI failed: {}", agent.display_name, stderr);
+        return Err(format!("{} CLI failed: {}", agent.display_name, stderr).into());
+    }
+
+    let response = String::from_utf8_lossy(&output.stdout).to_string();
+    parse_commit_message(&response).map_err(CommandError::from)
+}
+
+fn git_status_porcelain(path: &std::path::Path) -> Result<String, CommandError> {
+    let output = create_command("git")
+        .args(["status", "--porcelain"])
+        .current_dir(path)
+        .output()
+        .map_err(CommandError::from)?;
+    if !output.status.success() {
+        return Err("Failed to read git status".to_string().into());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Working-tree diff against HEAD (all tracked changes, staged or not). On an
+/// unborn branch (no commits) `git diff HEAD` fails; we return whatever stdout
+/// it produced (empty) and let the porcelain file list carry the context.
+fn git_working_diff(path: &std::path::Path) -> String {
+    create_command("git")
+        .args(["--no-pager", "diff", "HEAD"])
+        .current_dir(path)
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+        .unwrap_or_default()
+}
+
+fn build_commit_prompt(status: &str, diff: &str) -> String {
+    format!(
+        r###"Write a single-line git commit message summarizing these uncommitted changes.
+
+## Files changed (git status --porcelain)
+{status}
+
+## Diff (git diff HEAD)
+{diff}
+
+Rules:
+- Output ONLY the commit subject line — no body, no quotes, no backticks, no "TITLE:" or "Subject:" prefix, no surrounding explanation.
+- Imperative mood, under 72 characters, capitalized, no trailing period.
+- Optionally use a conventional-commit prefix (feat:, fix:, chore:, docs:, refactor:) when it clearly fits.
+- Describe what changed and why at a high level; do not just list filenames.
+"###
+    )
+}
+
+/// Extract a clean single-line subject from the agent's raw stdout, stripping
+/// the wrappers models tend to add (blank lines, quotes/backticks, label
+/// prefixes, trailing period) and capping the length.
+fn parse_commit_message(response: &str) -> Result<String, String> {
+    // First non-empty line — agents sometimes emit a leading blank line.
+    let line = response
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .ok_or_else(|| "AI returned an empty commit message".to_string())?;
+
+    // Strip wrappers the model tends to add — surrounding quotes/backticks and a
+    // leading label (which may itself be wrapped in quotes). Iterate to a
+    // fixpoint so `Subject: "Fix bug"` peels in either order.
+    let mut msg = line;
+    loop {
+        let before = msg;
+        msg = msg
+            .trim_matches(|c| c == '`' || c == '"' || c == '\'')
+            .trim();
+        for prefix in [
+            "subject:",
+            "commit message:",
+            "commit:",
+            "message:",
+            "title:",
+        ] {
+            if msg.len() >= prefix.len() && msg[..prefix.len()].eq_ignore_ascii_case(prefix) {
+                msg = msg[prefix.len()..].trim();
+                break;
+            }
+        }
+        if msg == before {
+            break;
+        }
+    }
+
+    // Conventional subjects omit the trailing period.
+    let msg = msg.trim_end_matches('.').trim();
+
+    if msg.is_empty() {
+        return Err("AI returned an empty commit message".to_string());
+    }
+
+    // Hard cap so a runaway response can't produce an enormous subject.
+    const MAX_SUBJECT_LEN: usize = 100;
+    if msg.chars().count() <= MAX_SUBJECT_LEN {
+        return Ok(msg.to_string());
+    }
+    let truncated: String = msg.chars().take(MAX_SUBJECT_LEN).collect();
+    Ok(match truncated.rfind(' ') {
+        Some(pos) => truncated[..pos].to_string(),
+        None => truncated,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -272,5 +487,145 @@ mod tests {
         let response = "";
         let result = parse_response(response);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_commit_message_plain() {
+        assert_eq!(
+            parse_commit_message("Add force_static_serve flag").unwrap(),
+            "Add force_static_serve flag"
+        );
+    }
+
+    #[test]
+    fn test_parse_commit_message_strips_wrappers() {
+        // leading blank line, surrounding quotes, label prefix, trailing period
+        assert_eq!(
+            parse_commit_message("\n\nSubject: \"Fix preview proxy crash.\"\n").unwrap(),
+            "Fix preview proxy crash"
+        );
+        assert_eq!(
+            parse_commit_message("`feat: add locale switcher`").unwrap(),
+            "feat: add locale switcher"
+        );
+    }
+
+    #[test]
+    fn test_parse_commit_message_takes_first_line_only() {
+        let response = "Update publish flow\n\nThis is a body paragraph that should be ignored.";
+        assert_eq!(
+            parse_commit_message(response).unwrap(),
+            "Update publish flow"
+        );
+    }
+
+    #[test]
+    fn test_parse_commit_message_caps_length() {
+        let long = "word ".repeat(40); // 200 chars
+        let result = parse_commit_message(&long).unwrap();
+        assert!(result.chars().count() <= 100);
+        assert!(!result.ends_with(' '));
+    }
+
+    #[test]
+    fn test_parse_commit_message_empty() {
+        assert!(parse_commit_message("").is_err());
+        assert!(parse_commit_message("\n\n  \n").is_err());
+        // a line that is *only* wrappers collapses to empty
+        assert!(parse_commit_message("\"\"").is_err());
+    }
+
+    #[test]
+    fn test_truncate_diff_under_limit() {
+        let diff = "small diff";
+        assert_eq!(truncate_diff(diff), diff);
+    }
+
+    #[test]
+    fn test_truncate_diff_over_limit_char_boundary() {
+        // A diff of multi-byte chars longer than MAX_DIFF_SIZE must not panic
+        // when the cut lands mid-codepoint.
+        let diff = "é".repeat(MAX_DIFF_SIZE); // 2 bytes each → well over the limit
+        let result = truncate_diff(&diff);
+        assert!(result.contains("diff truncated"));
+    }
+
+    #[tokio::test]
+    async fn resolve_uses_provided_message_without_touching_git() {
+        // A caller-supplied message short-circuits before any git/agent work,
+        // so even a bogus path is fine.
+        let msg = resolve_commit_message(
+            std::path::Path::new("/definitely/not/a/repo"),
+            Some("  Hand-written message  ".to_string()),
+        )
+        .await;
+        assert_eq!(msg, "Hand-written message"); // trimmed
+    }
+
+    #[tokio::test]
+    async fn resolve_falls_back_to_default_when_nothing_changed() {
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let git = |args: &[&str]| {
+            create_command("git")
+                .args(args)
+                .current_dir(dir)
+                .output()
+                .unwrap()
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "t@e.com"]);
+        git(&["config", "user.name", "T"]);
+        std::fs::write(dir.join("a.txt"), "x\n").unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-qm", "init"]);
+
+        // Clean tree → empty porcelain → generation short-circuits before any
+        // agent call → fallback. Non-flaky regardless of agent availability.
+        let msg = resolve_commit_message(dir, None).await;
+        assert_eq!(msg, DEFAULT_COMMIT_MESSAGE);
+    }
+
+    /// End-to-end check that actually shells out to the agent CLI. Ignored by
+    /// default (needs Claude installed + authenticated + network); run with
+    /// `cargo test --lib commands::ai -- --ignored`.
+    #[tokio::test]
+    #[ignore]
+    async fn e2e_generates_real_commit_message() {
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let git = |args: &[&str]| {
+            create_command("git")
+                .args(args)
+                .current_dir(dir)
+                .output()
+                .unwrap()
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "Test"]);
+        std::fs::write(dir.join("app.js"), "const x = 1;\n").unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-qm", "init"]);
+
+        // Make a meaningful, describable change against HEAD.
+        std::fs::write(
+            dir.join("app.js"),
+            "function greet(name) {\n  return `Hello, ${name}`;\n}\n",
+        )
+        .unwrap();
+        std::fs::write(dir.join("README.md"), "# Greeter\n").unwrap();
+
+        let msg = generate_commit_message_for_path(dir)
+            .await
+            .expect("generation should succeed");
+        println!("GENERATED COMMIT MESSAGE: {msg:?}");
+        assert!(!msg.is_empty());
+        assert_ne!(msg, DEFAULT_COMMIT_MESSAGE);
+        assert!(!msg.contains('\n'), "must be a single line");
+        assert!(msg.chars().count() <= 100);
     }
 }

--- a/src-tauri/src/commands/publishing.rs
+++ b/src-tauri/src/commands/publishing.rs
@@ -2,6 +2,7 @@
 //!
 //! Commands for publishing to GitHub, staging, and production.
 
+use crate::commands::ai::resolve_commit_message;
 use crate::commands::git::git_stage_and_commit;
 use crate::commands::github::ensure_git_identity;
 use crate::errors::CommandError;
@@ -16,7 +17,7 @@ pub async fn publish_to_github(
     commit_message: Option<String>,
 ) -> Result<(), CommandError> {
     let validated_path = validate_project_path(&project_path).map_err(CommandError::from)?;
-    let message = commit_message.unwrap_or_else(|| "Update from Ship Studio".to_string());
+    let message = resolve_commit_message(&validated_path, commit_message).await;
     info!(message = %message, "Publishing to GitHub");
 
     // Get current branch name
@@ -137,7 +138,7 @@ pub async fn publish_to_staging(
     commit_message: Option<String>,
 ) -> Result<PublishResult, CommandError> {
     let validated_path = validate_project_path(&project_path).map_err(CommandError::from)?;
-    let message = commit_message.unwrap_or_else(|| "Update from Ship Studio".to_string());
+    let message = resolve_commit_message(&validated_path, commit_message).await;
     info!(message = %message, "Publishing to staging");
 
     // Ensure git identity matches GitHub account before committing
@@ -188,7 +189,7 @@ pub async fn publish_to_production(
     commit_message: Option<String>,
 ) -> Result<PublishResult, CommandError> {
     let validated_path = validate_project_path(&project_path).map_err(CommandError::from)?;
-    let message = commit_message.unwrap_or_else(|| "Update from Ship Studio".to_string());
+    let message = resolve_commit_message(&validated_path, commit_message).await;
     info!(message = %message, "Publishing to production");
 
     // Ensure git identity matches GitHub account before committing
@@ -231,7 +232,7 @@ pub async fn publish_branch(
     commit_message: Option<String>,
 ) -> Result<PublishResult, CommandError> {
     let validated_path = validate_project_path(&project_path).map_err(CommandError::from)?;
-    let message = commit_message.unwrap_or_else(|| "Updates from Ship Studio".to_string());
+    let message = resolve_commit_message(&validated_path, commit_message).await;
 
     // Get current branch name
     let branch_output = create_command("git")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -457,6 +457,7 @@ pub fn run() {
             commands::settings::set_terminal_gpu_enabled,
             // AI generation
             commands::ai::generate_pr_description,
+            commands::ai::generate_commit_message,
             // Claude integration
             commands::claude::check_claude_cli_status,
             commands::claude::install_claude_cli,

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -35,3 +35,18 @@ export async function generatePRDescription(
     baseBranch,
   });
 }
+
+/**
+ * Generate a single-line commit message summarizing the project's current
+ * uncommitted changes, using the active agent CLI in print mode.
+ *
+ * The publish flow already calls this automatically on the backend; this
+ * wrapper exists for UI that wants to preview or regenerate the message.
+ *
+ * @param projectPath - Path to the project directory
+ * @returns A concise commit subject line
+ * @throws If no headless agent is available, there are no changes, or the CLI fails
+ */
+export async function generateCommitMessage(projectPath: string): Promise<string> {
+  return invoke<string>('generate_commit_message', { projectPath });
+}


### PR DESCRIPTION
## What

Publishing currently commits with a static `"Update from Ship Studio"` message every time. This replaces that with an **AI-generated, single-line commit subject** derived from the project's uncommitted changes — reusing the same agent print-mode (`-p`) pattern the PR-description generator already uses.

No frontend wiring was needed: the publish buttons already pass no message, so they get auto-generation for free.

## How

- **`generate_commit_message_for_path()`** (`ai.rs`) reads `git status --porcelain` + `git diff HEAD`, prompts the active agent for a conventional-style subject, and parses out the wrappers models tend to add (quotes, backticks, `Subject:` labels, trailing period), capping length.
- **`resolve_commit_message()`** is the publish entry point: caller-provided message if present → else generate → else fall back to the static default. It **never errors**, so publishing always proceeds.
- Wired into all four publish commands (`publish_to_github`, `publish_to_staging`, `publish_to_production`, `publish_branch`).
- Exposed `generate_commit_message` command + `generateCommitMessage()` wrapper for future regenerate UI.

## Safety / graceful degradation

- **Only runs for agents with a real headless print mode** (Claude today). Codex/Opencode have empty `print_mode_flags`, so they short-circuit to the static default instead of hanging an interactive session until the timeout.
- Skips the agent call entirely when nothing changed (empty porcelain).
- 30s timeout (vs 60s for PR gen, since this is on the publish path); falls back on any failure.

## Drive-by fix

Refactored the duplicated diff-truncation logic into `truncate_diff()` and made the cut floor to a UTF-8 char boundary — the old `&diff[..MAX_DIFF_SIZE]` could panic if the 40KB cut landed mid-codepoint.

## Testing

- ✅ **Live agent E2E** (`#[ignore]`d so CI stays offline): real Claude generated `"feat: add greet function"` from a real diff.
- ✅ Fallback-when-clean and provided-message paths (non-flaky, no agent needed).
- ✅ Parser + truncation unit tests.
- ✅ `cargo fmt`/clippy clean, `tsc --noEmit` clean, 302 command tests green.

**Not verified:** a real publish to a live GitHub remote landing the commit (needs remote + auth). The change is a one-line substitution feeding the existing, already-tested `git commit -m` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered commit message generation for projects.
  * Introduced a 30-second timeout for commit operations.
  * Added graceful fallback with a default commit message when AI generation fails or no changes are detected.

* **Bug Fixes**
  * Improved diff truncation to safely handle UTF-8 character boundaries and newline alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->