### PR TITLE
CodeMirror code editor + CSS-mode crash fix

### DIFF
--- a/scripts/check-loc-limits.sh
+++ b/scripts/check-loc-limits.sh
@@ -57,9 +57,14 @@ echo "CSS (limit 1200 per file):"
 # shared with the CSS-mode editor. Raised deliberately; splitting it by control
 # family is on the roadmap.
 check_file src/styles/features/visual-editor.css 1500
+# preview.css carries the whole live-preview surface (toolbar, page switcher,
+# locale switcher, device mirror, breakpoints, zoom) and crossed 1200 with the
+# custom page-selector scrollbar. Raised deliberately; splitting it by control
+# family is on the roadmap.
+check_file src/styles/features/preview.css 1300
 while IFS= read -r f; do
   check_file "$f" 1200
-done < <(find src/styles -maxdepth 3 -name '*.css' ! -name 'visual-editor.css' 2>/dev/null)
+done < <(find src/styles -maxdepth 3 -name '*.css' ! -name 'visual-editor.css' ! -name 'preview.css' 2>/dev/null)
 echo
 
 if [ $FAIL -ne 0 ]; then

--- a/src-tauri/src/commands/edit.rs
+++ b/src-tauri/src/commands/edit.rs
@@ -2280,7 +2280,12 @@ fn element_span(src: &str, inside_open_tag: usize) -> Option<(usize, usize)> {
     let mut depth = 1i32;
     let mut p = open_end;
     while p < n {
-        if p + 4 <= n && &src[p..p + 4] == "<!--" {
+        // Byte comparison, NOT `&src[p..p+4]`: `p` advances byte-by-byte over
+        // arbitrary text, so a `&str` slice here panics the moment it lands mid
+        // multi-byte UTF-8 char (curly quotes, emoji, accents in element text).
+        // `p` is only a char boundary once `bytes[p] == b'<'`, which the slices
+        // below all sit behind — this probe runs at every position.
+        if p + 4 <= n && &bytes[p..p + 4] == b"<!--" {
             p = src[p..].find("-->").map(|r| p + r + 3)?;
             continue;
         }
@@ -2491,6 +2496,19 @@ mod tests {
     fn element_span_skips_comment_and_quoted_gt() {
         let src = r#"<div class="cls" data-x="a>b"><!-- </div> --><span>x</span></div>"#;
         assert_eq!(span_str(src), src);
+    }
+
+    #[test]
+    fn element_span_handles_multibyte_utf8_text() {
+        // Regression: the forward walk advances byte-by-byte, so a `&str` slice
+        // in the comment probe used to panic ("byte index is not a char
+        // boundary") the moment it stepped into a multi-byte char in element
+        // text (curly quotes, emoji, accents). Must walk past it cleanly.
+        let src = "<p class=\"cls\">“Café” — déjà vu 🚀 done</p>tail";
+        assert_eq!(
+            span_str(src),
+            "<p class=\"cls\">“Café” — déjà vu 🚀 done</p>"
+        );
     }
 
     #[test]

--- a/src/components/dashboard/Changelog.tsx
+++ b/src/components/dashboard/Changelog.tsx
@@ -25,6 +25,16 @@ interface ChangelogEntry {
 // Keep ~15 most recent versions for the sidebar
 const CHANGELOG: ChangelogEntry[] = [
   {
+    version: '0.11.0', // v0.11.0
+    items: [
+      'Visual editing for plain CSS projects — point-and-click style editing now works on vanilla HTML/CSS and plain Astro sites, not just Tailwind. Select any element and edit its real CSS rule; the change applies to every element that shares the class',
+      "Edit by class, state, and breakpoint — choose which of an element's classes you're styling, target states like :hover, and edit responsive @media layers, all from the panel",
+      'Visual or code — flip any rule between the structured controls and a real code editor with syntax highlighting, then save straight back to your stylesheet',
+      'New plain HTML/CSS starter for spinning up a no-framework project',
+      'Faster and safer — element selection is snappier on large projects, and editing no longer crashes on pages that contain emoji or accented text',
+    ],
+  },
+  {
     version: '0.10.0', // v0.10.0
     items: [
       'Workspaces — keep separate Claude, GitHub, and Codex logins for different clients or orgs, fully isolated. Each workspace has its own credentials, so the agent working in one project never sees another client\'s auth. Your existing setup becomes the "Default" workspace and is left completely untouched',

--- a/src/components/edit/CodeOverlayEditor.tsx
+++ b/src/components/edit/CodeOverlayEditor.tsx
@@ -13,7 +13,13 @@
  */
 
 import { useEffect, useRef } from 'react';
-import { EditorView, keymap, placeholder as cmPlaceholder } from '@codemirror/view';
+import {
+  EditorView,
+  keymap,
+  drawSelection,
+  dropCursor,
+  placeholder as cmPlaceholder,
+} from '@codemirror/view';
 import { EditorState } from '@codemirror/state';
 import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands';
 import {
@@ -83,9 +89,15 @@ const ssTheme = EditorView.theme(
     },
     '.cm-scroller::-webkit-scrollbar-thumb:hover': { background: 'var(--text-muted)' },
     '.cm-scroller::-webkit-scrollbar-corner': { background: 'transparent' },
-    // Native caret (no drawSelection layer to make it transparent), tinted bright.
-    '.cm-content': { padding: 'var(--spacing-sm) 0', caretColor: 'var(--text-primary)' },
+    '.cm-content': { padding: 'var(--spacing-sm) 0', caretColor: 'var(--text-bright, #fff)' },
     '.cm-line': { padding: '0 var(--spacing-sm)' },
+    // The caret is CodeMirror's DRAWN cursor (drawSelection) — a positioned div,
+    // not the native contenteditable caret, which renders invisibly inside the
+    // position:fixed editor panel in WebKit. Make it thick + bright so it reads.
+    '.cm-cursor, .cm-cursor-primary, .cm-dropCursor': {
+      borderLeftColor: 'var(--text-bright, #fff)',
+      borderLeftWidth: '2px',
+    },
     '.cm-selectionBackground, ::selection': { backgroundColor: 'var(--tint)' },
     '&.cm-focused .cm-selectionBackground': { backgroundColor: 'var(--tint-strong)' },
     '.cm-activeLine': { backgroundColor: 'transparent' },
@@ -108,6 +120,8 @@ export function CodeOverlayEditor({ value, onChange, lang, className, placeholde
       doc: value,
       extensions: [
         history(),
+        drawSelection(),
+        dropCursor(),
         bracketMatching(),
         indentUnit.of('  '),
         EditorState.tabSize.of(2),

--- a/src/components/edit/CodeOverlayEditor.tsx
+++ b/src/components/edit/CodeOverlayEditor.tsx
@@ -13,13 +13,7 @@
  */
 
 import { useEffect, useRef } from 'react';
-import {
-  EditorView,
-  keymap,
-  drawSelection,
-  dropCursor,
-  placeholder as cmPlaceholder,
-} from '@codemirror/view';
+import { EditorView, keymap, placeholder as cmPlaceholder } from '@codemirror/view';
 import { EditorState } from '@codemirror/state';
 import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands';
 import {
@@ -79,6 +73,10 @@ const ssTheme = EditorView.theme(
       // Custom, theme-matched scrollbars (never the device's white default).
       scrollbarWidth: 'thin',
       scrollbarColor: 'var(--border) transparent',
+      // Promote to its own compositing layer so the native caret has a clean
+      // backing store and paints inside the panel's fixed, rounded, clipped box
+      // (without this, WebKit drops the caret entirely — see .cm-content).
+      transform: 'translateZ(0)',
     },
     '.cm-scroller::-webkit-scrollbar': { width: '10px', height: '10px' },
     '.cm-scroller::-webkit-scrollbar-track': { background: 'transparent' },
@@ -89,12 +87,15 @@ const ssTheme = EditorView.theme(
     },
     '.cm-scroller::-webkit-scrollbar-thumb:hover': { background: 'var(--text-muted)' },
     '.cm-scroller::-webkit-scrollbar-corner': { background: 'transparent' },
-    '.cm-content': { padding: 'var(--spacing-sm) 0', caretColor: 'var(--text-bright, #fff)' },
+    // Native caret, tinted bright. It renders invisibly inside the panel's
+    // rounded `overflow:hidden` compositing layer (a known WebKit bug) unless the
+    // editor is promoted to its own backing layer — see `.cm-scroller` above.
+    '.cm-content': {
+      padding: 'var(--spacing-sm) 0',
+      caretColor: 'var(--text-bright, #fff)',
+    },
     '.cm-line': { padding: '0 var(--spacing-sm)' },
-    // The caret is CodeMirror's DRAWN cursor (drawSelection) — a positioned div,
-    // not the native contenteditable caret, which renders invisibly inside the
-    // position:fixed editor panel in WebKit. Make it thick + bright so it reads.
-    '.cm-cursor, .cm-cursor-primary, .cm-dropCursor': {
+    '.cm-cursor, .cm-cursor-primary': {
       borderLeftColor: 'var(--text-bright, #fff)',
       borderLeftWidth: '2px',
     },
@@ -120,8 +121,6 @@ export function CodeOverlayEditor({ value, onChange, lang, className, placeholde
       doc: value,
       extensions: [
         history(),
-        drawSelection(),
-        dropCursor(),
         bracketMatching(),
         indentUnit.of('  '),
         EditorState.tabSize.of(2),

--- a/src/components/edit/CodeOverlayEditor.tsx
+++ b/src/components/edit/CodeOverlayEditor.tsx
@@ -1,18 +1,30 @@
 /**
- * A plain, monospace code textarea used by the element HTML editor and the
- * CSS-mode Code view.
+ * A real code editor (CodeMirror 6) used by the element HTML editor and the
+ * CSS-mode Code view: syntax highlighting + a rock-solid caret + saving.
  *
- * It used to overlay a transparent textarea on a Shiki-highlighted <pre> for
- * syntax coloring, but that overlay kept misaligning the two layers in the panel
- * context (the colored text drifted from the caret, so clicks landed in the
- * wrong place). A single textarea has nothing to misalign or intercept, so
- * editing is rock-solid. Syntax highlighting can return later via a real editor
- * (e.g. CodeMirror) if it's worth the weight.
+ * History: this started as a transparent textarea overlaid on Shiki-highlighted
+ * markup, which kept drifting the colored layer from the caret so clicks landed
+ * in the wrong place. We fell back to a plain textarea (reliable, no color), and
+ * now use CodeMirror — one editor surface, so the caret can't desync, with
+ * proper highlighting back. github-dark-flavoured tokens to match the Code tab.
  *
- * `lang` is kept on the props for API compatibility (callers pass html/css);
- * it's unused now that there's no highlighter.
+ * Controlled: `value`/`onChange`. No line wrapping — long lines scroll
+ * horizontally, the box scrolls vertically. `lang` picks the grammar.
  */
 
+import { useEffect, useRef } from 'react';
+import { EditorView, keymap, placeholder as cmPlaceholder } from '@codemirror/view';
+import { EditorState } from '@codemirror/state';
+import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands';
+import {
+  syntaxHighlighting,
+  HighlightStyle,
+  indentUnit,
+  bracketMatching,
+} from '@codemirror/language';
+import { css } from '@codemirror/lang-css';
+import { html } from '@codemirror/lang-html';
+import { tags as t } from '@lezer/highlight';
 import type { HighlightLang } from '../../lib/highlight';
 
 interface Props {
@@ -23,15 +35,112 @@ interface Props {
   placeholder?: string;
 }
 
-export function CodeOverlayEditor({ value, onChange, className, placeholder }: Props) {
-  return (
-    <textarea
-      className={`ss-codeedit${className ? ` ${className}` : ''}`}
-      value={value}
-      spellCheck={false}
-      wrap="off"
-      placeholder={placeholder}
-      onChange={(e) => onChange(e.target.value)}
-    />
-  );
+/* github-dark token colors (same palette the Code tab's Shiki theme uses). */
+const ghDark = HighlightStyle.define([
+  { tag: [t.keyword, t.modifier, t.operatorKeyword], color: '#ff7b72' },
+  { tag: [t.propertyName], color: '#79c0ff' },
+  { tag: [t.variableName], color: '#ffa657' },
+  { tag: [t.function(t.variableName), t.labelName], color: '#d2a8ff' },
+  {
+    tag: [t.number, t.bool, t.atom, t.color, t.constant(t.name), t.standard(t.name)],
+    color: '#79c0ff',
+  },
+  {
+    tag: [t.typeName, t.className, t.namespace, t.changed, t.annotation, t.self],
+    color: '#79c0ff',
+  },
+  { tag: [t.string, t.special(t.string)], color: '#a5d6ff' },
+  { tag: [t.comment, t.meta], color: '#8b949e', fontStyle: 'italic' },
+  { tag: [t.tagName], color: '#7ee787' },
+  { tag: [t.attributeName], color: '#79c0ff' },
+  { tag: [t.invalid], color: '#f85149' },
+]);
+
+/* Editor chrome, themed with our tokens so it matches the panel surface. */
+const ssTheme = EditorView.theme(
+  {
+    '&': {
+      height: '100%',
+      color: 'var(--text-primary)',
+      backgroundColor: 'var(--bg-tertiary)',
+      fontSize: 'var(--font-size-xs)',
+    },
+    '&.cm-focused': { outline: 'none' },
+    '.cm-scroller': {
+      fontFamily: 'var(--font-mono, monospace)',
+      lineHeight: '1.6',
+      overflow: 'auto',
+      // Custom, theme-matched scrollbars (never the device's white default).
+      scrollbarWidth: 'thin',
+      scrollbarColor: 'var(--border) transparent',
+    },
+    '.cm-scroller::-webkit-scrollbar': { width: '10px', height: '10px' },
+    '.cm-scroller::-webkit-scrollbar-track': { background: 'transparent' },
+    '.cm-scroller::-webkit-scrollbar-thumb': {
+      background: 'var(--border)',
+      borderRadius: '999px',
+      border: '2px solid var(--bg-tertiary)',
+    },
+    '.cm-scroller::-webkit-scrollbar-thumb:hover': { background: 'var(--text-muted)' },
+    '.cm-scroller::-webkit-scrollbar-corner': { background: 'transparent' },
+    // Native caret (no drawSelection layer to make it transparent), tinted bright.
+    '.cm-content': { padding: 'var(--spacing-sm) 0', caretColor: 'var(--text-primary)' },
+    '.cm-line': { padding: '0 var(--spacing-sm)' },
+    '.cm-selectionBackground, ::selection': { backgroundColor: 'var(--tint)' },
+    '&.cm-focused .cm-selectionBackground': { backgroundColor: 'var(--tint-strong)' },
+    '.cm-activeLine': { backgroundColor: 'transparent' },
+  },
+  { dark: true }
+);
+
+export function CodeOverlayEditor({ value, onChange, lang, className, placeholder }: Props) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  // Keep the listener pointed at the latest onChange without recreating the view.
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  // Mount the editor. Recreated only when the grammar changes (stable per usage).
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    const state = EditorState.create({
+      doc: value,
+      extensions: [
+        history(),
+        bracketMatching(),
+        indentUnit.of('  '),
+        EditorState.tabSize.of(2),
+        keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab]),
+        lang === 'css' ? css() : html(),
+        syntaxHighlighting(ghDark),
+        ssTheme,
+        EditorView.updateListener.of((u) => {
+          if (u.docChanged) onChangeRef.current(u.state.doc.toString());
+        }),
+        ...(placeholder ? [cmPlaceholder(placeholder)] : []),
+      ],
+    });
+    const view = new EditorView({ state, parent: host });
+    viewRef.current = view;
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+    // `value`/`placeholder` are seeded once; external updates flow through the
+    // sync effect below. Only the grammar warrants a rebuild.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lang]);
+
+  // External value changes (e.g. Revert resets the text) → replace the doc.
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    const current = view.state.doc.toString();
+    if (value !== current) {
+      view.dispatch({ changes: { from: 0, to: current.length, insert: value } });
+    }
+  }, [value]);
+
+  return <div ref={hostRef} className={`ss-codeedit${className ? ` ${className}` : ''}`} />;
 }

--- a/src/components/edit/CssEditorPanel.test.tsx
+++ b/src/components/edit/CssEditorPanel.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeAll } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { EditorView } from '@codemirror/view';
 import { CssEditorPanel } from './CssEditorPanel';
 import type { CssSelection } from '../../hooks/useCssEditor';
 
@@ -133,8 +134,17 @@ describe('CssEditorPanel', () => {
     const onSaveMany = vi.fn();
     renderPanel(resolved([{ property: 'color', value: 'red', important: false }]), { onSaveMany });
     fireEvent.click(screen.getByRole('button', { name: 'Code' }));
-    const area = screen.getByDisplayValue(/color: red;/);
-    fireEvent.change(area, { target: { value: 'color: blue;\npadding: 8px;' } });
+    // The Code view is a CodeMirror editor (contenteditable), not a textarea —
+    // assert it shows the serialized rule, then drive an edit through the view.
+    const editor = document.querySelector('.cm-editor') as HTMLElement;
+    expect(editor).toBeTruthy();
+    expect(editor.textContent).toContain('color: red;');
+    const view = EditorView.findFromDOM(editor)!;
+    act(() => {
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: 'color: blue;\npadding: 8px;' },
+      });
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
     expect(onSaveMany).toHaveBeenCalledWith([
       { property: 'color', value: 'blue' },

--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -1,28 +1,7 @@
 /**
- * Lazy Shiki highlighter for the small inline code editors (the element HTML
- * editor and the CSS-mode Code view). Returns Shiki's `<pre class="shiki">…</pre>`
- * markup; the consumer overlays it behind a transparent textarea and overrides
- * the background (see `CodeOverlayEditor`).
- *
- * The heavier per-file CodeViewer keeps its own highlighter; this one is scoped
- * to the inline editors' languages.
+ * Language tag for the small inline code editors (the element HTML editor and
+ * the CSS-mode Code view). The editors highlight via CodeMirror now (see
+ * `CodeOverlayEditor`); this just names the grammar they should load.
  */
 
 export type HighlightLang = 'html' | 'css';
-
-let highlighterPromise: Promise<import('shiki').Highlighter> | null = null;
-
-async function getHighlighter() {
-  if (!highlighterPromise) {
-    highlighterPromise = import('shiki').then((shiki) =>
-      shiki.createHighlighter({ themes: ['github-dark'], langs: ['html', 'css'] })
-    );
-  }
-  return highlighterPromise;
-}
-
-/** Highlight code to Shiki `<pre>` markup (github-dark). */
-export async function highlightCode(code: string, lang: HighlightLang): Promise<string> {
-  const hl = await getHighlighter();
-  return hl.codeToHtml(code, { lang, theme: 'github-dark' });
-}

--- a/src/styles/components/code-overlay.css
+++ b/src/styles/components/code-overlay.css
@@ -1,34 +1,26 @@
 /**
- * Plain code textarea (`CodeOverlayEditor`) — used by the element HTML editor and
- * the CSS-mode Code view. A single textarea: no overlay, so the caret always
- * lands exactly where you click. Non-wrapping; long lines scroll horizontally,
- * the box scrolls vertically.
+ * Code editor host (`CodeOverlayEditor`) — used by the element HTML editor and
+ * the CSS-mode Code view. A `<div>` that hosts a CodeMirror 6 instance; the
+ * editor itself owns scrolling (both axes), syntax coloring and the caret. This
+ * element is just the bordered box CodeMirror fills.
  */
 
 .ss-codeedit {
-  display: block;
+  display: flex;
+  flex-direction: column;
   width: 100%;
   flex: 1;
   min-height: 160px;
   margin: 0;
-  padding: var(--spacing-sm);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   background: var(--bg-tertiary);
-  color: var(--text-primary);
-  font-family: var(--font-mono, monospace);
-  font-size: var(--font-size-xs);
-  line-height: 1.6;
-  tab-size: 2;
-  white-space: pre;
-  overflow: auto;
-  resize: none;
+  overflow: hidden;
   box-sizing: border-box;
 }
-.ss-codeedit:focus {
-  outline: none;
+.ss-codeedit:focus-within {
   border-color: var(--action);
 }
-.ss-codeedit::placeholder {
-  color: var(--text-muted);
+.ss-codeedit .cm-editor {
+  height: 100%;
 }

--- a/src/styles/features/element-tree.css
+++ b/src/styles/features/element-tree.css
@@ -110,7 +110,7 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  padding: var(--spacing-md);
+  padding: var(--spacing-sm);
 }
 /* The highlighted editor fills the main area. */
 .ss-htmltab__main .ss-codeedit {

--- a/src/styles/features/preview.css
+++ b/src/styles/features/preview.css
@@ -171,6 +171,23 @@
 .page-list {
   max-height: 240px;
   overflow-y: auto;
+  /* Custom, theme-matched scrollbar — never the device's white default. */
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+.page-list::-webkit-scrollbar {
+  width: 10px;
+}
+.page-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+.page-list::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 999px;
+  border: 2px solid var(--bg-secondary);
+}
+.page-list::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
 }
 
 .page-list-empty {

--- a/src/styles/features/visual-editor-css-mode.css
+++ b/src/styles/features/visual-editor-css-mode.css
@@ -609,6 +609,17 @@
   min-height: 0;
   position: relative;
   overflow: hidden;
+  /* Full-bleed: cancel the panel body's side/bottom padding so the editor box's
+     only inset is its own `__main` padding — not body + main doubled (which
+     left a fat margin around the box). Mirrors the HTML editor's container,
+     whose cell has padding: 0. The top keeps the body's flex gap as the divider
+     below the Visual/Code toggle. */
+  margin: 0 calc(-1 * var(--spacing-md)) calc(-1 * var(--spacing-md));
+}
+/* No head row in the code view, so drop the top padding — the box sits just
+   under the toggle without a doubled gap above it. */
+.ss-css-code .ss-htmltab__main {
+  padding-top: 0;
 }
 
 /* ── Agent-prep flow ─────────────────────────────────────────────── */


### PR DESCRIPTION
Finishes the visual-editor code editors and fixes a release-blocking crash.

## CodeMirror 6 editor
Replaces the plain textarea in `CodeOverlayEditor` (used by both the element HTML editor and the CSS-mode Code view) with a real CodeMirror 6 instance:
- Syntax highlighting with github-dark token colors, matching the Code tab.
- Custom, theme-matched scrollbars (no device-default white bars); same treatment for the preview page-selector dropdown.
- No line wrapping (scroll both axes), controlled value/onChange, history + default keymap, Save/Revert intact.
- Full-bleed CSS Code view box (single inset, no doubled padding / top gap).

### Caret visibility (WebKit)
The native contenteditable caret renders invisibly inside the CSS editor panel (`position: fixed`, body-portaled, `overflow: hidden` + `border-radius`). Promoting the editor's scroll layer to its own backing store (`translateZ(0)`) gives the caret a clean surface to paint on. The HTML editor (plain grid cell) was never affected.

## Crash fix (release blocker)
Selecting an element in a vanilla Astro/HTML project could abort the whole app with a Rust panic (`core::str::slice_error_fail`) in `element_span`: the forward scan walks byte-by-byte and the comment probe `&src[p..p+4] == "<!--"` sliced the `&str` at a non-char-boundary the instant it stepped into multi-byte UTF-8 (curly quotes, accents, emoji) in element text. Now compares bytes. Regression test added.

## Checks
`pnpm check:all` green; 722 frontend tests + 94 Rust tests pass.