### PR TITLE
Fix "[object Object]" error when PR creation fails in the UI

### DIFF
--- a/src/components/branches/SubmitReviewModal.test.tsx
+++ b/src/components/branches/SubmitReviewModal.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Regression test for the "Submit for Review" PR-create error display.
+ *
+ * Tauri command rejections arrive as a structured `CommandError` *object*, not
+ * a JS `Error`. The submit handler used to render `String(e)` on failure, which
+ * stringified that object to a literal "[object Object]" in the modal. It must
+ * route the error through `formatCommandError(asCommandError(e))` so users see
+ * the real reason a PR couldn't be created.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SubmitReviewModal } from './SubmitReviewModal';
+
+vi.mock('../../lib/branches', () => ({
+  createPullRequest: vi.fn(),
+  mergePullRequest: vi.fn(),
+  switchBranch: vi.fn(),
+  deleteBranch: vi.fn(),
+}));
+vi.mock('../../lib/ai', () => ({ generatePRDescription: vi.fn() }));
+vi.mock('../../lib/git', () => ({ commitChanges: vi.fn() }));
+vi.mock('../../lib/analytics', () => ({ trackEvent: vi.fn(), trackError: vi.fn() }));
+
+import { createPullRequest } from '../../lib/branches';
+
+describe('SubmitReviewModal — PR create error display', () => {
+  const props = {
+    projectPath: '/path/to/project',
+    branchName: 'ptymoshenko/sanity',
+    baseBranches: ['main'],
+    aiAvailable: false,
+    onSuccess: vi.fn(),
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a formatted CommandError, never "[object Object]"', async () => {
+    // Tauri rejects with a tagged CommandError object (NOT a JS Error) — the
+    // shape that used to stringify to "[object Object]".
+    vi.mocked(createPullRequest).mockRejectedValue({
+      type: 'Process',
+      cmd: 'gh pr create',
+      exit_code: 1,
+      stderr: 'a pull request for branch "ptymoshenko/sanity" already exists',
+    });
+
+    render(<SubmitReviewModal {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /create pull request/i }));
+
+    // The real stderr is surfaced…
+    expect(
+      await screen.findByText(/a pull request for branch .* already exists/i)
+    ).toBeInTheDocument();
+    // …and the old broken output is gone.
+    expect(screen.queryByText(/\[object Object\]/)).not.toBeInTheDocument();
+  });
+
+  it('handles a bare string rejection too (legacy commands)', async () => {
+    vi.mocked(createPullRequest).mockRejectedValue('gh: not authenticated');
+
+    render(<SubmitReviewModal {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /create pull request/i }));
+
+    expect(await screen.findByText(/gh: not authenticated/i)).toBeInTheDocument();
+    expect(screen.queryByText(/\[object Object\]/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/branches/SubmitReviewModal.tsx
+++ b/src/components/branches/SubmitReviewModal.tsx
@@ -115,7 +115,7 @@ export function SubmitReviewModal({
       setUsedAiGeneration(true);
       void trackEvent('ai_pr_description_generated', { $screen_name: 'Submit Review' });
     } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
+      const message = formatCommandError(asCommandError(e));
       if (message.includes('No changes found')) {
         setNeedsCommit(true);
       } else {
@@ -150,7 +150,7 @@ export function SubmitReviewModal({
         $screen_name: 'Submit Review',
       });
     } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
+      const message = formatCommandError(asCommandError(e));
       trackError('ai_pr_commit_and_generate', e, 'Submit Review');
       setError(`Failed: ${message}`);
       onToast?.('Failed to generate PR description', 'error');
@@ -201,7 +201,7 @@ export function SubmitReviewModal({
         onClose();
       }
     } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
+      const message = formatCommandError(asCommandError(e));
       trackError('pr_create', e, 'Submit Review');
       setError(message);
       onToast?.('Failed to create pull request', 'error');


### PR DESCRIPTION
## The bug

Users creating a PR from the **Submit for Review** modal sometimes see a literal **`[object Object]`** as the error (screenshot below). Creating the PR with `gh pr create` from the terminal worked fine — so the backend was never the problem.

## Root cause

Tauri command rejections arrive in the frontend as a structured **`CommandError` object**, not a JS `Error`. The submit handler did:

```ts
const message = e instanceof Error ? e.message : String(e);
```

For a `CommandError` object, `e instanceof Error` is `false`, so it fell to `String(e)` → `"[object Object]"`. The real reason (e.g. *"a pull request for branch X already exists"*, an auth failure, a push rejection) was discarded.

## Fix

Route all three catch handlers in the modal (create PR + the two AI-generate paths) through `formatCommandError(asCommandError(e))` — the exact helpers the merge/cleanup handlers in this same file already use. `asCommandError` handles tagged-object, string, and `Error` inputs uniformly, so the real message is always surfaced.

## Tests

New `SubmitReviewModal.test.tsx` asserts that a tagged `CommandError` object **and** a bare string rejection both render a readable message and never `[object Object]`.

## Note (out of scope)

The same `String(err)` anti-pattern exists in a handful of other user-facing `setError()` sites (`McpModal`, `PluginManager`, `SkillsModal`). Left for a small focused follow-up to keep this fix reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed error message display during pull request creation and AI description generation to show properly formatted error details instead of placeholder text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->