### PR TITLE
Dashboard: fix macOS 12 launch crash from color-mix() in GitHub calendar theme

### DIFF
--- a/src/components/dashboard/GitHubCalendar.tsx
+++ b/src/components/dashboard/GitHubCalendar.tsx
@@ -31,8 +31,19 @@ interface GitHubCalendarProps {
   onHide?: () => void;
 }
 
-// Custom theme using app colors
+// Custom theme using app colors.
+//
+// BOTH `light` and `dark` MUST be provided as explicit 5-color hex scales, even
+// though we only ever render `colorScheme="dark"`. react-activity-calendar fills
+// any missing scale from its own default, and that default is generated with
+// `color-mix(in oklab, …)`. It mutates the passed-in theme object to cache that
+// scale, then re-validates it on a later render via `CSS.supports('color', …)`.
+// macOS 12 ships Safari 15, which predates `color-mix()` — so the check returns
+// false and the library throws "Invalid color …", white-screening the whole app
+// a few seconds after launch (once the calendar data loads and it re-renders).
+// Supplying both scales as plain hex keeps the library off every color-mix path.
 const theme = {
+  light: ['#ebedf0', '#9be9a8', '#40c463', '#30a14e', '#216e39'],
   dark: ['#2d2d2d', '#0e4429', '#006d32', '#26a641', '#54e36e'],
 };
 


### PR DESCRIPTION
## Summary
<!-- What changed and why. -->

Fixes the white-screen crash on launch on macOS 12 (Intel), reported in #121, where the app dies a few seconds after start with `Invalid color "color-mix(in oklab, hsl(0, 0%, 26%) 25%, hsl(0, 0%, 92%))" passed.`

**Root cause:** the dashboard GitHub contribution calendar (`GitHubCalendar.tsx`) passed a **dark-only** theme to `react-activity-calendar`. The library fills the missing `light` scale from its own default — which it generates with `color-mix(in oklab, …)` — mutates that scale onto the passed-in theme object, then re-validates it on a later render via `CSS.supports('color', …)`. macOS 12 ships **Safari 15**, which predates `color-mix()` (Safari 16.2+), so validation returns `false`, the library throws, and the React error boundary white-screens the whole app. The few-second delay matches the async GitHub-data fetch: the loading→loaded re-render is what trips the re-validation.

**Fix:** provide **both** `light` and `dark` as explicit 5-color hex scales. `color-mix()` is only emitted by the library's `calcColorScale`, which runs solely when a scale is a 2-color pair or when filling a missing default. Supplying both as full 5-color arrays means validation sees only plain hex, no default is filled, and no interpolation runs — keeping the library off every `color-mix()` path. We always render `colorScheme="dark"`, so the `light` values are never shown; a code comment documents why they must stay.

## Test plan
<!-- How you verified the change. -->
- [x] `tsc --noEmit`, `eslint`, `prettier --check`, and `pnpm check:patterns` pass (run directly); full frontend suite passes (722 passed) via the pre-push hook
- [ ] Not verified at runtime on real macOS 12 / Safari 15 (no access to that WebKit) — fix is correct by construction: it removes every code path that can emit `color-mix()`

## CI gates
<!-- These run automatically on the PR; running them locally first saves a round-trip. -->
- [ ] `pnpm check:all && pnpm test:run && pnpm rust:test` passes locally — frontend portions verified (typecheck/lint/format/patterns + full JS suite); change is frontend-only so Rust is unaffected, but the combined command was not run as one invocation

<details>
<summary><strong>Patterns checklist</strong> (only relevant if you changed code)</summary>

**Frontend**
- N/A — no new modals, buttons, async-state, polling, or modal-state; this is a one-constant change to a third-party theme prop

**CSS**
- N/A — the added hex values are a JS theme prop required by `react-activity-calendar` (it rejects CSS `var()`), not CSS declarations; `check:patterns` (which scans `src/styles`) passes

**Rust**
- N/A — no Rust changes

**Tests**
- [x] Noted why not: the regression depends on the host WebKit's `CSS.supports('color', 'color-mix(…)')`, which jsdom doesn't emulate, so a unit test wouldn't reproduce it; the fix is a static change to the theme's shape

</details>

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the GitHub Calendar component's theme configuration to properly display color themes in both light and dark modes. The component now explicitly defines all required color scales in the format expected by the library, ensuring correct and consistent visual rendering across all theme modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->