### PR TITLE
Add Cursor CLI as a fourth agent (+ Codex/Opencode brand icons)

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -47,6 +47,17 @@ pub struct AgentConfig {
     pub setup_item_ids: (&'static str, &'static str),
     /// Setup display names: (binary_name, auth_name)
     pub setup_display_names: (&'static str, &'static str),
+    /// Args that print sign-in status (e.g. ["status"]), for agents whose
+    /// credential lives outside the filesystem (system keychain) so the
+    /// `auth_indicators` file check is unreliable. `None` → use file indicators.
+    pub auth_status_args: Option<&'static [&'static str]>,
+    /// Substring in `auth_status_args` output that means "signed in"
+    /// (e.g. "Logged in as"). Only consulted when `auth_status_args` is set.
+    pub auth_status_ready_substr: Option<&'static str>,
+    /// Args that sign the agent out via the CLI (e.g. ["logout"]). Set for
+    /// agents whose token isn't a file we can delete. `None` → remove the
+    /// `auth_indicators` files instead.
+    pub logout_args: Option<&'static [&'static str]>,
 }
 
 /// Claude Code agent configuration.
@@ -73,6 +84,9 @@ pub const CLAUDE_CODE: AgentConfig = AgentConfig {
     uninstall_command_windows: Some("npm uninstall -g @anthropic-ai/claude-code"),
     setup_item_ids: ("claude", "claude_auth"),
     setup_display_names: ("Claude Code", "Claude Account"),
+    auth_status_args: None,
+    auth_status_ready_substr: None,
+    logout_args: None,
 };
 
 /// Codex agent configuration.
@@ -95,6 +109,9 @@ pub const CODEX: AgentConfig = AgentConfig {
     uninstall_command_windows: Some("npm uninstall -g @openai/codex"),
     setup_item_ids: ("codex", "codex_auth"),
     setup_display_names: ("Codex", "Codex Account"),
+    auth_status_args: None,
+    auth_status_ready_substr: None,
+    logout_args: None,
 };
 
 /// Opencode agent configuration.
@@ -121,10 +138,48 @@ pub const OPENCODE: AgentConfig = AgentConfig {
     uninstall_command_windows: Some("npm uninstall -g opencode-ai"),
     setup_item_ids: ("opencode", "opencode_auth"),
     setup_display_names: ("Opencode", "Opencode Account"),
+    auth_status_args: None,
+    auth_status_ready_substr: None,
+    logout_args: None,
+};
+
+/// Cursor CLI (`cursor-agent`) agent configuration.
+///
+/// Unlike the others, Cursor stores its credential in the system keychain (the
+/// only file it writes under `~/.cursor` is UI state), and it respects only
+/// `HOME` — there is no config-dir env var to redirect per workspace. So Cursor
+/// uses a single global login (auth detected via `cursor-agent status`, signed
+/// out via `cursor-agent logout`) rather than the per-workspace file isolation
+/// the other agents get.
+pub const CURSOR: AgentConfig = AgentConfig {
+    id: "cursor",
+    display_name: "Cursor",
+    binary_name: "cursor-agent",
+    process_name: "cursor-agent",
+    version_flag: "--version",
+    print_mode_flags: &["-p", "--print"],
+    auto_accept_flag: Some("--force"),
+    auth_trigger_args: &["login"],
+    auth_config_dir: ".cursor",
+    // Auth is keychain-based; detection goes through `auth_status_args` below.
+    auth_indicators: &[],
+    skills_agent_id: None,
+    skills_dir_name: None,
+    install_command_unix: Some("curl https://cursor.com/install -fsS | bash"),
+    install_message_windows: Some("irm 'https://cursor.com/install?win32=true' | iex"),
+    uninstall_command_unix: Some(
+        "rm -f \"$HOME/.local/bin/cursor-agent\" \"$HOME/.local/bin/agent\" 2>/dev/null; rm -rf \"$HOME/.local/share/cursor-agent\" 2>/dev/null; echo Uninstalled.",
+    ),
+    uninstall_command_windows: None,
+    setup_item_ids: ("cursor", "cursor_auth"),
+    setup_display_names: ("Cursor", "Cursor Account"),
+    auth_status_args: Some(&["status"]),
+    auth_status_ready_substr: Some("Logged in as"),
+    logout_args: Some(&["logout"]),
 };
 
 /// All available agent configurations.
-pub const ALL_AGENTS: &[&AgentConfig] = &[&CLAUDE_CODE, &CODEX, &OPENCODE];
+pub const ALL_AGENTS: &[&AgentConfig] = &[&CLAUDE_CODE, &CODEX, &OPENCODE, &CURSOR];
 
 /// In-memory cache for the default agent ID. `None` means unset (falls back to Claude Code).
 static DEFAULT_AGENT_ID: RwLock<Option<String>> = RwLock::new(None);
