### PR TITLE
Fix preview never opening for slow-compiling dev servers (Next 16 / Turbopack)

### DIFF
--- a/src/hooks/usePreviewConnection.test.ts
+++ b/src/hooks/usePreviewConnection.test.ts
@@ -57,8 +57,8 @@ function installSlowServerFetch() {
 
   return {
     fetchMock,
-    /** Every probe aborted? The bug is the probe timing out mid-compile. */
-    anyAborted: () => signals.some((s) => s.aborted),
+    callCount: () => signals.length,
+    lastSignal: () => signals[signals.length - 1],
     finishCompile: () => resolveResponse?.(),
   };
 }
@@ -82,7 +82,7 @@ describe('usePreviewConnection readiness probe', () => {
     expect(result.current.serverReady).toBe(false);
     expect(result.current.isLoading).toBe(true);
 
-    // The mount effect gates the first attempt behind a 1.5s settle timer.
+    // The mount effect gates the readiness probe behind a 1.5s settle timer.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1500);
     });
@@ -90,16 +90,18 @@ describe('usePreviewConnection readiness probe', () => {
       'http://localhost:3000',
       expect.objectContaining({ mode: 'no-cors' })
     );
+    const callsWhileCompiling = server.callCount();
 
-    // Advance well past the old 3s timeout (to ~10s) without the server
-    // responding. No probe may have been aborted — the readiness check must ride
-    // the in-flight compile. This is the exact regression: a 3s timeout aborted
-    // the probe at ~3s every attempt, so it never saw the (slow) success and the
-    // preview never opened, even though a plain browser loads it fine.
+    // Advance well past the old 3s timeout (to ~10s) while the server is still
+    // compiling (response withheld). The readiness probe must RIDE that single
+    // in-flight request — no new probe should fire. This is the exact
+    // regression: a 3s timeout aborted the probe at ~3s and the retry backoff
+    // fired fresh probes, so the count would climb here and the (slow) success
+    // was never observed, even though a plain browser loads the page fine.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(8500);
     });
-    expect(server.anyAborted()).toBe(false);
+    expect(server.callCount()).toBe(callsWhileCompiling);
     expect(result.current.serverReady).toBe(false);
 
     // The dev server finishes compiling and responds — preview opens. Flush the
