### PR TITLE
Per-workspace logins for all five tools, with clear machine-vs-workspace separation

### DIFF
--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -879,11 +879,41 @@ pub async fn get_account_credential_status(
         Err(_) => None,
     };
 
+    // Vercel identity, resolved the same way setup/status.rs does: verify the
+    // workspace's injected token via `vercel whoami`. The Default workspace
+    // (no injected token) falls back to the machine's native CLI session.
+    let vercel_username = {
+        let token = get_env_vars_for_account(&id).remove("VERCEL_TOKEN");
+        if token.is_some() || id == DEFAULT_ACCOUNT_ID {
+            if let Some(p) = find_binary_by_name("vercel") {
+                let mut cmd = tokio::process::Command::from(create_command(&p));
+                cmd.args(["whoami"]);
+                cmd.env("PATH", get_extended_path());
+                if let Some(ref t) = token {
+                    cmd.env("VERCEL_TOKEN", t);
+                }
+                match run_with_timeout(cmd, "vercel whoami", 10).await {
+                    Ok(output) if output.status.success() => {
+                        let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                        (!name.is_empty()).then_some(name)
+                    }
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        } else {
+            // Non-default workspace without a token → not connected for Vercel.
+            None
+        }
+    };
+
     Ok(AccountCredentialStatus {
         claude_auth_email,
         codex_auth_email,
         opencode_auth_email,
         github_auth_email,
+        vercel_username,
         has_anthropic_base_url: read_from_keychain(&id, "anthropic_base_url").is_some(),
         has_vercel_token: read_from_keychain(&id, "vercel_token").is_some(),
         has_git_name: read_from_keychain(&id, "git_name").is_some(),
@@ -1336,6 +1366,340 @@ pub fn disconnect_claude_account(id: String) -> Result<(), CommandError> {
     Ok(())
 }
 
+// ── Generalized per-workspace login PTY (GitHub / Codex / Opencode) ──────────
+//
+// Claude needs token scraping (its login is a global keychain entry), but the
+// other three logins are *config-dir* based: running their login CLI under the
+// workspace's injected `GH_CONFIG_DIR` / `CODEX_HOME` / `XDG_DATA_HOME` writes
+// the credentials into the workspace's isolated dir. So these reuse the same
+// backend-owned PTY machinery as Claude (ConnectSession + CONNECT_REGISTRY) but
+// stream output verbatim — there's no secret to redact — and treat process exit
+// as the completion signal (no "captured" event).
+
+/// A login service that authenticates by writing into a per-workspace config dir.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ConnectService {
+    Github,
+    Codex,
+    Opencode,
+}
+
+impl ConnectService {
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "github" => Some(Self::Github),
+            "codex" => Some(Self::Codex),
+            "opencode" => Some(Self::Opencode),
+            _ => None,
+        }
+    }
+
+    /// The CLI binary name to look up on PATH.
+    fn binary(self) -> &'static str {
+        match self {
+            Self::Github => "gh",
+            Self::Codex => "codex",
+            Self::Opencode => "opencode",
+        }
+    }
+
+    /// Login subcommand args for the binary.
+    fn args(self) -> &'static [&'static str] {
+        match self {
+            // `--web` uses the device flow (prints a one-time code + opens the
+            // browser); `--git-protocol https` skips the protocol prompt.
+            Self::Github => &["auth", "login", "--web", "--git-protocol", "https"],
+            Self::Codex => &["login"],
+            Self::Opencode => &["auth", "login"],
+        }
+    }
+
+    /// Whether this service's CLI pauses on a "Press Enter to open…" prompt that
+    /// we can auto-advance so the browser opens without a manual keystroke.
+    fn auto_enter(self) -> bool {
+        matches!(self, Self::Github)
+    }
+}
+
+/// Emit a chunk of PTY output to the webview for a workspace-connect session.
+fn emit_workspace_connect_data(app: &AppHandle, session_id: &str, bytes: &[u8]) {
+    let _ = app.emit(
+        "workspace-connect-data",
+        serde_json::json!({ "sessionId": session_id, "data": bytes }),
+    );
+}
+
+/// Start an interactive GitHub/Codex/Opencode login for a workspace in a
+/// backend-owned PTY.
+///
+/// Spawns the service's login CLI under the workspace's isolated env (so the
+/// credentials land in the workspace's config dir, never the global one).
+/// Output streams to the webview via `workspace-connect-data`; the user types
+/// into it via [`workspace_connect_write`]. There is no token to capture — the
+/// CLI writes its own credential files — so completion is signalled purely by
+/// `workspace-connect-exit` when the process ends. For GitHub we watch for the
+/// "Press Enter to open…" prompt and send Enter once so the browser opens
+/// immediately.
+#[tauri::command]
+#[tracing::instrument(skip(app), fields(session_id = %session_id, id = %id, service = %service))]
+pub fn workspace_connect_start(
+    app: AppHandle,
+    session_id: String,
+    id: String,
+    service: String,
+    cols: u16,
+    rows: u16,
+) -> Result<(), CommandError> {
+    validate_account_id(&id)?;
+    validate_account_id(&session_id)?;
+    let svc = ConnectService::parse(&service).ok_or_else(|| CommandError::Validation {
+        field: "service".into(),
+        reason: format!("unknown connect service '{service}'"),
+    })?;
+    if id == DEFAULT_ACCOUNT_ID {
+        return Err(CommandError::Validation {
+            field: "id".into(),
+            reason: "The Default workspace uses your machine's native logins; \
+                     run the CLI's login command in a terminal instead of connecting."
+                .into(),
+        });
+    }
+
+    let binary = find_binary_by_name(svc.binary()).ok_or_else(|| CommandError::Io {
+        message: format!(
+            "{} CLI not found. Install it first, then connect.",
+            svc.binary()
+        ),
+    })?;
+
+    // Idempotent: a live session under this id means connect is already running.
+    {
+        let map = CONNECT_REGISTRY
+            .lock()
+            .map_err(|e| format!("connect registry poisoned: {e}"))?;
+        if map.contains_key(&session_id) {
+            return Ok(());
+        }
+    }
+
+    let pair = native_pty_system()
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| format!("openpty: {e}"))?;
+    let writer = pair
+        .master
+        .take_writer()
+        .map_err(|e| format!("take_writer: {e}"))?;
+    let mut reader = pair
+        .master
+        .try_clone_reader()
+        .map_err(|e| format!("clone_reader: {e}"))?;
+
+    let mut cmd = CommandBuilder::new(&binary);
+    for arg in svc.args() {
+        cmd.arg(arg);
+    }
+    cmd.cwd(dirs::home_dir().unwrap_or_default());
+    cmd.env("PATH", get_extended_path());
+    cmd.env("TERM", "xterm-256color");
+    // Run inside the workspace's isolated env so the login writes into the
+    // workspace's config dir (GH_CONFIG_DIR / CODEX_HOME / XDG_DATA_HOME).
+    for (k, v) in get_env_vars_for_account(&id) {
+        cmd.env(k, v);
+    }
+
+    let mut child = pair
+        .slave
+        .spawn_command(cmd)
+        .map_err(|e| format!("spawn_command: {e}"))?;
+    let child_killer = child.clone_killer();
+
+    let session = Arc::new(ConnectSession {
+        writer: Mutex::new(writer),
+        child_killer: Mutex::new(child_killer),
+        master: Mutex::new(pair.master),
+        captured: AtomicBool::new(false),
+    });
+    CONNECT_REGISTRY
+        .lock()
+        .map_err(|e| format!("connect registry poisoned: {e}"))?
+        .insert(session_id.clone(), session.clone());
+
+    // Reader thread: stream output verbatim. For GitHub, auto-send Enter once we
+    // see the "Press Enter to open…" prompt so the browser launches itself.
+    {
+        let app = app.clone();
+        let session_id = session_id.clone();
+        let session = session.clone();
+        let auto_enter = svc.auto_enter();
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            let mut sent_enter = false;
+            // Small rolling window so the prompt is matched even when it straddles
+            // a read boundary.
+            let mut tail: Vec<u8> = Vec::new();
+            loop {
+                let n = match reader.read(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => n,
+                };
+                emit_workspace_connect_data(&app, &session_id, &buf[..n]);
+                if auto_enter && !sent_enter {
+                    tail.extend_from_slice(&buf[..n]);
+                    let hay = String::from_utf8_lossy(&tail).to_lowercase();
+                    if hay.contains("press enter") {
+                        if let Ok(mut w) = session.writer.lock() {
+                            let _ = w.write_all(b"\r");
+                        }
+                        sent_enter = true;
+                        tail.clear();
+                    } else if tail.len() > 4096 {
+                        // Bound the window; keep only the most recent bytes.
+                        let keep = tail.len() - 2048;
+                        tail.drain(..keep);
+                    }
+                }
+            }
+        });
+    }
+
+    // Waiter thread: reaps the child, drops the registry entry, signals exit.
+    {
+        let app = app.clone();
+        let session_id = session_id.clone();
+        std::thread::spawn(move || {
+            let code = match child.wait() {
+                Ok(status) if status.success() => 0,
+                Ok(status) => status.exit_code() as i32,
+                Err(_) => -1,
+            };
+            if let Ok(mut map) = CONNECT_REGISTRY.lock() {
+                map.remove(&session_id);
+            }
+            let _ = app.emit(
+                "workspace-connect-exit",
+                serde_json::json!({ "sessionId": session_id, "exitCode": code }),
+            );
+        });
+    }
+
+    Ok(())
+}
+
+/// Forward keystrokes to a workspace-connect PTY.
+#[tauri::command]
+#[tracing::instrument(skip(data))]
+pub fn workspace_connect_write(session_id: String, data: Vec<u8>) -> Result<(), CommandError> {
+    let session = {
+        let map = CONNECT_REGISTRY
+            .lock()
+            .map_err(|e| format!("connect registry poisoned: {e}"))?;
+        map.get(&session_id).cloned()
+    };
+    let Some(session) = session else {
+        return Err("unknown connect session".to_string().into());
+    };
+    let mut w = session
+        .writer
+        .lock()
+        .map_err(|e| format!("writer lock poisoned: {e}"))?;
+    w.write_all(&data).map_err(|e| format!("write: {e}"))?;
+    Ok(())
+}
+
+/// Resize a workspace-connect PTY to match the on-screen terminal.
+#[tauri::command]
+#[tracing::instrument]
+pub fn workspace_connect_resize(
+    session_id: String,
+    cols: u16,
+    rows: u16,
+) -> Result<(), CommandError> {
+    let session = {
+        let map = CONNECT_REGISTRY
+            .lock()
+            .map_err(|e| format!("connect registry poisoned: {e}"))?;
+        map.get(&session_id).cloned()
+    };
+    let Some(session) = session else {
+        return Err("unknown connect session".to_string().into());
+    };
+    let master = session
+        .master
+        .lock()
+        .map_err(|e| format!("master lock poisoned: {e}"))?;
+    master
+        .resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| format!("resize: {e}"))?;
+    Ok(())
+}
+
+/// Kill a workspace-connect PTY and drop its registry entry. Idempotent.
+#[tauri::command]
+#[tracing::instrument]
+pub fn workspace_connect_close(session_id: String) -> Result<(), CommandError> {
+    let session = {
+        let mut map = CONNECT_REGISTRY
+            .lock()
+            .map_err(|e| format!("connect registry poisoned: {e}"))?;
+        map.remove(&session_id)
+    };
+    if let Some(session) = session {
+        if let Ok(mut killer) = session.child_killer.lock() {
+            let _ = killer.kill();
+        }
+    }
+    Ok(())
+}
+
+/// Sign a workspace out of a config-dir login (GitHub / Codex / Opencode) by
+/// running the CLI's logout under the workspace's isolated env. Best-effort:
+/// returns the captured output for surfacing, but a non-zero exit (already
+/// logged out) is not treated as an error.
+#[tauri::command]
+#[tracing::instrument]
+pub fn workspace_disconnect_service(id: String, service: String) -> Result<(), CommandError> {
+    validate_account_id(&id)?;
+    let svc = ConnectService::parse(&service).ok_or_else(|| CommandError::Validation {
+        field: "service".into(),
+        reason: format!("unknown connect service '{service}'"),
+    })?;
+    if id == DEFAULT_ACCOUNT_ID {
+        return Err(CommandError::Validation {
+            field: "id".into(),
+            reason: "The Default workspace uses your machine's native logins; \
+                     sign out with the CLI directly."
+                .into(),
+        });
+    }
+    let binary = find_binary_by_name(svc.binary()).ok_or_else(|| CommandError::Io {
+        message: format!("{} CLI not found.", svc.binary()),
+    })?;
+    let logout_args: &[&str] = match svc {
+        ConnectService::Github => &["auth", "logout", "--hostname", "github.com"],
+        ConnectService::Codex => &["logout"],
+        ConnectService::Opencode => &["auth", "logout"],
+    };
+    let mut command = std::process::Command::new(&binary);
+    command.args(logout_args);
+    command.env("PATH", get_extended_path());
+    for (k, v) in get_env_vars_for_account(&id) {
+        command.env(k, v);
+    }
+    // Best-effort: failures (e.g. "not logged in") are fine.
+    let _ = command.output();
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1400,6 +1764,50 @@ mod tests {
         // Surrounding text is preserved verbatim.
         assert!(shown.contains("Long-lived token created!"));
         assert!(shown.contains("Store it."));
+    }
+
+    #[test]
+    fn connect_service_parses_known_services_only() {
+        assert_eq!(
+            ConnectService::parse("github"),
+            Some(ConnectService::Github)
+        );
+        assert_eq!(ConnectService::parse("codex"), Some(ConnectService::Codex));
+        assert_eq!(
+            ConnectService::parse("opencode"),
+            Some(ConnectService::Opencode)
+        );
+        assert_eq!(ConnectService::parse("claude"), None);
+        assert_eq!(ConnectService::parse("vercel"), None);
+        assert_eq!(ConnectService::parse(""), None);
+    }
+
+    #[test]
+    fn connect_service_only_github_auto_enters() {
+        // Only GitHub's device flow pauses on a "Press Enter to open…" prompt.
+        assert!(ConnectService::Github.auto_enter());
+        assert!(!ConnectService::Codex.auto_enter());
+        assert!(!ConnectService::Opencode.auto_enter());
+    }
+
+    #[test]
+    fn connect_service_uses_isolated_login_commands() {
+        assert_eq!(ConnectService::Github.binary(), "gh");
+        assert!(ConnectService::Github
+            .args()
+            .starts_with(&["auth", "login"]));
+        assert_eq!(ConnectService::Codex.binary(), "codex");
+        assert_eq!(ConnectService::Codex.args(), &["login"]);
+        assert_eq!(ConnectService::Opencode.binary(), "opencode");
+        assert_eq!(ConnectService::Opencode.args(), &["auth", "login"]);
+    }
+
+    #[test]
+    fn workspace_disconnect_rejects_default_and_unknown_service() {
+        // Unknown service is rejected before anything is run.
+        assert!(workspace_disconnect_service("some-workspace".into(), "bogus".into()).is_err());
+        // The Default workspace's native logins aren't managed here.
+        assert!(workspace_disconnect_service(DEFAULT_ACCOUNT_ID.into(), "github".into()).is_err());
     }
 
     #[test]

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -20,14 +20,20 @@
 //! `github`, and `pull_requests`.
 
 use crate::agent::AgentConfig;
+use crate::commands::claude::find_binary_by_name;
 use crate::commands::setup::{read_app_state, write_app_state};
 use crate::errors::CommandError;
 use crate::external_command::run_with_timeout;
 use crate::types::{Account, AccountCredentialStatus};
 use crate::utils::{create_command, get_extended_path};
+use portable_pty::{native_pty_system, ChildKiller, CommandBuilder, PtySize};
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
+use tauri::{AppHandle, Emitter};
 
 /// The ID of the built-in default account. Always exists; cannot be deleted.
 pub const DEFAULT_ACCOUNT_ID: &str = "default";
@@ -48,6 +54,36 @@ const ALL_CRED_KEYS: &[&str] = &[
     "git_name",
     "git_email",
 ];
+
+/// Credential keys managed internally by the backend (never settable or
+/// clearable through the frontend `set/clear_account_credential` commands, so
+/// they're deliberately NOT in `ALL_CRED_KEYS`). They still belong to the
+/// account, so they're wiped alongside the rest on account deletion.
+///
+/// `claude_oauth_token` is a long-lived token captured by `connect_claude_account`
+/// (via `claude setup-token`) and injected as `CLAUDE_CODE_OAUTH_TOKEN`; see
+/// `get_env_vars_for_account`. `claude_email` is the account identity captured
+/// at connect time, used only for display.
+const MANAGED_CRED_KEYS: &[&str] = &[
+    "claude_oauth_token",
+    "claude_email",
+    "claude_token_expires_at",
+];
+
+/// Keychain key holding a workspace's captured Claude OAuth token.
+const CLAUDE_TOKEN_KEY: &str = "claude_oauth_token";
+/// Keychain key holding the email for a workspace's connected Claude account.
+const CLAUDE_EMAIL_KEY: &str = "claude_email";
+/// Keychain key holding the unix-seconds expiry of the captured Claude token.
+const CLAUDE_EXPIRES_KEY: &str = "claude_token_expires_at";
+
+/// How long a `claude setup-token` token is valid. The CLI states "valid for 1
+/// year" when it mints one; we record an expiry at connect time and surface a
+/// "needs reconnect" (red) state once it passes. There is no cheap server-side
+/// validity check for these opaque tokens (verified: `claude auth status`
+/// reports `loggedIn:true` even for a garbage token), so this local expiry is
+/// our reconnect signal. Revocation before expiry isn't detected here.
+const CLAUDE_TOKEN_TTL_SECS: u64 = 365 * 24 * 60 * 60;
 
 /// Validates a frontend-supplied account id before it's joined into filesystem
 /// paths (`~/.ship-studio/accounts/<id>/`), keychain service names, or env vars.
@@ -149,9 +185,150 @@ fn delete_from_keychain(account_id: &str, key: &str) {
 }
 
 fn delete_all_account_credentials(account_id: &str) {
-    for key in ALL_CRED_KEYS {
+    for key in ALL_CRED_KEYS.iter().chain(MANAGED_CRED_KEYS.iter()) {
         delete_from_keychain(account_id, key);
     }
+}
+
+/// Persist a workspace's captured Claude OAuth token (and account email, when
+/// known) to its keychain vault. Called by the connect flow after a successful
+/// `claude setup-token`. Stored under [`MANAGED_CRED_KEYS`], so it's never
+/// writable via the frontend and is wiped when the workspace is deleted.
+pub fn store_claude_token(
+    account_id: &str,
+    token: &str,
+    email: Option<&str>,
+) -> Result<(), CommandError> {
+    write_to_keychain(account_id, CLAUDE_TOKEN_KEY, token.trim())?;
+    if let Some(email) = email.map(str::trim).filter(|e| !e.is_empty()) {
+        // Email is display-only; a failure to store it must not fail the connect.
+        let _ = write_to_keychain(account_id, CLAUDE_EMAIL_KEY, email);
+    } else {
+        // Reconnecting without re-supplying an email shouldn't leave a stale one.
+        delete_from_keychain(account_id, CLAUDE_EMAIL_KEY);
+    }
+    let expires_at = unix_now().saturating_add(CLAUDE_TOKEN_TTL_SECS);
+    let _ = write_to_keychain(account_id, CLAUDE_EXPIRES_KEY, &expires_at.to_string());
+    Ok(())
+}
+
+/// Remove a workspace's captured Claude token + email + expiry (i.e. disconnect
+/// Claude for that workspace). Its terminals fall back to no injected token.
+pub fn clear_claude_token(account_id: &str) {
+    delete_from_keychain(account_id, CLAUDE_TOKEN_KEY);
+    delete_from_keychain(account_id, CLAUDE_EMAIL_KEY);
+    delete_from_keychain(account_id, CLAUDE_EXPIRES_KEY);
+}
+
+/// Current wall-clock time in unix seconds (0 if the clock is before the epoch).
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Connection state of a workspace's Claude login, for the agent card.
+#[derive(serde::Serialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaudeConnState {
+    /// Never connected — render today's neutral "Not signed in / Sign in" UI.
+    NotConnected,
+    /// Connected with a token believed valid — green stroke, show email.
+    Connected,
+    /// Was connected but the token has expired — red stroke + inline Reconnect.
+    NeedsReconnect,
+}
+
+/// Resolved Claude identity for a workspace: connection state + the email to show.
+pub struct ClaudeIdentity {
+    pub state: ClaudeConnState,
+    pub email: Option<String>,
+}
+
+/// Resolve a workspace's Claude login state + display email.
+///
+/// - **Default workspace**: uses Claude's native keychain login, so we ask the
+///   CLI directly via `claude auth status` (which returns the email for a
+///   `claude.ai` login). No injected token.
+/// - **Other workspaces**: driven entirely by the per-workspace vault — token
+///   presence means connected, the stored expiry decides connected-vs-reconnect,
+///   and the email is whatever was captured at connect time. We deliberately do
+///   NOT shell out here (the opaque token can't be validated cheaply anyway).
+pub async fn resolve_claude_identity(account_id: &str) -> ClaudeIdentity {
+    if account_id == DEFAULT_ACCOUNT_ID {
+        return resolve_default_claude_identity().await;
+    }
+
+    let Some(_token) = read_from_keychain(account_id, CLAUDE_TOKEN_KEY) else {
+        return ClaudeIdentity {
+            state: ClaudeConnState::NotConnected,
+            email: None,
+        };
+    };
+    let email = read_from_keychain(account_id, CLAUDE_EMAIL_KEY);
+    let expired = read_from_keychain(account_id, CLAUDE_EXPIRES_KEY)
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .map(|exp| unix_now() >= exp)
+        // No expiry recorded (older connect): treat as still valid rather than
+        // nagging the user with a false red.
+        .unwrap_or(false);
+    ClaudeIdentity {
+        state: if expired {
+            ClaudeConnState::NeedsReconnect
+        } else {
+            ClaudeConnState::Connected
+        },
+        email,
+    }
+}
+
+/// Identity for the Default workspace via `claude auth status` (native login).
+async fn resolve_default_claude_identity() -> ClaudeIdentity {
+    let Some(binary) = find_binary_by_name("claude") else {
+        return ClaudeIdentity {
+            state: ClaudeConnState::NotConnected,
+            email: None,
+        };
+    };
+    let mut cmd = create_command(binary);
+    cmd.args(["auth", "status"]);
+    cmd.env("PATH", get_extended_path());
+    // Default = native locations; do NOT pin CLAUDE_CONFIG_DIR or inject a token.
+    let tokio_cmd = tokio::process::Command::from(cmd);
+    let stdout = match run_with_timeout(tokio_cmd, "claude auth status", 10).await {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).to_string(),
+        _ => {
+            return ClaudeIdentity {
+                state: ClaudeConnState::NotConnected,
+                email: None,
+            }
+        }
+    };
+    let (logged_in, email) = parse_claude_auth_status(&stdout);
+    ClaudeIdentity {
+        state: if logged_in {
+            ClaudeConnState::Connected
+        } else {
+            ClaudeConnState::NotConnected
+        },
+        email,
+    }
+}
+
+/// Parse `claude auth status` JSON → (logged_in, email). Tolerant of unknown
+/// fields and non-JSON output (returns `(false, None)`).
+fn parse_claude_auth_status(stdout: &str) -> (bool, Option<String>) {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(stdout.trim()) else {
+        return (false, None);
+    };
+    let logged_in = v.get("loggedIn").and_then(|b| b.as_bool()).unwrap_or(false);
+    let email = v
+        .get("email")
+        .and_then(|e| e.as_str())
+        .map(str::to_string)
+        .filter(|e| !e.is_empty());
+    (logged_in, email)
 }
 
 // ============ Config dir isolation ============
