### PR TITLE
Fix GitHub auth shown as disconnected when a second gh account has an invalid token

### DIFF
--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -396,36 +396,85 @@ pub fn get_env_vars_for_account(account_id: &str) -> HashMap<String, String> {
     vars
 }
 
-/// Parses `gh auth status` output for the logged-in github.com username.
+/// Parses `gh auth status` output, returning the connected github.com username
+/// or `None` when there is no usable login.
+///
+/// We intentionally key off the printed output, NOT the process exit code:
+/// `gh auth status` exits NON-ZERO whenever *any* configured account has an
+/// invalid token, even when a different account is logged in and active. A user
+/// with a stale second account (`X Failed to log in to github.com account ...`)
+/// was therefore reported as "Not connected" — a grey GitHub button that
+/// re-prompted in a loop. The `✓ Logged in to github.com ...` line is the
+/// source of truth.
+///
+/// When gh reports multiple accounts we prefer the one it marks
+/// `Active account: true`, because every git/gh operation the app runs uses
+/// that account — so its validity, not just "any login exists", determines
+/// whether we're really connected. If the active account's token is invalid we
+/// return `None` even if some other account is valid. When there's no active
+/// marker at all (older single-account gh), any valid login counts.
 ///
 /// `gh` changed the phrasing in ~v2.40: older builds print
 /// `Logged in to github.com as <user>` while newer ones print
 /// `Logged in to github.com account <user>`. We accept both so modern `gh`
 /// installs aren't reported as "Not connected".