@@ -115,6 +117,38 @@ describe('usePreviewConnection readiness probe', () => {
 
     // Tear down inside act() so the effect cleanups (proxy stop, interval clear)
     // don't update state after the test and trip React's act() warning.
+    await act(async () => {
+      unmount();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+  });
+
+  it('Stop aborts the in-flight probe instead of leaving a 30s fetch running', async () => {
+    const server = installSlowServerFetch();
+    const { result, unmount } = renderHook(() => usePreviewConnection(baseParams));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    const signal = server.lastSignal();
+    expect(signal?.aborted).toBe(false);
+    const callsBeforeStop = server.callCount();
+
+    // User hits Stop while the probe is mid-compile.
+    await act(async () => {
+      result.current.stopConnecting();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(signal?.aborted).toBe(true);
+    expect(result.current.isStopped).toBe(true);
+
+    // And no further probe fires afterward — the aborted probe must not schedule
+    // a retry behind the user's back, even past the longest backoff.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+    });
+    expect(server.callCount()).toBe(callsBeforeStop);
+
     await act(async () => {
       unmount();
       await vi.advanceTimersByTimeAsync(0);

--- a/src/hooks/usePreviewConnection.test.ts
+++ b/src/hooks/usePreviewConnection.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePreviewConnection } from './usePreviewConnection';
+
+// The hook reaches for Tauri IPC, the proxy, analytics, and a logger on the
+// readiness path; stub them all so the test exercises only the fetch-probe loop.
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn((cmd: string) => {
+    if (cmd === 'start_preview_proxy') return Promise.resolve(8080);
+    if (cmd === 'list_pages') return Promise.resolve([]);
+    return Promise.resolve(undefined);
+  }),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+vi.mock('../lib/analytics', () => ({
+  trackEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../lib/window', () => ({
+  getWindowLabel: vi.fn().mockReturnValue('main'),
+}));
+
+vi.mock('../lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const baseParams = {
+  port: 3000,
+  projectPath: '/path/to/project',
+  isDevServerRestarting: false,
+  isStaticProject: false,
+};
+
+/** Hook a controllable fetch that mimics a dev server: the request stays open
+ *  (as Next.js / Turbopack holds it during an on-demand compile) and rejects
+ *  with an AbortError if its signal fires. Returns helpers to inspect the
+ *  in-flight signal and to "finish compiling". */
+function installSlowServerFetch() {
+  const signals: AbortSignal[] = [];
+  let resolveResponse: (() => void) | undefined;
+
+  const fetchMock = vi.fn((_url: string, opts?: { signal?: AbortSignal }) => {
+    if (opts?.signal) signals.push(opts.signal);
+    return new Promise((resolve, reject) => {
+      // Latest call wins — the probe we ultimately "finish" is the in-flight one.
+      resolveResponse = () => resolve({} as Response);
+      opts?.signal?.addEventListener('abort', () =>
+        reject(new DOMException('The operation was aborted.', 'AbortError'))
+      );
+    });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  return {
+    fetchMock,
+    /** Every probe aborted? The bug is the probe timing out mid-compile. */
+    anyAborted: () => signals.some((s) => s.aborted),
+    finishCompile: () => resolveResponse?.(),
+  };
+}
+
+describe('usePreviewConnection readiness probe', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('rides a slow first compile (>3s) instead of aborting the probe', async () => {
+    const server = installSlowServerFetch();
+    const { result, unmount } = renderHook(() => usePreviewConnection(baseParams));
+
+    expect(result.current.serverReady).toBe(false);
+    expect(result.current.isLoading).toBe(true);
+
+    // The mount effect gates the first attempt behind a 1.5s settle timer.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    expect(server.fetchMock).toHaveBeenCalledWith(
+      'http://localhost:3000',
+      expect.objectContaining({ mode: 'no-cors' })
+    );
+
+    // Advance well past the old 3s timeout (to ~10s) without the server
+    // responding. No probe may have been aborted — the readiness check must ride
+    // the in-flight compile. This is the exact regression: a 3s timeout aborted
+    // the probe at ~3s every attempt, so it never saw the (slow) success and the
+    // preview never opened, even though a plain browser loads it fine.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8500);
+    });
+    expect(server.anyAborted()).toBe(false);
+    expect(result.current.serverReady).toBe(false);
+
+    // The dev server finishes compiling and responds — preview opens. Flush the
+    // follow-on effects (proxy start, page load) so their state updates settle
+    // inside act() rather than leaking past the assertion.
+    await act(async () => {
+      server.finishCompile();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.serverReady).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+
+    // Tear down inside act() so the effect cleanups (proxy stop, interval clear)
+    // don't update state after the test and trip React's act() warning.
+    await act(async () => {
+      unmount();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+  });
+});

--- a/src/hooks/usePreviewConnection.ts
+++ b/src/hooks/usePreviewConnection.ts
@@ -15,8 +15,22 @@ import { trackEvent } from '../lib/analytics';
 
 /** How often to refresh the page list (ms) */
 const PAGE_REFRESH_INTERVAL_MS = 5000;
-/** Timeout for dev server health check requests (ms) */
-const SERVER_CHECK_TIMEOUT_MS = 3000;
+/** Timeout for the periodic health check once the server is already up (ms).
+ *  The server is warm here, so a healthy reply is near-instant; 3s is plenty
+ *  and keeps a crashed server from lingering in the "ready" state. */
+const HEALTH_CHECK_TIMEOUT_MS = 3000;
+/** Timeout for an initial readiness probe (ms).
+ *
+ *  Must be generous: modern dev servers (Next.js / Turbopack, Vite) compile the
+ *  first route ON DEMAND and hold the HTTP request open until that compile
+ *  finishes — frequently 10–30s on a cold start with a real dependency tree.
+ *  The response headers don't arrive until then, so a short timeout aborts the
+ *  probe mid-compile every single attempt and the preview never opens, even
+ *  though the server is healthy (a plain browser, which doesn't abort, loads it
+ *  fine — just slowly). A genuinely-down server still rejects instantly with
+ *  connection-refused, so this longer window only affects the "connected but
+ *  still compiling" case it's meant to ride out. */
+const SERVER_READY_TIMEOUT_MS = 30000;
 /** Maximum retries before showing error state */
 export const SERVER_MAX_RETRIES = 60;
 /** Consecutive health check failures before marking server as down */
@@ -316,7 +330,7 @@ export function usePreviewConnection({
 
       try {
         const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), SERVER_CHECK_TIMEOUT_MS);
+        const timeoutId = setTimeout(() => controller.abort(), SERVER_READY_TIMEOUT_MS);
 
         await fetch(devServerUrl, { mode: 'no-cors', signal: controller.signal });
 
@@ -366,7 +380,7 @@ export function usePreviewConnection({
     const healthCheck = async () => {
       try {
         const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), SERVER_CHECK_TIMEOUT_MS);
+        const timeoutId = setTimeout(() => controller.abort(), HEALTH_CHECK_TIMEOUT_MS);
 
         await fetch(devServerUrl, { mode: 'no-cors', signal: controller.signal });
 

--- a/src/hooks/usePreviewConnection.ts
+++ b/src/hooks/usePreviewConnection.ts
@@ -99,6 +99,12 @@ export function usePreviewConnection({
   // The pending "schedule next attempt" timer, tracked so Stop can cancel it
   // immediately rather than letting one more attempt fire.
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The in-flight readiness probe's AbortController. A readiness probe can now
+  // ride a compile for up to SERVER_READY_TIMEOUT_MS (30s), so a superseded
+  // attempt (Stop, project switch, restart) must be aborted explicitly —
+  // otherwise the fetch and its 30s abort timer leak until they fire on a
+  // controller nobody is listening to anymore.
+  const readyProbeControllerRef = useRef<AbortController | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -328,13 +334,12 @@ export function usePreviewConnection({
       setHasError(false);
       setServerReady(false);
 
+      const controller = new AbortController();
+      readyProbeControllerRef.current = controller;
+      const timeoutId = setTimeout(() => controller.abort(), SERVER_READY_TIMEOUT_MS);
       try {
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), SERVER_READY_TIMEOUT_MS);
-
         await fetch(devServerUrl, { mode: 'no-cors', signal: controller.signal });
 
-        clearTimeout(timeoutId);
         logger.info('[Preview] Server check succeeded', { port });
         setIsLoading(false);
         setHasError(false);
@@ -350,12 +355,22 @@ export function usePreviewConnection({
         // The fetch may have resolved after the user hit Stop — don't schedule
         // another attempt or flip into the error state behind their back.
         if (isStoppedRef.current) return;
+        // If this probe was superseded (aborted by the effect cleanup on a
+        // project/port change or restart, or replaced by a newer attempt), the
+        // ref no longer points at our controller. The active attempt owns
+        // retrying — bailing here avoids a stray duplicate retry.
+        if (readyProbeControllerRef.current !== controller) return;
         if (retryCount < SERVER_MAX_RETRIES) {
           const delay = Math.min(1000 * Math.pow(1.5, retryCount), 5000);
           retryTimerRef.current = setTimeout(() => setRetryCount((c) => c + 1), delay);
         } else {
           setIsLoading(false);
           setHasError(true);
+        }
+      } finally {
+        clearTimeout(timeoutId);
+        if (readyProbeControllerRef.current === controller) {
+          readyProbeControllerRef.current = null;
         }
       }
     };
@@ -366,6 +381,11 @@ export function usePreviewConnection({
         clearTimeout(retryTimerRef.current);
         retryTimerRef.current = null;
       }
+      // Abort a probe left in flight by this attempt (project/port change,
+      // restart, or the next retry superseding it) so its long-lived fetch and
+      // 30s abort timer don't linger.
+      readyProbeControllerRef.current?.abort();
+      readyProbeControllerRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- port is covered by devServerUrl
   }, [devServerUrl, retryCount, isStopped]);
@@ -468,10 +488,18 @@ export function usePreviewConnection({
   // Halt the connect loop immediately — cancel any pending retry and drop out of
   // the loading state into a "stopped" state with Retry / Fix-with-agent actions.
   const stopConnecting = useCallback(() => {
+    // Set the ref before aborting so the probe's catch sees "stopped" and bails
+    // instead of scheduling another attempt (the state update won't have flushed
+    // to isStoppedRef by the time abort rejects the in-flight fetch).
+    isStoppedRef.current = true;
     if (retryTimerRef.current) {
       clearTimeout(retryTimerRef.current);
       retryTimerRef.current = null;
     }
+    // Abort the in-flight readiness probe so Stop is honored immediately rather
+    // than leaving a 30s fetch running in the background.
+    readyProbeControllerRef.current?.abort();
+    readyProbeControllerRef.current = null;
     setIsStopped(true);
     setIsLoading(false);
     setHasError(false);


### PR DESCRIPTION
## The bug

A user (Jesse) reported the live preview never opening for a **Next.js 16 + Supabase** project: `localhost` loads in a real browser (slowly, but it loads), yet Ship Studio's preview pane just spins and never connects. "Seems to only be an issue for this project."

## Root cause

The preview readiness probe (`usePreviewConnection.ts`) decides the dev server is ready by `fetch()`-ing `http://localhost:<port>` with an **AbortController timeout of 3s**, retrying with backoff.

Modern dev servers (Next.js 16 / Turbopack, Vite) compile the first route **on demand** and hold the HTTP request open until that compile finishes — frequently **10–30s on a cold start** with a real dependency tree. The response headers don't arrive until then, so the probe **aborted mid-compile on every single attempt** and never observed the (slow) success. A plain browser doesn't abort, so it just waits it out and eventually loads — exactly the discrepancy Jesse saw. It only bit *this* project because it has the slowest cold compile (Next 16 + Supabase SSR + Tailwind v4); faster projects squeak under the 3s wire.

## The fix

Split the single 3s timeout into two:

- **`SERVER_READY_TIMEOUT_MS = 30000`** — the initial readiness probe, so it rides the first compile.
- **`HEALTH_CHECK_TIMEOUT_MS = 3000`** — the ongoing post-ready health check (unchanged; server is warm here, a healthy reply is instant).

A genuinely-down server still rejects **instantly** with connection-refused, so the longer window only affects the "connected but still compiling" case it's meant to ride out — startup polling cadence is unchanged.

## Hardening (from review)

Marko-style review flagged that the now-30s probe makes three pre-existing latent issues user-visible, all from never aborting the probe's `AbortController`. Fixed together by tracking the controller in a ref:

- **Stop now aborts the in-flight probe** (was leaving a 30s fetch running in the background after the user bailed).
- **Superseded probes** (project/port switch, restart, next retry) are aborted instead of leaking their fetch + abort timer.
- **`clearTimeout` moved to `finally`** (was only clearing on success).
- Guarded the retry path so a superseded probe doesn't schedule a stray duplicate retry; set `isStoppedRef` synchronously in `stopConnecting` so the aborted fetch's `catch` bails before re-render.

## Tests

Two regression tests in `usePreviewConnection.test.ts` (both verified to fail without the corresponding fix):
1. The readiness probe **rides a slow (>3s) compile** without aborting/re-firing — fails under the old 3s timeout.
2. **Stop aborts the in-flight probe** and fires no further probes — fails without the abort.

Full suite: 682 passed, typecheck + lint + `check:patterns` clean.

## Known follow-up (not in this PR)

Worst-case wall-clock before "Could not connect" for a server that accepts TCP but never responds is now ~35 min across the 60-retry budget (was ~8 min). Stop fully interrupts it now, but a hard wall-clock ceiling on the readiness loop would be a good separate hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for preview connection readiness probes under slow server compilation and cancellation scenarios.

* **Improvements**
  * Enhanced preview connection handling for slow server compilation during initial readiness checks, preventing unnecessary retry cycles.
  * Improved connection stop behavior with faster, more responsive abort handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->