### PR TITLE
Fix install-flow bugs (Windows code tree + Claude install, password hint)

### DIFF
--- a/src-tauri/src/commands/code.rs
+++ b/src-tauri/src/commands/code.rs
@@ -61,6 +61,14 @@ pub fn list_project_files(project_path: &str) -> Result<Vec<FileEntry>, CommandE
         .git_global(true)
         .git_exclude(true)
         .max_depth(Some(20))
+        // Prune always-skip directories during the walk by their own name.
+        // This matters most on Windows and for non-git projects: the `ignore`
+        // crate only applies .gitignore when a `.git` dir is present, so without
+        // this `node_modules` would be descended into and flood the tree.
+        .filter_entry(|entry| {
+            let name = entry.file_name().to_string_lossy();
+            !SKIP_DIRS.contains(&name.as_ref())
+        })
         .build();
 
     for result in walker {
@@ -89,7 +97,7 @@ pub fn list_project_files(project_path: &str) -> Result<Vec<FileEntry>, CommandE
         let relative_str = relative.to_string_lossy().to_string();
 
         // Skip entries in always-skipped directories
-        if should_skip_path(&relative_str) {
+        if should_skip_path(relative) {
             continue;
         }
 
@@ -117,17 +125,17 @@ pub fn list_project_files(project_path: &str) -> Result<Vec<FileEntry>, CommandE
 }
 
 /// Check if a relative path should be skipped based on SKIP_DIRS.
-fn should_skip_path(relative_path: &str) -> bool {
-    for skip in SKIP_DIRS {
-        if relative_path == *skip
-            || relative_path.starts_with(&format!("{skip}/"))
-            || relative_path.contains(&format!("/{skip}/"))
-            || relative_path.ends_with(&format!("/{skip}"))
-        {
-            return true;
-        }
-    }
-    false
+///
+/// Matches on individual path components so it behaves identically on Windows
+/// (`\` separators) and Unix (`/`). The previous string-based matching on `/`
+/// silently failed on Windows and leaked `node_modules` contents into the tree.
+fn should_skip_path(relative: &Path) -> bool {
+    relative.components().any(|component| match component {
+        std::path::Component::Normal(name) => SKIP_DIRS
+            .iter()
+            .any(|skip| name == std::ffi::OsStr::new(skip)),
+        _ => false,
+    })
 }
 
 /// Read a single file from the project.
@@ -298,14 +306,32 @@ mod tests {
 
     #[test]
     fn test_should_skip_path() {
-        assert!(should_skip_path(".git"));
-        assert!(should_skip_path(".git/HEAD"));
-        assert!(should_skip_path("node_modules"));
-        assert!(should_skip_path("node_modules/react/index.js"));
-        assert!(should_skip_path(".shipstudio"));
-        assert!(should_skip_path("src/.shipstudio"));
-        assert!(!should_skip_path("src/main.rs"));
-        assert!(!should_skip_path("README.md"));
-        assert!(!should_skip_path("src/components/GitView.tsx"));
+        assert!(should_skip_path(Path::new(".git")));
+        assert!(should_skip_path(Path::new(".git/HEAD")));
+        assert!(should_skip_path(Path::new("node_modules")));
+        assert!(should_skip_path(Path::new("node_modules/react/index.js")));
+        assert!(should_skip_path(Path::new(".shipstudio")));
+        assert!(should_skip_path(Path::new("src/.shipstudio")));
+        assert!(!should_skip_path(Path::new("src/main.rs")));
+        assert!(!should_skip_path(Path::new("README.md")));
+        assert!(!should_skip_path(Path::new("src/components/GitView.tsx")));
+    }
+
+    /// Regression: Windows paths use `\` separators. The old string-based
+    /// matcher only checked `/`, so `node_modules` leaked into the Code tab on
+    /// Windows. Component matching handles both separators.
+    #[test]
+    fn test_should_skip_path_windows_separators() {
+        use std::path::PathBuf;
+        // PathBuf::from with backslashes is parsed as separators on Windows and
+        // as a single component on Unix, so build the path from components to
+        // exercise the component matcher identically on both platforms.
+        let nested: PathBuf = ["node_modules", ".cache", "@babel", "fixture.cjs"]
+            .iter()
+            .collect();
+        assert!(should_skip_path(&nested));
+
+        let real: PathBuf = ["src", "app", "page.tsx"].iter().collect();
+        assert!(!should_skip_path(&real));
     }
 }

--- a/src/components/setup/OnboardingScreen.tsx
+++ b/src/components/setup/OnboardingScreen.tsx
@@ -600,6 +600,10 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
                 args={terminalConfig.args}
                 onExit={(exitCode) => void handleTerminalExit(exitCode)}
               />
+              <div className="onboarding-terminal-hint">
+                <strong>If you're asked for a password</strong>, type it and press Enter. It stays
+                hidden as you type — no dots or characters appear — but it is being entered.
+              </div>
             </div>
           </div>
         )}

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -528,12 +528,11 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
         args: ['auth', 'login', '--web', '--git-protocol', 'https'],
       },
       claude: {
-        // Windows requires manual installer download
+        // Official native installer for Windows (mirrors the macOS install.sh
+        // path). `irm | iex` downloads and runs the install script in-session;
+        // it is not subject to the .ps1 script execution policy.
         command: 'powershell',
-        args: [
-          '-Command',
-          'Write-Host "Please download Claude Code from https://claude.ai"; Start-Process "https://claude.ai"',
-        ],
+        args: ['-Command', 'irm https://claude.ai/install.ps1 | iex'],
       },
       claude_auth: {
         command: 'claude',
@@ -548,11 +547,10 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
         args: [],
       },
       opencode: {
-        command: 'powershell',
-        args: [
-          '-Command',
-          'Write-Host "Please download Opencode from https://opencode.ai"; Start-Process "https://opencode.ai"',
-        ],
+        // No clean PowerShell one-liner installer exists for Windows; install
+        // via npm (Node is set up in step 1, same as Codex below).
+        command: 'npm',
+        args: ['install', '-g', 'opencode-ai'],
       },
       opencode_auth: {
         command: 'opencode',

--- a/src/styles/features/setup.css
+++ b/src/styles/features/setup.css
@@ -841,6 +841,20 @@
   background: var(--bg-primary);
 }
 
