### PR TITLE
Branch create: commit-or-stash modal for uncommitted changes (+ real error messages)

### DIFF
--- a/src-tauri/src/commands/git/stash.rs
+++ b/src-tauri/src/commands/git/stash.rs
@@ -22,6 +22,41 @@ pub async fn get_stash_info(
     Ok(metadata.stash_info)
 }
 
+/// Stash all current changes (tracked + untracked) so the working tree is clean.
+///
+/// Used by "Stash & create branch": the user has uncommitted changes that would
+/// be clobbered by branching off a different base, and chose to set them aside.
+/// This is a plain `git stash` (NOT the metadata-tracked auto-stash that switch
+/// uses), so the user restores it manually with `git stash pop`. Returns true if
+/// something was stashed, false if the tree was already clean.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn stash_changes(project_path: String) -> Result<bool, CommandError> {
+    let validated_path = validate_project_path(&project_path)?;
+
+    let output = create_command("git")
+        .args([
+            "stash",
+            "push",
+            "--include-untracked",
+            "-m",
+            "Ship Studio: set aside before creating a branch",
+        ])
+        .current_dir(&validated_path)
+        .output()
+        .map_err(|e| e.to_string())?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err((format!("Failed to stash changes: {stderr}")).into());
+    }
+
+    GIT_CACHE.invalidate_status(&project_path);
+    // `git stash` with nothing to save exits 0 and prints "No local changes…".
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(!stdout.contains("No local changes"))
+}
+
 /// Manually apply and clear the auto-stash
 #[tauri::command]
 #[tracing::instrument(fields(project = %project_path))]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -336,6 +336,7 @@ pub fn run() {
             commands::git::get_stash_info,
             commands::git::apply_stash,
             commands::git::drop_stash,
+            commands::git::stash_changes,
             commands::git::discard_changes,
             commands::git::commit_changes,
             commands::git::create_branch,

