### PR TITLE
Visual editor: support Vite (React) projects

### DIFF
--- a/src-tauri/src/commands/edit.rs
+++ b/src-tauri/src/commands/edit.rs
@@ -1953,6 +1953,33 @@ fn tailwind_active_at(root: &Path) -> bool {
     false
 }
 
+/// Whether the project depends on React. The visual editor resolves a clicked
+/// element back to a `className` literal in `.tsx`/`.jsx` source, so a Vite
+/// project only earns the editor when it's React-flavored: Vue (`.vue`) and
+/// Svelte (`.svelte`) keep their class strings in files the resolver never
+/// indexes, so enabling them would surface an edit button that can't write back.
+/// Meta-frameworks (Next.js) are gated by project type instead and don't need
+/// this. React Native is detected before Vite, so a `ProjectType::Vite` project
+/// matching here is genuinely a React web app.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub fn project_uses_react(project_path: String) -> Result<bool, CommandError> {
+    let root = validate_project_path(&project_path)?;
+    Ok(project_uses_react_at(&root))
+}
+
+/// Core of [`project_uses_react`], split out (no path validation) for unit testing.
+fn project_uses_react_at(root: &Path) -> bool {
+    let Ok(contents) = std::fs::read_to_string(root.join("package.json")) else {
+        return false;
+    };
+    // Match the `"react":` dependency key specifically. This excludes substrings
+    // like `"react-dom":`, `"@types/react":`, and `"@vitejs/plugin-react":` (none
+    // contain the exact quote-`react`-quote-colon sequence), so a Vue/Svelte Vite
+    // project that merely has a react-adjacent devDep won't be mistaken for React.
+    contents.contains("\"react\":")
+}
+
 #[tauri::command]
 #[tracing::instrument(fields(project = %project_path))]
 pub fn detect_breakpoints(project_path: String) -> Result<Vec<Breakpoint>, CommandError> {
@@ -3302,6 +3329,39 @@ const items = [];
         std::fs::create_dir_all(&c).unwrap();
         std::fs::write(c.join("tailwind.config.js"), "module.exports = {{}}").unwrap();
         assert!(chk(&c), "tailwind.config.js present → active");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn project_uses_react_matches_only_the_react_dependency() {
+        let dir = std::env::temp_dir().join(format!("ss-react-{}", std::process::id()));
+        let chk = project_uses_react_at;
+
+        // No package.json at all → not React.
+        let none = dir.join("none");
+        std::fs::create_dir_all(&none).unwrap();
+        assert!(!chk(&none), "no package.json → not react");
+
+        // A React Vite app declares the `react` dependency.
+        let react = dir.join("react");
+        std::fs::create_dir_all(&react).unwrap();
+        std::fs::write(
+            react.join("package.json"),
+            r#"{ "dependencies": { "react": "^18.2.0", "react-dom": "^18.2.0" } }"#,
+        )
+        .unwrap();
+        assert!(chk(&react), "react dependency present → react");
+
+        // A Vue Vite app has react-adjacent devDeps but no `react` dependency.
+        let vue = dir.join("vue");
+        std::fs::create_dir_all(&vue).unwrap();
+        std::fs::write(
+            vue.join("package.json"),
+            r#"{ "dependencies": { "vue": "^3.4.0" }, "devDependencies": { "@types/react": "^18.0.0" } }"#,
+        )
+        .unwrap();
+        assert!(!chk(&vue), "vue app with @types/react devDep → not react");
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -388,6 +388,7 @@ pub fn run() {
             commands::edit::apply_element_html,
             commands::edit::detect_breakpoints,
             commands::edit::is_tailwind_active,
+            commands::edit::project_uses_react,
             commands::edit_css::resolve_css_rule,
             commands::edit_css::set_css_declaration,
             commands::edit_css::create_css_class,

--- a/src/components/edit/VisualEditorPanel.tsx
+++ b/src/components/edit/VisualEditorPanel.tsx
@@ -143,8 +143,8 @@ function EditorIntro() {
         <li>
           <IntroCheck />
           <span>
-            Works with any <strong>Next.js</strong> or <strong>Astro</strong> project that uses
-            Tailwind
+            Works with any <strong>Next.js</strong>, <strong>Astro</strong>, or{' '}
+            <strong>Vite (React)</strong> project that uses Tailwind
           </span>
         </li>
         <li>

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -43,7 +43,12 @@ import { useVisualEditor } from '../../hooks/useVisualEditor';
 import { useCssEditor } from '../../hooks/useCssEditor';
 import { CssEditorPanel } from '../edit/CssEditorPanel';
 import { useBreakpoints } from '../../hooks/useBreakpoints';
-import { BASE_BREAKPOINT, isTailwindActive, type Breakpoint as TwBreakpoint } from '../../lib/edit';
+import {
+  BASE_BREAKPOINT,
+  isTailwindActive,
+  projectUsesReact,
+  type Breakpoint as TwBreakpoint,
+} from '../../lib/edit';
 import { VisualEditorPanel } from '../edit/VisualEditorPanel';
 import { ElementTreePanel } from '../edit/ElementTreePanel';
 import { useElementTree } from '../../hooks/useElementTree';
@@ -456,8 +461,29 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
   // `@import "tailwindcss"` without the Vite/PostCSS plugin produces dead classes.
   // Gate on a backend check so projects without Tailwind never show the edit button.
   const [tailwindActive, setTailwindActive] = useState(false);
+  // Vite is React-flavored? The className→source resolver only indexes
+  // `.tsx`/`.jsx`, so a Vite + Vue/Svelte project would get an edit button that
+  // can never write back. Gate Vite on React; meta-frameworks below are gated by
+  // type. False until the backend check resolves (so the button never flashes).
+  const [viteUsesReact, setViteUsesReact] = useState(false);
+  useEffect(() => {
+    if (projectType !== 'vite' || !projectPath) {
+      setViteUsesReact(false);
+      return;
+    }
+    let cancelled = false;
+    projectUsesReact(projectPath)
+      .then((isReact) => !cancelled && setViteUsesReact(isReact))
+      .catch(() => !cancelled && setViteUsesReact(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [projectType, projectPath]);
   const editorFramework =
-    projectType === 'nextjs' || projectType === 'astro' || projectType === 'shopifytheme';
+    projectType === 'nextjs' ||
+    projectType === 'astro' ||
+    projectType === 'shopifytheme' ||
+    (projectType === 'vite' && viteUsesReact);
   useEffect(() => {
     if (!projectPath || !editorFramework) {
       setTailwindActive(false);
@@ -472,10 +498,10 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     };
   }, [projectPath, editorFramework]);
 
-  // Visual editor supports className/class string resolution for React (Next.js),
-  // Astro, and Shopify Liquid templates — all resolve the same way in the Rust
-  // backend. The Tailwind gate keeps plain-CSS themes from showing an edit
-  // button whose class writes would never compile.
+  // Visual editor supports className/class string resolution for React (Next.js
+  // and Vite), Astro, and Shopify Liquid templates — all resolve the same way in
+  // the Rust backend. The Tailwind gate keeps plain-CSS themes from showing an
+  // edit button whose class writes would never compile.
   const editorEnabled = conn.serverReady && editorFramework && tailwindActive;
 
   // Locale config reported by the locale switcher (null when the project has
@@ -522,7 +548,7 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     resize.viewportWidth > 0 &&
     resize.viewportWidth < activeBreakpoint.minPx;
 
-  // Visual editor (Next.js + Astro). Inert until the user toggles edit mode.
+  // Visual editor (Next.js, Vite/React, Astro). Inert until the user toggles edit mode.
   const editor = useVisualEditor({
     iframeRef,
     projectPath,
@@ -796,8 +822,8 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
               <strong>Visual editing</strong>
               <span>
                 Click elements in the preview to edit their styles — no code. Works with Next.js,
-                Astro, and Shopify projects styled with Tailwind, and with Astro or plain HTML/CSS
-                projects styled with regular CSS.
+                Astro, Vite (React), and Shopify projects styled with Tailwind, and with Astro or
+                plain HTML/CSS projects styled with regular CSS.
               </span>
             </span>
           </span>

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -189,6 +189,14 @@ export function isTailwindActive(projectPath: string): Promise<boolean> {
   return invoke<boolean>('is_tailwind_active', { projectPath });
 }
 
+/** Whether the project depends on React. Used to gate the editor for Vite
+ *  projects: the className→source resolver only indexes `.tsx`/`.jsx`, so a
+ *  Vite + Vue/Svelte project would otherwise show an edit button that can't
+ *  write back. Meta-frameworks (Next.js) are gated by project type instead. */
+export function projectUsesReact(projectPath: string): Promise<boolean> {
+  return invoke<boolean>('project_uses_react', { projectPath });
+}
+
 /** The set of breakpoint prefixes used to recognize variant tokens. */
 export function breakpointPrefixes(breakpoints: Breakpoint[]): Set<string> {
   return new Set(breakpoints.map((b) => b.prefix).filter((p): p is string => p !== null));


### PR DESCRIPTION
## What

Enables the visual (Tailwind) editor on **Vite + React** projects. Previously the editor was gated to a Next.js / Astro / Shopify allowlist, even though the underlying mechanism is framework-agnostic.

## Why it's small

The editor maps a clicked DOM element back to source by **string-searching for the exact `className` literal** — no source maps, no Babel plugin, no framework runtime. The proxy injects the inspection script into any dev server's HTML, and the HMR reload-suppression already wraps Vite's WebSocket. So the backend was already Vite-capable; the only thing stopping it was a frontend allowlist (`Preview.tsx`).

## The React gate

The resolver only indexes `.tsx`/`.jsx` (and `.astro`/`.liquid`). A Vite + **Vue/Svelte** project would therefore surface an edit button that can never write back. To preserve the existing "no dead edit buttons" design intent, Vite is enabled only when the project depends on React:

- New backend command **`project_uses_react`** checks `package.json` for the `"react"` dependency (excludes `"react-dom"`, `"@types/react"`, `"@vitejs/plugin-react"`).
- React Native is detected before Vite, so a `ProjectType::Vite` match here is a genuine React web app.
- Vue/Svelte Vite projects keep showing the **disabled** edit button + explanatory tooltip.

Tailwind is still required (same `is_tailwind_active` gate as Next/Astro).

## Behavior matrix

| Project | Edit button |
|---|---|
| Vite + React + Tailwind | **Active** ✅ |
| Vite + React, no Tailwind | Disabled (tooltip: needs Tailwind) |
| Vite + Vue/Svelte | Disabled (React gate) |
| Next.js / Astro / Shopify + Tailwind | Active (unchanged) |

## Changes
- `edit.rs`: add `project_uses_react` command + core fn + unit test
- `lib.rs`: register the command
- `edit.ts`: `projectUsesReact` wrapper
- `Preview.tsx`: gate Vite on React; refresh editor copy/comments
- `VisualEditorPanel.tsx`: intro now lists Vite (React)

## Testing
- ✅ New Rust unit test (matches `"react":`, rejects Vue project with only `@types/react` devDep)
- ✅ `tsc --noEmit`, Prettier, `cargo fmt`, edit/preview Vitest suites
- ✅ Manually verified end-to-end on a fresh Vite + React + Tailwind project: edit mode activates, class edits live-update and save back to `src/App.tsx`

## Known Tier-1 limitations (follow-ups, not blockers)
- Plain Vite SPA gets no multi-page page-switcher (framework-specific) — editing still works on the rendered page.
- Vite + Vue/Svelte and Vite + CSS Modules are out of scope (the latter is fundamentally incompatible with string-search — hashed class names).
- No built-in Vite starter template yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended visual editor support to include Vite projects that use React.

* **Documentation**
  * Updated framework compatibility messaging to highlight Vite (React) as a supported option alongside Next.js, Astro, and Shopify Theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->