+.onboarding-terminal-hint {
+  padding: 10px 16px;
+  background: var(--bg-tertiary);
+  border-top: 1px solid var(--border);
+  font-size: var(--font-size-sm);
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+.onboarding-terminal-hint strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
 /* ============ Optional Items ============ */
 
 .setup-item-optional {


### PR DESCRIPTION
Three install/onboarding fixes reported by users in the community.

## 1. Code tab flooded with `node_modules` (Windows)
`should_skip_path` in `code.rs` matched on hardcoded `/` separators, which never matched Windows `\` paths — so `node_modules` (Babel/V8 test fixtures like `_class_check_private_static_access.cjs`) leaked into the file tree. It only surfaced on Windows and for non-git projects (the `ignore` crate only applies `.gitignore` when a `.git` dir is present, so `SKIP_DIRS` was the only defense).

- Prune `SKIP_DIRS` during the walk via `filter_entry` (also avoids descending into huge `node_modules` at all).
- `should_skip_path` now matches on path **components**, so it's separator-agnostic.
- Added a Windows-separator regression test.

## 2. "Install Claude Code" opened a browser instead of installing (Windows)
The Windows terminal command was a leftover placeholder from before Claude Code had a native Windows installer:
```
Start-Process "https://claude.ai"
```
…which just opened claude.ai in the browser (a new chat). Users reported this repeatedly.

- Claude → official native installer `irm https://claude.ai/install.ps1 | iex` (mirrors the macOS `install.sh` path; auto-updates).
- Same placeholder bug fixed for opencode → `npm install -g opencode-ai`.

Both run through `TERMINAL_COMMANDS`, so the onboarding wizard and the post-onboarding "Add agent" panel are both fixed.

## 3. Password hint in the install terminal (all platforms)
Users repeatedly report the install flow "won't accept" their password during sudo prompts — because the terminal hides keystrokes (no echo) as they type, so it looks like nothing happens. Added a persistent hint below the onboarding terminal: type the password and press Enter even though it stays hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)