--- a/src/components/branches/BranchesTab.tsx
+++ b/src/components/branches/BranchesTab.tsx
@@ -29,6 +29,7 @@ import {
 import { gitPull } from '../../lib/git';
 import { BranchIcon, PlusIcon } from '../icons';
 import { UnsavedChangesModal } from './UnsavedChangesModal';
+import { CreateBranchConflictModal } from './CreateBranchConflictModal';
 import { trackEvent, trackError } from '../../lib/analytics';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
@@ -39,6 +40,13 @@ import { asCommandError, formatCommandError } from '../../lib/errors';
  *  "[object Object]". Format it to the real human message (the git stderr). */
 function errText(e: unknown): string {
   return formatCommandError(asCommandError(e));
+}
+
+/** True when a git operation failed because uncommitted changes would be
+ *  clobbered by a checkout — git phrases this as "would be overwritten by
+ *  checkout" / "commit your changes or stash them". */
+function isUncommittedChangesError(e: unknown): boolean {
+  return /overwritten by checkout|commit your changes or stash/i.test(errText(e));
 }
 
 interface BranchesTabProps {
@@ -87,6 +95,12 @@ export function BranchesTab({
   const [newBranchName, setNewBranchName] = useState('');
   const [isCreatingBranch, setIsCreatingBranch] = useState(false);
   const [prefixUsername, setPrefixUsername] = useState(true);
+  // Set when create fails because uncommitted changes would be overwritten by
+  // the checkout — drives the commit-or-stash modal.
+  const [createConflict, setCreateConflict] = useState<{
+    targetBranch: string;
+    baseBranch: string;
+  } | null>(null);
 
   // Load prefix preference on mount
   useEffect(() => {
@@ -209,7 +223,18 @@ export function BranchesTab({
 
       // Create from main by default
       const baseBranch = branches.find((b) => b.isDefault)?.name || 'main';
-      await createBranch(projectPath, branchName, baseBranch);
+      try {
+        await createBranch(projectPath, branchName, baseBranch);
+      } catch (e) {
+        // Uncommitted changes would be overwritten by the checkout — hand off to
+        // the commit-or-stash modal instead of failing with a raw git error.
+        if (isUncommittedChangesError(e)) {
+          setCreateConflict({ targetBranch: branchName, baseBranch });
+          setShowNewBranch(false);
+          return;
+        }
+        throw e;
+      }
       void trackEvent('branch_created', { from_branch: baseBranch, $screen_name: 'Workspace' });
 
       // Switch to the new branch
@@ -502,6 +527,26 @@ export function BranchesTab({
             setPendingSwitch(null);
           }}
           onClose={() => setPendingSwitch(null)}
+        />
+      )}
+
+      {createConflict && (
+        <CreateBranchConflictModal
+          projectPath={projectPath}
+          currentBranch={currentBranch}
+          targetBranch={createConflict.targetBranch}
+          baseBranch={createConflict.baseBranch}
+          onCreated={(branchName) => {
+            onBranchSwitch(branchName);
+            void trackEvent('branch_created', {
+              from_branch: createConflict.baseBranch,
+              $screen_name: 'Workspace',
+            });
+            setCreateConflict(null);
+            setNewBranchName('');
+            onRefresh();
+          }}
+          onClose={() => setCreateConflict(null)}
         />
       )}
     </div>

--- a/src/components/branches/BranchesTab.tsx
+++ b/src/components/branches/BranchesTab.tsx
@@ -33,6 +33,13 @@ import { trackEvent, trackError } from '../../lib/analytics';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { useOptionalToast } from '../../contexts/ToastContext';
+import { asCommandError, formatCommandError } from '../../lib/errors';
+
+/** A Tauri-rejected `CommandError` is an object — `String(err)` renders it as
+ *  "[object Object]". Format it to the real human message (the git stderr). */
+function errText(e: unknown): string {
+  return formatCommandError(asCommandError(e));
+}
 
 interface BranchesTabProps {
   /** List of all branches */
@@ -143,7 +150,7 @@ export function BranchesTab({
       }
     } catch (e) {
       trackError('branch_switch', e, 'Workspace');
-      onToast?.(`Failed to switch: ${String(e)}`, 'error');
+      onToast?.(`Failed to switch: ${errText(e)}`, 'error');
     } finally {
       setSwitchingBranch(null);
     }
@@ -162,7 +169,7 @@ export function BranchesTab({
       onRefresh();
     } catch (e) {
       trackError('branch_delete', e, 'Workspace');
-      onToast?.(`Failed to delete: ${String(e)}`, 'error');
+      onToast?.(`Failed to delete: ${errText(e)}`, 'error');
     } finally {
       setDeletingBranch(null);
       setBranchToDelete(null);
@@ -183,7 +190,7 @@ export function BranchesTab({
       onRefresh();
     } catch (e) {
       trackError('branch_revert', e, 'Workspace');
-      onToast?.(`Failed to revert: ${String(e)}`, 'error');
+      onToast?.(`Failed to revert: ${errText(e)}`, 'error');
     } finally {
       setIsReverting(false);
     }
@@ -217,7 +224,7 @@ export function BranchesTab({
       onRefresh();
     } catch (e) {
       trackError('branch_create', e, 'Workspace');
-      onToast?.(`Failed to create branch: ${String(e)}`, 'error');
+      onToast?.(`Failed to create branch: ${errText(e)}`, 'error');
     } finally {
       setIsCreatingBranch(false);
     }

--- a/src/components/branches/CreateBranchConflictModal.tsx
+++ b/src/components/branches/CreateBranchConflictModal.tsx
@@ -1,0 +1,144 @@
+/**
+ * Shown when creating a branch fails because uncommitted changes would be
+ * overwritten by the checkout onto the new branch's base. Offers two ways
+ * forward (plus Cancel):
+ *
+ * - Commit & create — commit the changes on the CURRENT branch first (message
+ *   auto-generated from the diff, with a fallback), then create the branch.
+ * - Stash & create — set the changes aside with `git stash`, then create the
+ *   branch clean. The user restores them later with `git stash pop`.
+ *
+ * Either path ends by creating the branch (now that the tree is clean) and
+ * switching to it. Mirrors the switch-flow `UnsavedChangesModal`.
+ *
+ * @module components/CreateBranchConflictModal
+ */
+
+import { useState } from 'react';
+import { WarningIcon } from '../icons';
+import { createBranch, switchBranch } from '../../lib/branches';
+import { commitChanges, stashChanges } from '../../lib/git';
+import { generateCommitMessage } from '../../lib/ai';
+import { asCommandError, formatCommandError } from '../../lib/errors';
+import { ModalFrame } from '../primitives/ModalFrame';
+import { Button } from '../primitives/Button';
+import { useOptionalToast } from '../../contexts/ToastContext';
+
+/** Commit subject used when AI generation isn't available (no agent / it fails). */
+const FALLBACK_COMMIT_MESSAGE = 'Save work in progress';
+
+function errText(e: unknown): string {
+  return formatCommandError(asCommandError(e));
+}
+
+interface CreateBranchConflictModalProps {
+  /** Project path for git operations. */
+  projectPath: string;
+  /** The current branch the changes live on. */
+  currentBranch: string;
+  /** The branch name the user is trying to create. */
+  targetBranch: string;
+  /** The base branch the new branch is created from. */
+  baseBranch: string;
+  /** Called after the branch is created and switched to. */
+  onCreated: (branchName: string) => void;
+  /** Close the modal without doing anything. */
+  onClose: () => void;
+}
+
+export function CreateBranchConflictModal({
+  projectPath,
+  currentBranch,
+  targetBranch,
+  baseBranch,
+  onCreated,
+  onClose,
+}: CreateBranchConflictModalProps) {
+  const { showToast } = useOptionalToast();
+  const onToast = (message: string, type?: 'success' | 'error') => showToast(message, type);
+  const [isCommitting, setIsCommitting] = useState(false);
+  const [isStashing, setIsStashing] = useState(false);
+  const isLoading = isCommitting || isStashing;
+
+  /** Create the branch (tree is clean by now) and switch to it. */
+  const finishCreate = async (extra?: string) => {
+    await createBranch(projectPath, targetBranch, baseBranch);
+    const result = await switchBranch(projectPath, targetBranch, false);
+    if (result.success) {
+      onCreated(targetBranch);
+      onToast(`Created and switched to ${targetBranch}${extra ? ` — ${extra}` : ''}`, 'success');
+      onClose();
+    } else {
+      onToast(result.error || 'Failed to switch to the new branch', 'error');
+    }
+  };
+
+  const handleCommitAndCreate = async () => {
+    setIsCommitting(true);
+    try {
+      let message = FALLBACK_COMMIT_MESSAGE;
+      try {
+        const generated = (await generateCommitMessage(projectPath)).trim();
+        if (generated) message = generated;
+      } catch {
+        // No headless agent / generation failed — fall back to a plain subject.
+      }
+      await commitChanges(projectPath, message);
+      await finishCreate(`changes committed on ${currentBranch}`);
+    } catch (e) {
+      onToast(`Failed to create branch: ${errText(e)}`, 'error');
+    } finally {
+      setIsCommitting(false);
+    }
+  };
+
+  const handleStashAndCreate = async () => {
+    setIsStashing(true);
+    try {
+      await stashChanges(projectPath);
+      await finishCreate('your changes are stashed (run `git stash pop` to restore)');
+    } catch (e) {
+      onToast(`Failed to create branch: ${errText(e)}`, 'error');
+    } finally {
+      setIsStashing(false);
+    }
+  };
+
+  return (
+    <ModalFrame
+      isOpen
+      onClose={onClose}
+      dismissable={!isLoading}
+      className="unsaved-changes-content"
+      title={
+        <>
+          <WarningIcon size={20} />
+          <span>Uncommitted Changes</span>
+        </>
+      }
+    >
+      <div className="unsaved-changes-body">
+        <p>
+          You have uncommitted changes on <strong>{currentBranch}</strong> that would be lost
+          creating <strong>{targetBranch}</strong> from <strong>{baseBranch}</strong>. What would
+          you like to do with them?
+        </p>
+      </div>
+      <div className="unsaved-changes-actions">
+        <Button variant="secondary" onClick={onClose} disabled={isLoading}>
+          Cancel
+        </Button>
+        <Button
+          variant="secondary"
+          onClick={() => void handleStashAndCreate()}
+          disabled={isLoading}
+        >
+          {isStashing ? 'Stashing…' : 'Stash & Create'}
+        </Button>
+        <Button variant="primary" onClick={() => void handleCommitAndCreate()} disabled={isLoading}>
+          {isCommitting ? 'Committing…' : 'Commit & Create'}
+        </Button>
+      </div>
+    </ModalFrame>
+  );
+}

--- a/src/components/dashboard/Changelog.tsx
+++ b/src/components/dashboard/Changelog.tsx
@@ -25,6 +25,12 @@ interface ChangelogEntry {
 // Keep ~15 most recent versions for the sidebar
 const CHANGELOG: ChangelogEntry[] = [
   {
+    version: '0.11.2', // v0.11.2
+    items: [
+      "Creating a branch with unsaved work no longer errors out — if you have uncommitted changes, you now get a clear choice: commit them on your current branch first, or stash them aside, then the new branch is created and switched to. Git errors throughout the Branches tab also show a real message now instead of '[object Object]'",
+    ],
+  },
+  {
     version: '0.11.1', // v0.11.1
     items: [
       "GitHub connect fix — fixed a bug where connecting GitHub could get stuck in a loop: you'd authenticate in the browser, GitHub would show connected, but the button stayed grey and kept re-prompting. This hit Windows users especially (and some Macs); your default workspace now finds your existing GitHub login wherever it actually lives",

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -80,3 +80,15 @@ export async function gitPull(projectPath: string): Promise<void> {
 export async function commitChanges(projectPath: string, message: string): Promise<boolean> {
   return invoke<boolean>('commit_changes', { projectPath, message });
 }
+
+/**
+ * Stash all current changes (tracked + untracked) so the working tree is clean.
+ * A plain `git stash` set aside for manual restore (`git stash pop`) — not the
+ * metadata-tracked auto-stash that branch switching uses.
+ *
+ * @param projectPath - Absolute path to the project
+ * @returns true if something was stashed, false if the tree was already clean
+ */
+export async function stashChanges(projectPath: string): Promise<boolean> {
+  return invoke<boolean>('stash_changes', { projectPath });
+}


### PR DESCRIPTION
## Problem
Creating a branch while you have uncommitted changes failed with a raw, unhelpful toast: `Failed to create branch: [object Object]`. Two bugs:
1. **`[object Object]`** — all four catch blocks in `BranchesTab` toasted `String(e)`, which renders a Tauri `CommandError` object as `[object Object]`, hiding the real git stderr.
2. The underlying failure: creating from a different base does a hard `git checkout -b`, which git aborts when uncommitted changes would be overwritten (`commit your changes or stash them`).

## Fix
- **Real error messages**: route all branch-action catches through `formatCommandError(asCommandError(e))`.
- **Commit-or-stash modal**: when create hits the uncommitted-changes error, open `CreateBranchConflictModal` with three choices:
  - **Commit & Create** — auto-generate a commit message from the diff (same path as publish, with a fallback), commit on the *current* branch, then create + switch.
  - **Stash & Create** — `git stash` the changes aside (new `stash_changes` command), create the clean branch, switch; restore later with `git stash pop`.
  - **Cancel**.

New: `stash_changes` Tauri command + `stashChanges` wrapper; `CreateBranchConflictModal`.

Not related to the v0.11.1 GitHub-auth fix — that was `gh`/`GH_CONFIG_DIR`; this is local `git`.

## Checks
`pnpm check:all` green; frontend + backend tests pass; clippy clean. Verified live in dev.