@@ -376,6 +553,22 @@ pub fn get_env_vars_for_account(account_id: &str) -> HashMap<String, String> {
                 .to_string_lossy()
                 .to_string(),
         );
+
+        // Per-workspace Claude login. Unlike the CLI config dirs above, Claude
+        // Code on macOS stores its OAuth token in a single global Keychain
+        // entry that ignores CLAUDE_CONFIG_DIR (Claude bug #20553) — so config
+        // isolation alone can't separate logins, and an interactive `/login` in
+        // one workspace silently clobbers every other workspace's (and the
+        // Default workspace's) token. Instead we capture a long-lived token per
+        // workspace via `claude setup-token` (see connect_claude_account) and
+        // inject it here. CLAUDE_CODE_OAUTH_TOKEN takes precedence over the
+        // keychain, so each workspace authenticates as its own identity without
+        // ever reading or writing the shared keychain entry. Only injected when
+        // the workspace has actually connected Claude; otherwise its terminals
+        // stay logged out (the correct "not connected" state).
+        if let Some(token) = read_from_keychain(account_id, CLAUDE_TOKEN_KEY) {
+            vars.insert("CLAUDE_CODE_OAUTH_TOKEN".to_string(), token);
+        }
     }
 
     for (key, env_name) in CRED_ENV_VARS {
@@ -651,7 +844,21 @@ pub async fn get_account_credential_status(
             .any(|indicator| dir.join(indicator).exists())
             .then(|| "Connected".to_string())
     };
-    let claude_auth_email = agent_connected("claude-code");
+    // Claude can't use the file-indicator check: on macOS its login lives in a
+    // global keychain entry that ignores CLAUDE_CONFIG_DIR, so indicator files
+    // exist even for workspaces that were never connected. Use the real
+    // per-workspace token/identity instead, surfacing the actual email.
+    let claude = resolve_claude_identity(&id).await;
+    let claude_auth_email = match claude.state {
+        ClaudeConnState::Connected => Some(
+            claude
+                .email
+                .clone()
+                .unwrap_or_else(|| "Connected".to_string()),
+        ),
+        ClaudeConnState::NeedsReconnect => Some("Reconnect needed".to_string()),
+        ClaudeConnState::NotConnected => None,
+    };
     let codex_auth_email = agent_connected("codex");
     let opencode_auth_email = agent_connected("opencode");
 
@@ -732,6 +939,403 @@ pub fn clear_account_credential(id: String, key: String) -> Result<(), CommandEr
     Ok(())
 }
 
