### PR TITLE
Cmd+K: point "port" search at Project settings

### DIFF
--- a/src/commands/useAppCommands.tsx
+++ b/src/commands/useAppCommands.tsx
@@ -421,7 +421,7 @@ export function useAppCommands({
         icon: <SettingsIcon size={14} />,
         category: 'settings',
         when: 'project',
-        keywords: ['configure'],
+        keywords: ['port', 'localhost', '3000', 'configure'],
         run: () => openModal('projectSettings'),
       },
       {
@@ -430,7 +430,7 @@ export function useAppCommands({
         icon: <SettingsIcon size={14} />,
         category: 'settings',
         when: 'project',
-        keywords: ['port', 'server', 'script'],
+        keywords: ['server', 'script', 'command'],
         run: () => openModal('devCommand'),
       },
       {


### PR DESCRIPTION
## Summary

The per-project dev-server port is configured in the **Project Settings** modal, but the Cmd+K palette pointed users the wrong way:

- Typing **"port"** surfaced **"Configure dev command"** — a modal with *no* port field — because that command carried a `port` keyword.
- It never surfaced **"Project settings"** (the modal that actually has the port field), which only had `configure` as a keyword. The title doesn't contain the substring "port", so the search scored it 0.

This is a discoverability-only fix (no behavior change to the port logic itself): it repoints the search keywords so "port" resolves to the modal that can change it.

- Add `['port', 'localhost', '3000']` to `modal.projectSettings` keywords
- Drop the misleading `'port'` keyword from `modal.devCommand` (kept `server`, `script`, added `command`)

Keyword matching is handled by `scoreMatch` in `src/commands/score.ts` (title first, then keywords) — no logic change there.

## Test plan
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm check:patterns`, `pnpm check:loc` — all pass
- [x] `pnpm test:run` — 722 passed, 4 skipped
- [x] Manual (`pnpm tauri dev`): in a project, Cmd+K → "port" → "Project settings" is the top result and "Configure dev command" no longer appears for that query; "dev command"/"script" still surface the dev-command modal; the Dev Server Port field is present in Project Settings

## CI gates
- [x] Frontend gates pass locally (typecheck, lint, format:check, check:patterns, check:loc, test:run)
- [ ] Rust gates (`rust:fmt:check` / `rust:clippy` / `rust:test`) — not run: change is frontend-only, no Rust touched

Patterns checklist: not applicable — this changes two keyword arrays (config data), not logic, so no new primitives/tests are introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discoverability of modal commands by updating search keywords for project settings and dev command modals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->