### PR TITLE
Fix Windows onboarding: Node.js install failure + "[object Object]" error

### DIFF
--- a/src-tauri/src/commands/setup/install.rs
+++ b/src-tauri/src/commands/setup/install.rs
@@ -205,6 +205,34 @@ pub async fn install_brew_packages(
     Ok(())
 }
 
+/// Pull a human-readable error line out of winget's output.
+///
+/// winget renders download progress with carriage returns (`\r`) rather than
+/// newlines, so a naive `lines().next()` returns the entire progress animation
+/// as one giant line (the "[object Object]"-era wall of progress bars). Here we
+/// normalize CR→LF, drop blank and progress-only segments (block-bar glyphs and
+/// bare size/percent readouts), and return the last meaningful line — which on
+/// a failed install is the actual error (e.g. "failed when searching source:
+/// msstore").
+#[cfg(windows)]
+fn extract_winget_error(stderr: &str, stdout: &str) -> String {
+    let is_progress_only = |l: &str| {
+        l.chars().all(|c| {
+            c.is_ascii_digit() || matches!(c, '%' | '.' | ' ' | '/' | '█' | '▒' | '░' | '-')
+        }) || l.contains('█')
+            || l.contains('▒')
+            || l.contains('░')
+    };
+    format!("{stderr}\n{stdout}")
+        .replace('\r', "\n")
+        .lines()
+        .map(str::trim)
+        .filter(|&l| !l.is_empty() && !is_progress_only(l))
+        .last()
+        .unwrap_or("Unknown error")
+        .to_string()
+}
+
 /// Batch install multiple packages via Winget (Windows only).
 /// This is the Windows equivalent of install_brew_packages.
 ///
@@ -264,7 +292,18 @@ pub async fn install_winget_packages(
                 "--id",
                 package,
                 "--exact",
+                // Scope the search to the community `winget` source. Without
+                // this, winget also searches `msstore`, which needs Store
+                // sign-in and fails in this silent/headless context with
+                // "failed when searching source: msstore" — sinking the whole
+                // install even though the package lives in the winget source.
+                // All packages we install (OpenJS.NodeJS, Git.Git, GitHub.cli)
+                // are in the winget source, so this is safe.
+                "--source",
+                "winget",
                 "--silent",
+                // Never block on an interactive prompt in a headless install.
+                "--disable-interactivity",
                 "--accept-package-agreements",
                 "--accept-source-agreements",
             ])
@@ -279,10 +318,7 @@ pub async fn install_winget_packages(
                 return Err((format!(
                     "Failed to install {}: {}",
                     package,
-                    stderr
-                        .lines()
-                        .next()
-                        .unwrap_or(&stdout.lines().next().unwrap_or("Unknown error"))
+                    extract_winget_error(&stderr, &stdout)
                 ))
                 .into());
             }

--- a/src/components/setup/OnboardingScreen.test.tsx
+++ b/src/components/setup/OnboardingScreen.test.tsx
@@ -1090,6 +1090,46 @@ describe('OnboardingScreen', () => {
       });
     });
 