+// ============ Claude connect (backend-owned PTY) ============
+//
+// `claude setup-token` is inherently interactive: it prints an authorization
+// URL, the user logs in via the browser, and the hosted callback page shows a
+// code the user must PASTE BACK at the CLI's `Paste code here >` prompt. Run
+// headless (stdin closed) it hangs forever. So the backend spawns it in a real
+// pseudo-terminal, streams the terminal to the webview, accepts keystrokes via
+// a command — and, crucially, scrapes the printed `sk-ant-…` token out of the
+// byte stream and stores it IN RUST, redacting it from the streamed bytes so
+// the secret never reaches the webview.
+
+/// One in-flight `claude setup-token` PTY, keyed by a frontend-supplied session
+/// id. The backend owns the PTY end to end (spawn, stream, token capture).
+struct ConnectSession {
+    writer: Mutex<Box<dyn Write + Send>>,
+    child_killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
+    master: Mutex<Box<dyn portable_pty::MasterPty + Send>>,
+    /// Set once the token has been scraped + stored, so the reader thread stops
+    /// redacting and streams the remaining output verbatim.
+    captured: AtomicBool,
+}
+
+static CONNECT_REGISTRY: LazyLock<Mutex<HashMap<String, Arc<ConnectSession>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// The prefix every long-lived Claude token starts with.
+const TOKEN_PREFIX: &[u8] = b"sk-ant-";
+/// Real tokens are ~108 chars; guard against redacting a stray `sk-ant-` word.
+const TOKEN_MIN_LEN: usize = 20;
+/// What the user sees in the terminal where the token would have printed.
+const TOKEN_PLACEHOLDER: &[u8] = b"sk-ant-[redacted by Ship Studio]";
+
+fn is_token_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.')
+}
+
+/// First index of `needle` within `haystack`, if present.
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Length of the longest suffix of `data` that is a *proper* prefix of `prefix`.
+/// Used to hold back a partial `sk-ant-` straddling a read boundary so it isn't
+/// emitted before we can tell whether a token follows.
+fn partial_prefix_len(data: &[u8], prefix: &[u8]) -> usize {
+    let max = data.len().min(prefix.len().saturating_sub(1));
+    (1..=max)
+        .rev()
+        .find(|&k| data[data.len() - k..] == prefix[..k])
+        .unwrap_or(0)
+}
+
+/// Token-redaction pass over the PTY byte stream.
+///
+/// `carry` holds bytes received but not yet emitted. We split off the prefix
+/// that is safe to forward to the webview — with any complete `sk-ant-…` token
+/// replaced by [`TOKEN_PLACEHOLDER`] — and leave in `carry` only the trailing
+/// bytes that might still be (or begin) a token. The captured token, if a
+/// complete one was found, is returned so the caller can store it in the vault.
+///
+/// `eof` flips the "still growing" case: mid-stream an unterminated token is
+/// held back for the next read; at end-of-stream there is no next read, so a
+/// long-enough unterminated run IS the token.
+fn redact_token_stream(carry: &mut Vec<u8>, eof: bool) -> (Vec<u8>, Option<String>) {
+    let data = std::mem::take(carry);
+    let n = data.len();
+    let mut emit = Vec::with_capacity(n);
+    let mut captured: Option<String> = None;
+    let mut pos = 0;
+
+    loop {
+        match find_subslice(&data[pos..], TOKEN_PREFIX) {
+            Some(rel) => {
+                let i = pos + rel;
+                emit.extend_from_slice(&data[pos..i]);
+                let mut j = i + TOKEN_PREFIX.len();
+                while j < n && is_token_byte(data[j]) {
+                    j += 1;
+                }
+                let terminated = j < n;
+                if !terminated && !eof {
+                    // Token may still be growing — retain it for the next read.
+                    *carry = data[i..].to_vec();
+                    return (emit, captured);
+                }
+                if j - i >= TOKEN_MIN_LEN {
+                    if captured.is_none() {
+                        captured = Some(String::from_utf8_lossy(&data[i..j]).into_owned());
+                    }
+                    emit.extend_from_slice(TOKEN_PLACEHOLDER);
+                } else {
+                    // Too short to be a real token — pass through untouched.
+                    emit.extend_from_slice(&data[i..j]);
+                }
+                pos = j;
+                if pos >= n {
+                    return (emit, captured);
+                }
+            }
+            None => {
+                let rem = &data[pos..];
+                let hold = if eof {
+                    0
+                } else {
+                    partial_prefix_len(rem, TOKEN_PREFIX)
+                };
+                let split = rem.len() - hold;
+                emit.extend_from_slice(&rem[..split]);
+                *carry = rem[split..].to_vec();
+                return (emit, captured);
+            }
+        }
+    }
+}
+
+/// Emit a chunk of PTY output to the webview for the given connect session.
+fn emit_connect_data(app: &AppHandle, session_id: &str, bytes: &[u8]) {
+    let _ = app.emit(
+        "claude-connect-data",
+        serde_json::json!({ "sessionId": session_id, "data": bytes }),
+    );
+}
+
+/// Start an interactive Claude connect for a workspace in a backend-owned PTY.
+///
+/// Spawns `claude setup-token` in a real pseudo-terminal under the workspace's
+/// isolated env (minus any previously injected token, so identity comes from
+/// the fresh browser login). Output streams to the webview via
+/// `claude-connect-data` events; the user types into it via
+/// [`claude_connect_write`]. The reader thread scrapes the printed token,
+/// stores it in the workspace vault via [`store_claude_token`], emits
+/// `claude-connect-captured`, and redacts the token from the streamed bytes —
+/// so the secret is captured entirely in Rust and never crosses into the
+/// webview. `claude-connect-exit` fires when the process ends.
+///
+/// `email` is display-only: Claude exposes no way to resolve the account from
+/// the opaque token, so the caller passes what the user logged in as.
+#[tauri::command]
+#[tracing::instrument(skip(app, email), fields(session_id = %session_id, id = %id))]
+pub fn claude_connect_start(
+    app: AppHandle,
+    session_id: String,
+    id: String,
+    email: Option<String>,
+    cols: u16,
+    rows: u16,
+) -> Result<(), CommandError> {
+    validate_account_id(&id)?;
+    validate_account_id(&session_id)?;
+    if id == DEFAULT_ACCOUNT_ID {
+        return Err(CommandError::Validation {
+            field: "id".into(),
+            reason: "The Default workspace uses your machine's native Claude login; \
+                     run `claude` and use /login there instead of connecting a token."
+                .into(),
+        });
+    }
+
+    let binary = find_binary_by_name("claude").ok_or_else(|| CommandError::Io {
+        message: "Claude Code CLI not found. Install Claude Code first, then connect.".into(),
+    })?;
+
+    // Idempotent: a live session under this id means connect is already running.
+    {
+        let map = CONNECT_REGISTRY
+            .lock()
+            .map_err(|e| format!("claude connect registry poisoned: {e}"))?;
+        if map.contains_key(&session_id) {
+            return Ok(());
+        }
+    }
+
+    let pair = native_pty_system()
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| format!("openpty: {e}"))?;
+    let writer = pair
+        .master
+        .take_writer()
+        .map_err(|e| format!("take_writer: {e}"))?;
+    let mut reader = pair
+        .master
+        .try_clone_reader()
+        .map_err(|e| format!("clone_reader: {e}"))?;
+
+    let mut cmd = CommandBuilder::new(&binary);
+    cmd.arg("setup-token");
+    cmd.cwd(dirs::home_dir().unwrap_or_default());
+    cmd.env("PATH", get_extended_path());
+    // A real terminal type so the CLI renders its interactive prompts properly.
+    cmd.env("TERM", "xterm-256color");
+    // Run inside the workspace's isolated env so any files setup-token writes
+    // land under the workspace dir, never the global one. Strip any previously
+    // injected token: setup-token derives identity from the fresh BROWSER login,
+    // and a stale token in the env shouldn't shadow that.
+    let mut env = get_env_vars_for_account(&id);
+    env.remove("CLAUDE_CODE_OAUTH_TOKEN");
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+
+    let mut child = pair
+        .slave
+        .spawn_command(cmd)
+        .map_err(|e| format!("spawn_command: {e}"))?;
+    let child_killer = child.clone_killer();
+
+    let session = Arc::new(ConnectSession {
+        writer: Mutex::new(writer),
+        child_killer: Mutex::new(child_killer),
+        master: Mutex::new(pair.master),
+        captured: AtomicBool::new(false),
+    });
+    CONNECT_REGISTRY
+        .lock()
+        .map_err(|e| format!("claude connect registry poisoned: {e}"))?
+        .insert(session_id.clone(), session.clone());
+
+    // Reader thread: scrapes + redacts the token, streams the rest.
+    {
+        let app = app.clone();
+        let session_id = session_id.clone();
+        let account_id = id.clone();
+        let email = email
+            .as_deref()
+            .map(str::trim)
+            .filter(|e| !e.is_empty())
+            .map(str::to_string);
+        let session = session.clone();
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            let mut carry: Vec<u8> = Vec::new();
+            let store_and_signal = |token: String| {
+                if let Err(e) = store_claude_token(&account_id, &token, email.as_deref()) {
+                    tracing::warn!("failed to store captured Claude token: {e}");
+                }
+                session.captured.store(true, Ordering::Relaxed);
+                let _ = app.emit(
+                    "claude-connect-captured",
+                    serde_json::json!({ "sessionId": session_id }),
+                );
+            };
+            loop {
+                let n = match reader.read(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => n,
+                };
+                if session.captured.load(Ordering::Relaxed) {
+                    emit_connect_data(&app, &session_id, &buf[..n]);
+                    continue;
+                }
+                carry.extend_from_slice(&buf[..n]);
+                let (emit, token) = redact_token_stream(&mut carry, false);
+                if !emit.is_empty() {
+                    emit_connect_data(&app, &session_id, &emit);
+                }
+                if let Some(token) = token {
+                    store_and_signal(token);
+                    // The retained tail is unrelated text now — flush it raw.
+                    if !carry.is_empty() {
+                        let tail = std::mem::take(&mut carry);
+                        emit_connect_data(&app, &session_id, &tail);
+                    }
+                }
+            }
+            // EOF flush: treat end-of-stream as a token terminator.
+            if !session.captured.load(Ordering::Relaxed) {
+                let (emit, token) = redact_token_stream(&mut carry, true);
+                if !emit.is_empty() {
+                    emit_connect_data(&app, &session_id, &emit);
+                }
+                if let Some(token) = token {
+                    store_and_signal(token);
+                }
+            } else if !carry.is_empty() {
+                let tail = std::mem::take(&mut carry);
+                emit_connect_data(&app, &session_id, &tail);
+            }
+        });
+    }
+
+    // Waiter thread: reaps the child, drops the registry entry, signals exit.
+    {
+        let app = app.clone();
+        let session_id = session_id.clone();
+        std::thread::spawn(move || {
+            let code = match child.wait() {
+                Ok(status) if status.success() => 0,
+                Ok(status) => status.exit_code() as i32,
+                Err(_) => -1,
+            };
+            if let Ok(mut map) = CONNECT_REGISTRY.lock() {
+                map.remove(&session_id);
+            }
+            let _ = app.emit(
+                "claude-connect-exit",
+                serde_json::json!({ "sessionId": session_id, "exitCode": code }),
+            );
+        });
+    }
+
+    Ok(())
+}
+
+/// Forward keystrokes (e.g. the pasted authorization code) to a connect PTY.
+#[tauri::command]
+#[tracing::instrument(skip(data))]
+pub fn claude_connect_write(session_id: String, data: Vec<u8>) -> Result<(), CommandError> {
+    let session = {
+        let map = CONNECT_REGISTRY
+            .lock()
+            .map_err(|e| format!("claude connect registry poisoned: {e}"))?;
+        map.get(&session_id).cloned()
+    };
+    let Some(session) = session else {
+        return Err("unknown connect session".to_string().into());
+    };
+    let mut w = session
+        .writer
+        .lock()
+        .map_err(|e| format!("writer lock poisoned: {e}"))?;
+    w.write_all(&data).map_err(|e| format!("write: {e}"))?;
+    Ok(())
+}
+
+/// Resize a connect PTY to match the on-screen terminal.
+#[tauri::command]
+#[tracing::instrument]
+pub fn claude_connect_resize(session_id: String, cols: u16, rows: u16) -> Result<(), CommandError> {
+    let session = {
+        let map = CONNECT_REGISTRY
+            .lock()
+            .map_err(|e| format!("claude connect registry poisoned: {e}"))?;
+        map.get(&session_id).cloned()
+    };
+    let Some(session) = session else {
+        return Err("unknown connect session".to_string().into());
+    };
+    let master = session
+        .master
+        .lock()
+        .map_err(|e| format!("master lock poisoned: {e}"))?;
+    master
+        .resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| format!("resize: {e}"))?;
+    Ok(())
+}
+
+/// Kill a connect PTY and drop its registry entry. Idempotent — called when the
+/// user closes the connect modal (whether or not a token was captured).
+#[tauri::command]
+#[tracing::instrument]
+pub fn claude_connect_close(session_id: String) -> Result<(), CommandError> {
+    let session = {
+        let mut map = CONNECT_REGISTRY
+            .lock()
+            .map_err(|e| format!("claude connect registry poisoned: {e}"))?;
+        map.remove(&session_id)
+    };
+    if let Some(session) = session {
+        if let Ok(mut killer) = session.child_killer.lock() {
+            let _ = killer.kill();
+        }
+    }
+    Ok(())
+}
+
+/// Disconnect a workspace's Claude login: clears its captured token, email, and
+/// expiry. The workspace's terminals fall back to no injected token (logged out).
+#[tauri::command]
+#[tracing::instrument]
+pub fn disconnect_claude_account(id: String) -> Result<(), CommandError> {
+    validate_account_id(&id)?;
+    if id == DEFAULT_ACCOUNT_ID {
+        return Err(CommandError::Validation {
+            field: "id".into(),
+            reason: "The Default workspace's Claude login isn't managed by Ship Studio; \
+                     run `claude` and use /logout there instead."
+                .into(),
+        });
+    }
+    clear_claude_token(&id);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -751,8 +1355,10 @@ mod tests {
         assert!(vars.contains_key("GH_CONFIG_DIR"));
         assert!(vars.contains_key("CODEX_HOME"));
         assert!(vars.contains_key("XDG_DATA_HOME"));
-        // No credentials stored for this account, so no token vars
+        // No credentials stored for this account, so no token vars. Claude's
+        // per-workspace token is only injected once the workspace connects.
         assert!(!vars.contains_key("VERCEL_TOKEN"));
+        assert!(!vars.contains_key("CLAUDE_CODE_OAUTH_TOKEN"));
     }
 
     #[test]
@@ -766,6 +1372,138 @@ mod tests {
         assert!(!vars.contains_key("CLAUDE_CONFIG_DIR"));
         assert!(!vars.contains_key("CODEX_HOME"));
         assert!(!vars.contains_key("XDG_DATA_HOME"));
+        // The Default workspace uses Claude's native keychain login, never an
+        // injected token — injecting one would override the user's real login.
+        assert!(!vars.contains_key("CLAUDE_CODE_OAUTH_TOKEN"));
+    }
+
+    /// Convenience: run the stream redactor over a single complete buffer.
+    fn redact_once(input: &[u8]) -> (Vec<u8>, Option<String>) {
+        let mut carry = input.to_vec();
+        let (mut emit, token) = redact_token_stream(&mut carry, true);
+        // EOF flush leaves nothing behind, but be defensive.
+        emit.extend_from_slice(&carry);
+        (emit, token)
+    }
+
+    #[test]
+    fn redact_captures_token_and_replaces_it_in_the_stream() {
+        // Mirrors real `claude setup-token` output (token is sk-ant-oat…, ~108 chars).
+        let out =
+            b"\nLong-lived token created!\n\nsk-ant-oat01-abcDEF_123-456.789xyz\n\nStore it.\n";
+        let (emit, token) = redact_once(out);
+        assert_eq!(token.as_deref(), Some("sk-ant-oat01-abcDEF_123-456.789xyz"));
+        // The real token is gone from what the webview would see; placeholder stays.
+        let shown = String::from_utf8_lossy(&emit);
+        assert!(!shown.contains("oat01-abcDEF"), "token leaked: {shown}");
+        assert!(shown.contains("sk-ant-[redacted by Ship Studio]"));
+        // Surrounding text is preserved verbatim.
+        assert!(shown.contains("Long-lived token created!"));
+        assert!(shown.contains("Store it."));
+    }
+
+    #[test]
+    fn redact_handles_ansi_color_around_token() {
+        // setup-token may color the token; ANSI brackets it rather than splitting
+        // it, so the prefix is still found and the run terminates at the ESC.
+        let colored = b"\x1b[32msk-ant-oat01-tokenWithEnoughLength12345\x1b[0m done";
+        let (emit, token) = redact_once(colored);
+        assert_eq!(
+            token.as_deref(),
+            Some("sk-ant-oat01-tokenWithEnoughLength12345")
+        );
+        assert!(!String::from_utf8_lossy(&emit).contains("tokenWithEnoughLength"));
+    }
+
+    #[test]
+    fn redact_leaves_non_token_text_untouched() {
+        let (emit, token) = redact_once(b"no token here, just a prompt > ");
+        assert_eq!(token, None);
+        assert_eq!(emit, b"no token here, just a prompt > ");
+        // A too-short sk-ant- fragment is not mistaken for a token.
+        let (emit, token) = redact_once(b"see sk-ant-x in docs");
+        assert_eq!(token, None);
+        assert_eq!(emit, b"see sk-ant-x in docs");
+    }
+
+    #[test]
+    fn redact_captures_token_split_across_reads() {
+        // The token straddles two PTY reads — including a split mid-prefix. The
+        // held-back tail must let us still capture + redact it.
+        let mut carry: Vec<u8> = Vec::new();
+        let mut all_emitted: Vec<u8> = Vec::new();
+        let mut captured: Option<String> = None;
+
+        for chunk in [
+            &b"token: sk-an"[..],
+            &b"t-oat01-splitAcrossTwoReads99"[..],
+            &b"\n(done)"[..],
+        ] {
+            carry.extend_from_slice(chunk);
+            let (emit, token) = redact_token_stream(&mut carry, false);
+            all_emitted.extend_from_slice(&emit);
+            if token.is_some() {
+                captured = token;
+            }
+        }
+        let (emit, token) = redact_token_stream(&mut carry, true);
+        all_emitted.extend_from_slice(&emit);
+        if token.is_some() {
+            captured = token;
+        }
+
+        assert_eq!(
+            captured.as_deref(),
+            Some("sk-ant-oat01-splitAcrossTwoReads99")
+        );
+        let shown = String::from_utf8_lossy(&all_emitted);
+        assert!(
+            !shown.contains("splitAcrossTwoReads"),
+            "token leaked: {shown}"
+        );
+        assert!(shown.contains("sk-ant-[redacted by Ship Studio]"));
+        assert!(shown.contains("(done)"));
+    }
+
+    #[test]
+    fn redact_does_not_emit_a_partial_prefix_early() {
+        // A buffer ending mid-prefix must hold the partial back (not emit it),
+        // so a token completing on the next read is still redacted.
+        let mut carry = b"prompt sk-an".to_vec();
+        let (emit, token) = redact_token_stream(&mut carry, false);
+        assert_eq!(token, None);
+        assert_eq!(emit, b"prompt ");
+        assert_eq!(carry, b"sk-an"); // retained for the next read
+    }
+
+    #[test]
+    fn parse_claude_auth_status_reads_email_and_logged_in() {
+        // The shape `claude auth status` returns for a native claude.ai login.
+        let json = r#"{"loggedIn":true,"authMethod":"claude.ai","email":"a@b.com"}"#;
+        assert_eq!(
+            parse_claude_auth_status(json),
+            (true, Some("a@b.com".into()))
+        );
+
+        // Token-auth shape has no email — must not invent one.
+        let token_shape = r#"{"loggedIn":true,"authMethod":"oauth_token"}"#;
+        assert_eq!(parse_claude_auth_status(token_shape), (true, None));
+
+        // Non-JSON / empty → not logged in, no email (never panics).
+        assert_eq!(parse_claude_auth_status("not json"), (false, None));
+        assert_eq!(parse_claude_auth_status(""), (false, None));
+    }
+
+    #[test]
+    fn managed_cred_keys_are_not_frontend_settable() {
+        // claude_oauth_token / claude_email are backend-managed: the frontend
+        // must not be able to write or probe them via set/clear_account_credential.
+        for key in MANAGED_CRED_KEYS {
+            assert!(
+                validate_credential_key(key).is_err(),
+                "managed key {key:?} must be rejected by the frontend credential allowlist"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/commands/setup/agents.rs
+++ b/src-tauri/src/commands/setup/agents.rs
@@ -4,7 +4,9 @@
 //! installed/auth status, signing out, uninstalling.
 
 use crate::agent::{get_agent_by_id, ALL_AGENTS};
-use crate::commands::accounts::{agent_auth_dir, get_active_account_id};
+use crate::commands::accounts::{
+    agent_auth_dir, get_active_account_id, resolve_claude_identity, ClaudeConnState,
+};
 use crate::commands::claude::find_binary_by_name;
 use crate::errors::CommandError;
 use crate::utils::create_command;
@@ -20,6 +22,13 @@ pub struct AgentStatus {
     pub installed: bool,
     pub version: Option<String>,
     pub authed: bool,
+    /// The signed-in account's email, when known (currently only Claude Code,
+    /// resolved per active workspace). `None` for agents we can't identify.
+    pub auth_email: Option<String>,
+    /// True when the agent was connected but its credential has expired and the
+    /// user must reconnect — drives the red stroke + inline Reconnect on the card.
+    /// Never true for the "never connected" state (that keeps the neutral UI).
+    pub needs_reconnect: bool,
     pub is_default: bool,
     pub install_supported: bool,
     pub uninstall_supported: bool,
@@ -34,6 +43,11 @@ pub async fn get_agents_status() -> Vec<AgentStatus> {
         .default_agent_id
         .unwrap_or_else(|| "claude-code".to_string());
     let active_account_id = get_active_account_id().unwrap_or_else(|_| "default".to_string());
+
+    // Claude's auth can't be inferred from config files (its macOS login is a
+    // global keychain entry that ignores CLAUDE_CONFIG_DIR), so resolve the real
+    // per-workspace identity once up front and fold it into the Claude row below.
+    let claude_identity = resolve_claude_identity(&active_account_id).await;
 
     ALL_AGENTS
         .iter()
@@ -55,14 +69,23 @@ pub async fn get_agents_status() -> Vec<AgentStatus> {
                     })
             });
 
-            let authed = if !installed {
-                false
+            let is_claude = agent.id == "claude-code";
+            let (authed, auth_email, needs_reconnect) = if is_claude {
+                // Real per-workspace identity, not file existence.
+                (
+                    claude_identity.state != ClaudeConnState::NotConnected,
+                    claude_identity.email.clone(),
+                    claude_identity.state == ClaudeConnState::NeedsReconnect,
+                )
+            } else if !installed {
+                (false, None, false)
             } else {
                 let dir = agent_auth_dir(&active_account_id, agent);
-                agent
+                let authed = agent
                     .auth_indicators
                     .iter()
-                    .any(|indicator| dir.join(indicator).exists())
+                    .any(|indicator| dir.join(indicator).exists());
+                (authed, None, false)
             };
 
             #[cfg(windows)]
@@ -82,6 +105,8 @@ pub async fn get_agents_status() -> Vec<AgentStatus> {
                 installed,
                 version,
                 authed,
+                auth_email,
+                needs_reconnect,
                 is_default: agent.id == default_id,
                 install_supported,
                 uninstall_supported,
@@ -311,6 +336,8 @@ mod tests {
             installed: true,
             version: Some("1.2.3".to_string()),
             authed: true,
+            auth_email: Some("user@example.com".to_string()),
+            needs_reconnect: false,
             is_default: true,
             install_supported: true,
             uninstall_supported: true,
@@ -322,5 +349,7 @@ mod tests {
         assert!(json.contains("\"isDefault\":true"));
         assert!(json.contains("\"installSupported\":true"));
         assert!(json.contains("\"uninstallSupported\":true"));
+        assert!(json.contains("\"authEmail\":\"user@example.com\""));
+        assert!(json.contains("\"needsReconnect\":false"));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -486,6 +486,11 @@ pub fn run() {
             commands::accounts::claude_connect_resize,
             commands::accounts::claude_connect_close,
             commands::accounts::disconnect_claude_account,
+            commands::accounts::workspace_connect_start,
+            commands::accounts::workspace_connect_write,
+            commands::accounts::workspace_connect_resize,
+            commands::accounts::workspace_connect_close,
+            commands::accounts::workspace_disconnect_service,
             // Projects folder
             commands::settings::get_projects_root,
             commands::settings::set_projects_root,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -481,6 +481,11 @@ pub fn run() {
             commands::accounts::get_account_credential_status,
             commands::accounts::set_account_credential,
             commands::accounts::clear_account_credential,
+            commands::accounts::claude_connect_start,
+            commands::accounts::claude_connect_write,
+            commands::accounts::claude_connect_resize,
+            commands::accounts::claude_connect_close,
+            commands::accounts::disconnect_claude_account,
             // Projects folder
             commands::settings::get_projects_root,
             commands::settings::set_projects_root,

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -809,6 +809,9 @@ pub struct AccountCredentialStatus {
     pub codex_auth_email: Option<String>,
     pub opencode_auth_email: Option<String>,
     pub github_auth_email: Option<String>,
+    /// Vercel identity (`vercel whoami`) verified with this workspace's injected
+    /// `VERCEL_TOKEN`. `None` when no token is set or the token is invalid.
+    pub vercel_username: Option<String>,
     pub has_anthropic_base_url: bool,
     pub has_vercel_token: bool,
     pub has_git_name: bool,

--- a/src/components/accounts/AccountSettingsModal.tsx
+++ b/src/components/accounts/AccountSettingsModal.tsx
@@ -9,6 +9,8 @@ import { useEffect, useState, useCallback } from 'react';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { Spinner } from '../primitives/Spinner';
+import { GitHubIcon, VercelIcon } from '../icons';
+import { useWorkspaceConnect, type ConnectServiceId } from '../../hooks/useWorkspaceConnect';
 import { useOptionalToast } from '../../contexts/ToastContext';
 import {
   updateAccount,
@@ -71,6 +73,20 @@ export function AccountSettingsModal({
       setIsLoadingCreds(false);
     }
   }, []);
+
+  // The same shared connect layer the dashboard uses, so the two surfaces can
+  // never drift. Works for any workspace (not just the active one) — this is the
+  // only place to manage a *non-active* workspace's logins.
+  const {
+    connect: connectService,
+    disconnect: disconnectService,
+    modals: connectModals,
+  } = useWorkspaceConnect({
+    accountId: account.id,
+    accountName: account.name,
+    isDefault: account.isDefault,
+    onChanged: () => void loadCredStatus(account.id),
+  });
 
   useEffect(() => {
     if (!isOpen) return;
@@ -149,242 +165,298 @@ export function AccountSettingsModal({
     : [];
 
   return (
-    <ModalFrame
-      isOpen={isOpen}
-      onClose={onClose}
-      title="Workspace Settings"
-      className="account-modal-frame"
-    >
-      <div className="account-detail">
-        <div className="account-detail-scroll">
-          {/* Name + color */}
-          <div>
-            <div className="account-section-title">Name</div>
-            <div className="account-header-row">
-              <input
-                className="account-name-input"
-                value={editName}
-                onChange={(e) => setEditName(e.target.value)}
-                disabled={account.isDefault}
-                placeholder="Workspace name"
-              />
+    <>
+      <ModalFrame
+        isOpen={isOpen}
+        onClose={onClose}
+        title="Workspace Settings"
+        className="account-modal-frame"
+      >
+        <div className="account-detail">
+          <div className="account-detail-scroll">
+            {/* Name + color */}
+            <div>
+              <div className="account-section-title">Name</div>
+              <div className="account-header-row">
+                <input
+                  className="account-name-input"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  disabled={account.isDefault}
+                  placeholder="Workspace name"
+                />
+              </div>
+              {!account.isDefault && (
+                <div style={{ marginTop: 'var(--spacing-sm)' }}>
+                  <div className="account-section-title">Color</div>
+                  <div className="account-color-picker">
+                    {ACCOUNT_COLORS.map((c) => (
+                      <button
+                        key={c}
+                        className={`account-color-swatch ${c === editColor ? 'selected' : ''}`}
+                        style={{ background: c }}
+                        onClick={() => setEditColor(c)}
+                        title={c}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
-            {!account.isDefault && (
-              <div style={{ marginTop: 'var(--spacing-sm)' }}>
-                <div className="account-section-title">Color</div>
-                <div className="account-color-picker">
-                  {ACCOUNT_COLORS.map((c) => (
-                    <button
-                      key={c}
-                      className={`account-color-swatch ${c === editColor ? 'selected' : ''}`}
-                      style={{ background: c }}
-                      onClick={() => setEditColor(c)}
-                      title={c}
-                    />
+
+            {/* Coding agents — status only; sign-in is managed from the dashboard's
+              Workspace accounts card (which also owns install / default state). */}
+            <div>
+              <div className="account-section-title">Coding agents</div>
+              {isLoadingCreds ? (
+                <Spinner size="sm" />
+              ) : (
+                <div className="account-cred-list">
+                  {(
+                    [
+                      { label: 'Claude Code', identity: credStatus?.claudeAuthEmail },
+                      { label: 'Codex', identity: credStatus?.codexAuthEmail },
+                      { label: 'Opencode', identity: credStatus?.opencodeAuthEmail },
+                    ] as const
+                  ).map((row) => (
+                    <div key={row.label} className="account-cred-row">
+                      <span className="account-cred-label">{row.label}</span>
+                      <div className="account-cred-status">
+                        <span className={`account-cred-badge ${row.identity ? 'set' : 'unset'}`}>
+                          {row.identity ? 'Connected' : 'Not connected'}
+                        </span>
+                      </div>
+                    </div>
                   ))}
                 </div>
-              </div>
-            )}
-          </div>
+              )}
+              <p className="account-settings-hint">
+                Sign coding agents in from the dashboard’s <strong>Workspace accounts</strong> card.
+              </p>
+            </div>
 
-          {/* Connection status */}
-          <div>
-            <div className="account-section-title">Connections</div>
-            {isLoadingCreds ? (
-              <Spinner size="sm" />
-            ) : (
-              <div className="account-cred-list">
-                <div className="account-cred-row">
-                  <span className="account-cred-label">Claude Code</span>
-                  <div className="account-cred-status">
-                    <span
-                      className={`account-cred-badge ${credStatus?.claudeAuthEmail ? 'set' : 'unset'}`}
-                    >
-                      {credStatus?.claudeAuthEmail ? 'Connected' : 'Not connected'}
-                    </span>
-                  </div>
-                </div>
-                <div className="account-cred-row">
-                  <span className="account-cred-label">Codex</span>
-                  <div className="account-cred-status">
-                    <span
-                      className={`account-cred-badge ${credStatus?.codexAuthEmail ? 'set' : 'unset'}`}
-                    >
-                      {credStatus?.codexAuthEmail ? 'Connected' : 'Not connected'}
-                    </span>
-                  </div>
-                </div>
-                <div className="account-cred-row">
-                  <span className="account-cred-label">Opencode</span>
-                  <div className="account-cred-status">
-                    <span
-                      className={`account-cred-badge ${credStatus?.opencodeAuthEmail ? 'set' : 'unset'}`}
-                    >
-                      {credStatus?.opencodeAuthEmail ? 'Connected' : 'Not connected'}
-                    </span>
-                  </div>
-                </div>
-                <div className="account-cred-row">
-                  <span className="account-cred-label">GitHub</span>
-                  <div className="account-cred-status">
-                    <span
-                      className={`account-cred-badge ${credStatus?.githubAuthEmail ? 'set' : 'unset'}`}
-                    >
-                      {credStatus?.githubAuthEmail
-                        ? `Connected as ${credStatus.githubAuthEmail}`
-                        : 'Not connected'}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            )}
-            <p className="account-settings-hint">
-              Run <code>claude</code> or <code>gh auth login</code> in a terminal for this workspace
-              to connect these accounts.
-            </p>
-          </div>
-
-          {/* Credential vault */}
-          <div>
-            <div className="account-section-title">Credential Vault</div>
-            {isLoadingCreds ? (
-              <Spinner size="sm" />
-            ) : (
-              <div className="account-cred-list">
-                {credRows.map(([statusField, key]) => {
-                  const isSet = credStatus ? credStatus[statusField] : false;
-                  const isEditing = editingCred?.key === key;
-                  const isSensitive = SENSITIVE_KEYS.has(key);
-                  const revealed = showValues.has(key);
-
-                  return (
-                    <div key={key} className={`account-cred-row${isEditing ? ' is-editing' : ''}`}>
-                      {isEditing ? (
-                        <div className="account-cred-input-row">
-                          <input
-                            className="account-cred-input"
-                            type={isSensitive && !revealed ? 'password' : 'text'}
-                            value={editingCred.value}
-                            onChange={(e) => setEditingCred({ key, value: e.target.value })}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter') void handleSaveCred();
-                              if (e.key === 'Escape') setEditingCred(null);
-                            }}
-                            autoFocus
-                            placeholder={isSensitive ? '••••••••' : CREDENTIAL_LABELS[key]}
-                          />
-                          {isSensitive && (
-                            <button
-                              type="button"
-                              className="account-cred-reveal"
-                              onClick={() => toggleShowValue(key)}
-                              title={revealed ? 'Hide' : 'Show'}
-                            >
-                              {revealed ? 'Hide' : 'Show'}
-                            </button>
-                          )}
+            {/* Services — actionable via the same shared connect layer as the
+              dashboard, so the two surfaces stay in sync. */}
+            <div>
+              <div className="account-section-title">Services</div>
+              {isLoadingCreds ? (
+                <Spinner size="sm" />
+              ) : (
+                <div className="account-cred-list">
+                  {(
+                    [
+                      {
+                        id: 'github' as ConnectServiceId,
+                        label: 'GitHub',
+                        icon: <GitHubIcon size={16} />,
+                        identity: credStatus?.githubAuthEmail ?? null,
+                      },
+                      {
+                        id: 'vercel' as ConnectServiceId,
+                        label: 'Vercel',
+                        icon: <VercelIcon size={14} />,
+                        identity: credStatus?.vercelUsername ?? null,
+                      },
+                    ] as const
+                  ).map((svc) => {
+                    const connected = !!svc.identity;
+                    return (
+                      <div key={svc.id} className="account-cred-row">
+                        <span className="account-cred-label">
+                          {svc.icon} {svc.label}
+                        </span>
+                        <div className="account-cred-status">
+                          <span className={`account-cred-badge ${connected ? 'set' : 'unset'}`}>
+                            {connected ? `Connected as ${svc.identity}` : 'Not connected'}
+                          </span>
                           <div className="account-cred-actions">
-                            <Button
-                              variant="primary"
-                              size="sm"
-                              onClick={() => void handleSaveCred()}
-                              disabled={!editingCred.value.trim() || isSavingCred}
-                            >
-                              {isSavingCred ? <Spinner size="sm" /> : 'Save'}
-                            </Button>
-                            <Button variant="ghost" size="sm" onClick={() => setEditingCred(null)}>
-                              Cancel
-                            </Button>
+                            {connected ? (
+                              <>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => connectService(svc.id)}
+                                >
+                                  {account.isDefault ? 'Sign in again' : 'Switch'}
+                                </Button>
+                                {!account.isDefault && (
+                                  <Button
+                                    variant="danger"
+                                    size="sm"
+                                    onClick={() => void disconnectService(svc.id)}
+                                  >
+                                    Disconnect
+                                  </Button>
+                                )}
+                              </>
+                            ) : (
+                              <Button
+                                variant="primary"
+                                size="sm"
+                                onClick={() => connectService(svc.id)}
+                              >
+                                Connect
+                              </Button>
+                            )}
                           </div>
                         </div>
-                      ) : (
-                        <>
-                          <div className="account-cred-info">
-                            <span className="account-cred-label">{CREDENTIAL_LABELS[key]}</span>
-                            <span className="account-cred-description">
-                              {CREDENTIAL_DESCRIPTIONS[key]}
-                            </span>
-                          </div>
-                          <div className="account-cred-status">
-                            <span className={`account-cred-badge ${isSet ? 'set' : 'unset'}`}>
-                              {isSet ? 'Set' : 'Not set'}
-                            </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            {/* Credential vault */}
+            <div>
+              <div className="account-section-title">Credential Vault</div>
+              {isLoadingCreds ? (
+                <Spinner size="sm" />
+              ) : (
+                <div className="account-cred-list">
+                  {credRows.map(([statusField, key]) => {
+                    const isSet = credStatus ? credStatus[statusField] : false;
+                    const isEditing = editingCred?.key === key;
+                    const isSensitive = SENSITIVE_KEYS.has(key);
+                    const revealed = showValues.has(key);
+
+                    return (
+                      <div
+                        key={key}
+                        className={`account-cred-row${isEditing ? ' is-editing' : ''}`}
+                      >
+                        {isEditing ? (
+                          <div className="account-cred-input-row">
+                            <input
+                              className="account-cred-input"
+                              type={isSensitive && !revealed ? 'password' : 'text'}
+                              value={editingCred.value}
+                              onChange={(e) => setEditingCred({ key, value: e.target.value })}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter') void handleSaveCred();
+                                if (e.key === 'Escape') setEditingCred(null);
+                              }}
+                              autoFocus
+                              placeholder={isSensitive ? '••••••••' : CREDENTIAL_LABELS[key]}
+                            />
+                            {isSensitive && (
+                              <button
+                                type="button"
+                                className="account-cred-reveal"
+                                onClick={() => toggleShowValue(key)}
+                                title={revealed ? 'Hide' : 'Show'}
+                              >
+                                {revealed ? 'Hide' : 'Show'}
+                              </button>
+                            )}
                             <div className="account-cred-actions">
+                              <Button
+                                variant="primary"
+                                size="sm"
+                                onClick={() => void handleSaveCred()}
+                                disabled={!editingCred.value.trim() || isSavingCred}
+                              >
+                                {isSavingCred ? <Spinner size="sm" /> : 'Save'}
+                              </Button>
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                onClick={() => setEditingCred({ key, value: '' })}
+                                onClick={() => setEditingCred(null)}
                               >
-                                {isSet ? 'Update' : 'Set'}
+                                Cancel
                               </Button>
-                              {isSet && (
-                                <Button
-                                  variant="danger"
-                                  size="sm"
-                                  onClick={() => void handleClearCred(key)}
-                                >
-                                  Clear
-                                </Button>
-                              )}
                             </div>
                           </div>
-                        </>
-                      )}
-                    </div>
-                  );
-                })}
+                        ) : (
+                          <>
+                            <div className="account-cred-info">
+                              <span className="account-cred-label">{CREDENTIAL_LABELS[key]}</span>
+                              <span className="account-cred-description">
+                                {CREDENTIAL_DESCRIPTIONS[key]}
+                              </span>
+                            </div>
+                            <div className="account-cred-status">
+                              <span className={`account-cred-badge ${isSet ? 'set' : 'unset'}`}>
+                                {isSet ? 'Set' : 'Not set'}
+                              </span>
+                              <div className="account-cred-actions">
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setEditingCred({ key, value: '' })}
+                                >
+                                  {isSet ? 'Update' : 'Set'}
+                                </Button>
+                                {isSet && (
+                                  <Button
+                                    variant="danger"
+                                    size="sm"
+                                    onClick={() => void handleClearCred(key)}
+                                  >
+                                    Clear
+                                  </Button>
+                                )}
+                              </div>
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="account-detail-footer">
+            {account.isDefault ? (
+              <span style={{ fontSize: 'var(--font-size-xs)', color: 'var(--text-muted)' }}>
+                The Default workspace cannot be renamed or deleted.
+              </span>
+            ) : confirmingDelete ? (
+              <div className="account-delete-confirm">
+                <span className="account-delete-confirm-text">
+                  Delete “{account.name}”? Its stored credentials are removed and any projects in it
+                  move to Default — your files aren’t touched.
+                </span>
+                <div className="account-delete-confirm-actions">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setConfirmingDelete(false)}
+                    disabled={isDeleting}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    onClick={() => void handleDelete()}
+                    disabled={isDeleting}
+                  >
+                    {isDeleting ? <Spinner size="sm" /> : 'Delete'}
+                  </Button>
+                </div>
               </div>
+            ) : (
+              <>
+                <Button variant="danger" size="sm" onClick={() => setConfirmingDelete(true)}>
+                  Delete Workspace
+                </Button>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() => void handleSave()}
+                  disabled={!editName.trim() || isSaving}
+                >
+                  {isSaving ? <Spinner size="sm" /> : 'Save Changes'}
+                </Button>
+              </>
             )}
           </div>
         </div>
-
-        <div className="account-detail-footer">
-          {account.isDefault ? (
-            <span style={{ fontSize: 'var(--font-size-xs)', color: 'var(--text-muted)' }}>
-              The Default workspace cannot be renamed or deleted.
-            </span>
-          ) : confirmingDelete ? (
-            <div className="account-delete-confirm">
-              <span className="account-delete-confirm-text">
-                Delete “{account.name}”? Its stored credentials are removed and any projects in it
-                move to Default — your files aren’t touched.
-              </span>
-              <div className="account-delete-confirm-actions">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setConfirmingDelete(false)}
-                  disabled={isDeleting}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  variant="danger"
-                  size="sm"
-                  onClick={() => void handleDelete()}
-                  disabled={isDeleting}
-                >
-                  {isDeleting ? <Spinner size="sm" /> : 'Delete'}
-                </Button>
-              </div>
-            </div>
-          ) : (
-            <>
-              <Button variant="danger" size="sm" onClick={() => setConfirmingDelete(true)}>
-                Delete Workspace
-              </Button>
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={() => void handleSave()}
-                disabled={!editName.trim() || isSaving}
-              >
-                {isSaving ? <Spinner size="sm" /> : 'Save Changes'}
-              </Button>
-            </>
-          )}
-        </div>
-      </div>
-    </ModalFrame>
+      </ModalFrame>
+      {connectModals}
+    </>
   );
 }

--- a/src/components/dashboard/AgentsPanel.test.tsx
+++ b/src/components/dashboard/AgentsPanel.test.tsx
@@ -68,10 +68,24 @@ vi.mock('./ClaudeConnectTerminal', () => ({
   ),
 }));
 
+// Generic per-workspace connect terminal (GitHub/Codex/Opencode) — stub it so
+// tests can drive the exit signal without an xterm + live PTY.
+vi.mock('./WorkspaceConnectTerminal', () => ({
+  WorkspaceConnectTerminal: ({ onExit }: { onExit: (c: number) => void }) => (
+    <div data-testid="mock-workspace-connect-terminal">
+      <button data-testid="workspace-connect-exit-0" onClick={() => onExit(0)}>
+        exit 0
+      </button>
+    </div>
+  ),
+}));
+
 // Strip heavy icon SVGs; only need predictable DOM.
 vi.mock('../icons', () => ({
   CheckIcon: () => <span data-testid="check-icon" />,
   ClaudeIcon: () => <span data-testid="claude-icon" />,
+  GitHubIcon: () => <span data-testid="github-icon" />,
+  VercelIcon: () => <span data-testid="vercel-icon" />,
 }));
 
 import { AgentsPanel } from './AgentsPanel';
@@ -165,7 +179,12 @@ describe('AgentsPanel', () => {
     mockInvoke('get_agents_status', [CLAUDE_DEFAULT, CODEX_READY]);
     render(<AgentsPanel />);
 
-    await waitFor(() => expect(screen.getByText('Default')).toBeInTheDocument());
+    // The workspace badge can also read "Default", so target the pill by role
+    // (the badge is a span). "Set default" has a lowercase d, so /Default/ only
+    // matches the active "Default" pill.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Default/ })).toBeInTheDocument()
+    );
     const defaultPill = screen.getByRole('button', { name: /Default/ });
     expect(defaultPill).toBeDisabled();
   });
@@ -206,7 +225,8 @@ describe('AgentsPanel', () => {
     await waitFor(() => expect(screen.queryByText('Switching…')).not.toBeInTheDocument());
 
     // Codex row should now own the Default pill; Claude Code should show "Set default".
-    expect(screen.getByText('Default')).toBeInTheDocument();
+    // (Query the pill by role — the workspace badge also reads "Default".)
+    expect(screen.getByRole('button', { name: /Default/ })).toBeInTheDocument();
     expect(screen.getByText('Set default')).toBeInTheDocument();
 
     // Confirm the backend was actually called with the right agent id.
@@ -293,7 +313,7 @@ describe('AgentsPanel', () => {
 
     // Load resolves (via catch) and the header still renders; no rows.
     await waitFor(() =>
-      expect(screen.getByText(/Install, sign in, or switch/)).toBeInTheDocument()
+      expect(screen.getByText(/each workspace signs in separately/)).toBeInTheDocument()
     );
     expect(screen.queryByText('Claude Code')).not.toBeInTheDocument();
   });
@@ -355,7 +375,8 @@ describe('AgentsPanel', () => {
     await waitFor(() =>
       expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument()
     );
-    expect(screen.getByText(/Circa/)).toBeInTheDocument();
+    // The workspace name appears in both the header badge and the modal copy.
+    expect(screen.getAllByText(/Circa/).length).toBeGreaterThan(0);
     expect(screen.queryByTestId('mock-terminal')).not.toBeInTheDocument();
     expect(screen.queryByTestId('mock-connect-terminal')).not.toBeInTheDocument();
   });
@@ -406,5 +427,112 @@ describe('AgentsPanel', () => {
     await waitFor(() => expect(screen.getByTestId('mock-terminal')).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('mock-connect-terminal')).not.toBeInTheDocument();
+  });
+
+  // ============ Workspace badge + section grouping + Services rows ============
+
+  const CIRCA = { id: 'circa', name: 'Circa', color: '#abcdef', isDefault: false, createdAt: 0 };
+  const DEFAULT_WS = {
+    id: 'default',
+    name: 'Default',
+    color: '#000',
+    isDefault: true,
+    createdAt: 0,
+  };
+
+  function mockWorkspace(account: typeof CIRCA | typeof DEFAULT_WS) {
+    mockInvoke('get_active_account_id', account.id);
+    mockInvoke('list_accounts', [account]);
+  }
+
+  it('names the active workspace and groups rows under Coding agents / Services', async () => {
+    mockInvoke('get_agents_status', [CLAUDE_DEFAULT]);
+    mockWorkspace(CIRCA);
+    render(<AgentsPanel />);
+
+    await waitFor(() => expect(invokeCalls.some((c) => c.cmd === 'list_accounts')).toBe(true));
+    // Workspace badge names the active workspace.
+    await waitFor(() => expect(screen.getAllByText(/Circa/).length).toBeGreaterThan(0));
+    // The two section subheaders are present.
+    expect(screen.getByText('Coding agents')).toBeInTheDocument();
+    expect(screen.getByText('Services')).toBeInTheDocument();
+    // The Services rows render for GitHub + Vercel.
+    expect(screen.getByText('GitHub')).toBeInTheDocument();
+    expect(screen.getByText('Vercel')).toBeInTheDocument();
+  });
+
+  it('shows the workspace Vercel identity once the credential status resolves', async () => {
+    mockInvoke('get_agents_status', [CLAUDE_DEFAULT]);
+    mockWorkspace(CIRCA);
+    mockInvoke('get_account_credential_status', {
+      githubAuthEmail: 'octocat@github.com',
+      vercelUsername: 'circa-team',
+    });
+    render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('circa-team')).toBeInTheDocument());
+    expect(screen.getByText('octocat@github.com')).toBeInTheDocument();
+    // Connected services show a kebab, not a Connect button.
+    expect(screen.queryByRole('button', { name: 'Connect' })).not.toBeInTheDocument();
+  });
+
+  it('non-default workspace: Vercel "Connect" opens the token modal and saves the credential', async () => {
+    mockInvoke('get_agents_status', [CLAUDE_DEFAULT]);
+    mockWorkspace(CIRCA);
+    // No credential status → both services read "Connect".
+    render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Vercel')).toBeInTheDocument());
+    // Both GitHub + Vercel offer Connect; grab them in row order.
+    const connectButtons = screen.getAllByRole('button', { name: 'Connect' });
+    expect(connectButtons).toHaveLength(2);
+    fireEvent.click(connectButtons[1]); // Vercel row
+
+    // Token modal opens (no native terminal).
+    const input = await screen.findByPlaceholderText('vercel_xxxxxxxxxxxxxxxx');
+    expect(screen.queryByTestId('mock-terminal')).not.toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: '  vercel_abc123  ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      const call = invokeCalls.find((c) => c.cmd === 'set_account_credential');
+      expect(call?.args).toMatchObject({
+        id: 'circa',
+        key: 'vercel_token',
+        value: 'vercel_abc123',
+      });
+    });
+  });
+
+  it('non-default workspace: GitHub "Connect" routes through the backend PTY modal', async () => {
+    mockInvoke('get_agents_status', [CLAUDE_DEFAULT]);
+    mockWorkspace(CIRCA);
+    render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('GitHub')).toBeInTheDocument());
+    fireEvent.click(screen.getAllByRole('button', { name: 'Connect' })[0]); // GitHub row
+
+    // The generic workspace-connect terminal mounts (config-dir PTY login),
+    // not the native machine terminal.
+    await waitFor(() =>
+      expect(screen.getByTestId('mock-workspace-connect-terminal')).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId('mock-terminal')).not.toBeInTheDocument();
+  });
+
+  it('Default workspace: GitHub + Vercel "Connect" use the native machine terminal', async () => {
+    mockInvoke('get_agents_status', [CLAUDE_DEFAULT]);
+    mockWorkspace(DEFAULT_WS);
+    render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('GitHub')).toBeInTheDocument());
+    fireEvent.click(screen.getAllByRole('button', { name: 'Connect' })[0]); // GitHub row
+
+    // Default uses the machine's native logins — the native OnboardingTerminal,
+    // never the workspace-isolated PTY or the Vercel token modal.
+    await waitFor(() => expect(screen.getByTestId('mock-terminal')).toBeInTheDocument());
+    expect(screen.queryByTestId('mock-workspace-connect-terminal')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('vercel_xxxxxxxxxxxxxxxx')).not.toBeInTheDocument();
   });
 });

--- a/src/components/dashboard/AgentsPanel.test.tsx
+++ b/src/components/dashboard/AgentsPanel.test.tsx
@@ -47,6 +47,27 @@ vi.mock('../setup/OnboardingTerminal', () => ({
   ),
 }));
 
+// Backend-owned connect terminal — stub it so tests can drive the
+// captured/exit signals without an xterm + live PTY.
+vi.mock('./ClaudeConnectTerminal', () => ({
+  ClaudeConnectTerminal: ({
+    onCaptured,
+    onExit,
+  }: {
+    onCaptured: () => void;
+    onExit: (c: number) => void;
+  }) => (
+    <div data-testid="mock-connect-terminal">
+      <button data-testid="connect-captured" onClick={() => onCaptured()}>
+        captured
+      </button>
+      <button data-testid="connect-exit" onClick={() => onExit(0)}>
+        exit
+      </button>
+    </div>
+  ),
+}));
+
 // Strip heavy icon SVGs; only need predictable DOM.
 vi.mock('../icons', () => ({
   CheckIcon: () => <span data-testid="check-icon" />,
@@ -65,6 +86,8 @@ function agent(overrides: Partial<AgentStatus> = {}): AgentStatus {
     installed: true,
     version: '1.2.3',
     authed: true,
+    authEmail: null,
+    needsReconnect: false,
     isDefault: false,
     installSupported: true,
     uninstallSupported: true,
@@ -273,5 +296,115 @@ describe('AgentsPanel', () => {
       expect(screen.getByText(/Install, sign in, or switch/)).toBeInTheDocument()
     );
     expect(screen.queryByText('Claude Code')).not.toBeInTheDocument();
+  });
+
+  // ============ Per-workspace Claude auth (email + reconnect) ============
+
+  it('shows the account email instead of a generic "Signed in"', async () => {
+    mockInvoke('get_agents_status', [
+      agent({ isDefault: true, authEmail: 'circa@circabranding.com' }),
+    ]);
+    render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Claude Code')).toBeInTheDocument());
+    expect(screen.getByText('v1.2.3 · circa@circabranding.com')).toBeInTheDocument();
+  });
+
+  it('renders a red Reconnect button + status when the token needs reconnect', async () => {
+    mockInvoke('get_agents_status', [
+      agent({ authed: true, needsReconnect: true, authEmail: 'circa@circabranding.com' }),
+    ]);
+    const { container } = render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Claude Code')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Reconnect' })).toBeInTheDocument();
+    expect(screen.getByText('circa@circabranding.com · Reconnect needed')).toBeInTheDocument();
+    // The card carries the red stroke class, not the green connected one.
+    expect(container.querySelector('.agents-panel-row.needs-reconnect')).toBeInTheDocument();
+    expect(container.querySelector('.agents-panel-row.is-connected')).not.toBeInTheDocument();
+    // No "Set default" pill while a reconnect is pending.
+    expect(screen.queryByText('Set default')).not.toBeInTheDocument();
+  });
+
+  it('keeps the neutral never-connected UI (no red, plain "Sign in")', async () => {
+    mockInvoke('get_agents_status', [agent({ authed: false, needsReconnect: false })]);
+    const { container } = render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Claude Code')).toBeInTheDocument());
+    expect(screen.getByText('Not signed in')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+    expect(container.querySelector('.needs-reconnect')).not.toBeInTheDocument();
+    expect(container.querySelector('.is-connected')).not.toBeInTheDocument();
+  });
+
+  it('routes Claude "Sign in" to the connect modal in a non-default workspace', async () => {
+    mockInvoke('get_agents_status', [agent({ authed: false })]);
+    mockInvoke('get_active_account_id', 'circa');
+    mockInvoke('list_accounts', [
+      { id: 'circa', name: 'Circa', color: '#000', isDefault: false, createdAt: 0 },
+    ]);
+    render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Claude Code')).toBeInTheDocument());
+    // Wait for the active workspace to resolve, then click Sign in.
+    await waitFor(() => expect(invokeCalls.some((c) => c.cmd === 'list_accounts')).toBe(true));
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    // The connect modal opens at its email phase (no OnboardingTerminal),
+    // naming the workspace.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument()
+    );
+    expect(screen.getByText(/Circa/)).toBeInTheDocument();
+    expect(screen.queryByTestId('mock-terminal')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-connect-terminal')).not.toBeInTheDocument();
+  });
+
+  it('connect flow: Continue opens the PTY terminal; capture closes + refreshes', async () => {
+    mockInvoke('get_agents_status', [agent({ authed: false })]);
+    mockInvoke('get_active_account_id', 'circa');
+    mockInvoke('list_accounts', [
+      { id: 'circa', name: 'Circa', color: '#000', isDefault: false, createdAt: 0 },
+    ]);
+    render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Claude Code')).toBeInTheDocument());
+    await waitFor(() => expect(invokeCalls.some((c) => c.cmd === 'list_accounts')).toBe(true));
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    // Email phase → Continue advances to the backend-PTY terminal phase.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    await waitFor(() => expect(screen.getByTestId('mock-connect-terminal')).toBeInTheDocument());
+
+    // Rust signals the token was captured → modal closes and status refreshes.
+    const refreshesBefore = invokeCalls.filter((c) => c.cmd === 'get_agents_status').length;
+    fireEvent.click(screen.getByTestId('connect-captured'));
+    await waitFor(() =>
+      expect(screen.queryByTestId('mock-connect-terminal')).not.toBeInTheDocument()
+    );
+    expect(invokeCalls.filter((c) => c.cmd === 'get_agents_status').length).toBeGreaterThan(
+      refreshesBefore
+    );
+  });
+
+  it('Default workspace Claude "Sign in" still uses the terminal flow', async () => {
+    mockInvoke('get_agents_status', [agent({ authed: false })]);
+    mockInvoke('get_active_account_id', 'default');
+    mockInvoke('list_accounts', [
+      { id: 'default', name: 'Default', color: '#000', isDefault: true, createdAt: 0 },
+    ]);
+    render(<AgentsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Claude Code')).toBeInTheDocument());
+    await waitFor(() => expect(invokeCalls.some((c) => c.cmd === 'list_accounts')).toBe(true));
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    // Terminal modal opens; no connect modal.
+    await waitFor(() => expect(screen.getByTestId('mock-terminal')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-connect-terminal')).not.toBeInTheDocument();
   });
 });

--- a/src/components/dashboard/AgentsPanel.tsx
+++ b/src/components/dashboard/AgentsPanel.tsx
@@ -24,15 +24,22 @@ import {
   uninstallAgent,
   disconnectClaudeAccount,
 } from '../../lib/agents-management';
-import { getActiveAccountId, listAccounts, DEFAULT_ACCOUNT_ID } from '../../lib/accounts';
+import {
+  getActiveAccountId,
+  listAccounts,
+  getAccountCredentialStatus,
+  DEFAULT_ACCOUNT_ID,
+  type AccountCredentialStatus,
+} from '../../lib/accounts';
 import { OnboardingTerminal } from '../setup/OnboardingTerminal';
 import { ClaudeConnectTerminal } from './ClaudeConnectTerminal';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { Spinner } from '../primitives/Spinner';
 import { useOptionalToast } from '../../contexts/ToastContext';
+import { useWorkspaceConnect } from '../../hooks/useWorkspaceConnect';
 import { logger } from '../../lib/logger';
-import { CheckIcon, ClaudeIcon } from '../icons';
+import { CheckIcon, ClaudeIcon, GitHubIcon, VercelIcon } from '../icons';
 
 function KebabGlyph() {
   return (
@@ -149,18 +156,18 @@ function ClaudeConnectModal({
       isOpen
       onClose={onClose}
       title={reconnect ? 'Reconnect Claude' : 'Connect Claude'}
-      className={phase === 'terminal' ? 'agents-panel-terminal-modal' : 'claude-connect-modal'}
+      className={phase === 'terminal' ? 'agents-panel-terminal-modal' : 'connect-modal'}
     >
       {phase === 'email' ? (
-        <div className="claude-connect-body">
+        <div className="connect-modal-body">
           <p>
             A browser window will open. Sign in with the Claude account you want{' '}
             <strong>{workspaceName}</strong> to use — its login stays isolated to this workspace and
             won't affect your other workspaces or your machine's default login.
           </p>
-          <label className="claude-connect-field">
+          <label className="connect-modal-field">
             <span>
-              Account email <span className="claude-connect-muted">(shown on the card)</span>
+              Account email <span className="connect-modal-muted">(shown on the card)</span>
             </span>
             <input
               type="email"
@@ -173,7 +180,7 @@ function ClaudeConnectModal({
               }}
             />
           </label>
-          <div className="claude-connect-actions">
+          <div className="connect-modal-actions">
             <Button variant="secondary" onClick={onClose}>
               Cancel
             </Button>
@@ -183,8 +190,8 @@ function ClaudeConnectModal({
           </div>
         </div>
       ) : (
-        <div className="claude-connect-terminal-phase">
-          <p className="claude-connect-instructions">
+        <div className="connect-modal-terminal-phase">
+          <p className="connect-modal-instructions">
             Sign in in the browser, then <strong>paste the code it shows</strong> into the terminal
             below and press Enter.
           </p>
@@ -206,8 +213,8 @@ function ClaudeConnectModal({
             />
           </div>
           {exited && (
-            <div className="claude-connect-actions">
-              <span className="claude-connect-muted">Login didn't finish.</span>
+            <div className="connect-modal-actions">
+              <span className="connect-modal-muted">Login didn't finish.</span>
               <Button variant="secondary" onClick={beginTerminal}>
                 Start over
               </Button>
@@ -232,8 +239,12 @@ export function AgentsPanel() {
   const [activeAccount, setActiveAccount] = useState<{
     id: string;
     name: string;
+    color: string;
     isDefault: boolean;
   } | null>(null);
+  // Workspace-scoped login/credential status for the Services rows (GitHub,
+  // Vercel). Same source the Settings modal reads, so the two surfaces agree.
+  const [credStatus, setCredStatus] = useState<AccountCredentialStatus | null>(null);
   // When set, the Claude connect/reconnect modal is open for the active workspace.
   const [claudeConnect, setClaudeConnect] = useState<{ reconnect: boolean } | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -277,15 +288,65 @@ export function AgentsPanel() {
         const acc = accounts.find((a) => a.id === id);
         setActiveAccount(
           acc
-            ? { id: acc.id, name: acc.name, isDefault: acc.isDefault }
-            : { id, name: 'Workspace', isDefault: id === DEFAULT_ACCOUNT_ID }
+            ? { id: acc.id, name: acc.name, color: acc.color, isDefault: acc.isDefault }
+            : {
+                id,
+                name: 'Workspace',
+                color: 'var(--text-muted)',
+                isDefault: id === DEFAULT_ACCOUNT_ID,
+              }
         );
       } catch {
         // Fall back to treating it as Default (native login) on failure.
-        setActiveAccount({ id: DEFAULT_ACCOUNT_ID, name: 'Default', isDefault: true });
+        setActiveAccount({
+          id: DEFAULT_ACCOUNT_ID,
+          name: 'Default',
+          color: 'var(--text-muted)',
+          isDefault: true,
+        });
       }
     })();
   }, []);
+
+  // Workspace-scoped login status for the Services rows. Shells out to
+  // `gh auth status` / `vercel whoami` (~10s worst case), so fetch on mount and
+  // after connect actions — never on a tight poll.
+  const loadCredStatus = useCallback(async (accountId: string) => {
+    try {
+      setCredStatus(await getAccountCredentialStatus(accountId));
+    } catch {
+      logger.warn('Failed to load workspace credential status');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (activeAccount) void loadCredStatus(activeAccount.id);
+  }, [activeAccount, loadCredStatus]);
+
+  // Reload everything after a connect/disconnect. A freshly-written auth
+  // indicator can land a beat late, so re-check on the same staggered cadence
+  // the agent rows use.
+  const refreshAll = useCallback(() => {
+    void refresh();
+    const id = activeAccount?.id;
+    if (id) {
+      void loadCredStatus(id);
+      [600, 1500, 3000].forEach((delay) => setTimeout(() => void loadCredStatus(id), delay));
+    }
+  }, [refresh, loadCredStatus, activeAccount]);
+
+  // One shared connect layer for the Services rows (GitHub, Vercel), the same
+  // hook the per-workspace Settings modal uses so the surfaces never drift.
+  const {
+    connect: connectService,
+    disconnect: disconnectService,
+    modals: connectModals,
+  } = useWorkspaceConnect({
+    accountId: activeAccount?.id ?? DEFAULT_ACCOUNT_ID,
+    accountName: activeAccount?.name ?? 'Workspace',
+    isDefault: activeAccount?.isDefault ?? true,
+    onChanged: refreshAll,
+  });
 
   // Close kebab menu on outside click
   useEffect(() => {
@@ -429,14 +490,25 @@ export function AgentsPanel() {
     <section className="agents-panel" ref={panelRef}>
       <header className="agents-panel-header">
         <div>
-          <h3 className="agents-panel-title">Coding Agents</h3>
+          <h3 className="agents-panel-title">Workspace accounts</h3>
           <p className="agents-panel-subtitle">
-            Install, sign in, or switch the default agent new terminals use.
+            Logins for{' '}
+            {activeAccount && (
+              <span className="agents-panel-badge">
+                <span
+                  className="agents-panel-badge-dot"
+                  style={{ background: activeAccount.color }}
+                />
+                {activeAccount.name}
+              </span>
+            )}{' '}
+            — each workspace signs in separately, like a separate client.
           </p>
         </div>
         {loading && <Spinner size="sm" className="agents-panel-spinner" />}
       </header>
 
+      <p className="agents-section-title">Coding agents</p>
       <div className="agents-panel-list">
         {agents.map((agent) => {
           // "Ready" (eligible to be the default agent) means connected AND valid.
@@ -598,6 +670,111 @@ export function AgentsPanel() {
           );
         })}
       </div>
+
+      {activeAccount && (
+        <>
+          <p className="agents-section-title">Services</p>
+          <div className="agents-panel-list">
+            {(
+              [
+                {
+                  id: 'github' as const,
+                  name: 'GitHub',
+                  icon: <GitHubIcon size={18} />,
+                  identity: credStatus?.githubAuthEmail ?? null,
+                },
+                {
+                  id: 'vercel' as const,
+                  name: 'Vercel',
+                  icon: <VercelIcon size={16} />,
+                  identity: credStatus?.vercelUsername ?? null,
+                },
+              ] as const
+            ).map((svc) => {
+              const connected = !!svc.identity;
+              const menuKey = `service:${svc.id}`;
+              const menuOpen = openMenuId === menuKey;
+              // Until the (slow) status fetch resolves, say "Checking…" rather
+              // than flashing a false "Not connected".
+              const statusText = connected
+                ? svc.identity
+                : credStatus
+                  ? 'Not connected'
+                  : 'Checking…';
+              // Services never show the red reconnect stroke — there's no expiry
+              // signal here, only connected vs. never-connected (neutral border).
+              const stateClass = connected ? 'is-connected' : '';
+              // Disconnect manages the workspace's own credential; the Default
+              // workspace's logins are the machine's native ones — leave untouched.
+              const canDisconnect = connected && !activeAccount.isDefault;
+
+              return (
+                <div key={svc.id} className={`agents-panel-row ${stateClass}`}>
+                  <div className="agents-panel-row-icon">{svc.icon}</div>
+
+                  <div className="agents-panel-row-main">
+                    <div className="agents-panel-row-name">{svc.name}</div>
+                    <div className="agents-panel-row-status">{statusText}</div>
+                  </div>
+
+                  <div className="agents-panel-row-actions">
+                    {!connected && (
+                      <Button variant="primary" size="sm" onClick={() => connectService(svc.id)}>
+                        Connect
+                      </Button>
+                    )}
+
+                    {connected && (
+                      <div className="agents-panel-menu-wrap">
+                        <button
+                          type="button"
+                          className="agents-panel-kebab"
+                          onClick={() => setOpenMenuId(menuOpen ? null : menuKey)}
+                          title={`More actions for ${svc.name}`}
+                          aria-label={`More actions for ${svc.name}`}
+                          aria-haspopup="menu"
+                          aria-expanded={menuOpen}
+                        >
+                          <KebabGlyph />
+                        </button>
+                        {menuOpen && (
+                          <div className="agents-panel-menu" role="menu">
+                            <button
+                              type="button"
+                              role="menuitem"
+                              onClick={() => {
+                                setOpenMenuId(null);
+                                connectService(svc.id);
+                              }}
+                            >
+                              {activeAccount.isDefault ? 'Sign in again' : 'Switch account'}
+                            </button>
+                            {canDisconnect && (
+                              <button
+                                type="button"
+                                role="menuitem"
+                                className="agents-panel-menu-danger"
+                                onClick={() => {
+                                  setOpenMenuId(null);
+                                  void disconnectService(svc.id);
+                                }}
+                              >
+                                Disconnect
+                              </button>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+
+      {connectModals}
 
       {claudeConnect && activeAccount && (
         <ClaudeConnectModal

--- a/src/components/dashboard/AgentsPanel.tsx
+++ b/src/components/dashboard/AgentsPanel.tsx
@@ -22,8 +22,11 @@ import {
   getAgentsStatus,
   signOutAgent,
   uninstallAgent,
+  disconnectClaudeAccount,
 } from '../../lib/agents-management';
+import { getActiveAccountId, listAccounts, DEFAULT_ACCOUNT_ID } from '../../lib/accounts';
 import { OnboardingTerminal } from '../setup/OnboardingTerminal';
+import { ClaudeConnectTerminal } from './ClaudeConnectTerminal';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { Spinner } from '../primitives/Spinner';
@@ -90,9 +93,130 @@ function iconFor(agentId: string) {
 
 function statusLine(a: AgentStatus): string {
   if (!a.installed) return 'Not installed';
+  // Expired/needs-reconnect: surface the account (if known) plus the call to action.
+  if (a.needsReconnect) {
+    return a.authEmail ? `${a.authEmail} · Reconnect needed` : 'Reconnect needed';
+  }
   if (!a.authed) return 'Not signed in';
   const v = formatVersion(a.version);
-  return v ? `v${v} · Signed in` : 'Signed in';
+  // Prefer the real account email over the generic "Signed in" when we have it.
+  const who = a.authEmail ?? 'Signed in';
+  return v ? `v${v} · ${who}` : who;
+}
+
+/**
+ * Modal for connecting a workspace's isolated Claude login.
+ *
+ * Two phases:
+ *  1. **Email** — the user names the account (display-only) and continues.
+ *  2. **Terminal** — a backend-owned PTY runs `claude setup-token`: the browser
+ *     opens, the user signs in, then pastes the shown code into the embedded
+ *     terminal. Rust scrapes + stores the token (never crossing to the webview)
+ *     and signals capture, at which point we report success.
+ */
+function ClaudeConnectModal({
+  workspaceName,
+  accountId,
+  reconnect,
+  onSuccess,
+  onClose,
+}: {
+  workspaceName: string;
+  accountId: string;
+  reconnect: boolean;
+  onSuccess: (email?: string) => void;
+  onClose: () => void;
+}) {
+  const [phase, setPhase] = useState<'email' | 'terminal'>('email');
+  const [email, setEmail] = useState('');
+  // A fresh session id per terminal attempt so "Start over" spawns a new PTY.
+  const [sessionId, setSessionId] = useState('');
+  const [exited, setExited] = useState(false);
+  // Latch capture so a near-simultaneous exit event can't fire a failure toast.
+  const capturedRef = useRef(false);
+
+  const trimmedEmail = email.trim() || undefined;
+
+  const beginTerminal = () => {
+    capturedRef.current = false;
+    setExited(false);
+    setSessionId(crypto.randomUUID());
+    setPhase('terminal');
+  };
+
+  return (
+    <ModalFrame
+      isOpen
+      onClose={onClose}
+      title={reconnect ? 'Reconnect Claude' : 'Connect Claude'}
+      className={phase === 'terminal' ? 'agents-panel-terminal-modal' : 'claude-connect-modal'}
+    >
+      {phase === 'email' ? (
+        <div className="claude-connect-body">
+          <p>
+            A browser window will open. Sign in with the Claude account you want{' '}
+            <strong>{workspaceName}</strong> to use — its login stays isolated to this workspace and
+            won't affect your other workspaces or your machine's default login.
+          </p>
+          <label className="claude-connect-field">
+            <span>
+              Account email <span className="claude-connect-muted">(shown on the card)</span>
+            </span>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@company.com"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') beginTerminal();
+              }}
+            />
+          </label>
+          <div className="claude-connect-actions">
+            <Button variant="secondary" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button variant="primary" onClick={beginTerminal}>
+              Continue
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="claude-connect-terminal-phase">
+          <p className="claude-connect-instructions">
+            Sign in in the browser, then <strong>paste the code it shows</strong> into the terminal
+            below and press Enter.
+          </p>
+          <div className="agents-panel-terminal-body">
+            <ClaudeConnectTerminal
+              key={sessionId}
+              sessionId={sessionId}
+              accountId={accountId}
+              email={trimmedEmail}
+              onCaptured={() => {
+                capturedRef.current = true;
+                onSuccess(trimmedEmail);
+              }}
+              onExit={() => {
+                // Token already captured → success path handles close. Otherwise
+                // the user cancelled or login failed; offer a retry.
+                if (!capturedRef.current) setExited(true);
+              }}
+            />
+          </div>
+          {exited && (
+            <div className="claude-connect-actions">
+              <span className="claude-connect-muted">Login didn't finish.</span>
+              <Button variant="secondary" onClick={beginTerminal}>
+                Start over
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </ModalFrame>
+  );
 }
 
 export function AgentsPanel() {
@@ -102,8 +226,23 @@ export function AgentsPanel() {
   const [terminalTask, setTerminalTask] = useState<TerminalTask | null>(null);
   const [confirmUninstall, setConfirmUninstall] = useState<UninstallConfirm | null>(null);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  // The active workspace decides how Claude auth works: the Default workspace
+  // uses the machine's native `claude` login (today's terminal flow), while a
+  // non-default workspace gets its own isolated token via the connect modal.
+  const [activeAccount, setActiveAccount] = useState<{
+    id: string;
+    name: string;
+    isDefault: boolean;
+  } | null>(null);
+  // When set, the Claude connect/reconnect modal is open for the active workspace.
+  const [claudeConnect, setClaudeConnect] = useState<{ reconnect: boolean } | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  // Stable handle to openTerminal so auth routing doesn't depend on definition
+  // order; kept current by an effect once openTerminal is defined below.
+  const openTerminalRef = useRef<(agent: AgentStatus, kind: 'install' | 'auth') => void>(() => {});
   const { showToast } = useOptionalToast();
+
+  const isWorkspaceActive = !!activeAccount && !activeAccount.isDefault;
 
   // Keep showToast in a ref so refresh() has a stable identity — otherwise
   // the mount effect re-fires on every render (useOptionalToast returns a
@@ -129,6 +268,24 @@ export function AgentsPanel() {
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  // Resolve the active workspace so Claude auth routes to the right flow.
+  useEffect(() => {
+    void (async () => {
+      try {
+        const [id, accounts] = await Promise.all([getActiveAccountId(), listAccounts()]);
+        const acc = accounts.find((a) => a.id === id);
+        setActiveAccount(
+          acc
+            ? { id: acc.id, name: acc.name, isDefault: acc.isDefault }
+            : { id, name: 'Workspace', isDefault: id === DEFAULT_ACCOUNT_ID }
+        );
+      } catch {
+        // Fall back to treating it as Default (native login) on failure.
+        setActiveAccount({ id: DEFAULT_ACCOUNT_ID, name: 'Default', isDefault: true });
+      }
+    })();
+  }, []);
 
   // Close kebab menu on outside click
   useEffect(() => {
@@ -171,7 +328,13 @@ export function AgentsPanel() {
       setOpenMenuId(null);
       setBusy(agent.id);
       try {
-        await signOutAgent(agent.id);
+        // Claude in a non-default workspace is the per-workspace token, not the
+        // file-based native login — clear the vaulted token instead.
+        if (agent.id === 'claude-code' && isWorkspaceActive && activeAccount) {
+          await disconnectClaudeAccount(activeAccount.id);
+        } else {
+          await signOutAgent(agent.id);
+        }
         showToast(`Signed out of ${agent.displayName}`, 'success');
         await refresh();
       } catch (err) {
@@ -180,7 +343,31 @@ export function AgentsPanel() {
         setBusy(null);
       }
     },
-    [busy, refresh, showToast]
+    [busy, refresh, showToast, isWorkspaceActive, activeAccount]
+  );
+
+  // Route a Claude "Sign in"/"Reconnect" to the per-workspace token flow when a
+  // non-default workspace is active; everything else uses the terminal flow.
+  const startAuth = useCallback(
+    (agent: AgentStatus, reconnect: boolean) => {
+      setOpenMenuId(null);
+      if (agent.id === 'claude-code' && isWorkspaceActive) {
+        setClaudeConnect({ reconnect });
+      } else {
+        openTerminalRef.current(agent, 'auth');
+      }
+    },
+    [isWorkspaceActive]
+  );
+
+  // Called by the connect modal once Rust has captured + stored the token.
+  const handleClaudeConnected = useCallback(
+    (email?: string) => {
+      showToast(email ? `Connected Claude as ${email}` : 'Connected Claude', 'success');
+      setClaudeConnect(null);
+      void refresh();
+    },
+    [refresh, showToast]
   );
 
   const handleUninstall = useCallback(
@@ -217,6 +404,12 @@ export function AgentsPanel() {
     });
   }, []);
 
+  // Keep the ref pointed at the latest openTerminal so startAuth can call it
+  // without a definition-order dependency.
+  useEffect(() => {
+    openTerminalRef.current = openTerminal;
+  }, [openTerminal]);
+
   const handleTerminalExit = useCallback(
     (exitCode: number | null) => {
       setTerminalTask(null);
@@ -246,14 +439,23 @@ export function AgentsPanel() {
 
       <div className="agents-panel-list">
         {agents.map((agent) => {
-          const ready = agent.installed && agent.authed;
+          // "Ready" (eligible to be the default agent) means connected AND valid.
+          // A needs-reconnect agent is excluded so it shows Reconnect, not the pill.
+          const ready = agent.installed && agent.authed && !agent.needsReconnect;
           const isBusy = busy === agent.id;
           const menuOpen = openMenuId === agent.id;
+          // Stroke: red when attention needed, green when connected & valid,
+          // neutral otherwise (never-connected keeps today's plain border).
+          const stateClass = agent.needsReconnect
+            ? 'needs-reconnect'
+            : agent.authed
+              ? 'is-connected'
+              : '';
 
           return (
             <div
               key={agent.id}
-              className={`agents-panel-row ${agent.isDefault ? 'is-default' : ''}`}
+              className={`agents-panel-row ${agent.isDefault ? 'is-default' : ''} ${stateClass}`}
             >
               <div className="agents-panel-row-icon">{iconFor(agent.id)}</div>
 
@@ -278,10 +480,22 @@ export function AgentsPanel() {
                   <Button
                     variant="primary"
                     size="sm"
-                    onClick={() => openTerminal(agent, 'auth')}
+                    onClick={() => startAuth(agent, false)}
                     disabled={isBusy}
                   >
                     Sign in
+                  </Button>
+                )}
+
+                {agent.installed && agent.needsReconnect && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="agents-reconnect-btn"
+                    onClick={() => startAuth(agent, true)}
+                    disabled={isBusy}
+                  >
+                    Reconnect
                   </Button>
                 )}
 
@@ -354,7 +568,7 @@ export function AgentsPanel() {
                           <button
                             type="button"
                             role="menuitem"
-                            onClick={() => openTerminal(agent, 'auth')}
+                            onClick={() => startAuth(agent, false)}
                           >
                             Sign in
                           </button>
@@ -384,6 +598,16 @@ export function AgentsPanel() {
           );
         })}
       </div>
+
+      {claudeConnect && activeAccount && (
+        <ClaudeConnectModal
+          workspaceName={activeAccount.name}
+          accountId={activeAccount.id}
+          reconnect={claudeConnect.reconnect}
+          onSuccess={handleClaudeConnected}
+          onClose={() => setClaudeConnect(null)}
+        />
+      )}
 
       {terminalTask && (
         <ModalFrame

--- a/src/components/dashboard/ClaudeConnectTerminal.tsx
+++ b/src/components/dashboard/ClaudeConnectTerminal.tsx
@@ -1,0 +1,185 @@
+/**
+ * Terminal view for the backend-owned Claude connect flow.
+ *
+ * Unlike {@link OnboardingTerminal} (which spawns its PTY via `tauri-pty` in
+ * the webview), this terminal is a thin view over a PTY the *backend* owns: it
+ * subscribes to `claude-connect-*` events for output, forwards keystrokes via
+ * `claude_connect_write`, and never sees the captured token — Rust scrapes and
+ * redacts it before any byte reaches here (see `claudeConnectStart`).
+ *
+ * The user logs in via the browser, then pastes the authorization code at the
+ * CLI's prompt. When Rust captures the token it emits `claude-connect-captured`
+ * → {@link onCaptured}; process end → {@link onExit}.
+ */
+
+import { useEffect, useRef } from 'react';
+import { Terminal as XTerm } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { Unicode11Addon } from '@xterm/addon-unicode11';
+import { createWebLinksAddon } from '../../lib/terminalLinks';
+import { loadNerdFonts } from '../../lib/fonts';
+import { logger } from '../../lib/logger';
+import {
+  claudeConnectStart,
+  claudeConnectWrite,
+  claudeConnectResize,
+  claudeConnectClose,
+  onClaudeConnectData,
+  onClaudeConnectCaptured,
+  onClaudeConnectExit,
+} from '../../lib/agents-management';
+import '@xterm/xterm/css/xterm.css';
+
+interface ClaudeConnectTerminalProps {
+  /** Stable id correlating this terminal with its backend PTY session. */
+  sessionId: string;
+  /** Workspace whose Claude login is being connected. */
+  accountId: string;
+  /** Display-only email the user is signing in as. */
+  email?: string;
+  /** Fired when Rust has scraped + stored the token (the success signal). */
+  onCaptured: () => void;
+  /** Fired when the connect process exits, with its exit code. */
+  onExit: (exitCode: number) => void;
+}
+
+export function ClaudeConnectTerminal({
+  sessionId,
+  accountId,
+  email,
+  onCaptured,
+  onExit,
+}: ClaudeConnectTerminalProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Refs for callbacks so the setup effect runs exactly once per session.
+  const onCapturedRef = useRef(onCaptured);
+  const onExitRef = useRef(onExit);
+  useEffect(() => {
+    onCapturedRef.current = onCaptured;
+    onExitRef.current = onExit;
+  }, [onCaptured, onExit]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let mounted = true;
+    let term: XTerm | null = null;
+    let fitAddon: FitAddon | null = null;
+    let resizeObserver: ResizeObserver | null = null;
+    const unlisteners: Array<() => void> = [];
+
+    const setup = async () => {
+      await loadNerdFonts();
+      if (!mounted) return;
+
+      term = new XTerm({
+        fontFamily: '"JetBrainsMono NF", Menlo, Monaco, "Courier New", monospace',
+        fontSize: 13,
+        lineHeight: 1.2,
+        cursorBlink: true,
+        cursorStyle: 'block',
+        scrollback: 1000,
+        allowProposedApi: true,
+        theme: {
+          background: '#1e1e1e',
+          foreground: '#cccccc',
+          cursor: '#ffffff',
+          selectionBackground: '#3a3d41',
+          black: '#000000',
+          red: '#cd3131',
+          green: '#0dbc79',
+          yellow: '#e5e510',
+          blue: '#2472c8',
+          magenta: '#bc3fbc',
+          cyan: '#11a8cd',
+          white: '#e5e5e5',
+          brightBlack: '#666666',
+          brightRed: '#f14c4c',
+          brightGreen: '#23d18b',
+          brightYellow: '#f5f543',
+          brightBlue: '#3b8eea',
+          brightMagenta: '#d670d6',
+          brightCyan: '#29b8db',
+          brightWhite: '#ffffff',
+        },
+      });
+
+      fitAddon = new FitAddon();
+      const unicode11Addon = new Unicode11Addon();
+      term.loadAddon(fitAddon);
+      term.loadAddon(unicode11Addon);
+      term.loadAddon(createWebLinksAddon());
+      term.unicode.activeVersion = '11';
+      term.open(container);
+      fitAddon.fit();
+
+      // Keystrokes -> backend PTY.
+      term.onData((data) => {
+        void claudeConnectWrite(sessionId, data).catch(() => {
+          /* session may have exited; ignore */
+        });
+      });
+
+      // Subscribe BEFORE starting so we don't miss the initial auth URL.
+      unlisteners.push(
+        await onClaudeConnectData(sessionId, (bytes) => {
+          term?.write(bytes);
+        })
+      );
+      unlisteners.push(
+        await onClaudeConnectCaptured(sessionId, () => {
+          onCapturedRef.current();
+        })
+      );
+      unlisteners.push(
+        await onClaudeConnectExit(sessionId, (code) => {
+          onExitRef.current(code);
+        })
+      );
+      if (!mounted) return;
+
+      try {
+        await claudeConnectStart({
+          sessionId,
+          accountId,
+          email,
+          cols: term.cols,
+          rows: term.rows,
+        });
+      } catch (err) {
+        logger.warn('[ClaudeConnectTerminal] failed to start connect', { error: String(err) });
+        term.write(`\r\n\x1b[31mCouldn't start Claude login: ${String(err)}\x1b[0m\r\n`);
+        return;
+      }
+
+      term.focus();
+
+      resizeObserver = new ResizeObserver(() => {
+        if (!fitAddon || !term) return;
+        fitAddon.fit();
+        void claudeConnectResize(sessionId, term.cols, term.rows).catch(() => {
+          /* ignore */
+        });
+      });
+      resizeObserver.observe(container);
+    };
+
+    void setup();
+
+    return () => {
+      mounted = false;
+      resizeObserver?.disconnect();
+      for (const off of unlisteners) off();
+      void claudeConnectClose(sessionId).catch(() => {
+        /* ignore */
+      });
+      term?.dispose();
+    };
+    // Callbacks are held via refs, so the effect re-runs only when the session
+    // identity changes — the PTY isn't torn down on every parent re-render.
+  }, [sessionId, accountId, email]);
+
+  return <div ref={containerRef} className="onboarding-terminal-container" />;
+}

--- a/src/components/dashboard/MachineToolsPanel.test.tsx
+++ b/src/components/dashboard/MachineToolsPanel.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Tests for MachineToolsPanel — the machine-tier half of the dashboard
+ * integration split.
+ *
+ * The one behaviour that matters here and can't be eyeballed: this card lists
+ * ONLY machine-tier tools (Homebrew, Node, Git, CLI binaries) and never the
+ * per-workspace `*_auth` logins, which belong to AgentsPanel ("Workspace
+ * accounts"). It's also purely informational — no Connect/Install actions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { SetupItem } from '../../lib/setup';
+
+const invokeResults = new Map<string, { value?: unknown; error?: Error }>();
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn((cmd: string) => {
+    const result = invokeResults.get(cmd);
+    if (result?.error) return Promise.reject(result.error);
+    if (result) return Promise.resolve(result.value);
+    return Promise.resolve(undefined);
+  }),
+}));
+
+vi.mock('../icons', () => ({
+  CheckIcon: () => <span data-testid="check-icon" />,
+  WarningIcon: () => <span data-testid="warning-icon" />,
+  ChevronIcon: () => <span data-testid="chevron-icon" />,
+  ClaudeIcon: () => <span data-testid="claude-icon" />,
+  GitHubIcon: () => <span data-testid="github-icon" />,
+}));
+
+import { MachineToolsPanel } from './MachineToolsPanel';
+
+function item(overrides: Partial<SetupItem> & { id: string; friendlyName: string }): SetupItem {
+  return { status: 'ready', version: '1.0.0', ...overrides };
+}
+
+function mockSetupStatus(items: SetupItem[]) {
+  invokeResults.set('get_full_setup_status', {
+    value: {
+      allReady: false,
+      items,
+      optionalAuths: { githubAuthenticated: false },
+      detectedAgents: [],
+    },
+  });
+}
+
+describe('MachineToolsPanel', () => {
+  beforeEach(() => {
+    invokeResults.clear();
+  });
+
+  it('renders the machine-tools card title', async () => {
+    mockSetupStatus([item({ id: 'homebrew', friendlyName: 'Homebrew' })]);
+    render(<MachineToolsPanel />);
+    await waitFor(() => expect(screen.getByText('Tools on this Mac')).toBeInTheDocument());
+  });
+
+  it('lists only machine-tier tools and never the per-workspace logins', async () => {
+    mockSetupStatus([
+      item({ id: 'homebrew', friendlyName: 'Homebrew' }),
+      item({ id: 'git', friendlyName: 'Git' }),
+      item({ id: 'gh', friendlyName: 'GitHub CLI' }),
+      // Workspace-tier logins — must be filtered out of this card.
+      item({ id: 'gh_auth', friendlyName: 'GitHub account' }),
+      item({ id: 'claude_auth', friendlyName: 'Claude account' }),
+      item({ id: 'vercel_auth', friendlyName: 'Vercel account' }),
+    ]);
+    render(<MachineToolsPanel />);
+
+    // Collapsed by default — expand to reveal the rows.
+    await waitFor(() => expect(screen.getByText('Tools on this Mac')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+
+    await waitFor(() => expect(screen.getByText('Homebrew')).toBeInTheDocument());
+    expect(screen.getByText('Git')).toBeInTheDocument();
+    expect(screen.getByText('GitHub CLI')).toBeInTheDocument();
+
+    // None of the workspace-login rows leak into the machine card.
+    expect(screen.queryByText('GitHub account')).not.toBeInTheDocument();
+    expect(screen.queryByText('Claude account')).not.toBeInTheDocument();
+    expect(screen.queryByText('Vercel account')).not.toBeInTheDocument();
+  });
+
+  it('shows the version when ready and "Not installed" otherwise', async () => {
+    mockSetupStatus([
+      item({ id: 'homebrew', friendlyName: 'Homebrew', status: 'ready', version: '4.2.1' }),
+      item({ id: 'node', friendlyName: 'Node.js', status: 'not_installed', version: undefined }),
+    ]);
+    render(<MachineToolsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Tools on this Mac')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+
+    await waitFor(() => expect(screen.getByText('4.2.1')).toBeInTheDocument());
+    expect(screen.getByText('Not installed')).toBeInTheDocument();
+  });
+
+  it('is purely informational — no Connect or Install buttons', async () => {
+    mockSetupStatus([
+      item({ id: 'node', friendlyName: 'Node.js', status: 'not_installed', version: undefined }),
+    ]);
+    render(<MachineToolsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Tools on this Mac')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+
+    await waitFor(() => expect(screen.getByText('Node.js')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /Connect/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Install/ })).not.toBeInTheDocument();
+  });
+
+  it('swallows a backend error without crashing', async () => {
+    invokeResults.set('get_full_setup_status', { error: new Error('boom') });
+    render(<MachineToolsPanel />);
+    // Header still renders; no rows.
+    await waitFor(() => expect(screen.getByText('Tools on this Mac')).toBeInTheDocument());
+  });
+});

--- a/src/components/dashboard/MachineToolsPanel.tsx
+++ b/src/components/dashboard/MachineToolsPanel.tsx
@@ -1,26 +1,27 @@
 /**
- * IntegrationBar — required-integrations card at the bottom of the dashboard.
+ * MachineToolsPanel — machine-tier tools card on the dashboard.
  *
- * Styled as a shared .dashboard-card so it reads as part of the same stack
- * as the Coding Agents and Preferences cards. Collapsed by default — the
- * summary line ("All integrations connected" or "X/Y ready") sits inside
- * the card header, and the individual integration rows reveal on expand.
+ * The other half of the integration split (see {@link AgentsPanel}, the
+ * workspace-tier "Workspace accounts" card). This card lists only the tools
+ * that are installed **once on the machine and shared by every workspace** —
+ * Homebrew, Node, Git, and the CLI binaries — so the user can tell at a glance
+ * what's "global" versus what's a per-client login. It's purely informational:
+ * installing/updating these tools is owned by onboarding and, for the agent
+ * CLIs, the per-agent Install button in {@link AgentsPanel}.
  *
- * @module components/IntegrationBar
+ * Styled as a shared .dashboard-card so it reads as part of the same stack as
+ * the Workspace accounts and Preferences cards. Collapsed by default.
+ *
+ * @module components/dashboard/MachineToolsPanel
  */
 
 import { useState, useEffect } from 'react';
 import { CheckIcon, WarningIcon, ChevronIcon, ClaudeIcon, GitHubIcon } from '../icons';
 import { Spinner } from '../primitives/Spinner';
-import { getFullSetupStatus, SetupItem, SETUP_ITEM_ORDER } from '../../lib/setup';
+import { getFullSetupStatus, SetupItem, SETUP_ITEM_ORDER, MACHINE_ITEM_IDS } from '../../lib/setup';
 import { logger } from '../../lib/logger';
 
-interface IntegrationBarProps {
-  /** Callback to connect GitHub account */
-  onGitHubConnect?: () => void;
-}
-
-export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
+export function MachineToolsPanel() {
   const [isExpanded, setIsExpanded] = useState(false);
   const [setupItems, setSetupItems] = useState<SetupItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -30,10 +31,10 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
       setIsLoading(true);
       try {
         const status = await getFullSetupStatus();
-        const sorted = [...status.items].sort((a, b) => {
-          return SETUP_ITEM_ORDER.indexOf(a.id) - SETUP_ITEM_ORDER.indexOf(b.id);
-        });
-        setSetupItems(sorted);
+        const machineItems = status.items
+          .filter((item) => MACHINE_ITEM_IDS.has(item.id))
+          .sort((a, b) => SETUP_ITEM_ORDER.indexOf(a.id) - SETUP_ITEM_ORDER.indexOf(b.id));
+        setSetupItems(machineItems);
       } catch (error) {
         logger.error('Failed to load setup status', {
           error: error instanceof Error ? error.message : String(error),
@@ -47,42 +48,37 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
 
   const readyCount = setupItems.filter((item) => item.status === 'ready').length;
   const totalCount = setupItems.length;
-  const allConnected = totalCount > 0 && readyCount === totalCount;
+  const allInstalled = totalCount > 0 && readyCount === totalCount;
 
   const getItemIcon = (itemId: string) => {
     switch (itemId) {
       case 'claude':
-      case 'claude_auth':
         return <ClaudeIcon />;
       case 'gh':
-      case 'gh_auth':
         return <GitHubIcon />;
       default:
         return <CheckIcon size={16} />;
     }
   };
 
+  // Machine tools have no login — "ready" means installed, otherwise it's just
+  // not installed yet (the version string doubles as the installed indicator).
   const getStatusText = (item: SetupItem) => {
     if (item.status === 'ready') {
-      return item.username || item.version || 'Ready';
+      return item.version || 'Installed';
     }
-    return item.status === 'not_installed' ? 'Not installed' : 'Not connected';
-  };
-
-  const getConnectHandler = (itemId: string) => {
-    if (itemId === 'gh_auth') return onGitHubConnect;
-    return undefined;
+    return 'Not installed';
   };
 
   const subtitle = isLoading
     ? 'Checking…'
-    : allConnected
-      ? 'All integrations connected'
-      : `${readyCount}/${totalCount} ready`;
+    : allInstalled
+      ? 'All tools installed'
+      : `${readyCount}/${totalCount} installed`;
 
   const statusIcon = isLoading ? (
     <Spinner size="sm" />
-  ) : allConnected ? (
+  ) : allInstalled ? (
     <CheckIcon size={14} className="integration-bar-status-icon success" />
   ) : (
     <WarningIcon size={14} className="integration-bar-status-icon warning" />
@@ -91,7 +87,7 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
   return (
     <section
       className={`dashboard-card integration-bar ${isExpanded ? 'is-expanded' : ''}`}
-      data-education-id="integration-bar"
+      data-education-id="machine-tools"
     >
       <button
         type="button"
@@ -100,10 +96,13 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
         aria-expanded={isExpanded}
       >
         <div>
-          <h3 className="dashboard-card-title">Integrations</h3>
+          <h3 className="dashboard-card-title">Tools on this Mac</h3>
           <p className="dashboard-card-subtitle integration-bar-subtitle">
             {statusIcon}
             <span>{subtitle}</span>
+            <span className="machine-tools-shared-hint">
+              · installed once, shared by every workspace
+            </span>
           </p>
         </div>
         <ChevronIcon
@@ -115,10 +114,7 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
       {isExpanded && (
         <div className="dashboard-card-rows">
           {setupItems.map((item) => {
-            const connectHandler = getConnectHandler(item.id);
-            const showConnectButton = item.status !== 'ready' && connectHandler;
             const isReady = item.status === 'ready';
-
             return (
               <div key={item.id} className="dashboard-card-row is-static">
                 <div className={`dashboard-card-row-icon ${isReady ? 'success' : ''}`}>
@@ -130,17 +126,6 @@ export function IntegrationBar({ onGitHubConnect }: IntegrationBarProps) {
                     {getStatusText(item)}
                   </span>
                 </div>
-                {showConnectButton && (
-                  <button
-                    className="integration-bar-item-connect"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      connectHandler();
-                    }}
-                  >
-                    Connect
-                  </button>
-                )}
               </div>
             );
           })}

--- a/src/components/dashboard/ProjectList.tsx
+++ b/src/components/dashboard/ProjectList.tsx
@@ -43,7 +43,7 @@ import {
 } from '../../lib/folders';
 import { DashboardHeader } from './DashboardHeader';
 import { AgentsPanel } from './AgentsPanel';
-import { IntegrationBar } from './IntegrationBar';
+import { MachineToolsPanel } from './MachineToolsPanel';
 import { NewFolderModal } from './NewFolderModal';
 import { ProjectGridView } from './ProjectGridView';
 import { RenameProjectModal } from './RenameProjectModal';
@@ -96,8 +96,6 @@ interface ProjectListProps {
   isGitHubAuthenticated?: boolean;
   /** Callback when user tries to import without GitHub auth */
   onGitHubConnectForImport?: () => void;
-  /** Callback to connect GitHub account */
-  onGitHubConnect?: () => void;
   /** GitHub username for contribution calendar */
   githubUsername?: string | null;
   /** Whether the initial auth check has completed */
@@ -120,7 +118,6 @@ export function ProjectList({
   onImportProject,
   isGitHubAuthenticated = true,
   onGitHubConnectForImport,
-  onGitHubConnect,
   githubUsername,
   isAuthCheckDone = false,
   onLoadingChange,
@@ -737,7 +734,7 @@ export function ProjectList({
           </div>
         </section>
 
-        <IntegrationBar onGitHubConnect={onGitHubConnect} />
+        <MachineToolsPanel />
 
         {/* Physical bottom spacer — guarantees the Integrations card never
             butts up against the scroll edge, regardless of how the outer

--- a/src/components/dashboard/ProjectsView.tsx
+++ b/src/components/dashboard/ProjectsView.tsx
@@ -103,7 +103,6 @@ export const ProjectsView = memo(function ProjectsView({
             onImportProject={onImportProject}
             isGitHubAuthenticated={isGitHubAuthenticated}
             onGitHubConnectForImport={() => void onGitHubConnect()}
-            onGitHubConnect={onGitHubConnect}
             githubUsername={githubUsername}
             isAuthCheckDone={isAuthCheckDone}
             onLoadingChange={onLoadingChange}

--- a/src/components/dashboard/VercelTokenModal.tsx
+++ b/src/components/dashboard/VercelTokenModal.tsx
@@ -1,0 +1,86 @@
+/**
+ * VercelTokenModal — connect a workspace's Vercel account via an access token.
+ *
+ * Vercel's browser login (`vercel login`) stores one *global* CLI session that
+ * would bleed across workspaces, so each workspace instead supplies its own
+ * access token. The token is stored in the OS keychain (`setAccountCredential`)
+ * and injected as `VERCEL_TOKEN` only into this workspace's terminals — it never
+ * crosses back into the webview. Works for any workspace, including Default.
+ */
+
+import { useState } from 'react';
+import { openUrl } from '@tauri-apps/plugin-opener';
+import { ModalFrame } from '../primitives/ModalFrame';
+import { Button } from '../primitives/Button';
+import { setAccountCredential } from '../../lib/accounts';
+import { useOptionalToast } from '../../contexts/ToastContext';
+
+const VERCEL_TOKENS_URL = 'https://vercel.com/account/tokens';
+
+export function VercelTokenModal({
+  accountId,
+  workspaceName,
+  onSaved,
+  onClose,
+}: {
+  accountId: string;
+  workspaceName: string;
+  onSaved: () => void;
+  onClose: () => void;
+}) {
+  const [token, setToken] = useState('');
+  const [saving, setSaving] = useState(false);
+  const { showToast } = useOptionalToast();
+
+  const save = async () => {
+    const trimmed = token.trim();
+    if (!trimmed || saving) return;
+    setSaving(true);
+    try {
+      await setAccountCredential(accountId, 'vercel_token', trimmed);
+      onSaved();
+    } catch (err) {
+      showToast(`Couldn't save Vercel token: ${String(err)}`, 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <ModalFrame isOpen onClose={onClose} title="Connect Vercel" className="connect-modal">
+      <div className="connect-modal-body">
+        <p>
+          Create an access token for the Vercel account you want <strong>{workspaceName}</strong> to
+          publish with, then paste it below. It's stored in your Keychain and used only by this
+          workspace.
+        </p>
+        <Button variant="secondary" size="sm" onClick={() => void openUrl(VERCEL_TOKENS_URL)}>
+          Open vercel.com/account/tokens →
+        </Button>
+        <label className="connect-modal-field">
+          <span>
+            Vercel token <span className="connect-modal-muted">(stays in your Keychain)</span>
+          </span>
+          <input
+            type="password"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            placeholder="vercel_xxxxxxxxxxxxxxxx"
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void save();
+            }}
+          />
+        </label>
+        <div className="connect-modal-actions">
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={() => void save()} disabled={!token.trim() || saving}>
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
+      </div>
+    </ModalFrame>
+  );
+}

--- a/src/components/dashboard/WorkspaceConnectModal.tsx
+++ b/src/components/dashboard/WorkspaceConnectModal.tsx
@@ -1,0 +1,107 @@
+/**
+ * WorkspaceConnectModal — connect a (non-default) workspace's GitHub / Codex /
+ * Opencode login via a backend-owned PTY.
+ *
+ * The sibling of {@link ClaudeConnectModal}, for the config-dir logins. It runs
+ * the service's own login CLI under the workspace's isolated env (so creds land
+ * in the workspace's config dir) and streams it into an embedded terminal. There
+ * is no token to scrape, so **process exit 0 is the success signal** — at which
+ * point we auto-close and refresh. A "Done" button is the manual safety net, and
+ * a non-zero exit offers "Start over".
+ */
+
+import { useRef, useState } from 'react';
+import { ModalFrame } from '../primitives/ModalFrame';
+import { Button } from '../primitives/Button';
+import { WorkspaceConnectTerminal } from './WorkspaceConnectTerminal';
+import type { WorkspaceConnectService } from '../../lib/accounts';
+
+const SERVICE_META: Record<WorkspaceConnectService, { label: string; instructions: string }> = {
+  github: {
+    label: 'GitHub',
+    instructions:
+      'A browser window will open — authorize there, then return here. This finishes on its own when you’re signed in.',
+  },
+  codex: {
+    label: 'Codex',
+    instructions:
+      'A browser window will open — sign in to Codex, then return here. This finishes on its own when you’re signed in.',
+  },
+  opencode: {
+    label: 'Opencode',
+    instructions:
+      'Follow the prompts in the terminal to choose a provider and sign in. This finishes on its own when you’re done.',
+  },
+};
+
+export function WorkspaceConnectModal({
+  accountId,
+  workspaceName,
+  service,
+  onSuccess,
+  onClose,
+}: {
+  accountId: string;
+  workspaceName: string;
+  service: WorkspaceConnectService;
+  onSuccess: () => void;
+  onClose: () => void;
+}) {
+  // A fresh session id per attempt so "Start over" spawns a new PTY.
+  const [sessionId, setSessionId] = useState(() => crypto.randomUUID());
+  const [exited, setExited] = useState(false);
+  // Latch success so we don't also show the "didn't finish" state on exit.
+  const succeededRef = useRef(false);
+  const meta = SERVICE_META[service];
+
+  const restart = () => {
+    succeededRef.current = false;
+    setExited(false);
+    setSessionId(crypto.randomUUID());
+  };
+
+  return (
+    <ModalFrame
+      isOpen
+      onClose={onClose}
+      title={`Connect ${meta.label}`}
+      className="agents-panel-terminal-modal"
+    >
+      <div className="connect-modal-terminal-phase">
+        <p className="connect-modal-instructions">
+          Signing in <strong>{workspaceName}</strong> to {meta.label}. {meta.instructions}
+        </p>
+        <div className="agents-panel-terminal-body">
+          <WorkspaceConnectTerminal
+            key={sessionId}
+            sessionId={sessionId}
+            accountId={accountId}
+            service={service}
+            onExit={(code) => {
+              if (code === 0) {
+                succeededRef.current = true;
+                onSuccess();
+              } else if (!succeededRef.current) {
+                setExited(true);
+              }
+            }}
+          />
+        </div>
+        <div className="connect-modal-actions">
+          {exited ? (
+            <>
+              <span className="connect-modal-muted">Login didn’t finish.</span>
+              <Button variant="secondary" onClick={restart}>
+                Start over
+              </Button>
+            </>
+          ) : (
+            <Button variant="secondary" onClick={onClose}>
+              Done
+            </Button>
+          )}
+        </div>
+      </div>
+    </ModalFrame>
+  );
+}

--- a/src/components/dashboard/WorkspaceConnectTerminal.tsx
+++ b/src/components/dashboard/WorkspaceConnectTerminal.tsx
@@ -1,0 +1,174 @@
+/**
+ * Terminal view for the generalized per-workspace connect flow
+ * (GitHub / Codex / Opencode).
+ *
+ * A sibling of {@link ClaudeConnectTerminal}, but for the *config-dir* logins:
+ * there's no secret to scrape, so this streams the CLI's output verbatim over
+ * `workspace-connect-*` events and treats process exit (`onExit`) as the only
+ * completion signal — there is no "captured" event. The backend spawns the
+ * login under the workspace's isolated env so credentials land in that
+ * workspace's config dir (see `workspaceConnectStart`). For GitHub the backend
+ * auto-advances the "Press Enter to open…" prompt so the browser opens itself.
+ */
+
+import { useEffect, useRef } from 'react';
+import { Terminal as XTerm } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { Unicode11Addon } from '@xterm/addon-unicode11';
+import { createWebLinksAddon } from '../../lib/terminalLinks';
+import { loadNerdFonts } from '../../lib/fonts';
+import { logger } from '../../lib/logger';
+import {
+  workspaceConnectStart,
+  workspaceConnectWrite,
+  workspaceConnectResize,
+  workspaceConnectClose,
+  onWorkspaceConnectData,
+  onWorkspaceConnectExit,
+  type WorkspaceConnectService,
+} from '../../lib/accounts';
+import '@xterm/xterm/css/xterm.css';
+
+interface WorkspaceConnectTerminalProps {
+  /** Stable id correlating this terminal with its backend PTY session. */
+  sessionId: string;
+  /** Workspace whose login is being connected. */
+  accountId: string;
+  /** Which config-dir login to run. */
+  service: WorkspaceConnectService;
+  /** Fired when the connect process exits, with its exit code. */
+  onExit: (exitCode: number) => void;
+}
+
+export function WorkspaceConnectTerminal({
+  sessionId,
+  accountId,
+  service,
+  onExit,
+}: WorkspaceConnectTerminalProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Held in a ref so the setup effect runs exactly once per session.
+  const onExitRef = useRef(onExit);
+  useEffect(() => {
+    onExitRef.current = onExit;
+  }, [onExit]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let mounted = true;
+    let term: XTerm | null = null;
+    let fitAddon: FitAddon | null = null;
+    let resizeObserver: ResizeObserver | null = null;
+    const unlisteners: Array<() => void> = [];
+
+    const setup = async () => {
+      await loadNerdFonts();
+      if (!mounted) return;
+
+      term = new XTerm({
+        fontFamily: '"JetBrainsMono NF", Menlo, Monaco, "Courier New", monospace',
+        fontSize: 13,
+        lineHeight: 1.2,
+        cursorBlink: true,
+        cursorStyle: 'block',
+        scrollback: 1000,
+        allowProposedApi: true,
+        theme: {
+          background: '#1e1e1e',
+          foreground: '#cccccc',
+          cursor: '#ffffff',
+          selectionBackground: '#3a3d41',
+          black: '#000000',
+          red: '#cd3131',
+          green: '#0dbc79',
+          yellow: '#e5e510',
+          blue: '#2472c8',
+          magenta: '#bc3fbc',
+          cyan: '#11a8cd',
+          white: '#e5e5e5',
+          brightBlack: '#666666',
+          brightRed: '#f14c4c',
+          brightGreen: '#23d18b',
+          brightYellow: '#f5f543',
+          brightBlue: '#3b8eea',
+          brightMagenta: '#d670d6',
+          brightCyan: '#29b8db',
+          brightWhite: '#ffffff',
+        },
+      });
+
+      fitAddon = new FitAddon();
+      const unicode11Addon = new Unicode11Addon();
+      term.loadAddon(fitAddon);
+      term.loadAddon(unicode11Addon);
+      term.loadAddon(createWebLinksAddon());
+      term.unicode.activeVersion = '11';
+      term.open(container);
+      fitAddon.fit();
+
+      // Keystrokes -> backend PTY.
+      term.onData((data) => {
+        void workspaceConnectWrite(sessionId, data).catch(() => {
+          /* session may have exited; ignore */
+        });
+      });
+
+      // Subscribe BEFORE starting so we don't miss the initial output.
+      unlisteners.push(
+        await onWorkspaceConnectData(sessionId, (bytes) => {
+          term?.write(bytes);
+        })
+      );
+      unlisteners.push(
+        await onWorkspaceConnectExit(sessionId, (code) => {
+          onExitRef.current(code);
+        })
+      );
+      if (!mounted) return;
+
+      try {
+        await workspaceConnectStart({
+          sessionId,
+          accountId,
+          service,
+          cols: term.cols,
+          rows: term.rows,
+        });
+      } catch (err) {
+        logger.warn('[WorkspaceConnectTerminal] failed to start connect', { error: String(err) });
+        term.write(`\r\n\x1b[31mCouldn't start login: ${String(err)}\x1b[0m\r\n`);
+        return;
+      }
+
+      term.focus();
+
+      resizeObserver = new ResizeObserver(() => {
+        if (!fitAddon || !term) return;
+        fitAddon.fit();
+        void workspaceConnectResize(sessionId, term.cols, term.rows).catch(() => {
+          /* ignore */
+        });
+      });
+      resizeObserver.observe(container);
+    };
+
+    void setup();
+
+    return () => {
+      mounted = false;
+      resizeObserver?.disconnect();
+      for (const off of unlisteners) off();
+      void workspaceConnectClose(sessionId).catch(() => {
+        /* ignore */
+      });
+      term?.dispose();
+    };
+    // Callbacks are held via refs, so the effect re-runs only when the session
+    // identity changes — the PTY isn't torn down on every parent re-render.
+  }, [sessionId, accountId, service]);
+
+  return <div ref={containerRef} className="onboarding-terminal-container" />;
+}

--- a/src/components/icons/brand.tsx
+++ b/src/components/icons/brand.tsx
@@ -25,6 +25,14 @@ export function GitHubIcon({ size = 16 }: IconProps) {
   );
 }
 
+export function VercelIcon({ size = 16 }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 2 22 20H2L12 2Z" />
+    </svg>
+  );
+}
+
 export function VSCodeIcon({ size = 14 }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 32 32" fill="currentColor">

--- a/src/components/terminal/StaleEnvBanner.test.tsx
+++ b/src/components/terminal/StaleEnvBanner.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Tests for StaleEnvBanner — the "your login changed, restart to apply" notice.
+ *
+ * The behaviour that matters: it appears only when the *matching* workspace's
+ * credentials change while a tab is running, and it clears on dismiss.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { sessionRegistry } from '../../lib/sessionRegistry';
+import { notifyAccountCredentialsChanged } from '../../lib/accounts';
+
+const getProjectAccountId = vi.fn<(p: string) => Promise<string>>();
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn((cmd: string, args?: { projectPath?: string }) => {
+    if (cmd === 'get_project_account_id') return getProjectAccountId(args!.projectPath!);
+    return Promise.resolve(undefined);
+  }),
+}));
+
+vi.mock('../icons', () => ({ WarningIcon: () => <span data-testid="warning-icon" /> }));
+
+import { StaleEnvBanner } from './StaleEnvBanner';
+
+const PATH = '/tmp/proj';
+
+function seedRunningTab() {
+  sessionRegistry.getOrCreate(PATH);
+  sessionRegistry.setTerminalTabs(
+    PATH,
+    [{ id: 1, agentId: 'claude-code', sessionId: 's1', status: 'running' }],
+    0
+  );
+}
+
+describe('StaleEnvBanner', () => {
+  beforeEach(() => {
+    sessionRegistry._resetForTests();
+    getProjectAccountId.mockReset();
+  });
+  afterEach(() => {
+    sessionRegistry._resetForTests();
+  });
+
+  it('does not render when no tabs are stale', () => {
+    seedRunningTab();
+    render(<StaleEnvBanner projectPath={PATH} />);
+    expect(screen.queryByText(/login changed/i)).not.toBeInTheDocument();
+  });
+
+  it('appears when the matching workspace credentials change, then clears on dismiss', async () => {
+    seedRunningTab();
+    getProjectAccountId.mockResolvedValue('circa');
+    render(<StaleEnvBanner projectPath={PATH} />);
+
+    await act(async () => {
+      notifyAccountCredentialsChanged('circa');
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.getByText(/login changed/i)).toBeInTheDocument());
+    expect(sessionRegistry.hasStaleTabs(PATH)).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    await waitFor(() => expect(screen.queryByText(/login changed/i)).not.toBeInTheDocument());
+    expect(sessionRegistry.hasStaleTabs(PATH)).toBe(false);
+  });
+
+  it('ignores a credential change for a different workspace', async () => {
+    seedRunningTab();
+    getProjectAccountId.mockResolvedValue('circa');
+    render(<StaleEnvBanner projectPath={PATH} />);
+
+    await act(async () => {
+      notifyAccountCredentialsChanged('some-other-workspace');
+      await Promise.resolve();
+    });
+
+    // Give the async resolver a tick; the banner must stay hidden.
+    await Promise.resolve();
+    expect(sessionRegistry.hasStaleTabs(PATH)).toBe(false);
+    expect(screen.queryByText(/login changed/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/terminal/StaleEnvBanner.tsx
+++ b/src/components/terminal/StaleEnvBanner.tsx
@@ -1,0 +1,73 @@
+/**
+ * StaleEnvBanner — a non-destructive notice shown above a project's terminal
+ * when its workspace login changed *after* the terminal started.
+ *
+ * A PTY captures the workspace's login env once, at spawn (see `pty/spawn.rs`);
+ * there's no way to re-inject `CLAUDE_CODE_OAUTH_TOKEN` / `VERCEL_TOKEN` /
+ * `GH_CONFIG_DIR` into a live process. So when a connect/disconnect fires
+ * {@link ACCOUNT_CREDENTIALS_CHANGED_EVENT} for the workspace this project
+ * belongs to, we flag its running tabs (see {@link sessionRegistry.markProjectTabsStale})
+ * and surface this banner. Restarting a tab re-reads the fresh env and clears
+ * the flag automatically; "Dismiss" just hides the notice.
+ *
+ * @module components/terminal/StaleEnvBanner
+ */
+
+import { useEffect, useSyncExternalStore } from 'react';
+import { WarningIcon } from '../icons';
+import { Button } from '../primitives/Button';
+import { sessionRegistry } from '../../lib/sessionRegistry';
+import {
+  ACCOUNT_CREDENTIALS_CHANGED_EVENT,
+  getProjectAccountId,
+  type AccountCredentialsChangedDetail,
+} from '../../lib/accounts';
+import '../../styles/features/stale-env-banner.css';
+
+export function StaleEnvBanner({ projectPath }: { projectPath: string }) {
+  // Re-render whenever the registry changes; staleness is derived live.
+  useSyncExternalStore(sessionRegistry.subscribeSimple, () => sessionRegistry.getVersion());
+  const isStale = sessionRegistry.hasStaleTabs(projectPath);
+
+  useEffect(() => {
+    const onChanged = (event: Event) => {
+      const changedAccountId = (event as CustomEvent<AccountCredentialsChangedDetail>).detail
+        ?.accountId;
+      // Only flag this project if it actually belongs to the workspace whose
+      // login changed — otherwise editing one client's token would needlessly
+      // pester every open project. Best-effort: if we can't resolve the mapping,
+      // err toward showing the banner (non-destructive).
+      void (async () => {
+        try {
+          const projectAccountId = await getProjectAccountId(projectPath);
+          if (!changedAccountId || projectAccountId === changedAccountId) {
+            sessionRegistry.markProjectTabsStale(projectPath);
+          }
+        } catch {
+          sessionRegistry.markProjectTabsStale(projectPath);
+        }
+      })();
+    };
+    window.addEventListener(ACCOUNT_CREDENTIALS_CHANGED_EVENT, onChanged);
+    return () => window.removeEventListener(ACCOUNT_CREDENTIALS_CHANGED_EVENT, onChanged);
+  }, [projectPath]);
+
+  if (!isStale) return null;
+
+  return (
+    <div className="stale-env-banner" role="status">
+      <WarningIcon size={14} className="stale-env-banner-icon" />
+      <span className="stale-env-banner-text">
+        This workspace’s login changed. Open agent terminals keep the previous login until you
+        restart them.
+      </span>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => sessionRegistry.clearProjectStaleEnv(projectPath)}
+      >
+        Dismiss
+      </Button>
+    </div>
+  );
+}

--- a/src/components/workspace/CompactWorkspace.tsx
+++ b/src/components/workspace/CompactWorkspace.tsx
@@ -18,6 +18,7 @@
  */
 
 import { Terminal } from '../terminal/Terminal';
+import { StaleEnvBanner } from '../terminal/StaleEnvBanner';
 import type { TerminalHandle, AgentStatus } from '../terminal/Terminal';
 import { PlusIcon } from '../icons';
 import { CompactTopbar } from './CompactTopbar';
@@ -190,6 +191,8 @@ export function CompactWorkspace({
           </button>
         )}
       </div>
+
+      <StaleEnvBanner projectPath={currentProject.path} />
 
       <div className="compact-terminal-stack">
         {allSessions.flatMap((session) =>

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -23,6 +23,7 @@ import { listen } from '@tauri-apps/api/event';
 import { logger } from '../../lib/logger';
 import { setTerminalState } from '../../lib/project';
 import { Terminal } from '../terminal/Terminal';
+import { StaleEnvBanner } from '../terminal/StaleEnvBanner';
 import { DevServerLogs } from '../terminal/DevServerLogs';
 import { Preview } from '../preview/Preview';
 import type { PreviewHandle, InspectTab } from '../preview/Preview';
@@ -1180,6 +1181,7 @@ export const WorkspaceView = memo(function WorkspaceView({
                             />
                           </div>
                         </div>
+                        <StaleEnvBanner projectPath={currentProject.path} />
                         <div
                           className={`terminal-content${isSplitActive ? ' split' : ''}`}
                           data-education-id="claude-terminal"

--- a/src/hooks/useWorkspaceConnect.tsx
+++ b/src/hooks/useWorkspaceConnect.tsx
@@ -1,0 +1,181 @@
+/**
+ * useWorkspaceConnect — one shared connect/disconnect layer for a workspace's
+ * per-client logins (GitHub, Codex, Opencode, Vercel), consumed by *both* the
+ * dashboard's Workspace-accounts card and the per-workspace Settings modal so
+ * the two surfaces can never drift.
+ *
+ * It owns the modal state and renders the right flow per service:
+ *  - **Vercel** → {@link VercelTokenModal} (token paste; works for any workspace).
+ *  - **GitHub / Codex / Opencode**, non-default workspace → {@link WorkspaceConnectModal}
+ *    (backend PTY under the workspace's isolated env, so creds land in its config dir).
+ *  - **GitHub / Codex / Opencode**, Default workspace → the native CLI login in an
+ *    in-webview {@link OnboardingTerminal} (the machine's native env, left untouched).
+ *
+ * Claude is intentionally *not* handled here — it keeps its existing token-capture
+ * flow in {@link AgentsPanel} (a global-keychain entry needs `resolve_claude_identity`,
+ * not a config-dir login).
+ *
+ * @module hooks/useWorkspaceConnect
+ */
+
+import { useCallback, useState, type ReactNode } from 'react';
+import { ModalFrame } from '../components/primitives/ModalFrame';
+import { OnboardingTerminal } from '../components/setup/OnboardingTerminal';
+import { WorkspaceConnectModal } from '../components/dashboard/WorkspaceConnectModal';
+import { VercelTokenModal } from '../components/dashboard/VercelTokenModal';
+import {
+  clearAccountCredential,
+  workspaceDisconnectService,
+  notifyAccountCredentialsChanged,
+  type WorkspaceConnectService,
+} from '../lib/accounts';
+import { useOptionalToast } from '../contexts/ToastContext';
+
+/** Every login this hook can connect. (`vercel` is token-based, the rest are PTY.) */
+export type ConnectServiceId = WorkspaceConnectService | 'vercel';
+
+/**
+ * Native CLI login command per service, used for the Default workspace — which
+ * deliberately uses the machine's native logins (no token injection, nothing
+ * pinned to an isolated config dir). Vercel here is the native browser login,
+ * NOT a token, so Default is never given an injected `VERCEL_TOKEN`.
+ */
+const NATIVE_LOGIN: Record<ConnectServiceId, { command: string; args: string[] }> = {
+  github: { command: 'gh', args: ['auth', 'login', '--web', '--git-protocol', 'https'] },
+  codex: { command: 'codex', args: ['login'] },
+  opencode: { command: 'opencode', args: ['auth', 'login'] },
+  vercel: { command: 'vercel', args: ['login'] },
+};
+
+const SERVICE_LABEL: Record<ConnectServiceId, string> = {
+  github: 'GitHub',
+  codex: 'Codex',
+  opencode: 'Opencode',
+  vercel: 'Vercel',
+};
+
+interface UseWorkspaceConnectArgs {
+  accountId: string;
+  accountName: string;
+  isDefault: boolean;
+  /** Called after a successful connect/disconnect so callers can re-fetch status. */
+  onChanged?: () => void;
+}
+
+export function useWorkspaceConnect({
+  accountId,
+  accountName,
+  isDefault,
+  onChanged,
+}: UseWorkspaceConnectArgs) {
+  const { showToast } = useOptionalToast();
+  const [ptyService, setPtyService] = useState<WorkspaceConnectService | null>(null);
+  const [nativeService, setNativeService] = useState<ConnectServiceId | null>(null);
+  const [vercelOpen, setVercelOpen] = useState(false);
+
+  const connect = useCallback(
+    (service: ConnectServiceId) => {
+      // Default workspace uses the machine's native logins for everything (incl.
+      // Vercel's browser login) — never a token, never an isolated config dir.
+      if (isDefault) {
+        setNativeService(service);
+        return;
+      }
+      // A non-default workspace: Vercel via token (its browser login is global
+      // and would bleed across workspaces), the rest via the backend PTY under
+      // the workspace's isolated env.
+      if (service === 'vercel') {
+        setVercelOpen(true);
+      } else {
+        setPtyService(service);
+      }
+    },
+    [isDefault]
+  );
+
+  const disconnect = useCallback(
+    async (service: ConnectServiceId) => {
+      try {
+        if (service === 'vercel') {
+          await clearAccountCredential(accountId, 'vercel_token');
+        } else {
+          // Backend rejects the Default workspace (native logins are managed by
+          // the CLI directly), so only offer this for non-default workspaces.
+          await workspaceDisconnectService(accountId, service);
+        }
+        showToast(`Disconnected ${SERVICE_LABEL[service]}`, 'success');
+        onChanged?.();
+      } catch (err) {
+        showToast(`Couldn't disconnect ${SERVICE_LABEL[service]}: ${String(err)}`, 'error');
+      }
+    },
+    [accountId, showToast, onChanged]
+  );
+
+  const succeed = useCallback(
+    (service: ConnectServiceId, message?: string) => {
+      showToast(message ?? `Connected ${SERVICE_LABEL[service]}`, 'success');
+      // The workspace's login env just changed — let open terminals surface a
+      // "restart to apply" banner (PTY/native logins don't go through the
+      // credential-vault wrappers that already emit this).
+      notifyAccountCredentialsChanged(accountId);
+      onChanged?.();
+    },
+    [showToast, onChanged, accountId]
+  );
+
+  const modals: ReactNode = (
+    <>
+      {ptyService && (
+        <WorkspaceConnectModal
+          accountId={accountId}
+          workspaceName={accountName}
+          service={ptyService}
+          onSuccess={() => {
+            const svc = ptyService;
+            setPtyService(null);
+            succeed(svc);
+          }}
+          onClose={() => setPtyService(null)}
+        />
+      )}
+
+      {nativeService && (
+        <ModalFrame
+          isOpen
+          onClose={() => setNativeService(null)}
+          title={`Connect ${SERVICE_LABEL[nativeService]}`}
+          className="agents-panel-terminal-modal"
+        >
+          <div className="agents-panel-terminal-body">
+            <OnboardingTerminal
+              command={NATIVE_LOGIN[nativeService].command}
+              args={NATIVE_LOGIN[nativeService].args}
+              onExit={(code) => {
+                const svc = nativeService;
+                setNativeService(null);
+                // Native login: exit 0 == success. A late-written indicator is
+                // picked up by the caller's staggered refresh.
+                if (code === 0 && svc) succeed(svc);
+              }}
+            />
+          </div>
+        </ModalFrame>
+      )}
+
+      {vercelOpen && (
+        <VercelTokenModal
+          accountId={accountId}
+          workspaceName={accountName}
+          onSaved={() => {
+            setVercelOpen(false);
+            succeed('vercel', 'Connected Vercel');
+          }}
+          onClose={() => setVercelOpen(false)}
+        />
+      )}
+    </>
+  );
+
+  return { connect, disconnect, modals };
+}

--- a/src/lib/accounts.ts
+++ b/src/lib/accounts.ts
@@ -12,6 +12,7 @@
  */
 
 import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 
 /** A Workspace for isolating Claude/GitHub config and credentials per org/client. */
 export interface Account {
@@ -34,6 +35,8 @@ export interface AccountCredentialStatus {
   codexAuthEmail: string | null;
   opencodeAuthEmail: string | null;
   githubAuthEmail: string | null;
+  /** Vercel identity verified with this workspace's token; null if unset/invalid. */
+  vercelUsername: string | null;
   hasAnthropicBaseUrl: boolean;
   hasVercelToken: boolean;
   hasGitName: boolean;
@@ -72,7 +75,11 @@ export const SENSITIVE_KEYS = new Set<CredentialKey>(['anthropic_base_url', 'ver
 export const STATUS_FIELD_TO_KEY: Record<
   Exclude<
     keyof AccountCredentialStatus,
-    'claudeAuthEmail' | 'codexAuthEmail' | 'opencodeAuthEmail' | 'githubAuthEmail'
+    | 'claudeAuthEmail'
+    | 'codexAuthEmail'
+    | 'opencodeAuthEmail'
+    | 'githubAuthEmail'
+    | 'vercelUsername'
   >,
   CredentialKey
 > = {
@@ -106,6 +113,30 @@ export const ACCOUNTS_CHANGED_EVENT = 'shipstudio:accounts-changed';
 
 function notifyAccountsChanged(): void {
   window.dispatchEvent(new Event(ACCOUNTS_CHANGED_EVENT));
+}
+
+/**
+ * Event fired when a workspace's *login credentials* change (a service
+ * connect/disconnect or a credential-vault edit) — as opposed to the workspace
+ * set/identity ({@link ACCOUNTS_CHANGED_EVENT}). Carries the affected workspace
+ * id so listeners can scope their reaction. Terminals capture the workspace's
+ * env once at PTY spawn and can't pick up a change live, so the terminal area
+ * uses this to surface a non-destructive "restart to apply" banner.
+ */
+export const ACCOUNT_CREDENTIALS_CHANGED_EVENT = 'shipstudio:account-credentials-changed';
+
+/** Payload for {@link ACCOUNT_CREDENTIALS_CHANGED_EVENT}. */
+export interface AccountCredentialsChangedDetail {
+  /** The workspace whose login env just changed. */
+  accountId: string;
+}
+
+export function notifyAccountCredentialsChanged(accountId: string): void {
+  window.dispatchEvent(
+    new CustomEvent<AccountCredentialsChangedDetail>(ACCOUNT_CREDENTIALS_CHANGED_EVENT, {
+      detail: { accountId },
+    })
+  );
 }
 
 export async function listAccounts(): Promise<Account[]> {
@@ -147,11 +178,96 @@ export async function setAccountCredential(
   key: CredentialKey,
   value: string
 ): Promise<void> {
-  return invoke('set_account_credential', { id, key, value });
+  await invoke('set_account_credential', { id, key, value });
+  notifyAccountCredentialsChanged(id);
 }
 
 export async function clearAccountCredential(id: string, key: CredentialKey): Promise<void> {
-  return invoke('clear_account_credential', { id, key });
+  await invoke('clear_account_credential', { id, key });
+  notifyAccountCredentialsChanged(id);
+}
+
+/**
+ * Config-dir login services that authenticate by writing into a workspace's
+ * isolated config dir (GH_CONFIG_DIR / CODEX_HOME / XDG_DATA_HOME). Unlike
+ * Claude (a global keychain entry needing token capture), these just run the
+ * CLI's own login under the workspace's env — so the connect PTY streams output
+ * verbatim and treats process exit as completion.
+ */
+export type WorkspaceConnectService = 'github' | 'codex' | 'opencode';
+
+/**
+ * Start a backend-owned PTY login for a workspace's GitHub/Codex/Opencode
+ * account. Mirrors {@link claudeConnectStart} but with no token scraping: the
+ * CLI writes its own credential files into the workspace's isolated config dir.
+ * Output streams as `workspace-connect-data`; completion is `workspace-connect-exit`.
+ * Rejected for the Default workspace (it uses the machine's native logins).
+ */
+export async function workspaceConnectStart(args: {
+  sessionId: string;
+  accountId: string;
+  service: WorkspaceConnectService;
+  cols: number;
+  rows: number;
+}): Promise<void> {
+  await invoke('workspace_connect_start', {
+    sessionId: args.sessionId,
+    id: args.accountId,
+    service: args.service,
+    cols: args.cols,
+    rows: args.rows,
+  });
+}
+
+/** Forward keystrokes to a workspace-connect PTY. */
+export async function workspaceConnectWrite(sessionId: string, data: string): Promise<void> {
+  const bytes = Array.from(new TextEncoder().encode(data));
+  await invoke('workspace_connect_write', { sessionId, data: bytes });
+}
+
+/** Resize a workspace-connect PTY to match the on-screen terminal. */
+export async function workspaceConnectResize(
+  sessionId: string,
+  cols: number,
+  rows: number
+): Promise<void> {
+  await invoke('workspace_connect_resize', { sessionId, cols, rows });
+}
+
+/** Kill a workspace-connect PTY and drop its backend registry entry. Idempotent. */
+export async function workspaceConnectClose(sessionId: string): Promise<void> {
+  await invoke('workspace_connect_close', { sessionId });
+}
+
+/** Subscribe to a workspace-connect session's terminal output (raw bytes). */
+export async function onWorkspaceConnectData(
+  sessionId: string,
+  handler: (bytes: Uint8Array) => void
+): Promise<UnlistenFn> {
+  return listen<{ sessionId: string; data: number[] }>('workspace-connect-data', (event) => {
+    if (event.payload.sessionId !== sessionId) return;
+    handler(new Uint8Array(event.payload.data));
+  });
+}
+
+/** Fires when a workspace-connect process exits (clean or not). */
+export async function onWorkspaceConnectExit(
+  sessionId: string,
+  handler: (exitCode: number) => void
+): Promise<UnlistenFn> {
+  return listen<{ sessionId: string; exitCode: number }>('workspace-connect-exit', (event) => {
+    if (event.payload.sessionId !== sessionId) return;
+    handler(event.payload.exitCode);
+  });
+}
+
+/** Sign a workspace out of a config-dir login (GitHub/Codex/Opencode). */
+export async function workspaceDisconnectService(
+  id: string,
+  service: WorkspaceConnectService
+): Promise<void> {
+  await invoke('workspace_disconnect_service', { id, service });
+  notifyAccountCredentialsChanged(id);
 }
 
 export async function moveProjectToAccount(projectPath: string, accountId: string): Promise<void> {

--- a/src/lib/agents-management.ts
+++ b/src/lib/agents-management.ts
@@ -8,6 +8,7 @@
  */
 
 import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 
 /** Rich per-agent status returned by the backend for the dashboard panel. */
 export interface AgentStatus {
@@ -17,6 +18,12 @@ export interface AgentStatus {
   installed: boolean;
   version: string | null;
   authed: boolean;
+  /** Signed-in account email when known (currently Claude Code, per active
+   *  workspace). Null when not connected or identity is unknown. */
+  authEmail: string | null;
+  /** True when previously connected but the credential expired — drives the
+   *  red stroke + inline Reconnect. Never true for the never-connected state. */
+  needsReconnect: boolean;
   isDefault: boolean;
   installSupported: boolean;
   uninstallSupported: boolean;
@@ -35,4 +42,94 @@ export async function signOutAgent(agentId: string): Promise<void> {
 /** Run the agent's uninstall command (best-effort, idempotent). */
 export async function uninstallAgent(agentId: string): Promise<string> {
   return invoke<string>('uninstall_agent', { agentId });
+}
+
+/**
+ * Backend-owned PTY connect flow for a (non-default) workspace's Claude login.
+ *
+ * `claude setup-token` is interactive — it prints an auth URL and waits for the
+ * user to paste back a code — so the backend runs it in a real pseudo-terminal,
+ * streams the output here as `claude-connect-data` events, and accepts
+ * keystrokes via {@link claudeConnectWrite}. The reader thread scrapes the
+ * printed `sk-ant-…` token, stores it in the workspace vault, redacts it from
+ * the stream, and emits `claude-connect-captured` — so the secret is handled
+ * entirely in Rust and never reaches this layer. `email` is display-only.
+ *
+ * Wired event-style (mirrors {@link module:lib/ptySession}): the caller owns a
+ * stable `sessionId`, calls `start` once, subscribes to the data/captured/exit
+ * events, and calls {@link claudeConnectClose} on teardown.
+ */
+export async function claudeConnectStart(args: {
+  sessionId: string;
+  accountId: string;
+  email?: string;
+  cols: number;
+  rows: number;
+}): Promise<void> {
+  await invoke('claude_connect_start', {
+    sessionId: args.sessionId,
+    id: args.accountId,
+    email: args.email ?? null,
+    cols: args.cols,
+    rows: args.rows,
+  });
+}
+
+/** Forward keystrokes (e.g. the pasted code) to a connect PTY. */
+export async function claudeConnectWrite(sessionId: string, data: string): Promise<void> {
+  const bytes = Array.from(new TextEncoder().encode(data));
+  await invoke('claude_connect_write', { sessionId, data: bytes });
+}
+
+/** Resize a connect PTY to match the on-screen terminal. */
+export async function claudeConnectResize(
+  sessionId: string,
+  cols: number,
+  rows: number
+): Promise<void> {
+  await invoke('claude_connect_resize', { sessionId, cols, rows });
+}
+
+/** Kill a connect PTY and drop its backend registry entry. Idempotent. */
+export async function claudeConnectClose(sessionId: string): Promise<void> {
+  await invoke('claude_connect_close', { sessionId });
+}
+
+/** Subscribe to a connect session's terminal output (raw bytes for xterm). */
+export async function onClaudeConnectData(
+  sessionId: string,
+  handler: (bytes: Uint8Array) => void
+): Promise<UnlistenFn> {
+  return listen<{ sessionId: string; data: number[] }>('claude-connect-data', (event) => {
+    if (event.payload.sessionId !== sessionId) return;
+    handler(new Uint8Array(event.payload.data));
+  });
+}
+
+/** Fires once the token has been captured + stored in Rust (the success
+ *  signal). Payload never carries the token. */
+export async function onClaudeConnectCaptured(
+  sessionId: string,
+  handler: () => void
+): Promise<UnlistenFn> {
+  return listen<{ sessionId: string }>('claude-connect-captured', (event) => {
+    if (event.payload.sessionId !== sessionId) return;
+    handler();
+  });
+}
+
+/** Fires when the connect process exits (clean or not). */
+export async function onClaudeConnectExit(
+  sessionId: string,
+  handler: (exitCode: number) => void
+): Promise<UnlistenFn> {
+  return listen<{ sessionId: string; exitCode: number }>('claude-connect-exit', (event) => {
+    if (event.payload.sessionId !== sessionId) return;
+    handler(event.payload.exitCode);
+  });
+}
+
+/** Disconnect a workspace's Claude login (clears its stored token + email). */
+export async function disconnectClaudeAccount(accountId: string): Promise<void> {
+  return invoke('disconnect_claude_account', { id: accountId });
 }

--- a/src/lib/educationContent.ts
+++ b/src/lib/educationContent.ts
@@ -56,10 +56,10 @@ export const educationContent: Record<string, EducationItem> = {
     description:
       'Customize your dashboard — show or hide the activity calendar and community banner, and manage analytics preferences.',
   },
-  'integration-bar': {
-    title: 'Integrations',
+  'machine-tools': {
+    title: 'Tools on this Mac',
     description:
-      'See which tools are connected and ready. Click to expand and check the status of your coding agent, GitHub, and other services.',
+      'The tools installed once on your machine and shared by every workspace — Homebrew, Node, Git, and the agent CLIs. Click to expand and check what is installed.',
   },
   'changelog-sidebar': {
     title: "What's New",

--- a/src/lib/sessionRegistry.test.ts
+++ b/src/lib/sessionRegistry.test.ts
@@ -197,3 +197,78 @@ describe('SessionRegistry — snapshots', () => {
     expect(sessionRegistry.snapshot('/tmp/missing')).toBeUndefined();
   });
 });
+
+describe('SessionRegistry — stale login env', () => {
+  const PATH = '/tmp/stale';
+
+  function seedTabs(statuses: Array<import('./sessionRegistry').TabStatus | undefined>) {
+    sessionRegistry.getOrCreate(PATH);
+    sessionRegistry.setTerminalTabs(
+      PATH,
+      statuses.map((status, i) => ({
+        id: i + 1,
+        agentId: 'claude-code',
+        sessionId: `s${i + 1}`,
+        status,
+      })),
+      0
+    );
+  }
+
+  it('flags only running tabs and leaves exited/crashed tabs alone', () => {
+    seedTabs(['running', 'exited', 'crashed', 'thinking', undefined]);
+    sessionRegistry.markProjectTabsStale(PATH);
+
+    const tabs = sessionRegistry.snapshot(PATH)!.terminalTabs;
+    expect(tabs.find((t) => t.id === 1)!.staleEnv).toBe(true); // running
+    expect(tabs.find((t) => t.id === 2)!.staleEnv).toBeFalsy(); // exited
+    expect(tabs.find((t) => t.id === 3)!.staleEnv).toBeFalsy(); // crashed
+    expect(tabs.find((t) => t.id === 4)!.staleEnv).toBe(true); // thinking
+    expect(tabs.find((t) => t.id === 5)!.staleEnv).toBe(true); // unknown == starting
+    expect(sessionRegistry.hasStaleTabs(PATH)).toBe(true);
+  });
+
+  it('is a no-op for an unknown project', () => {
+    expect(() => sessionRegistry.markProjectTabsStale('/tmp/nope')).not.toThrow();
+    expect(sessionRegistry.hasStaleTabs('/tmp/nope')).toBe(false);
+  });
+
+  it('clearProjectStaleEnv resets every flagged tab', () => {
+    seedTabs(['running', 'running']);
+    sessionRegistry.markProjectTabsStale(PATH);
+    expect(sessionRegistry.hasStaleTabs(PATH)).toBe(true);
+
+    sessionRegistry.clearProjectStaleEnv(PATH);
+    expect(sessionRegistry.hasStaleTabs(PATH)).toBe(false);
+  });
+
+  it('clears a tab’s stale flag when it is restarted (sessionId changes)', () => {
+    seedTabs(['running']);
+    sessionRegistry.markProjectTabsStale(PATH);
+    expect(sessionRegistry.hasStaleTabs(PATH)).toBe(true);
+
+    // A restart mints a fresh sessionId for the same tab id — a new PTY that
+    // captured the current env, so staleness must clear.
+    sessionRegistry.setTerminalTabs(
+      PATH,
+      [{ id: 1, agentId: 'claude-code', sessionId: 's-restarted', status: 'starting' }],
+      0
+    );
+    expect(sessionRegistry.hasStaleTabs(PATH)).toBe(false);
+  });
+
+  it('notifies subscribers when staleness changes, not when it does not', () => {
+    seedTabs(['running']);
+    const calls: Array<string | null> = [];
+    const unsub = sessionRegistry.subscribe((changedPath) => calls.push(changedPath));
+
+    sessionRegistry.markProjectTabsStale(PATH);
+    expect(calls).toEqual([PATH]);
+
+    // Already stale — second call changes nothing, so no extra notify.
+    sessionRegistry.markProjectTabsStale(PATH);
+    expect(calls).toEqual([PATH]);
+
+    unsub();
+  });
+});

--- a/src/lib/sessionRegistry.ts
+++ b/src/lib/sessionRegistry.ts
@@ -68,6 +68,11 @@ export interface SessionTerminalTab {
   exitCode?: number | null;
   /** Unix millis of the most recent status update for this tab. */
   lastActivityAt?: number;
+  /** True when this tab's PTY captured a now-outdated workspace login env at
+   *  spawn (a credential changed after it started). Non-destructive UI hint:
+   *  the terminal area shows a "restart to apply" banner. Cleared when the tab
+   *  is restarted (its sessionId changes) or the banner is dismissed. */
+  staleEnv?: boolean;
 }
 
 /**
@@ -333,6 +338,9 @@ class SessionRegistry {
         pid: t.pid ?? (agentChanged ? null : prev.pid),
         exitCode: t.exitCode ?? (agentChanged ? null : prev.exitCode),
         lastActivityAt: t.lastActivityAt ?? (agentChanged ? Date.now() : prev.lastActivityAt),
+        // A new sessionId means a fresh PTY that captured the *current* env, so
+        // staleness clears on restart / agent switch. Otherwise it carries over.
+        staleEnv: t.staleEnv ?? (agentChanged ? undefined : prev.staleEnv),
       };
     });
     session.activeTabIndex = Math.max(0, Math.min(activeTabIndex, tabs.length - 1));
@@ -440,6 +448,56 @@ class SessionRegistry {
         changed = true;
       }
       return next;
+    });
+    if (changed) this.notify(projectPath);
+  }
+
+  /**
+   * Flag a project's currently-running terminal tabs as having a stale login
+   * env — their PTY captured the workspace's credentials at spawn and can't
+   * pick up a change without a restart. Only running tabs are flagged: an
+   * exited tab re-reads fresh env on its next (Enter-to-)restart anyway.
+   * Non-destructive — it only drives a "restart to apply" banner.
+   */
+  markProjectTabsStale(projectPath: string): void {
+    const session = this.sessions.get(projectPath);
+    if (!session) return;
+    let changed = false;
+    session.terminalTabs = session.terminalTabs.map((tab) => {
+      const isRunning =
+        tab.status === undefined ||
+        tab.status === 'starting' ||
+        tab.status === 'running' ||
+        tab.status === 'thinking' ||
+        tab.status === 'waiting';
+      if (isRunning && !tab.staleEnv) {
+        changed = true;
+        return { ...tab, staleEnv: true };
+      }
+      return tab;
+    });
+    if (changed) this.notify(projectPath);
+  }
+
+  /** True when the project has at least one tab flagged with a stale env. */
+  hasStaleTabs(projectPath: string): boolean {
+    const session = this.sessions.get(projectPath);
+    if (!session) return false;
+    return session.terminalTabs.some((t) => t.staleEnv);
+  }
+
+  /** Clear the stale-env flag on every tab of a project (e.g. on banner
+   *  dismiss). Restarting a tab clears its own flag via {@link setTerminalTabs}. */
+  clearProjectStaleEnv(projectPath: string): void {
+    const session = this.sessions.get(projectPath);
+    if (!session) return;
+    let changed = false;
+    session.terminalTabs = session.terminalTabs.map((tab) => {
+      if (tab.staleEnv) {
+        changed = true;
+        return { ...tab, staleEnv: false };
+      }
+      return tab;
     });
     if (changed) this.notify(projectPath);
   }

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -102,6 +102,48 @@ export const OPTIONAL_ITEMS = new Set([
   'vercel_auth',
 ]);
 
+/**
+ * Tier classification for a setup item.
+ *
+ * The app conflated two very different things in one flat list: tools that are
+ * installed once on the machine and shared by every workspace, and logins that
+ * are isolated per workspace. Splitting them is purely a frontend concern — the
+ * id taxonomy already encodes the tier (the five `*_auth` ids are the logins),
+ * so we classify here rather than widening the backend SetupItemInfo.
+ *
+ *  - `machine`   — Homebrew, Node, Git, and the CLI binaries. Installed once.
+ *  - `workspace` — the five logins (gh / claude / codex / opencode / vercel),
+ *                  isolated per workspace via `get_env_vars_for_account`.
+ */
+export type SetupTier = 'machine' | 'workspace';
+
+/** The five per-workspace logins (the `*_auth` items). Everything else is machine-tier. */
+export const WORKSPACE_LOGIN_ITEM_IDS = new Set([
+  'gh_auth',
+  'claude_auth',
+  'codex_auth',
+  'opencode_auth',
+  'vercel_auth',
+]);
+
+/** Machine-tier items: runtimes + CLI binaries installed once and shared by every workspace. */
+export const MACHINE_ITEM_IDS = new Set([
+  'homebrew',
+  'node',
+  'npm_fix',
+  'git',
+  'gh',
+  'claude',
+  'codex',
+  'opencode',
+  'vercel',
+]);
+
+/** Classify a setup item id as machine- or workspace-tier. */
+export function tierOf(itemId: string): SetupTier {
+  return WORKSPACE_LOGIN_ITEM_IDS.has(itemId) ? 'workspace' : 'machine';
+}
+
 /** Quick setup check result (fast Tier-1 check) */
 interface QuickSetupCheck {
   /** Whether all binaries and auth files exist */

--- a/src/styles/features/agents-panel.css
+++ b/src/styles/features/agents-panel.css
@@ -35,6 +35,44 @@
   color: var(--text-muted);
 }
 
+/* Workspace badge in the header — names the workspace these logins belong to,
+   the single clearest "which account am I looking at?" cue. A compact tag, not
+   a stretched pill. */
+.agents-panel-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: 1px var(--spacing-sm);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-weight: 500;
+  vertical-align: baseline;
+}
+
+.agents-panel-badge-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+
+/* Subheader splitting the card into "Coding agents" and "Services" tiers. */
+.agents-section-title {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin: var(--spacing-md) 0 var(--spacing-sm);
+}
+
+/* First subheader sits right under the header — trim its top gap. */
+.agents-panel-header + .agents-section-title {
+  margin-top: 0;
+}
+
 .agents-panel-list {
   display: flex;
   flex-direction: column;
@@ -426,26 +464,27 @@ button.dashboard-card-row {
   background: var(--error-light);
 }
 
-/* ── Claude connect modal ──────────────────────────────────────────────── */
-.claude-connect-body {
+/* ── Connect modals (shared: Claude token, GitHub/Codex/Opencode PTY, Vercel
+   token) — one visual language so the surfaces never drift. ────────────── */
+.connect-modal-body {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-lg);
   padding: var(--spacing-lg) var(--spacing-xl) var(--spacing-xl);
 }
 
-.claude-connect-body p {
+.connect-modal-body p {
   margin: 0;
   color: var(--text-secondary);
   font-size: var(--font-size-base);
   line-height: 1.5;
 }
 
-.claude-connect-body strong {
+.connect-modal-body strong {
   color: var(--text-primary);
 }
 
-.claude-connect-field {
+.connect-modal-field {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-xs);
@@ -453,7 +492,7 @@ button.dashboard-card-row {
   color: var(--text-primary);
 }
 
-.claude-connect-field input {
+.connect-modal-field input {
   padding: var(--spacing-sm) var(--spacing-md);
   background: var(--bg-primary);
   border: 1px solid var(--border);
@@ -462,17 +501,17 @@ button.dashboard-card-row {
   font-size: var(--font-size-md);
 }
 
-.claude-connect-field input:focus {
+.connect-modal-field input:focus {
   outline: none;
   border-color: var(--action);
 }
 
-.claude-connect-muted {
+.connect-modal-muted {
   color: var(--text-secondary);
   font-weight: 400;
 }
 
-.claude-connect-actions {
+.connect-modal-actions {
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -481,7 +520,7 @@ button.dashboard-card-row {
 
 /* Terminal phase — fills the (terminal-sized) modal: instructions on top, the
    embedded backend-PTY terminal taking the remaining height. */
-.claude-connect-terminal-phase {
+.connect-modal-terminal-phase {
   display: flex;
   flex: 1;
   min-height: 0;
@@ -490,13 +529,13 @@ button.dashboard-card-row {
   padding: var(--spacing-lg) var(--spacing-xl) var(--spacing-xl);
 }
 
-.claude-connect-instructions {
+.connect-modal-instructions {
   margin: 0;
   color: var(--text-secondary);
   font-size: var(--font-size-base);
   line-height: 1.5;
 }
 
-.claude-connect-instructions strong {
+.connect-modal-instructions strong {
   color: var(--text-primary);
 }

--- a/src/styles/features/agents-panel.css
+++ b/src/styles/features/agents-panel.css
@@ -400,3 +400,103 @@ button.dashboard-card-row {
   color: var(--text-muted);
   flex-shrink: 0;
 }
+
+/* ── Auth connection-state strokes ─────────────────────────────────────────
+   Green = connected & valid, red = needs attention (expired/needs reconnect).
+   A never-connected card keeps the plain neutral border (no class). These come
+   after .is-default so connection state wins the border color when both apply;
+   red (needs-reconnect) always trumps green. */
+.agents-panel-row.is-connected {
+  border-color: var(--success);
+}
+
+.agents-panel-row.needs-reconnect {
+  border-color: var(--danger);
+  box-shadow: inset 0 0 0 1px var(--danger);
+}
+
+/* Inline Reconnect button — red-tinted to read as "needs attention" without the
+   full weight of a destructive (delete) action. */
+.agents-reconnect-btn {
+  color: var(--danger);
+  border-color: var(--danger);
+}
+
+.agents-reconnect-btn:hover:not(:disabled) {
+  background: var(--error-light);
+}
+
+/* ── Claude connect modal ──────────────────────────────────────────────── */
+.claude-connect-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  padding: var(--spacing-lg) var(--spacing-xl) var(--spacing-xl);
+}
+
+.claude-connect-body p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-base);
+  line-height: 1.5;
+}
+
+.claude-connect-body strong {
+  color: var(--text-primary);
+}
+
+.claude-connect-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-base);
+  color: var(--text-primary);
+}
+
+.claude-connect-field input {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-size: var(--font-size-md);
+}
+
+.claude-connect-field input:focus {
+  outline: none;
+  border-color: var(--action);
+}
+
+.claude-connect-muted {
+  color: var(--text-secondary);
+  font-weight: 400;
+}
+
+.claude-connect-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+}
+
+/* Terminal phase — fills the (terminal-sized) modal: instructions on top, the
+   embedded backend-PTY terminal taking the remaining height. */
+.claude-connect-terminal-phase {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  padding: var(--spacing-lg) var(--spacing-xl) var(--spacing-xl);
+}
+
+.claude-connect-instructions {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-base);
+  line-height: 1.5;
+}
+
+.claude-connect-instructions strong {
+  color: var(--text-primary);
+}

--- a/src/styles/features/dashboard/projects.css
+++ b/src/styles/features/dashboard/projects.css
@@ -255,6 +255,12 @@
   gap: var(--spacing-xs);
 }
 
+/* Inline clarification that machine tools are global, not per-workspace. Muted
+   so it reads as a quiet aside next to the X/Y count. */
+.machine-tools-shared-hint {
+  color: var(--text-muted);
+}
+
 .integration-bar-status-icon.success {
   color: var(--success);
 }

--- a/src/styles/features/stale-env-banner.css
+++ b/src/styles/features/stale-env-banner.css
@@ -1,0 +1,23 @@
+/* Stale login-env banner — sits between the terminal tab bar and the terminal
+   content. Warning-tinted, compact, non-blocking. */
+
+.stale-env-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-md);
+  background: rgba(var(--warning-rgb), 0.1);
+  border-bottom: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+.stale-env-banner-icon {
+  flex-shrink: 0;
+  color: var(--warning);
+}
+
+.stale-env-banner-text {
+  flex: 1;
+  line-height: 1.4;
+}


### PR DESCRIPTION
## What this is

Ship Studio lets you keep separate workspaces (one per client, basically), but logging into tools never really respected that. The integrations list lumped three different things together — tools you install once on the Mac, logins that are meant to be per workspace, and per-project stuff — so a workspace looked like it "had" tools it had never set up. And only Claude/GitHub had any kind of connect button; Vercel, Codex and Opencode had none, even though the backend already supported isolating all of them.

The worst part was that the same login could read as two different accounts depending on where you looked. The dashboard resolved Vercel against the *active* workspace and showed `circa-3183`; the agent terminal resolved it against the *project's* workspace (captured stale at spawn) and showed `awhitten`. Same screen, two answers, no explanation.

This PR makes all five logins — Claude, GitHub, Vercel, Codex, Opencode — genuinely per workspace, and reorganizes the UI so it's clear what's machine-level and what's workspace-level.

## The three tiers, made visible

- **Machine** — installed once and shared by everything: Homebrew, node, git, and the CLI binaries.
- **Workspace** — isolated per workspace: the five logins, git identity, Anthropic base URL.
- **Project** — `.vercel` link, git remote. Out of scope here; just no longer conflated with the rest.

## Changes

**Dashboard is now two cards instead of one list.** "Tools on this Mac" shows only the machine tools. "Workspace accounts" carries the five logins, split into coding agents and services, with a badge naming the active workspace so there's no ambiguity about which account you're looking at.

**One shared connect layer drives both surfaces.** A `useWorkspaceConnect` hook owns the connect actions and modal state, and both the dashboard card and the per-workspace Settings modal use it — so the two can't drift out of sync the way they did before. GitHub/Codex/Opencode log in through a workspace-scoped PTY (same pattern as Claude below); Vercel takes a pasted token into the existing credential vault and injects it as `VERCEL_TOKEN` (via env, never on argv where `ps` could see it).

**Claude per-workspace login (the part of this branch that landed first).** Claude Code stores its macOS OAuth login in a single global Keychain entry that ignores `CLAUDE_CONFIG_DIR`, so signing in on one workspace bled into all of them. The fix captures a per-workspace long-lived token (`claude setup-token`) and injects it as `CLAUDE_CODE_OAUTH_TOKEN`. The token is captured entirely in Rust and never crosses IPC into the webview: the backend runs the login in its own pseudo-terminal, streams output to an xterm view, scrapes the printed `sk-ant-…` token out of the byte stream (with a hold-back buffer so a token split across reads is still caught), stores it in the vault, and redacts it from the stream before the frontend ever sees it.

**The Default workspace is deliberately left alone.** It keeps using the machine's native logins — no token injection, same UI it had before. Every new connect button gates on this, and the backend `workspace_connect_start` rejects `default` the same way `claude_connect_start` does.

**Stale-env banner.** A terminal captures its login env once, when it spawns — there's no way to re-inject a token into a process that's already running. So if you change a login while a terminal is open, instead of silently using the old account, the project shows a small "this workspace's login changed, restart the terminal to apply" banner. It's informational and dismissible; it won't kill a running agent out from under you.

## Notable bits for review

- Backend mirrors the existing Claude PTY pattern: `workspace_connect_*` over `get_env_vars_for_account`, streaming bytes verbatim (no redaction needed — these aren't token logins). No change to how env is captured at spawn.
- Dashboard reads the *active* workspace by design; the terminal reads the *project's* workspace. These are genuinely different things, so rather than try to force them into one number, the workspace badge just makes the distinction legible.
- `gh`'s device flow needs an Enter to open the browser, so the connect terminal auto-sends one after spawn.

## Testing

- Rust: `accounts` and `setup::agents` suites pass, including the token-redaction tests (ANSI-wrapped tokens, tokens split across reads) and new tests that `workspace_connect_start` rejects the default workspace and validates the session id.
- Frontend: `AgentsPanel` (22), new `MachineToolsPanel` (5), `sessionRegistry` stale-flag tests (part of 27), and a new `StaleEnvBanner` test (3). Full suite green apart from two pre-existing localStorage/jsdom failures unrelated to this branch.
- `tsc`, `eslint`, `clippy`, and `check:patterns` clean.
- Walked through it end-to-end in `pnpm tauri dev`: connect Vercel by token paste in a non-default workspace → dashboard and Settings both show that workspace's identity, and a fresh terminal's `vercel whoami` reports it too; connect GitHub via the PTY → browser opens without manual Enter and the modal closes on success; confirmed the Default workspace still uses native logins; changed a credential with a terminal open → banner appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added backend-managed, workspace-scoped Claude sign-in for non-default workspaces with a dedicated connect modal and live terminal-based token capture.
  * Added per-workspace Claude “Reconnect needed” and a Claude disconnect action.
  * Added Vercel token connection for non-default workspaces.
  * Added a stale login-environment banner above workspace terminals.

* **Improvements**
  * Updated agents dashboard to reflect workspace-specific Claude auth state and reconnection status.
  * Added Vercel identity display when credentials are present.
  * Replaced the dashboard integration bar with a machine tools panel.

* **Tests**
  * Expanded coverage for Claude/Vercel connection flows, token capture/redaction, and stale-env behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
