### PR TITLE
Fix pinned edit-panel not scrolling (WebKit grid track sizing)

### DIFF
--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -1088,7 +1088,15 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
               onTogglePin={toggleEditorPinned}
             />
           );
-          return editorPinned ? panel : createPortal(panel, document.body);
+          // Pinned: wrap in a relative "dock" grid cell and absolutely-position
+          // the panel inside it. An absolute panel can't grow its grid track, so
+          // it's bounded to the cell's real height and its body scrolls — an
+          // in-flow panel was growing its row past the viewport in WebKit.
+          return editorPinned ? (
+            <div className="ss-edit-panel-dock">{panel}</div>
+          ) : (
+            createPortal(panel, document.body)
+          );
         })()}
     </div>
   );

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -301,13 +301,27 @@
   grid-column: 1 / -1;
 }
 
+/* The pinned panel's grid cell. The panel inside is absolutely positioned, so it
+   contributes nothing to grid track sizing — the cell is sized purely by the
+   canvas column, which is bounded. This is what lets the panel body scroll: an
+   in-flow panel was growing its own grid row past the viewport in WebKit, so the
+   body never scrolled. */
+.ss-edit-panel-dock {
+  grid-area: 2 / -2 / -1 / -1;
+  position: relative;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
 /* Compound selector: this file loads before visual-editor.css, so the pinned
    overrides need higher specificity than the base .ss-edit-panel rules. */
 .ss-edit-panel.ss-edit-panel--pinned {
-  position: static;
-  grid-area: 2 / -2 / -1 / -1;
+  position: absolute;
+  inset: 0;
   width: auto;
   min-width: 0;
+  min-height: 0;
   max-height: none;
   border-radius: 0;
   border-top: none;


### PR DESCRIPTION
The pinned visual-editor panel didn't scroll — long content ran off the bottom and the Save footer could be clipped. Pre-existing bug in released builds.

**Cause:** the pinned panel spans the preview container's canvas grid row. As an in-flow grid item, WKWebView let it grow that row past the viewport, so the whole panel grew to fit its content instead of its body scrolling. (Floating mode was unaffected — it has an explicit `max-height`.)

**Fix:** wrap the pinned panel in a relative `.ss-edit-panel-dock` grid cell and absolutely position the panel (`inset: 0`) inside it. An absolute element contributes nothing to grid track sizing, so the cell stays bounded by the canvas column and the panel body's `overflow-y` scrolls. No change to floating mode.

Two files, no behavior change beyond the fix. Verified the height chain across logs-open, element-tree, and fullscreen states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)