@@ -160,6 +215,7 @@ pub fn get_agent_by_id(id: &str) -> &'static AgentConfig {
     match id {
         "codex" => &CODEX,
         "opencode" => &OPENCODE,
+        "cursor" => &CURSOR,
         _ => &CLAUDE_CODE,
     }
 }
@@ -194,8 +250,8 @@ mod tests {
     }
 
     #[test]
-    fn all_agents_has_length_3() {
-        assert_eq!(ALL_AGENTS.len(), 3);
+    fn all_agents_has_length_4() {
+        assert_eq!(ALL_AGENTS.len(), 4);
     }
 
     #[test]
@@ -203,6 +259,38 @@ mod tests {
         let agent = get_agent_by_id("opencode");
         assert_eq!(agent.id, "opencode");
         assert_eq!(agent.display_name, "Opencode");
+    }
+
+    #[test]
+    fn get_agent_by_id_cursor() {
+        let agent = get_agent_by_id("cursor");
+        assert_eq!(agent.id, "cursor");
+        assert_eq!(agent.display_name, "Cursor");
+        assert_eq!(agent.binary_name, "cursor-agent");
+    }
+
+    #[test]
+    fn cursor_uses_command_based_auth() {
+        // Cursor's token is in the keychain, so it must declare a status command
+        // and a logout command rather than relying on file indicators.
+        assert!(CURSOR.auth_status_args.is_some());
+        assert!(CURSOR.auth_status_ready_substr.is_some());
+        assert!(CURSOR.logout_args.is_some());
+        assert!(CURSOR.auth_indicators.is_empty());
+    }
+
+    #[test]
+    fn file_based_agents_have_no_status_command() {
+        // The keychain path must stay opt-in: the file-indicator agents must not
+        // accidentally declare a status command (which would change detection).
+        for agent in [&CLAUDE_CODE, &CODEX, &OPENCODE] {
+            assert!(
+                agent.auth_status_args.is_none(),
+                "{} should use file-based auth",
+                agent.id
+            );
+            assert!(agent.logout_args.is_none());
+        }
     }
 
     #[test]

--- a/src-tauri/src/commands/setup/agents.rs
+++ b/src-tauri/src/commands/setup/agents.rs
@@ -34,6 +34,26 @@ pub struct AgentStatus {
     pub uninstall_supported: bool,
 }
 
+/// Determine an agent's sign-in state by asking its own CLI, for agents whose
+/// credential lives outside the filesystem (e.g. Cursor keeps its token in the
+/// system keychain, so no auth-indicator file is reliable). Runs the agent's
+/// `auth_status_args` and looks for `auth_status_ready_substr` in the output.
+///
+/// Returns `None` for agents that use file-based auth indicators — the caller
+/// then falls back to checking `auth_indicators` on disk.
+pub fn agent_command_auth_status(agent: &crate::agent::AgentConfig) -> Option<bool> {
+    let args = agent.auth_status_args?;
+    let needle = agent.auth_status_ready_substr?;
+    let binary = find_binary_by_name(agent.binary_name)?;
+    let output = create_command(&binary).args(args).output().ok()?;
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    Some(combined.contains(needle))
+}
+
 /// Return the status of every known agent in a single call.
 /// Avoids the N round-trips the dashboard would otherwise need.
 #[tauri::command]
@@ -79,6 +99,9 @@ pub async fn get_agents_status() -> Vec<AgentStatus> {
                 )
             } else if !installed {
                 (false, None, false)
+            } else if let Some(authed) = agent_command_auth_status(agent) {
+                // Keychain-based agents (Cursor): ask the CLI, not the filesystem.
+                (authed, None, false)
             } else {
                 let dir = agent_auth_dir(&active_account_id, agent);
                 let authed = agent
@@ -125,6 +148,19 @@ pub async fn sign_out_agent(agent_id: String) -> Result<(), CommandError> {
     // Reject unknown IDs: get_agent_by_id falls back to CLAUDE_CODE, so explicitly check.
     if agent.id != agent_id {
         return Err((format!("Unknown agent: {agent_id}")).into());
+    }
+
+    // Keychain-based agents (Cursor) can't be signed out by deleting files —
+    // their token lives in the system keychain. Use the CLI's own logout.
+    if let Some(args) = agent.logout_args {
+        if let Some(binary) = find_binary_by_name(agent.binary_name) {
+            let _ = create_command(&binary).args(args).output();
+        }
+        tracing::info!(
+            agent_id = agent_id.as_str(),
+            "Agent signed out via CLI logout"
+        );
+        return Ok(());
     }
 
     let active_account_id = get_active_account_id().unwrap_or_else(|_| "default".to_string());

--- a/src-tauri/src/commands/setup/auth.rs
+++ b/src-tauri/src/commands/setup/auth.rs
@@ -136,6 +136,11 @@ pub async fn check_claude_auth_status(agent_id: Option<String>) -> bool {
         return false;
     }
 
+    // Keychain-based agents (Cursor): ask the CLI rather than checking files.
+    if let Some(authed) = crate::commands::setup::agents::agent_command_auth_status(agent) {
+        return authed;
+    }
+
     let active_account_id = get_active_account_id().unwrap_or_else(|_| "default".to_string());
     let agent_dir = agent_auth_dir(&active_account_id, agent);
     agent.auth_indicators.iter().any(|indicator| {

--- a/src-tauri/src/commands/setup/mod.rs
+++ b/src-tauri/src/commands/setup/mod.rs
@@ -71,13 +71,15 @@ const ALL_ITEMS: &[&str] = &[
     "codex_auth",
     "opencode",
     "opencode_auth",
+    "cursor",
+    "cursor_auth",
     "vercel",
     "vercel_auth",
 ];
 
 /// Tool items (not auth)
 const TOOL_ITEMS: &[&str] = &[
-    "homebrew", "node", "git", "gh", "claude", "codex", "opencode", "vercel",
+    "homebrew", "node", "git", "gh", "claude", "codex", "opencode", "cursor", "vercel",
 ];
 
 // ============ App State Persistence (shared helpers) ============
@@ -196,7 +198,7 @@ fn get_scenario_items(scenario: &str) -> Vec<&'static str> {
         // Vercel installed and authed (for testing hosting step)
         "vercel-ready" => vec!["vercel", "vercel_auth"],
 
-        // Only Codex installed (no Claude, no Opencode)
+        // Only Codex installed (no Claude, no Opencode, no Cursor)
         "codex-only" => ALL_ITEMS
             .iter()
             .filter(|&&item| {
@@ -204,15 +206,22 @@ fn get_scenario_items(scenario: &str) -> Vec<&'static str> {
                     && item != "claude_auth"
                     && item != "opencode"
                     && item != "opencode_auth"
+                    && item != "cursor"
+                    && item != "cursor_auth"
             })
             .copied()
             .collect(),
 
-        // Only Opencode installed (no Claude, no Codex)
+        // Only Opencode installed (no Claude, no Codex, no Cursor)
         "opencode-only" => ALL_ITEMS
             .iter()
             .filter(|&&item| {
-                item != "claude" && item != "claude_auth" && item != "codex" && item != "codex_auth"
+                item != "claude"
+                    && item != "claude_auth"
+                    && item != "codex"
+                    && item != "codex_auth"
+                    && item != "cursor"
+                    && item != "cursor_auth"
             })
             .copied()
             .collect(),
@@ -361,22 +370,25 @@ mod tests {
     }
 
     #[test]
-    fn all_items_contains_13_items_including_all_agents_and_vercel() {
-        assert_eq!(ALL_ITEMS.len(), 13);
+    fn all_items_contains_15_items_including_all_agents_and_vercel() {
+        assert_eq!(ALL_ITEMS.len(), 15);
         assert!(ALL_ITEMS.contains(&"codex"));
         assert!(ALL_ITEMS.contains(&"codex_auth"));
         assert!(ALL_ITEMS.contains(&"opencode"));
         assert!(ALL_ITEMS.contains(&"opencode_auth"));
+        assert!(ALL_ITEMS.contains(&"cursor"));
+        assert!(ALL_ITEMS.contains(&"cursor_auth"));
         assert!(ALL_ITEMS.contains(&"vercel"));
         assert!(ALL_ITEMS.contains(&"vercel_auth"));
     }
 
     #[test]
-    fn tool_items_contains_8_items_including_all_agents_and_vercel() {
-        assert_eq!(TOOL_ITEMS.len(), 8);
+    fn tool_items_contains_9_items_including_all_agents_and_vercel() {
+        assert_eq!(TOOL_ITEMS.len(), 9);
         assert!(TOOL_ITEMS.contains(&"codex"));
         assert!(TOOL_ITEMS.contains(&"claude"));
         assert!(TOOL_ITEMS.contains(&"opencode"));
+        assert!(TOOL_ITEMS.contains(&"cursor"));
         assert!(TOOL_ITEMS.contains(&"vercel"));
     }
 

--- a/src-tauri/src/commands/setup/status.rs
+++ b/src-tauri/src/commands/setup/status.rs
@@ -37,6 +37,8 @@ pub async fn get_full_setup_status() -> FullSetupStatus {
             ("codex_auth", "Codex Account", Some("codex")),
             ("opencode", "Opencode", None),
             ("opencode_auth", "Opencode Account", Some("opencode")),
+            ("cursor", "Cursor", None),
+            ("cursor_auth", "Cursor Account", Some("cursor")),
             ("vercel", "Vercel CLI", None),
             ("vercel_auth", "Vercel Account", Some("vercel")),
         ];
@@ -359,14 +361,19 @@ pub async fn get_full_setup_status() -> FullSetupStatus {
         });
 
         // Agent Auth
-        let agent_auth = if binary_ready {
+        let agent_auth = if !binary_ready {
+            false
+        } else if let Some(authed) =
+            crate::commands::setup::agents::agent_command_auth_status(agent)
+        {
+            // Keychain-based agents (Cursor): ask the CLI, not the filesystem.
+            authed
+        } else {
             let agent_dir = agent_auth_dir(&active_account_id, agent);
             agent.auth_indicators.iter().any(|indicator| {
                 let path = agent_dir.join(indicator);
                 path.exists()
             })
-        } else {
-            false
         };
         items.push(SetupItemInfo {
             id: agent.setup_item_ids.1.to_string(),
@@ -389,14 +396,20 @@ pub async fn get_full_setup_status() -> FullSetupStatus {
         // Workspace that hasn't signed into any agent yet would force the
         // user back into the onboarding wizard. Check the Default account's
         // (real, global) auth dir for this purpose.
-        let agent_auth_global = if binary_ready {
+        let agent_auth_global = if !binary_ready {
+            false
+        } else if let Some(authed) =
+            crate::commands::setup::agents::agent_command_auth_status(agent)
+        {
+            // Cursor's keychain login is already global (no per-account dir), so
+            // the CLI status check is the same answer for every account.
+            authed
+        } else {
             let agent_dir = agent_auth_dir(crate::commands::accounts::DEFAULT_ACCOUNT_ID, agent);
             agent
                 .auth_indicators
                 .iter()
                 .any(|indicator| agent_dir.join(indicator).exists())
-        } else {
-            false
         };
 
         if binary_ready && agent_auth_global {

--- a/src/components/dashboard/AgentsPanel.test.tsx
+++ b/src/components/dashboard/AgentsPanel.test.tsx
@@ -84,6 +84,9 @@ vi.mock('./WorkspaceConnectTerminal', () => ({
 vi.mock('../icons', () => ({
   CheckIcon: () => <span data-testid="check-icon" />,
   ClaudeIcon: () => <span data-testid="claude-icon" />,
+  CodexIcon: () => <span data-testid="codex-icon" />,
+  OpencodeIcon: () => <span data-testid="opencode-icon" />,
+  CursorIcon: () => <span data-testid="cursor-icon" />,
   GitHubIcon: () => <span data-testid="github-icon" />,
   VercelIcon: () => <span data-testid="vercel-icon" />,
 }));

--- a/src/components/dashboard/AgentsPanel.tsx
+++ b/src/components/dashboard/AgentsPanel.tsx
@@ -39,7 +39,7 @@ import { Spinner } from '../primitives/Spinner';
 import { useOptionalToast } from '../../contexts/ToastContext';
 import { useWorkspaceConnect } from '../../hooks/useWorkspaceConnect';
 import { logger } from '../../lib/logger';
-import { CheckIcon, ClaudeIcon, GitHubIcon, VercelIcon } from '../icons';
+import { CheckIcon, ClaudeIcon, CursorIcon, GitHubIcon, VercelIcon } from '../icons';
 
 function KebabGlyph() {
   return (
@@ -64,8 +64,13 @@ interface UninstallConfirm {
   displayName: string;
 }
 
-function getSetupItemId(binaryName: string, kind: 'install' | 'auth'): string | null {
-  const pair = AGENT_ITEM_PAIRS.find((p) => p.binaryId === binaryName);
+function getSetupItemId(agent: AgentStatus, kind: 'install' | 'auth'): string | null {
+  // A setup item id (e.g. "cursor") isn't always the binary name (e.g.
+  // "cursor-agent"), so match the pair by binary name OR agent id. The other
+  // three agents have binaryName === binaryId, so this is a superset.
+  const pair = AGENT_ITEM_PAIRS.find(
+    (p) => p.binaryId === agent.binaryName || p.binaryId === agent.id
+  );
   if (!pair) return null;
   return kind === 'install' ? pair.binaryId : pair.authId;
 }
@@ -94,6 +99,9 @@ function GenericAgentIcon({ size = 16 }: { size?: number }) {
 function iconFor(agentId: string) {
   if (agentId === 'claude-code') {
     return <ClaudeIcon size={18} />;
+  }
+  if (agentId === 'cursor') {
+    return <CursorIcon size={18} />;
   }
   return <GenericAgentIcon size={18} />;
 }
@@ -450,7 +458,7 @@ export function AgentsPanel() {
 
   const openTerminal = useCallback((agent: AgentStatus, kind: 'install' | 'auth') => {
     setOpenMenuId(null);
-    const itemId = getSetupItemId(agent.binaryName, kind);
+    const itemId = getSetupItemId(agent, kind);
     if (!itemId) {
       return;
     }

--- a/src/components/dashboard/AgentsPanel.tsx
+++ b/src/components/dashboard/AgentsPanel.tsx
@@ -39,7 +39,15 @@ import { Spinner } from '../primitives/Spinner';
 import { useOptionalToast } from '../../contexts/ToastContext';
 import { useWorkspaceConnect } from '../../hooks/useWorkspaceConnect';
 import { logger } from '../../lib/logger';
-import { CheckIcon, ClaudeIcon, CursorIcon, GitHubIcon, VercelIcon } from '../icons';
+import {
+  CheckIcon,
+  ClaudeIcon,
+  CodexIcon,
+  CursorIcon,
+  GitHubIcon,
+  OpencodeIcon,
+  VercelIcon,
+} from '../icons';
 
 function KebabGlyph() {
   return (
@@ -99,6 +107,12 @@ function GenericAgentIcon({ size = 16 }: { size?: number }) {
 function iconFor(agentId: string) {
   if (agentId === 'claude-code') {
     return <ClaudeIcon size={18} />;
+  }
+  if (agentId === 'codex') {
+    return <CodexIcon size={18} />;
+  }
+  if (agentId === 'opencode') {
+    return <OpencodeIcon size={18} />;
   }
   if (agentId === 'cursor') {
     return <CursorIcon size={18} />;

--- a/src/components/icons/brand.tsx
+++ b/src/components/icons/brand.tsx
@@ -49,6 +49,36 @@ export function CursorIcon({ size = 14 }: IconProps) {
   );
 }
 
+export function CodexIcon({ size = 16 }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      fillRule="evenodd"
+      aria-hidden="true"
+    >
+      <path
+        clipRule="evenodd"
+        d="M8.086.457a6.105 6.105 0 013.046-.415c1.333.153 2.521.72 3.564 1.7a.117.117 0 00.107.029c1.408-.346 2.762-.224 4.061.366l.063.03.154.076c1.357.703 2.33 1.77 2.918 3.198.278.679.418 1.388.421 2.126a5.655 5.655 0 01-.18 1.631.167.167 0 00.04.155 5.982 5.982 0 011.578 2.891c.385 1.901-.01 3.615-1.183 5.14l-.182.22a6.063 6.063 0 01-2.934 1.851.162.162 0 00-.108.102c-.255.736-.511 1.364-.987 1.992-1.199 1.582-2.962 2.462-4.948 2.451-1.583-.008-2.986-.587-4.21-1.736a.145.145 0 00-.14-.032c-.518.167-1.04.191-1.604.185a5.924 5.924 0 01-2.595-.622 6.058 6.058 0 01-2.146-1.781c-.203-.269-.404-.522-.551-.821a7.74 7.74 0 01-.495-1.283 6.11 6.11 0 01-.017-3.064.166.166 0 00.008-.074.115.115 0 00-.037-.064 5.958 5.958 0 01-1.38-2.202 5.196 5.196 0 01-.333-1.589 6.915 6.915 0 01.188-2.132c.45-1.484 1.309-2.648 2.577-3.493.282-.188.55-.334.802-.438.286-.12.573-.22.861-.304a.129.129 0 00.087-.087A6.016 6.016 0 015.635 2.31C6.315 1.464 7.132.846 8.086.457zm-.804 7.85a.848.848 0 00-1.473.842l1.694 2.965-1.688 2.848a.849.849 0 001.46.864l1.94-3.272a.849.849 0 00.007-.854l-1.94-3.393zm5.446 6.24a.849.849 0 000 1.695h4.848a.849.849 0 000-1.696h-4.848z"
+      />
+    </svg>
+  );
+}
+
+export function OpencodeIcon({ size = 16 }: IconProps) {
+  // Brand mark is a 240×300 two-tone nested square. Rendered in `currentColor`
+  // (frame solid, inner block at reduced opacity) so it adapts to light/dark,
+  // and centered in a square viewBox so the portrait art isn't stretched.
+  return (
+    <svg width={size} height={size} viewBox="-30 0 300 300" fill="currentColor" aria-hidden="true">
+      <path fillRule="evenodd" d="M180 60H60V240H180V60ZM240 300H0V0H240V300Z" />
+      <path fillOpacity="0.5" d="M180 240H60V120H180V240Z" />
+    </svg>
+  );
+}
+
 export function SlackIcon({ size = 18 }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">

--- a/src/components/setup/steps/AgentStep.tsx
+++ b/src/components/setup/steps/AgentStep.tsx
@@ -22,6 +22,7 @@ const AGENT_DESCRIPTIONS: Record<string, string> = {
   claude: "Anthropic's coding agent",
   codex: "OpenAI's coding agent",
   opencode: 'Open-source coding agent',
+  cursor: "Cursor's coding agent",
 };
 
 interface AgentStepProps {

--- a/src/lib/agent.test.ts
+++ b/src/lib/agent.test.ts
@@ -99,25 +99,26 @@ describe('getActiveAgent', () => {
 // ============ ALL_AGENTS / ALL_TAB_OPTIONS ============
 
 describe('ALL_AGENTS', () => {
-  it('has exactly 3 entries', () => {
-    expect(ALL_AGENTS).toHaveLength(3);
+  it('has exactly 4 entries', () => {
+    expect(ALL_AGENTS).toHaveLength(4);
   });
 
-  it('contains CLAUDE_CODE, CODEX, and OPENCODE', () => {
-    expect(ALL_AGENTS.map((a) => a.id)).toEqual(['claude-code', 'codex', 'opencode']);
+  it('contains CLAUDE_CODE, CODEX, OPENCODE, and CURSOR', () => {
+    expect(ALL_AGENTS.map((a) => a.id)).toEqual(['claude-code', 'codex', 'opencode', 'cursor']);
   });
 });
 
 describe('ALL_TAB_OPTIONS', () => {
-  it('has exactly 4 entries (agents + terminal)', () => {
-    expect(ALL_TAB_OPTIONS).toHaveLength(4);
+  it('has exactly 5 entries (agents + terminal)', () => {
+    expect(ALL_TAB_OPTIONS).toHaveLength(5);
   });
 
-  it('contains CLAUDE_CODE, CODEX, OPENCODE, and TERMINAL', () => {
+  it('contains CLAUDE_CODE, CODEX, OPENCODE, CURSOR, and TERMINAL', () => {
     expect(ALL_TAB_OPTIONS.map((a) => a.id)).toEqual([
       'claude-code',
       'codex',
       'opencode',
+      'cursor',
       'terminal',
     ]);
   });

--- a/src/lib/agent.ts
+++ b/src/lib/agent.ts
@@ -81,6 +81,21 @@ export const OPENCODE: AgentConfig = {
   installHint: 'Make sure Opencode is installed: curl -fsSL https://opencode.ai/install | bash',
 };
 
+/** Cursor CLI (`cursor-agent`) agent configuration. */
+export const CURSOR: AgentConfig = {
+  id: 'cursor',
+  displayName: 'Cursor',
+  binaryName: 'cursor-agent',
+  processName: 'cursor-agent',
+  autoAcceptFlag: '--force',
+  supportsSkills: false,
+  supportsMcp: false,
+  supportsStatusDetection: false,
+  loadingMessage: 'Starting Cursor...',
+  notFoundMessage: 'Error starting Cursor',
+  installHint: 'Make sure Cursor CLI is installed: curl https://cursor.com/install -fsS | bash',
+};
+
 /** Raw terminal (shell) configuration — not an AI agent. */
 export const TERMINAL: AgentConfig = {
   id: 'terminal',
@@ -97,10 +112,10 @@ export const TERMINAL: AgentConfig = {
 };
 
 /** All available agents (AI coding assistants). */
-export const ALL_AGENTS: AgentConfig[] = [CLAUDE_CODE, CODEX, OPENCODE];
+export const ALL_AGENTS: AgentConfig[] = [CLAUDE_CODE, CODEX, OPENCODE, CURSOR];
 
 /** All options available in the tab dropdown (agents + terminal). */
-export const ALL_TAB_OPTIONS: AgentConfig[] = [CLAUDE_CODE, CODEX, OPENCODE, TERMINAL];
+export const ALL_TAB_OPTIONS: AgentConfig[] = [CLAUDE_CODE, CODEX, OPENCODE, CURSOR, TERMINAL];
 
 /** In-memory cache for the default agent ID. Null means unset (falls back to Claude Code). */
 let defaultAgentId: string | null = null;

--- a/src/lib/setup.test.ts
+++ b/src/lib/setup.test.ts
@@ -234,14 +234,16 @@ describe('isAtLeastOneAgentReady', () => {
 // ============ AGENT_ITEM_IDS ============
 
 describe('AGENT_ITEM_IDS', () => {
-  it('contains all 6 agent item IDs', () => {
+  it('contains all 8 agent item IDs', () => {
     expect(AGENT_ITEM_IDS.has('claude')).toBe(true);
     expect(AGENT_ITEM_IDS.has('claude_auth')).toBe(true);
     expect(AGENT_ITEM_IDS.has('codex')).toBe(true);
     expect(AGENT_ITEM_IDS.has('codex_auth')).toBe(true);
     expect(AGENT_ITEM_IDS.has('opencode')).toBe(true);
     expect(AGENT_ITEM_IDS.has('opencode_auth')).toBe(true);
-    expect(AGENT_ITEM_IDS.size).toBe(6);
+    expect(AGENT_ITEM_IDS.has('cursor')).toBe(true);
+    expect(AGENT_ITEM_IDS.has('cursor_auth')).toBe(true);
+    expect(AGENT_ITEM_IDS.size).toBe(8);
   });
 
   it('does not contain non-agent items', () => {

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -9,6 +9,7 @@
  * - Claude Code + auth
  * - Codex + auth
  * - Opencode + auth
+ * - Cursor + auth
  *
  * @module lib/setup
  */
@@ -98,6 +99,8 @@ export const OPTIONAL_ITEMS = new Set([
   'codex_auth',
   'opencode',
   'opencode_auth',
+  'cursor',
+  'cursor_auth',
   'vercel',
   'vercel_auth',
 ]);
@@ -123,6 +126,7 @@ export const WORKSPACE_LOGIN_ITEM_IDS = new Set([
   'claude_auth',
   'codex_auth',
   'opencode_auth',
+  'cursor_auth',
   'vercel_auth',
 ]);
 
@@ -136,6 +140,7 @@ export const MACHINE_ITEM_IDS = new Set([
   'claude',
   'codex',
   'opencode',
+  'cursor',
   'vercel',
 ]);
 
@@ -167,6 +172,8 @@ export function getSetupDependencies(): Record<string, string[]> {
     codex_auth: ['codex'],
     opencode: [], // Uses its own installer
     opencode_auth: ['opencode'],
+    cursor: [], // Uses its own installer
+    cursor_auth: ['cursor'],
     vercel: [], // Uses npm global install
     vercel_auth: ['vercel'],
   };
@@ -189,6 +196,8 @@ export const SETUP_ITEM_ORDER = [
   'codex_auth',
   'opencode',
   'opencode_auth',
+  'cursor',
+  'cursor_auth',
   'vercel',
   'vercel_auth',
 ];
@@ -207,6 +216,8 @@ export const SETUP_FRIENDLY_NAMES: Record<string, string> = {
   codex_auth: 'Codex Account',
   opencode: 'Opencode',
   opencode_auth: 'Opencode Account',
+  cursor: 'Cursor',
+  cursor_auth: 'Cursor Account',
   vercel: 'Vercel CLI',
   vercel_auth: 'Vercel Account',
 };
@@ -225,6 +236,8 @@ export const SETUP_PROGRESS_MESSAGES: Record<string, string> = {
   codex_auth: 'Connecting to Codex...',
   opencode: 'Installing Opencode...',
   opencode_auth: 'Connecting to Opencode...',
+  cursor: 'Installing Cursor...',
+  cursor_auth: 'Connecting to Cursor...',
   vercel: 'Installing Vercel CLI...',
   vercel_auth: 'Connecting to Vercel...',
 };
@@ -243,6 +256,8 @@ export const SETUP_TIME_ESTIMATES: Record<string, string> = {
   codex_auth: '~15 sec',
   opencode: '~15 sec',
   opencode_auth: '~15 sec',
+  cursor: '~10 sec',
+  cursor_auth: '~15 sec',
   vercel: '~10 sec',
   vercel_auth: '~15 sec',
 };
@@ -254,6 +269,7 @@ export const AGENT_ITEM_PAIRS = [
   { binaryId: 'claude', authId: 'claude_auth' },
   { binaryId: 'codex', authId: 'codex_auth' },
   { binaryId: 'opencode', authId: 'opencode_auth' },
+  { binaryId: 'cursor', authId: 'cursor_auth' },
 ] as const;
 
 /** Agent item IDs (all binary + auth IDs) */
@@ -270,6 +286,7 @@ export const AGENT_DOC_LINKS: { binaryId: string; name: string; url: string }[] 
   { binaryId: 'claude', name: 'Claude Code', url: 'https://code.claude.com/docs/en/setup' },
   { binaryId: 'codex', name: 'Codex', url: 'https://github.com/openai/codex' },
   { binaryId: 'opencode', name: 'opencode', url: 'https://opencode.ai/docs/' },
+  { binaryId: 'cursor', name: 'Cursor CLI', url: 'https://cursor.com/docs/cli/overview' },
 ];
 
 /**
@@ -367,7 +384,16 @@ export const WIZARD_STEPS: WizardStepDef[] = [
     id: 'agent',
     title: 'AI Agent',
     subtitle: 'Install at least one AI coding assistant',
-    itemIds: ['claude', 'claude_auth', 'codex', 'codex_auth', 'opencode', 'opencode_auth'],
+    itemIds: [
+      'claude',
+      'claude_auth',
+      'codex',
+      'codex_auth',
+      'opencode',
+      'opencode_auth',
+      'cursor',
+      'cursor_auth',
+    ],
     skippable: false,
   },
   {
@@ -609,6 +635,16 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
         command: 'opencode',
         args: ['auth', 'login'],
       },
+      cursor: {
+        // Official Windows installer (downloads + runs the install script
+        // in-session; not subject to the .ps1 execution policy).
+        command: 'powershell',
+        args: ['-Command', "irm 'https://cursor.com/install?win32=true' | iex"],
+      },
+      cursor_auth: {
+        command: 'cursor-agent',
+        args: ['login'],
+      },
       vercel: {
         command: 'npm',
         args: ['install', '-g', 'vercel'],
@@ -680,6 +716,14 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
         command: 'opencode',
         args: ['auth', 'login'],
       },
+      cursor: {
+        command: '/bin/bash',
+        args: ['-c', 'curl https://cursor.com/install -fsS | bash'],
+      },
+      cursor_auth: {
+        command: 'cursor-agent',
+        args: ['login'],
+      },
       vercel: {
         command: '/bin/bash',
         args: ['-c', 'npm install -g vercel'],
@@ -706,6 +750,8 @@ export const USES_TERMINAL = new Set([
   'codex_auth',
   'opencode',
   'opencode_auth',
+  'cursor',
+  'cursor_auth',
   'vercel',
   'vercel_auth',
 ]);


### PR DESCRIPTION
## What

Adds **Cursor CLI** (`cursor-agent`) as a first-class fourth coding agent — across the terminal tab dropdown, the dashboard Agents panel, and onboarding step 3 — and gives **Codex** and **Opencode** their real brand icons (they were using the generic glyph).

## Cursor integration

Install via the official script (`curl …/install` on macOS/Linux, the PowerShell one-liner on Windows), authenticate via `cursor-agent login` in an interactive terminal, and spawn `cursor-agent` (auto-accept `--force`) in the workspace terminal. Reuses the existing cube `CursorIcon`.

### The interesting part: keychain-based auth, done generically

Unlike Claude/Codex/Opencode, Cursor stores its credential in the **system keychain** (the only file under `~/.cursor` is UI state) and respects only `HOME` — there's no config-dir env var to redirect per workspace. So file-based auth indicators don't work for it.

Rather than scatter `if id == "cursor"` across every detector, `AgentConfig` gains **three optional fields** — `auth_status_args`, `auth_status_ready_substr`, `logout_args` — all `None` for the existing agents (**zero behavior change**), `Some` for Cursor. A shared `agent_command_auth_status` helper runs `cursor-agent status` and parses `Logged in as`; all four detection sites (Agents panel, setup status ×2, auth check) fall back to it before file indicators. Sign-out routes through `cursor-agent logout`.

**Scope note (intentional v1 limitations):**
- **Global auth** — Cursor can't isolate logins per workspace (no config-dir env), so all workspaces share one `~/.cursor` login. Documented in the code.
- **MCP** is out of scope — users add Cursor MCPs the normal way.

## Codex / Opencode icons

Added `CodexIcon` and `OpencodeIcon` to `brand.tsx` and wired them into the panel's `iconFor`. Opencode's two-tone 240×300 mark is rendered in `currentColor` (frame solid, inner block at reduced opacity), centered in a square viewBox so it adapts to light/dark and isn't stretched.

## Files

- **Backend**: `agent.rs` (CURSOR config + 3 fields + helper), `setup/{agents,auth,status,mod}.rs` (command-based auth detection + enumerations + mock scenarios).
- **Frontend**: `agent.ts` (CURSOR config), `setup.ts` (all setup enumerations + terminal commands), `AgentStep.tsx` (description), `AgentsPanel.tsx` (icons + a `getSetupItemId` fix so the `cursor`/`cursor-agent` id-vs-binary-name mismatch resolves), `brand.tsx` (Codex/Opencode icons).

## Testing

- ✅ New Rust unit tests (Cursor uses command-based auth; file-based agents don't declare a status command); updated `ALL_AGENTS`/`ALL_ITEMS`/`TOOL_ITEMS` counts.
- ✅ Updated frontend tests (`ALL_AGENTS`/`ALL_TAB_OPTIONS`/`AGENT_ITEM_IDS` counts, icon mock). Full suite: **748 passed**.
- ✅ `tsc`, Prettier, `cargo fmt`, clippy (warnings-only, same as main).
- ✅ Verified end-to-end in `tauri dev`: Cursor appears installed + connected (auth detected via `cursor-agent status`); **sign-out** (`cursor-agent logout`) and **sign-in** (`cursor-agent login` terminal) both work; Codex/Opencode show their brand marks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cursor agent is now available as an AI coding assistant option
  * Cursor integrated into agent selection interface and setup onboarding flow
  * Cursor authentication status managed via command-line interface
  * Added Cursor brand icons and descriptive labels throughout the UI

* **Tests**
  * Updated test coverage for Cursor agent functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->