### PR TITLE
Configurable projects folder (Settings → Projects folder)

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -138,6 +138,15 @@ The modal id is baked into the event name (`modal_<id>_opened` / `modal_<id>_clo
 
 To get an aggregate "any modal opened" count in PostHog, use a regex match on event name (`modal_.*_opened`) or a property filter on `modal_id`.
 
+### Settings
+
+| Event | Properties |
+|---|---|
+| `calendar_visibility_toggled` | `visible` |
+| `terminal_gpu_toggled` | `enabled` |
+| `projects_root_changed` | `is_custom` (false when reset to the default `~/ShipStudio`) |
+| `projects_moved` | `moved_count`, `skipped_count` (after moving projects into a newly-chosen folder) |
+
 ### Plugins / Skills / MCP
 
 | Event | Properties |

--- a/src-tauri/src/commands/external_projects.rs
+++ b/src-tauri/src/commands/external_projects.rs
@@ -176,12 +176,14 @@ pub async fn register_external_project(app: AppHandle) -> Result<Option<String>,
     let canonical = dunce::canonicalize(&folder_path).map_err(|e| format!("Invalid path: {e}"))?;
     let canonical_str = canonical.to_string_lossy().to_string();
 
-    // Check if already inside ~/ShipStudio
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
-    let shipstudio_dir = home.join("ShipStudio");
-    if canonical.starts_with(&shipstudio_dir) {
+    // Reject folders that already live under a projects root (configured or
+    // default) — those are listed automatically and aren't "external".
+    if crate::utils::allowed_project_roots()
+        .iter()
+        .any(|root| canonical.starts_with(root))
+    {
         return Err(
-            "This project is already inside ~/ShipStudio. It will appear automatically."
+            "This project is already inside your projects folder. It will appear automatically."
                 .to_string()
                 .into(),
         );
@@ -324,10 +326,12 @@ pub async fn ensure_external_project_registered(
     let canonical =
         dunce::canonicalize(Path::new(&path)).map_err(|e| format!("Invalid path: {e}"))?;
 
-    // Skip if already inside ~/ShipStudio
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
-    let shipstudio_dir = home.join("ShipStudio");
-    if canonical.starts_with(&shipstudio_dir) {
+    // Skip if already inside a projects root (configured or default) — those are
+    // already trusted by validate_project_path and listed automatically.
+    if crate::utils::allowed_project_roots()
+        .iter()
+        .any(|root| canonical.starts_with(root))
+    {
         return Ok(false);
     }
 

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -236,27 +236,24 @@ pub async fn check_prerequisites() -> Vec<PrerequisiteCheck> {
     results
 }
 
-/// Returns the path to ~/ShipStudio directory
+/// Returns the configured projects root directory (custom or default `~/ShipStudio`).
 #[tauri::command]
 #[tracing::instrument]
 pub async fn get_shipstudio_dir() -> Result<String, CommandError> {
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
-    let shipstudio_dir = home.join("ShipStudio");
-    Ok(shipstudio_dir.to_string_lossy().to_string())
+    Ok(crate::utils::projects_root()?.to_string_lossy().to_string())
 }
 
-/// Creates ~/ShipStudio directory if it doesn't exist
+/// Creates the configured projects root directory if it doesn't exist.
 #[tauri::command]
 #[tracing::instrument]
 pub async fn ensure_shipstudio_dir() -> Result<String, CommandError> {
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
-    let shipstudio_dir = home.join("ShipStudio");
+    let projects_dir = crate::utils::projects_root()?;
 
-    if !shipstudio_dir.exists() {
-        std::fs::create_dir_all(&shipstudio_dir).map_err(|e| e.to_string())?;
+    if !projects_dir.exists() {
+        std::fs::create_dir_all(&projects_dir).map_err(|e| e.to_string())?;
     }
 
-    Ok(shipstudio_dir.to_string_lossy().to_string())
+    Ok(projects_dir.to_string_lossy().to_string())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -101,7 +101,7 @@ fn ensure_gitignore_has_shipstudio_sync(project: &std::path::Path) -> Result<(),
 /// Check if a directory is a valid project.
 /// Accepts any directory inside ~/ShipStudio that has project files,
 /// a .gitignore (blank projects), or a .shipstudio metadata folder.
-fn is_valid_project(path: &std::path::Path) -> bool {
+pub(crate) fn is_valid_project(path: &std::path::Path) -> bool {
     path.is_dir()
         && (path.join("package.json").exists()
             || detection::has_html_files(path)
@@ -115,8 +115,7 @@ fn is_valid_project(path: &std::path::Path) -> bool {
 #[tauri::command]
 #[tracing::instrument]
 pub async fn list_projects() -> Result<Vec<ProjectInfo>, CommandError> {
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
-    let shipstudio_dir = home.join("ShipStudio");
+    let shipstudio_dir = crate::utils::projects_root()?;
 
     if !shipstudio_dir.exists() {
         return Ok(Vec::new());
@@ -208,8 +207,7 @@ pub async fn list_projects() -> Result<Vec<ProjectInfo>, CommandError> {
 #[tauri::command]
 #[tracing::instrument]
 pub async fn get_dashboard_projects() -> Result<Vec<DashboardProject>, CommandError> {
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
-    let shipstudio_dir = home.join("ShipStudio");
+    let shipstudio_dir = crate::utils::projects_root()?;
 
     if !shipstudio_dir.exists() {
         return Ok(Vec::new());
@@ -493,15 +491,16 @@ pub async fn ensure_gitignore_has_shipstudio(project_path: String) -> Result<(),
 #[tracing::instrument(fields(project = %project_path))]
 pub async fn create_blank_project(project_path: String) -> Result<(), CommandError> {
     // Can't use validate_project_path because the directory doesn't exist yet.
-    // Instead, validate that the parent is within ~/ShipStudio.
+    // Instead, validate that the parent is within an allowed projects root.
     let path = std::path::Path::new(&project_path);
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
-    let shipstudio_dir = home.join("ShipStudio");
     let parent = path.parent().ok_or("Invalid project path")?;
     let canonical_parent =
         dunce::canonicalize(parent).map_err(|e| format!("Invalid parent path: {e}"))?;
-    if !canonical_parent.starts_with(&shipstudio_dir) {
-        return Err(("Project must be inside ~/ShipStudio".to_string()).into());
+    if !crate::utils::allowed_project_roots()
+        .iter()
+        .any(|root| canonical_parent.starts_with(root))
+    {
+        return Err(("Project must be inside the projects directory".to_string()).into());
     }
 
     std::fs::create_dir_all(path)
@@ -550,11 +549,11 @@ pub async fn delete_project(path: String) -> Result<(), CommandError> {
         );
     }
 
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
-    let shipstudio_dir = home.join("ShipStudio");
-
-    if !canonical.starts_with(&shipstudio_dir) {
-        return Err(("Can only delete projects from ShipStudio directory".to_string()).into());
+    if !crate::utils::allowed_project_roots()
+        .iter()
+        .any(|root| canonical.starts_with(root))
+    {
+        return Err(("Can only delete projects from the projects directory".to_string()).into());
     }
 
     std::fs::remove_dir_all(&canonical).map_err(|e| e.to_string())?;
@@ -634,11 +633,12 @@ pub async fn rename_project(
         );
     }
 
-    // Must live inside ~/ShipStudio.
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
-    let shipstudio_dir = home.join("ShipStudio");
-    if !project_path.starts_with(&shipstudio_dir) {
-        return Err(("Can only rename projects in the ShipStudio directory".to_string()).into());
+    // Must live inside an allowed projects root.
+    if !crate::utils::allowed_project_roots()
+        .iter()
+        .any(|root| project_path.starts_with(root))
+    {
+        return Err(("Can only rename projects in the projects directory".to_string()).into());
     }
 
     // Validate + normalize the requested name.
@@ -708,6 +708,221 @@ pub async fn rename_project(
     Ok(new_path_str)
 }
 
+// ============ Move projects between roots ============
+
+/// Projects in a source root bucketed by how they'd move into a destination root.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MovableProjects {
+    /// Projects that can be moved cleanly.
+    pub movable: Vec<String>,
+    /// Projects whose name already exists in the destination.
+    pub collisions: Vec<String>,
+    /// Projects currently open in a window or running a hot session.
+    pub open: Vec<String>,
+}
+
+/// One project skipped during a move, with a human-readable reason.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkippedProject {
+    pub name: String,
+    pub reason: String,
+}
+
+/// Outcome of moving projects between roots.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MoveReport {
+    pub moved: Vec<String>,
+    pub skipped: Vec<SkippedProject>,
+}
+
+/// Whether a project path is open in a window or has an active hot session.
+fn is_project_open(path: &str) -> bool {
+    if crate::state::get_window_for_project(path).is_some() {
+        return true;
+    }
+    matches!(
+        crate::state::get_session(path),
+        Some(s) if s.status == crate::state::SessionStatus::Active
+    )
+}
+
+/// Recursively copy a directory tree (cross-volume fallback for [`move_dir`]).
+fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else if file_type.is_symlink() {
+            #[cfg(unix)]
+            {
+                let target = std::fs::read_link(&from)?;
+                std::os::unix::fs::symlink(target, &to)?;
+            }
+            #[cfg(not(unix))]
+            {
+                std::fs::copy(&from, &to)?;
+            }
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+/// Move a directory, falling back to copy+delete when `rename` can't cross volumes.
+fn move_dir(src: &std::path::Path, dst: &std::path::Path) -> Result<(), String> {
+    if std::fs::rename(src, dst).is_ok() {
+        return Ok(());
+    }
+    copy_dir_recursive(src, dst).map_err(|e| format!("copy failed: {e}"))?;
+    std::fs::remove_dir_all(src).map_err(|e| format!("cleanup after copy failed: {e}"))?;
+    Ok(())
+}
+
+/// Bucket immediate project subfolders of `from` by movable / collision / open.
+/// Hidden dirs (e.g. the `.shipstudio` app-config dir, which stays at the default
+/// root regardless of where projects live) are skipped.
+fn scan_movable(
+    from: &std::path::Path,
+    to: &std::path::Path,
+) -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut movable = Vec::new();
+    let mut collisions = Vec::new();
+    let mut open = Vec::new();
+    let Ok(entries) = std::fs::read_dir(from) else {
+        return (movable, collisions, open);
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') {
+            continue;
+        }
+        let path = entry.path();
+        if !is_valid_project(&path) {
+            continue;
+        }
+        let src_str = path.to_string_lossy().to_string();
+        if is_project_open(&src_str) {
+            open.push(name);
+        } else if to.join(&name).exists() {
+            collisions.push(name);
+        } else {
+            movable.push(name);
+        }
+    }
+    movable.sort();
+    collisions.sort();
+    open.sort();
+    (movable, collisions, open)
+}
+
+/// Preview which projects in `from` can be moved into `to` (drives the move prompt).
+#[tauri::command]
+#[tracing::instrument]
+pub async fn list_movable_projects(
+    from: String,
+    to: String,
+) -> Result<MovableProjects, CommandError> {
+    let from_dir = std::path::Path::new(&from);
+    let to_dir = std::path::Path::new(&to);
+    // Same folder (or missing source) → nothing to move.
+    if !from_dir.is_dir() || dunce::canonicalize(from_dir).ok() == dunce::canonicalize(to_dir).ok()
+    {
+        return Ok(MovableProjects {
+            movable: vec![],
+            collisions: vec![],
+            open: vec![],
+        });
+    }
+    let (movable, collisions, open) = scan_movable(from_dir, to_dir);
+    Ok(MovableProjects {
+        movable,
+        collisions,
+        open,
+    })
+}
+
+/// Move project folders from one projects root into another.
+///
+/// Skips projects that are currently open or whose name collides in the
+/// destination. For each moved project, rekeys pins, folder membership, and
+/// session state so the dashboard stays consistent. Returns a per-project report.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn move_projects_to_root(from: String, to: String) -> Result<MoveReport, CommandError> {
+    let from_dir = std::path::Path::new(&from);
+    let to_dir = std::path::Path::new(&to);
+
+    if !from_dir.is_dir() {
+        return Err((format!("Source folder doesn't exist: {from}")).into());
+    }
+    if !to_dir.is_dir() {
+        return Err((format!("Destination folder doesn't exist: {to}")).into());
+    }
+    if dunce::canonicalize(from_dir).ok() == dunce::canonicalize(to_dir).ok() {
+        return Ok(MoveReport {
+            moved: vec![],
+            skipped: vec![],
+        });
+    }
+
+    let mut moved = Vec::new();
+    let mut skipped = Vec::new();
+
+    let entries = std::fs::read_dir(from_dir).map_err(|e| e.to_string())?;
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') {
+            continue;
+        }
+        let src = entry.path();
+        if !is_valid_project(&src) {
+            continue;
+        }
+        let src_str = src.to_string_lossy().to_string();
+        if is_project_open(&src_str) {
+            skipped.push(SkippedProject {
+                name,
+                reason: "currently open — close it first".into(),
+            });
+            continue;
+        }
+        let dst = to_dir.join(&name);
+        if dst.exists() {
+            skipped.push(SkippedProject {
+                name,
+                reason: "a folder with the same name already exists in the destination".into(),
+            });
+            continue;
+        }
+        match move_dir(&src, &dst) {
+            Ok(()) => {
+                let dst_str = dst.to_string_lossy().to_string();
+                // Rekey path-keyed stores (best-effort; the move already succeeded).
+                if let Err(e) = pins::rename_pinned_path(&src_str, &dst_str) {
+                    tracing::warn!(error = %e, "Failed to rekey pins after project move");
+                }
+                if let Err(e) = crate::commands::folders::rename_project_path(&src_str, &dst_str) {
+                    tracing::warn!(error = %e, "Failed to rekey folder membership after project move");
+                }
+                crate::state::rename_session_path(&src_str, &dst_str);
+                moved.push(name);
+            }
+            Err(e) => skipped.push(SkippedProject { name, reason: e }),
+        }
+    }
+
+    tracing::info!("Moved {} project(s) from {} to {}", moved.len(), from, to);
+    Ok(MoveReport { moved, skipped })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -730,5 +945,50 @@ mod tests {
         assert!(validate_project_name("..").is_err());
         assert!(validate_project_name(".hidden").is_err());
         assert!(validate_project_name(&"x".repeat(256)).is_err());
+    }
+
+    /// Create a minimal valid project directory (a `.gitignore` makes
+    /// `is_valid_project` return true).
+    fn make_project(root: &std::path::Path, name: &str) {
+        let dir = root.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(".gitignore"), ".shipstudio/\n").unwrap();
+    }
+
+    #[test]
+    fn scan_movable_buckets_clean_collision_and_skips_hidden() {
+        let from = tempfile::tempdir().unwrap();
+        let to = tempfile::tempdir().unwrap();
+
+        make_project(from.path(), "alpha"); // movable
+        make_project(from.path(), "beta"); // collides below
+        make_project(to.path(), "beta"); // destination already has beta
+
+        // A hidden config dir and a non-project dir must be ignored.
+        std::fs::create_dir_all(from.path().join(".shipstudio")).unwrap();
+        std::fs::create_dir_all(from.path().join("not-a-project")).unwrap();
+
+        let (movable, collisions, open) = scan_movable(from.path(), to.path());
+
+        assert_eq!(movable, vec!["alpha".to_string()]);
+        assert_eq!(collisions, vec!["beta".to_string()]);
+        assert!(open.is_empty());
+    }
+
+    #[test]
+    fn move_dir_relocates_a_directory_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        let dst = tmp.path().join("dst");
+        std::fs::create_dir_all(src.join("nested")).unwrap();
+        std::fs::write(src.join("nested").join("file.txt"), "hello").unwrap();
+
+        move_dir(&src, &dst).unwrap();
+
+        assert!(!src.exists());
+        assert_eq!(
+            std::fs::read_to_string(dst.join("nested").join("file.txt")).unwrap(),
+            "hello"
+        );
     }
 }

--- a/src-tauri/src/commands/projects/templates.rs
+++ b/src-tauri/src/commands/projects/templates.rs
@@ -26,13 +26,12 @@ pub async fn extract_template_zip(
     zip_data: Option<Vec<u8>>,
     zip_path: Option<String>,
 ) -> Result<String, CommandError> {
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
-    let shipstudio_dir = home.join("ShipStudio");
+    let shipstudio_dir = crate::utils::projects_root()?;
 
-    // Ensure ShipStudio directory exists
+    // Ensure the projects root exists
     if !shipstudio_dir.exists() {
         std::fs::create_dir_all(&shipstudio_dir)
-            .map_err(|e| format!("Failed to create ShipStudio directory: {e}"))?;
+            .map_err(|e| format!("Failed to create projects directory: {e}"))?;
     }
 
     // Sanitize project name

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,9 +1,13 @@
 //! # Settings Commands
 //!
-//! Persisted UI preferences (calendar visibility, etc.).
+//! Persisted UI preferences (calendar visibility, projects root, etc.).
 
 use crate::commands::setup::{read_app_state, write_app_state};
 use crate::errors::CommandError;
+use crate::utils::{invalidate_projects_root_cache, projects_root};
+use std::path::Path;
+use tauri::AppHandle;
+use tauri_plugin_dialog::DialogExt;
 
 /// Get whether the GitHub contribution calendar is hidden on the dashboard.
 #[tauri::command]
@@ -54,4 +58,89 @@ pub fn set_terminal_gpu_enabled(enabled: bool) -> Result<(), CommandError> {
     let mut state = read_app_state();
     state.terminal_gpu_enabled = Some(enabled);
     write_app_state(&state).map_err(CommandError::from)
+}
+
+/// Get the projects root directory (absolute path). Falls back to the default
+/// `~/ShipStudio` when no custom root is configured.
+#[tauri::command]
+#[tracing::instrument]
+pub fn get_projects_root() -> Result<String, CommandError> {
+    Ok(projects_root()?.to_string_lossy().to_string())
+}
+
+/// Whether a custom (non-default) projects root is currently configured.
+#[tauri::command]
+#[tracing::instrument]
+pub fn is_custom_projects_root() -> Result<bool, CommandError> {
+    let state = read_app_state();
+    Ok(state
+        .projects_root
+        .as_deref()
+        .map(|s| !s.trim().is_empty())
+        .unwrap_or(false))
+}
+
+/// Set (or clear) the projects root directory.
+///
+/// An empty string resets to the default `~/ShipStudio`. A non-empty value must
+/// be an existing, writable, absolute directory. The cache is invalidated so the
+/// change takes effect immediately.
+#[tauri::command]
+#[tracing::instrument]
+pub fn set_projects_root(path: String) -> Result<(), CommandError> {
+    let trimmed = path.trim();
+    let mut state = read_app_state();
+
+    if trimmed.is_empty() {
+        state.projects_root = None;
+    } else {
+        let pb = Path::new(trimmed);
+        if !pb.is_absolute() {
+            return Err("Projects folder must be an absolute path"
+                .to_string()
+                .into());
+        }
+        if !pb.is_dir() {
+            return Err(format!("Not a folder: {trimmed}").into());
+        }
+        // Guardrail: never allow the filesystem root as the projects folder.
+        if pb.parent().is_none() {
+            return Err("Refusing to use the filesystem root as the projects folder"
+                .to_string()
+                .into());
+        }
+        // Confirm the folder is writable (creating projects needs write access).
+        let probe = pb.join(".shipstudio-write-test");
+        std::fs::write(&probe, b"test").map_err(|e| format!("Folder isn't writable: {e}"))?;
+        let _ = std::fs::remove_file(&probe);
+
+        state.projects_root = Some(trimmed.to_string());
+    }
+
+    write_app_state(&state).map_err(CommandError::from)?;
+    invalidate_projects_root_cache();
+    Ok(())
+}
+
+/// Open a native folder picker for choosing the projects folder.
+/// Returns the selected absolute path, or `None` if the user cancelled.
+/// Does not persist anything — the frontend calls `set_projects_root` with the result.
+#[tauri::command]
+#[tracing::instrument(skip(app))]
+pub async fn pick_projects_root(app: AppHandle) -> Result<Option<String>, CommandError> {
+    let folder = app
+        .dialog()
+        .file()
+        .set_title("Choose Projects Folder")
+        .blocking_pick_folder();
+
+    match folder {
+        Some(path) => {
+            let pb = path
+                .into_path()
+                .map_err(|e| format!("Invalid folder path: {e}"))?;
+            Ok(Some(pb.to_string_lossy().to_string()))
+        }
+        None => Ok(None),
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -461,6 +461,12 @@ pub fn run() {
             commands::settings::set_slack_cta_hidden,
             commands::settings::get_terminal_gpu_enabled,
             commands::settings::set_terminal_gpu_enabled,
+            commands::settings::get_projects_root,
+            commands::settings::set_projects_root,
+            commands::settings::is_custom_projects_root,
+            commands::settings::pick_projects_root,
+            commands::projects::list_movable_projects,
+            commands::projects::move_projects_to_root,
             // AI generation
             commands::ai::generate_pr_description,
             commands::ai::generate_commit_message,

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -752,6 +752,12 @@ pub struct AppState {
     /// macOS beta / GPU-driver combinations).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub terminal_gpu_enabled: Option<bool>,
+    /// User-configured root directory where projects are listed and created.
+    /// None falls back to the built-in default (`~/ShipStudio`). The default root
+    /// always stays valid even when a custom one is set, so projects already in
+    /// `~/ShipStudio` keep opening.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub projects_root: Option<String>,
 }
 
 // ============ Compact Mode ============

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -3,7 +3,7 @@
 //! This module contains shared utility functions used across the Ship Studio backend.
 
 use std::process::Command;
-use std::sync::{LazyLock, Mutex};
+use std::sync::{LazyLock, Mutex, RwLock};
 use std::time::Instant;
 
 /// Creates a `Command` that won't spawn a visible console window on Windows.
@@ -341,18 +341,98 @@ pub fn find_executable(cmd: &str) -> Option<std::path::PathBuf> {
     None
 }
 
-/// Validates that a project path is inside the ~/ShipStudio directory
-/// or is a registered external project.
-/// Prevents path traversal attacks where frontend could pass arbitrary paths.
+/// Caches the resolved projects root so path validation (called by most
+/// commands) doesn't read `app_state.json` on every invocation. Invalidated by
+/// [`invalidate_projects_root_cache`] when the setting changes.
+static PROJECTS_ROOT_CACHE: RwLock<Option<std::path::PathBuf>> = RwLock::new(None);
+
+/// The built-in default projects root, `~/ShipStudio`.
+///
+/// This always remains a valid location even when the user configures a custom
+/// root, so projects already living in `~/ShipStudio` keep opening.
+pub fn default_projects_root() -> Result<std::path::PathBuf, String> {
+    let home = dirs::home_dir().ok_or("Could not find home directory")?;
+    Ok(home.join("ShipStudio"))
+}
+
+/// The directory Ship Studio uses to list and create projects.
+///
+/// Resolves the user-configured root from persisted app state (cached), falling
+/// back to `~/ShipStudio`. A configured path that no longer exists on disk falls
+/// back to the default, so the app never points at a dead directory.
+pub fn projects_root() -> Result<std::path::PathBuf, String> {
+    if let Some(cached) = PROJECTS_ROOT_CACHE
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+    {
+        return Ok(cached);
+    }
+    let resolved = resolve_projects_root_uncached()?;
+    *PROJECTS_ROOT_CACHE
+        .write()
+        .unwrap_or_else(|e| e.into_inner()) = Some(resolved.clone());
+    Ok(resolved)
+}
+
+fn resolve_projects_root_uncached() -> Result<std::path::PathBuf, String> {
+    let default = default_projects_root()?;
+    let configured = crate::commands::setup::read_app_state().projects_root;
+    match configured {
+        Some(p) if !p.trim().is_empty() => {
+            let pb = std::path::PathBuf::from(p);
+            // Only honor a configured root that still exists; otherwise fall
+            // back so a deleted/renamed folder doesn't strand the dashboard.
+            if pb.is_dir() {
+                Ok(pb)
+            } else {
+                Ok(default)
+            }
+        }
+        _ => Ok(default),
+    }
+}
+
+/// Drop the cached projects root. Call after persisting a new value so the next
+/// `projects_root()` re-reads from app state.
+pub fn invalidate_projects_root_cache() {
+    *PROJECTS_ROOT_CACHE
+        .write()
+        .unwrap_or_else(|e| e.into_inner()) = None;
+}
+
+/// The set of root directories a project path is allowed to live under: the
+/// configured root plus the built-in default (kept for backward compatibility).
+/// Each is canonicalized where it exists so symlinked roots still match the
+/// canonicalized candidate in the containment checks below.
+pub(crate) fn allowed_project_roots() -> Vec<std::path::PathBuf> {
+    let mut roots: Vec<std::path::PathBuf> = Vec::new();
+    if let Ok(r) = projects_root() {
+        roots.push(r);
+    }
+    if let Ok(d) = default_projects_root() {
+        if !roots.contains(&d) {
+            roots.push(d);
+        }
+    }
+    roots
+        .into_iter()
+        .map(|r| dunce::canonicalize(&r).unwrap_or(r))
+        .collect()
+}
+
+/// Validates that a project path is inside an allowed projects root (the
+/// configured root or the default `~/ShipStudio`) or is a registered external
+/// project. Prevents path traversal where the frontend could pass arbitrary paths.
 pub fn validate_project_path(project_path: &str) -> Result<std::path::PathBuf, String> {
     let path = std::path::Path::new(project_path);
     let canonical = dunce::canonicalize(path).map_err(|e| format!("Invalid path: {e}"))?;
 
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
-    let shipstudio_dir = home.join("ShipStudio");
-
-    // Allow paths inside ~/ShipStudio
-    if canonical.starts_with(&shipstudio_dir) {
+    // Allow paths inside any allowed projects root
+    if allowed_project_roots()
+        .iter()
+        .any(|root| canonical.starts_with(root))
+    {
         return Ok(canonical);
     }
 
@@ -362,7 +442,7 @@ pub fn validate_project_path(project_path: &str) -> Result<std::path::PathBuf, S
     }
 
     Err(format!(
-        "Security error: path '{project_path}' is outside ShipStudio directory"
+        "Security error: path '{project_path}' is outside the projects directory"
     ))
 }
 
@@ -393,15 +473,14 @@ pub fn validate_project_file_path(file_path: &str) -> Result<std::path::PathBuf,
     // containment check below can't be defeated lexically.
     let canonical_parent = dunce::canonicalize(parent).map_err(|e| format!("Invalid path: {e}"))?;
 
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
-    let shipstudio_dir = home.join("ShipStudio");
-
-    let allowed = canonical_parent.starts_with(&shipstudio_dir)
+    let allowed = allowed_project_roots()
+        .iter()
+        .any(|root| canonical_parent.starts_with(root))
         || crate::commands::external_projects::is_registered_external_path(&canonical_parent)?;
 
     if !allowed {
         return Err(format!(
-            "Security error: path '{file_path}' is outside ShipStudio directory"
+            "Security error: path '{file_path}' is outside the projects directory"
         ));
     }
 

--- a/src/components/dashboard/ProjectList.tsx
+++ b/src/components/dashboard/ProjectList.tsx
@@ -746,6 +746,7 @@ export function ProjectList({
           onClose={() => setShowSettings(false)}
           onCalendarHiddenChange={setCalendarHidden}
           onSlackCtaHiddenChange={setSlackCtaHidden}
+          onProjectsRootChanged={() => void loadProjects()}
         />
 
         {/* What's New Modal */}

--- a/src/components/dashboard/SettingsModal.tsx
+++ b/src/components/dashboard/SettingsModal.tsx
@@ -1,7 +1,9 @@
 /**
  * SettingsModal - app-level settings accessible from the dashboard.
  *
- * Currently contains:
+ * Contains:
+ * - Projects folder (where projects are listed/created), with an optional move
+ * - Activity calendar / community banner / terminal GPU visibility toggles
  * - Analytics opt-out toggle
  *
  * @module components/SettingsModal
@@ -9,7 +11,9 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { ModalFrame } from '../primitives/ModalFrame';
+import { Button } from '../primitives/Button';
 import { getAnalyticsEnabled, setAnalyticsEnabled, trackEvent } from '../../lib/analytics';
+import { useOptionalToast } from '../../contexts/ToastContext';
 import {
   getCalendarHidden,
   setCalendarHidden,
@@ -17,13 +21,33 @@ import {
   setSlackCtaHidden,
   getTerminalGpuEnabled,
   setTerminalGpuEnabled,
+  getProjectsRoot,
+  isCustomProjectsRoot,
+  pickProjectsRoot,
+  setProjectsRoot,
+  listMovableProjects,
+  moveProjectsToRoot,
+  type MovableProjects,
 } from '../../lib/settings';
+import { asCommandError, formatCommandError } from '../../lib/errors';
+
+const errMsg = (err: unknown) => formatCommandError(asCommandError(err));
 
 interface SettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
   onCalendarHiddenChange?: (hidden: boolean) => void;
   onSlackCtaHiddenChange?: (hidden: boolean) => void;
+  /** Called after the projects folder changes (and after a move) so the
+   *  dashboard can re-list projects. */
+  onProjectsRootChanged?: () => void;
+}
+
+/** Pending "move existing projects?" prompt state. */
+interface MovePrompt {
+  from: string;
+  to: string;
+  info: MovableProjects;
 }
 
 export function SettingsModal({
@@ -31,28 +55,41 @@ export function SettingsModal({
   onClose,
   onCalendarHiddenChange,
   onSlackCtaHiddenChange,
+  onProjectsRootChanged,
 }: SettingsModalProps) {
+  const { showToast } = useOptionalToast();
+
   const [analyticsEnabled, setLocalAnalyticsEnabled] = useState(true);
   const [calendarVisible, setLocalCalendarVisible] = useState(true);
   const [slackCtaVisible, setLocalSlackCtaVisible] = useState(true);
   const [terminalGpuEnabled, setLocalTerminalGpuEnabled] = useState(true);
   const [loading, setLoading] = useState(true);
 
+  const [projectsRoot, setLocalProjectsRoot] = useState('');
+  const [customRoot, setCustomRoot] = useState(false);
+  const [savingRoot, setSavingRoot] = useState(false);
+  const [movePrompt, setMovePrompt] = useState<MovePrompt | null>(null);
+  const [moving, setMoving] = useState(false);
+
   useEffect(() => {
     if (!isOpen) return;
     let cancelled = false;
     void (async () => {
-      const [enabled, calHidden, slackHidden, gpuEnabled] = await Promise.all([
+      const [enabled, calHidden, slackHidden, gpuEnabled, root, custom] = await Promise.all([
         getAnalyticsEnabled(),
         getCalendarHidden(),
         getSlackCtaHidden(),
         getTerminalGpuEnabled(),
+        getProjectsRoot().catch(() => ''),
+        isCustomProjectsRoot(),
       ]);
       if (!cancelled) {
         setLocalAnalyticsEnabled(enabled);
         setLocalCalendarVisible(!calHidden);
         setLocalSlackCtaVisible(!slackHidden);
         setLocalTerminalGpuEnabled(gpuEnabled);
+        setLocalProjectsRoot(root);
+        setCustomRoot(custom);
         setLoading(false);
       }
     })();
@@ -99,90 +136,259 @@ export function SettingsModal({
     });
   }, [terminalGpuEnabled]);
 
+  // Persist a new projects root, then offer to move existing projects over.
+  const applyNewRoot = useCallback(
+    async (newRoot: string) => {
+      const previous = projectsRoot;
+      if (!newRoot || newRoot === previous) return;
+      setSavingRoot(true);
+      try {
+        await setProjectsRoot(newRoot);
+        setLocalProjectsRoot(newRoot);
+        setCustomRoot(true);
+        onProjectsRootChanged?.();
+        void trackEvent('projects_root_changed', { is_custom: true, $screen_name: 'Settings' });
+        showToast('Projects folder updated', 'success');
+
+        // Offer to move any projects left behind in the previous folder.
+        if (previous && previous !== newRoot) {
+          const info = await listMovableProjects(previous, newRoot).catch(() => null);
+          if (info && (info.movable.length || info.collisions.length || info.open.length)) {
+            setMovePrompt({ from: previous, to: newRoot, info });
+          }
+        }
+      } catch (err) {
+        showToast(errMsg(err), 'error');
+      } finally {
+        setSavingRoot(false);
+      }
+    },
+    [projectsRoot, onProjectsRootChanged, showToast]
+  );
+
+  const handleChangeFolder = useCallback(async () => {
+    try {
+      const picked = await pickProjectsRoot();
+      if (picked) await applyNewRoot(picked);
+    } catch (err) {
+      showToast(errMsg(err), 'error');
+    }
+  }, [applyNewRoot, showToast]);
+
+  const handleResetFolder = useCallback(async () => {
+    setSavingRoot(true);
+    try {
+      await setProjectsRoot('');
+      const root = await getProjectsRoot();
+      setLocalProjectsRoot(root);
+      setCustomRoot(false);
+      onProjectsRootChanged?.();
+      void trackEvent('projects_root_changed', { is_custom: false, $screen_name: 'Settings' });
+      showToast('Reset to the default projects folder', 'success');
+    } catch (err) {
+      showToast(errMsg(err), 'error');
+    } finally {
+      setSavingRoot(false);
+    }
+  }, [onProjectsRootChanged, showToast]);
+
+  const handleConfirmMove = useCallback(async () => {
+    if (!movePrompt) return;
+    setMoving(true);
+    try {
+      const report = await moveProjectsToRoot(movePrompt.from, movePrompt.to);
+      onProjectsRootChanged?.();
+      void trackEvent('projects_moved', {
+        moved_count: report.moved.length,
+        skipped_count: report.skipped.length,
+        $screen_name: 'Settings',
+      });
+      const movedMsg = `Moved ${report.moved.length} project${report.moved.length === 1 ? '' : 's'}`;
+      const skipMsg = report.skipped.length ? `, skipped ${report.skipped.length}` : '';
+      showToast(`${movedMsg}${skipMsg}`, report.skipped.length ? 'info' : 'success');
+      setMovePrompt(null);
+    } catch (err) {
+      showToast(errMsg(err), 'error');
+    } finally {
+      setMoving(false);
+    }
+  }, [movePrompt, onProjectsRootChanged, showToast]);
+
   return (
-    <ModalFrame isOpen={isOpen} onClose={onClose} title="Settings" className="settings-modal">
-      <div className="settings-modal-body">
-        <div className="settings-section">
-          <div className="settings-row">
-            <div className="settings-row-info">
-              <span className="settings-row-label">Activity calendar</span>
-              <span className="settings-row-description">
-                Show your GitHub contribution graph on the dashboard.
-              </span>
+    <>
+      <ModalFrame isOpen={isOpen} onClose={onClose} title="Settings" className="settings-modal">
+        <div className="settings-modal-body">
+          <div className="settings-section">
+            <div className="settings-row settings-row--stacked">
+              <div className="settings-row-info">
+                <span className="settings-row-label">Projects folder</span>
+                <span className="settings-row-description">
+                  Where Ship Studio lists and creates your projects. Point this at an existing dev
+                  directory to keep everything in one place.
+                </span>
+                <span className="settings-folder-path" title={projectsRoot}>
+                  {projectsRoot || '—'}
+                  {!customRoot && projectsRoot ? ' (default)' : ''}
+                </span>
+              </div>
+              <div className="settings-folder-actions">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => void handleChangeFolder()}
+                  disabled={savingRoot || loading}
+                >
+                  Change…
+                </Button>
+                {customRoot && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => void handleResetFolder()}
+                    disabled={savingRoot}
+                  >
+                    Reset to default
+                  </Button>
+                )}
+              </div>
             </div>
-            <button
-              className={`settings-toggle ${calendarVisible ? 'on' : 'off'}`}
-              onClick={handleCalendarToggle}
-              disabled={loading}
-              role="switch"
-              aria-checked={calendarVisible}
-            >
-              <span className="settings-toggle-track">
-                <span className="settings-toggle-thumb" />
-              </span>
-            </button>
-          </div>
-          <div className="settings-row">
-            <div className="settings-row-info">
-              <span className="settings-row-label">Community banner</span>
-              <span className="settings-row-description">
-                Show the Slack community invite on the dashboard.
-              </span>
+            <div className="settings-row">
+              <div className="settings-row-info">
+                <span className="settings-row-label">Activity calendar</span>
+                <span className="settings-row-description">
+                  Show your GitHub contribution graph on the dashboard.
+                </span>
+              </div>
+              <button
+                className={`settings-toggle ${calendarVisible ? 'on' : 'off'}`}
+                onClick={handleCalendarToggle}
+                disabled={loading}
+                role="switch"
+                aria-checked={calendarVisible}
+              >
+                <span className="settings-toggle-track">
+                  <span className="settings-toggle-thumb" />
+                </span>
+              </button>
             </div>
-            <button
-              className={`settings-toggle ${slackCtaVisible ? 'on' : 'off'}`}
-              onClick={handleSlackCtaToggle}
-              disabled={loading}
-              role="switch"
-              aria-checked={slackCtaVisible}
-            >
-              <span className="settings-toggle-track">
-                <span className="settings-toggle-thumb" />
-              </span>
-            </button>
-          </div>
-          <div className="settings-row">
-            <div className="settings-row-info">
-              <span className="settings-row-label">Terminal GPU acceleration</span>
-              <span className="settings-row-description">
-                Use GPU rendering for faster, smoother terminals. Turn off if agent output looks
-                garbled or fragmented (a known issue on some macOS beta builds). Applies to newly
-                opened terminals.
-              </span>
+            <div className="settings-row">
+              <div className="settings-row-info">
+                <span className="settings-row-label">Community banner</span>
+                <span className="settings-row-description">
+                  Show the Slack community invite on the dashboard.
+                </span>
+              </div>
+              <button
+                className={`settings-toggle ${slackCtaVisible ? 'on' : 'off'}`}
+                onClick={handleSlackCtaToggle}
+                disabled={loading}
+                role="switch"
+                aria-checked={slackCtaVisible}
+              >
+                <span className="settings-toggle-track">
+                  <span className="settings-toggle-thumb" />
+                </span>
+              </button>
             </div>
-            <button
-              className={`settings-toggle ${terminalGpuEnabled ? 'on' : 'off'}`}
-              onClick={handleTerminalGpuToggle}
-              disabled={loading}
-              role="switch"
-              aria-checked={terminalGpuEnabled}
-            >
-              <span className="settings-toggle-track">
-                <span className="settings-toggle-thumb" />
-              </span>
-            </button>
-          </div>
-          <div className="settings-row">
-            <div className="settings-row-info">
-              <span className="settings-row-label">Usage analytics</span>
-              <span className="settings-row-description">
-                Help improve Ship Studio by sharing usage data like feature usage, and errors.
-              </span>
+            <div className="settings-row">
+              <div className="settings-row-info">
+                <span className="settings-row-label">Terminal GPU acceleration</span>
+                <span className="settings-row-description">
+                  Use GPU rendering for faster, smoother terminals. Turn off if agent output looks
+                  garbled or fragmented (a known issue on some macOS beta builds). Applies to newly
+                  opened terminals.
+                </span>
+              </div>
+              <button
+                className={`settings-toggle ${terminalGpuEnabled ? 'on' : 'off'}`}
+                onClick={handleTerminalGpuToggle}
+                disabled={loading}
+                role="switch"
+                aria-checked={terminalGpuEnabled}
+              >
+                <span className="settings-toggle-track">
+                  <span className="settings-toggle-thumb" />
+                </span>
+              </button>
             </div>
-            <button
-              className={`settings-toggle ${analyticsEnabled ? 'on' : 'off'}`}
-              onClick={handleToggle}
-              disabled={loading}
-              role="switch"
-              aria-checked={analyticsEnabled}
-            >
-              <span className="settings-toggle-track">
-                <span className="settings-toggle-thumb" />
-              </span>
-            </button>
+            <div className="settings-row">
+              <div className="settings-row-info">
+                <span className="settings-row-label">Usage analytics</span>
+                <span className="settings-row-description">
+                  Help improve Ship Studio by sharing usage data like feature usage, and errors.
+                </span>
+              </div>
+              <button
+                className={`settings-toggle ${analyticsEnabled ? 'on' : 'off'}`}
+                onClick={handleToggle}
+                disabled={loading}
+                role="switch"
+                aria-checked={analyticsEnabled}
+              >
+                <span className="settings-toggle-track">
+                  <span className="settings-toggle-thumb" />
+                </span>
+              </button>
+            </div>
           </div>
         </div>
-      </div>
-    </ModalFrame>
+      </ModalFrame>
+
+      {movePrompt && (
+        <ModalFrame
+          isOpen={true}
+          onClose={() => !moving && setMovePrompt(null)}
+          title="Move existing projects?"
+          className="settings-modal"
+        >
+          <div className="settings-modal-body">
+            <p className="settings-move-intro">
+              {movePrompt.info.movable.length > 0 ? (
+                <>
+                  Move{' '}
+                  <strong>
+                    {movePrompt.info.movable.length} project
+                    {movePrompt.info.movable.length === 1 ? '' : 's'}
+                  </strong>{' '}
+                  from your previous folder into the new one?
+                </>
+              ) : (
+                <>There are no projects that can be moved cleanly into the new folder.</>
+              )}
+            </p>
+            <p className="settings-move-paths">
+              <span title={movePrompt.from}>{movePrompt.from}</span>
+              <span aria-hidden> → </span>
+              <span title={movePrompt.to}>{movePrompt.to}</span>
+            </p>
+            {movePrompt.info.collisions.length > 0 && (
+              <p className="settings-move-note">
+                {movePrompt.info.collisions.length} skipped — a folder with the same name already
+                exists in the destination.
+              </p>
+            )}
+            {movePrompt.info.open.length > 0 && (
+              <p className="settings-move-note">
+                {movePrompt.info.open.length} skipped — currently open. Close them first to move.
+              </p>
+            )}
+            <div className="settings-move-actions">
+              <Button variant="ghost" onClick={() => setMovePrompt(null)} disabled={moving}>
+                Not now
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => void handleConfirmMove()}
+                disabled={moving || movePrompt.info.movable.length === 0}
+              >
+                {moving
+                  ? 'Moving…'
+                  : `Move ${movePrompt.info.movable.length} project${movePrompt.info.movable.length === 1 ? '' : 's'}`}
+              </Button>
+            </div>
+          </div>
+        </ModalFrame>
+      )}
+    </>
   );
 }

--- a/src/components/dashboard/SettingsModal.tsx
+++ b/src/components/dashboard/SettingsModal.tsx
@@ -30,6 +30,7 @@ import {
   type MovableProjects,
 } from '../../lib/settings';
 import { asCommandError, formatCommandError } from '../../lib/errors';
+import { EditIcon } from '../icons';
 
 const errMsg = (err: unknown) => formatCommandError(asCommandError(err));
 
@@ -226,29 +227,29 @@ export function SettingsModal({
                   Where Ship Studio lists and creates your projects. Point this at an existing dev
                   directory to keep everything in one place.
                 </span>
-                <span className="settings-folder-path" title={projectsRoot}>
-                  {projectsRoot || '—'}
-                  {!customRoot && projectsRoot ? ' (default)' : ''}
-                </span>
-              </div>
-              <div className="settings-folder-actions">
-                <Button
-                  variant="secondary"
-                  size="sm"
+                <button
+                  type="button"
+                  className="settings-folder-field"
                   onClick={() => void handleChangeFolder()}
                   disabled={savingRoot || loading}
+                  title="Change projects folder"
+                  aria-label="Change projects folder"
                 >
-                  Change…
-                </Button>
+                  <span className="settings-folder-field-path">
+                    {projectsRoot || '—'}
+                    {!customRoot && projectsRoot ? ' (default)' : ''}
+                  </span>
+                  <EditIcon size={14} />
+                </button>
                 {customRoot && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
+                  <button
+                    type="button"
+                    className="settings-folder-reset"
                     onClick={() => void handleResetFolder()}
                     disabled={savingRoot}
                   >
                     Reset to default
-                  </Button>
+                  </button>
                 )}
               </div>
             </div>

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -76,3 +76,73 @@ export async function setTerminalGpuEnabled(enabled: boolean): Promise<void> {
     // Silently fail
   }
 }
+
+// ============ Projects root directory ============
+
+/**
+ * Get the projects root directory (absolute path). This is where Ship Studio
+ * lists and creates projects. Falls back to the default `~/ShipStudio` when no
+ * custom folder is configured.
+ */
+export async function getProjectsRoot(): Promise<string> {
+  return invoke<string>('get_projects_root');
+}
+
+/**
+ * Open a native folder picker for the projects folder. Returns the selected
+ * absolute path, or `null` if the user cancelled. Does not persist — pass the
+ * result to {@link setProjectsRoot}.
+ */
+export async function pickProjectsRoot(): Promise<string | null> {
+  return invoke<string | null>('pick_projects_root');
+}
+
+/** Whether a custom (non-default) projects folder is currently configured. */
+export async function isCustomProjectsRoot(): Promise<boolean> {
+  try {
+    return await invoke<boolean>('is_custom_projects_root');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Set (or clear) the projects folder. Pass an empty string to reset to the
+ * default `~/ShipStudio`. Throws (with a user-facing message) if the chosen path
+ * isn't an existing, writable directory.
+ */
+export async function setProjectsRoot(path: string): Promise<void> {
+  await invoke('set_projects_root', { path });
+}
+
+/** A project folder's eligibility for moving into a new projects folder. */
+export interface MovableProjects {
+  /** Projects that can be moved cleanly. */
+  movable: string[];
+  /** Projects whose name already exists in the destination. */
+  collisions: string[];
+  /** Projects currently open in a window or running a hot session. */
+  open: string[];
+}
+
+/** One project skipped during a move, with a human-readable reason. */
+export interface SkippedProject {
+  name: string;
+  reason: string;
+}
+
+/** Outcome of moving projects between folders. */
+export interface MoveReport {
+  moved: string[];
+  skipped: SkippedProject[];
+}
+
+/** Preview which projects in `from` can be moved into `to`. */
+export async function listMovableProjects(from: string, to: string): Promise<MovableProjects> {
+  return invoke<MovableProjects>('list_movable_projects', { from, to });
+}
+
+/** Move project folders from one projects folder into another. */
+export async function moveProjectsToRoot(from: string, to: string): Promise<MoveReport> {
+  return invoke<MoveReport>('move_projects_to_root', { from, to });
+}

--- a/src/styles/features/settings.css
+++ b/src/styles/features/settings.css
@@ -60,6 +60,58 @@
   line-height: 1.4;
 }
 
+/* Projects folder row (stacked: label/description/path above the actions) */
+.settings-row--stacked {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.settings-folder-path {
+  margin-top: var(--spacing-xs);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  color: var(--text-secondary);
+  word-break: break-all;
+}
+
+.settings-folder-actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+}
+
+/* Move-projects prompt */
+.settings-move-intro {
+  font-size: var(--font-size-md);
+  color: var(--text-primary);
+  line-height: 1.5;
+  margin: 0 0 var(--spacing-md);
+}
+
+.settings-move-paths {
+  font-size: var(--font-size-base);
+  color: var(--text-secondary);
+  word-break: break-all;
+  margin: 0 0 var(--spacing-md);
+}
+
+.settings-move-note {
+  font-size: var(--font-size-base);
+  color: var(--text-muted);
+  line-height: 1.4;
+  margin: 0 0 var(--spacing-sm);
+}
+
+.settings-move-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-lg);
+}
+
 /* Toggle switch */
 .settings-toggle {
   flex-shrink: 0;

--- a/src/styles/features/settings.css
+++ b/src/styles/features/settings.css
@@ -66,21 +66,68 @@
   align-items: stretch;
 }
 
-.settings-folder-path {
+/* The path field is itself the click target — a pencil sits on the right. */
+.settings-folder-field {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  width: 100%;
   margin-top: var(--spacing-xs);
   padding: var(--spacing-sm) var(--spacing-md);
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
-  font-size: var(--font-size-base);
   color: var(--text-secondary);
-  word-break: break-all;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--transition),
+    background-color var(--transition),
+    color var(--transition);
 }
 
-.settings-folder-actions {
-  display: flex;
-  gap: var(--spacing-sm);
+.settings-folder-field:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+
+.settings-folder-field:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.settings-folder-field-path {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--font-size-base);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.settings-folder-field :last-child {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+.settings-folder-field:hover:not(:disabled) :last-child {
+  color: var(--accent);
+}
+
+.settings-folder-reset {
+  align-self: flex-start;
   margin-top: var(--spacing-sm);
+  padding: 0;
+  background: none;
+  border: none;
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color var(--transition);
+}
+
+.settings-folder-reset:hover:not(:disabled) {
+  color: var(--text-secondary);
 }
 
 /* Move-projects prompt */


### PR DESCRIPTION
Lets users point Ship Studio at an existing dev directory (e.g. `~/WEBDEV`) instead of being locked to `~/ShipStudio`. Common community request.

## Backend
- `AppState` gains `projects_root: Option<String>` (serde-default; old state files still load).
- New `projects_root()` helper in `utils.rs` is the **single source of truth** — reads the configured root (cached in a `RwLock` so path validation doesn't hit disk on every command), falls back to `~/ShipStudio`, and falls back again if the configured folder no longer exists.
- All 13 hardcoded `home.join("ShipStudio")` sites (list/create/delete/rename/templates/`get`+`ensure_shipstudio_dir`) resolve through it.
- **Security**: `validate_project_path` / `validate_project_file_path` allow the configured root **OR** the legacy `~/ShipStudio` **OR** the external registry — so existing projects keep opening after a switch. All existing path-validation tests still pass.
- **App-config decoupled**: `folders.json` / `external-projects.json` stay at the fixed `~/ShipStudio/.shipstudio` path, so switching folders never wipes dashboard organization.
- New commands: `get_projects_root` / `set_projects_root` / `is_custom_projects_root` / `pick_projects_root`, plus `list_movable_projects` and `move_projects_to_root` (rekeys pins, folder membership, and sessions; skips open projects + name collisions; rename with cross-volume copy fallback).

## Frontend
- Settings → **Projects folder** row: clickable path field with an inline pencil icon (native folder picker) and a reset-to-default link when custom.
- After switching, offers to **move** projects left behind in the old folder, summarizing what moved/was skipped.

## Tests
- New backend tests: `scan_movable` bucketing + `move_dir` tree relocation.
- 711 frontend tests pass; typecheck + `check:patterns` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)