-fn parse_gh_auth_status(success: bool, stdout: &str, stderr: &str) -> Option<String> {
-    if !success {
-        return None;
+pub(crate) fn parse_gh_auth_status(stdout: &str, stderr: &str) -> Option<String> {
+    const LOGGED_IN: &str = "Logged in to github.com ";
+    const FAILED: &str = "Failed to log in to github.com ";
+
+    // Extract the username following the connector word ("as" on older gh,
+    // "account" on ~v2.40+) after `marker` within `line`.
+    fn username_after(line: &str, marker: &str) -> Option<String> {
+        let idx = line.find(marker)?;
+        let rest = &line[idx + marker.len()..];
+        let mut words = rest.split_whitespace();
+        match words.next() {
+            Some("as") | Some("account") => {
+                words.next().filter(|u| !u.is_empty()).map(String::from)
+            }
+            _ => None,
+        }
     }
+
+    // One account block in the output. `valid` is the ✓ vs ✗ distinction;
+    // `active` is set when the following `- Active account: true` line is seen.
+    struct Entry {
+        user: String,
+        valid: bool,
+        active: bool,
+    }
+
     let combined = format!("{stdout}{stderr}");
-    const PREFIX: &str = "Logged in to github.com ";
+    let mut entries: Vec<Entry> = Vec::new();
     for line in combined.lines() {
         let trimmed = line.trim();
-        let Some(idx) = trimmed.find(PREFIX) else {
-            continue;
-        };
-        let rest = &trimmed[idx + PREFIX.len()..];
-        let mut words = rest.split_whitespace();
-        // The connector word is "as" (old) or "account" (new); the username
-        // follows it.
-        if matches!(words.next(), Some("as") | Some("account")) {
-            if let Some(username) = words.next() {
-                if !username.is_empty() {
-                    return Some(username.to_string());
-                }
+        // "Failed to log in" does not contain "Logged in" (capital L), so the two
+        // markers never collide — a failed account is never read as a login.
+        if let Some(user) = username_after(trimmed, LOGGED_IN) {
+            entries.push(Entry {
+                user,
+                valid: true,
+                active: false,
+            });
+        } else if let Some(user) = username_after(trimmed, FAILED) {
+            entries.push(Entry {
+                user,
+                valid: false,
+                active: false,
+            });
+        } else if trimmed.contains("Active account: true") {
+            if let Some(last) = entries.last_mut() {
+                last.active = true;
             }
         }
     }
-    None
+
+    // Prefer the account gh treats as active; the app operates as that account.
+    if let Some(active) = entries.iter().find(|e| e.active) {
+        return active.valid.then(|| active.user.clone());
+    }
+    // No active marker (older single-account gh): any valid login counts.
+    entries.into_iter().find(|e| e.valid).map(|e| e.user)
 }
 
 // ============ Tauri commands ============
@@ -617,7 +666,6 @@ pub async fn get_account_credential_status(
     }
     let github_auth_email = match run_with_timeout(gh_cmd, "gh auth status", 10).await {
         Ok(output) => parse_gh_auth_status(
-            output.status.success(),
             &String::from_utf8_lossy(&output.stdout),
             &String::from_utf8_lossy(&output.stderr),
         ),
@@ -730,17 +778,14 @@ mod tests {
 
     #[test]
     fn parse_gh_auth_status_extracts_username() {
-        // Old gh phrasing ("... as <user>").
+        // Old gh phrasing ("... as <user>"), no "Active account" marker.
         let old = "github.com\n  Logged in to github.com as octocat (oauth_token)\n";
-        assert_eq!(
-            parse_gh_auth_status(true, old, ""),
-            Some("octocat".to_string())
-        );
+        assert_eq!(parse_gh_auth_status(old, ""), Some("octocat".to_string()));
 
         // New gh phrasing (~v2.40+: "... account <user>"), with the ✓ glyph.
         let new = "github.com\n  ✓ Logged in to github.com account julianmemberstack (keyring)\n  - Active account: true\n";
         assert_eq!(
-            parse_gh_auth_status(true, new, ""),
+            parse_gh_auth_status(new, ""),
             Some("julianmemberstack".to_string())
         );
     }
@@ -748,9 +793,29 @@ mod tests {
     #[test]
     fn parse_gh_auth_status_returns_none_when_not_logged_in() {
         assert_eq!(
-            parse_gh_auth_status(false, "", "You are not logged into any GitHub hosts."),
+            parse_gh_auth_status("", "You are not logged into any GitHub hosts."),
             None
         );
+    }
+
+    #[test]
+    fn parse_gh_auth_status_finds_active_login_despite_failed_second_account() {
+        // Regression (grey GitHub button / connect loop): `gh auth status` exits
+        // NON-ZERO when any configured account has an invalid token, even though a
+        // different account is logged in and active. We must report the user as
+        // connected by reading the ✓ active login, not the exit code — and the
+        // "X Failed to log in" line must NOT be mistaken for a login.
+        let out = "github.com\n  \u{2713} Logged in to github.com account octocat (keyring)\n  - Active account: true\n  - Token scopes: 'gist', 'read:org', 'repo'\n\n  X Failed to log in to github.com account hubot (keyring)\n  - Active account: false\n  - The token in keyring is invalid.\n";
+        assert_eq!(parse_gh_auth_status(out, ""), Some("octocat".to_string()));
+    }
+
+    #[test]
+    fn parse_gh_auth_status_reports_disconnected_when_active_account_invalid() {
+        // Inverse edge: the *active* account's token is invalid while a different
+        // (non-active) account is still valid. gh operations run as the active
+        // account, so this must report "not connected" rather than a false green.
+        let out = "github.com\n  X Failed to log in to github.com account broken-active (keyring)\n  - Active account: true\n  - The token in keyring is invalid.\n\n  \u{2713} Logged in to github.com account good-inactive (keyring)\n  - Active account: false\n";
+        assert_eq!(parse_gh_auth_status(out, ""), None);
     }
 
     #[test]

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -104,18 +104,30 @@ pub async fn check_github_cli_status() -> GitHubCliStatus {
         };
     }
 
-    // Check if authenticated (with timeout to prevent hanging)
+    // Check if authenticated (with timeout to prevent hanging).
+    //
+    // We derive "authenticated" by parsing the output for a valid active login,
+    // NOT from the exit code: `gh auth status` exits non-zero whenever any
+    // configured account has an invalid token, even when the active account is
+    // logged in and working. Trusting the exit code reported users with a stale
+    // second account as "not connected" and looped them through the connect flow
+    // (grey GitHub button). See accounts::parse_gh_auth_status.
     let start = std::time::Instant::now();
     let mut auth_cmd = get_gh_command();
     auth_cmd.args(["auth", "status"]);
     let authenticated = match run_command_with_timeout(auth_cmd, GITHUB_CLI_TIMEOUT_SECS).await {
         Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let authed =
+                crate::commands::accounts::parse_gh_auth_status(&stdout, &stderr).is_some();
             debug!(
                 elapsed_ms = start.elapsed().as_millis() as u64,
-                success = output.status.success(),
+                exit_success = output.status.success(),
+                authed,
                 "gh auth status completed"
             );
-            output.status.success()
+            authed
         }
         Err(e) => {
             warn!(elapsed_ms = start.elapsed().as_millis() as u64, error = %e, "gh auth status failed/timed out");

--- a/src-tauri/src/commands/setup/status.rs
+++ b/src-tauri/src/commands/setup/status.rs
@@ -274,11 +274,23 @@ pub async fn get_full_setup_status() -> FullSetupStatus {
     });
 
     // 5. GitHub Auth
+    //
+    // Parse the output for a valid active login rather than trusting the exit
+    // code: `gh auth status` exits non-zero if any configured account has an
+    // invalid token, even when the active account is fine — which would wrongly
+    // strand the user on the GitHub step of onboarding. See
+    // accounts::parse_gh_auth_status.
     let gh_auth = if gh_path.is_some() {
         get_gh_command()
             .args(["auth", "status"])
             .output()
-            .map(|o| o.status.success())
+            .map(|o| {
+                crate::commands::accounts::parse_gh_auth_status(
+                    &String::from_utf8_lossy(&o.stdout),
+                    &String::from_utf8_lossy(&o.stderr),
+                )
+                .is_some()
+            })
             .unwrap_or(false)
     } else {
         false


### PR DESCRIPTION
## The bug
A user with a valid, active GitHub login still saw a **grey GitHub button that re-prompted in a connect loop** — if their `gh` config also held a *second* account whose token had gone stale/invalid.

`gh auth status` exits **non-zero** whenever *any* configured account has an invalid token, even when a different account is logged in and active. All three of our auth checks treated that non-zero exit as "not connected".

Confirmed on macOS via a real user whose `gh auth status` looked like this (usernames are placeholders):
```
✓ Logged in to github.com account octocat        (valid, Active account: true)
X Failed to log in to github.com account hubot   (token in keyring is invalid)
```
The user *is* logged in and active on the valid account, but the failed second account flipped the exit code, so the app reported "not connected".

This is **independent of #125** (the config-dir fix) and is platform-agnostic — it has nothing to do with where the token lives; the token is found fine. Only the success check was wrong.

## The fix
Derive "connected" by **parsing the output for a valid login** instead of trusting the exit code.

- When gh reports multiple accounts we prefer the one marked `Active account: true` — the account every git/gh operation actually runs as — so an invalid **active** account still reports *disconnected* rather than a false green. With no active marker (older single-account gh), any valid login counts.
- The `X Failed to log in` line uses different wording than `Logged in`, so a failed account is never mistaken for a login.

Centralized in `accounts::parse_gh_auth_status` (now `pub(crate)`, exit-code-independent) and routed all three call sites through it:
- `github::check_github_cli_status` — dashboard / workspace button
- `accounts::get_account_credential_status` — per-workspace settings status
- `setup::get_full_setup_status` — onboarding GitHub step

## Tests
- `parse_gh_auth_status_finds_active_login_despite_failed_second_account` — the reported case: returns the active valid user despite the failed second account
- `parse_gh_auth_status_reports_disconnected_when_active_account_invalid` — inverse edge: active account invalid, other valid → `None` (no false green)
- Updated existing parser tests to the new signature

All 502 backend tests pass; `cargo clippy` clean (no new warnings); `check:loc` / `check:patterns` / rustfmt pass. Backend-only change — no frontend files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub authentication detection reliability by refining how authentication status is parsed from CLI output
  * Now correctly identifies valid authenticated accounts even when multiple accounts are configured with varying authentication states
  * Better handles edge cases where some accounts have authentication issues while others remain valid

<!-- end of auto-generated comment: release notes by coderabbit.ai -->