+    it('renders CommandError objects as a real message, not "[object Object]"', async () => {
+      // Regression: Tauri commands reject with a structured CommandError
+      // *object* (e.g. install_winget_packages on Windows), not an Error
+      // instance. The catch handler used to do `String(err)`, which rendered
+      // "[object Object]" in the UI (the literal symptom seen on Windows when
+      // Node.js install failed). It must format the CommandError instead.
+      const items = FRESH_INSTALL_ITEMS.map((i) =>
+        i.id === 'homebrew' ? { ...i, status: 'ready' as const, version: '4.2.0' } : i
+      );
+      const status = makeSetupStatus({ items, detectedAgents: [] });
+      mockInvoke('get_full_setup_status', status);
+
+      // The real shape rejected over the IPC boundary: a plain object, not an Error.
+      const commandError = {
+        type: 'Other',
+        message: 'Failed to install OpenJS.NodeJS: winget exited with status 1',
+      };
+      invokeResults.set('install_brew_packages', {
+        error: commandError as unknown as Error,
+      });
+
+      render(<OnboardingScreen onComplete={onComplete} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Quick Setup')).toBeInTheDocument();
+      });
+
+      const installButtons = screen.getAllByText('Install');
+      act(() => {
+        fireEvent.click(installButtons[0]);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Failed to install OpenJS.NodeJS: winget exited with status 1')
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+    });
+
     it('empty error message falls back to default', async () => {
       const items = FRESH_INSTALL_ITEMS.map((i) =>
         i.id === 'homebrew' ? { ...i, status: 'ready' as const, version: '4.2.0' } : i

--- a/src/components/setup/OnboardingScreen.tsx
+++ b/src/components/setup/OnboardingScreen.tsx
@@ -43,6 +43,7 @@ import {
 } from '../../lib/setup';
 import { initDefaultAgent } from '../../lib/agent';
 import { checkGitHubCliStatus } from '../../lib/github';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { SlackIcon } from '../icons';
 
@@ -344,7 +345,10 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
         setActiveItemId(null);
       } catch (err) {
         logger.warn(`Failed to process ${itemId}`);
-        const errorMessage = err instanceof Error ? err.message : String(err);
+        // Tauri commands reject with a structured CommandError object (not an
+        // Error instance), so `String(err)` would render "[object Object]".
+        // Route through the shared helpers to get a real user-facing message.
+        const errorMessage = formatCommandError(asCommandError(err));
         const cleanedMessage = errorMessage.replace(/\[[\w_]+\]\s*/g, '').trim();
 
         if (PKG_MGR_PACKAGES.has(itemId)) {


### PR DESCRIPTION
## Summary

Fixes two bugs that made the Windows onboarding wizard unusable at the Node.js step. Found and verified on a real Windows machine using an unsigned test build of this branch.

### 1. Node.js (and Git / GitHub CLI) install always failed
`install_winget_packages` ran `winget install` without scoping the source. winget searches both the community `winget` source and the Microsoft Store `msstore` source; `msstore` requires Store sign-in and fails in our silent/headless context with `failed when searching source: msstore`, which sank the whole install **even though the package downloaded fine** and lives in the `winget` source.

- Pass `--source winget` so the install only uses the community source (all packages we install — `OpenJS.NodeJS`, `Git.Git`, `GitHub.cli` — are there).
- Pass `--disable-interactivity` so a hidden prompt can never stall a headless install.

### 2. The error rendered as `[object Object]`
The catch handler in `OnboardingScreen` used `err instanceof Error ? err.message : String(err)`. Tauri commands reject with a structured `CommandError` **object**, not an `Error` instance, so it fell through to `String(err)` and showed `[object Object]` instead of the real reason — which is what hid bug #1.

- Route the caught value through the existing `asCommandError` / `formatCommandError` helpers.
- Add a regression test that rejects with a `CommandError` object (existing failure tests only used `Error` instances, which is why this slipped through).

### 3. Cleaner winget error messages (bonus)
winget streams download progress with carriage returns, so the old `lines().next()` returned the entire progress animation as one giant line. Added `extract_winget_error()` to normalize CR→LF, drop progress-only segments, and surface the actual final error line.

## Testing
- ✅ Built an unsigned NSIS installer from this branch, installed on a real Windows machine, and walked through onboarding — Node.js now installs successfully.
- ✅ Added frontend regression test for the `CommandError` rendering.
- ⚠️ Windows-specific Rust (`#[cfg(windows)]`) can't be compiled from macOS; verified via the Windows build + manual end-to-end test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error message handling during package installation to display meaningful, user-friendly messages
  * Enhanced Windows-based package installation with more reliable error parsing and reporting
  * Fixed issue where certain error types weren't properly formatted for display

* **Tests**
  * Added regression test to verify proper error message rendering during installation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->