### PR TITLE
Element-tree search (Meno filter engine) + arrow-key navigation

### DIFF
--- a/src/components/edit/ElementTreePanel.test.tsx
+++ b/src/components/edit/ElementTreePanel.test.tsx
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ElementTreePanel } from './ElementTreePanel';
+import type { ElementTreeNode } from '../../hooks/useElementTree';
+
+// body
+//   header (2)
+//   div.route-fade (3)
+//     h2 (5)
+//     span (6)
+//   footer (4)
+const TREE: ElementTreeNode = {
+  id: 1,
+  tag: 'body',
+  cls: '',
+  text: '',
+  children: [
+    { id: 2, tag: 'header', cls: '', text: '', children: [] },
+    {
+      id: 3,
+      tag: 'div',
+      cls: 'route-fade',
+      text: '',
+      children: [
+        { id: 5, tag: 'h2', cls: '', text: '', children: [] },
+        { id: 6, tag: 'span', cls: '', text: '', children: [] },
+      ],
+    },
+    { id: 4, tag: 'footer', cls: '', text: '', children: [] },
+  ],
+};
+
+function setup(selectedId: number | null) {
+  const onSelect = vi.fn<(id: number) => void>();
+  render(
+    <ElementTreePanel
+      tree={TREE}
+      truncated={false}
+      selectedId={selectedId}
+      onSelect={onSelect}
+      onHover={() => {}}
+      projectPath="/tmp/project"
+      selectedSignature={null}
+    />
+  );
+  return { onSelect };
+}
+
+describe('ElementTreePanel keyboard navigation', () => {
+  it('ArrowDown selects the next sibling', () => {
+    const { onSelect } = setup(3);
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+    expect(onSelect).toHaveBeenCalledWith(4);
+  });
+
+  it('ArrowUp selects the previous sibling', () => {
+    const { onSelect } = setup(3);
+    fireEvent.keyDown(document.body, { key: 'ArrowUp' });
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+
+  it('ArrowLeft selects the parent', () => {
+    const { onSelect } = setup(3);
+    fireEvent.keyDown(document.body, { key: 'ArrowLeft' });
+    expect(onSelect).toHaveBeenCalledWith(1);
+  });
+
+  it('ArrowRight dives into the first child', () => {
+    const { onSelect } = setup(3);
+    fireEvent.keyDown(document.body, { key: 'ArrowRight' });
+    expect(onSelect).toHaveBeenCalledWith(5);
+  });
+
+  it('does not wrap past the first sibling', () => {
+    const { onSelect } = setup(2); // header is the first child of body
+    fireEvent.keyDown(document.body, { key: 'ArrowUp' });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('does not wrap past the last sibling', () => {
+    const { onSelect } = setup(4); // footer is the last child of body
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for the root (no parent, no siblings)', () => {
+    const { onSelect } = setup(1);
+    fireEvent.keyDown(document.body, { key: 'ArrowUp' });
+    fireEvent.keyDown(document.body, { key: 'ArrowLeft' });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no element is selected', () => {
+    const { onSelect } = setup(null);
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('ignores arrows while a text field is focused (e.g. the edit panel)', () => {
+    const onSelect = vi.fn<(id: number) => void>();
+    render(
+      <>
+        <input data-testid="field" />
+        <ElementTreePanel
+          tree={TREE}
+          truncated={false}
+          selectedId={3}
+          onSelect={onSelect}
+          onHover={() => {}}
+          projectPath="/tmp/project"
+          selectedSignature={null}
+        />
+      </>
+    );
+    const field = screen.getByTestId('field');
+    field.focus();
+    expect(document.activeElement).toBe(field);
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe('ElementTreePanel search', () => {
+  function renderPanel() {
+    render(
+      <ElementTreePanel
+        tree={TREE}
+        truncated={false}
+        selectedId={null}
+        onSelect={() => {}}
+        onHover={() => {}}
+        projectPath="/tmp/project"
+        selectedSignature={null}
+      />
+    );
+    return screen.getByLabelText('Search elements');
+  }
+
+  const type = (input: HTMLElement, value: string) =>
+    fireEvent.change(input, { target: { value } });
+
+  it('renders a search box', () => {
+    renderPanel();
+    expect(screen.getByLabelText('Search elements')).toBeInTheDocument();
+  });
+
+  it('filters to matching nodes plus their ancestor path', () => {
+    const input = renderPanel();
+    type(input, 'footer');
+    expect(screen.getByText('footer')).toBeInTheDocument(); // the match
+    expect(screen.getByText('body')).toBeInTheDocument(); // its ancestor
+    expect(screen.queryByText('header')).not.toBeInTheDocument();
+    expect(screen.queryByText('div')).not.toBeInTheDocument();
+  });
+
+  it('matches on class and drops non-matching descendants', () => {
+    const input = renderPanel();
+    type(input, 'route'); // div.route-fade
+    expect(screen.getByText('div')).toBeInTheDocument();
+    expect(screen.getByText('body')).toBeInTheDocument();
+    expect(screen.queryByText('h2')).not.toBeInTheDocument();
+    expect(screen.queryByText('span')).not.toBeInTheDocument();
+    expect(screen.queryByText('header')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when nothing matches', () => {
+    const input = renderPanel();
+    type(input, 'zzz-no-match');
+    expect(screen.getByText('No matching elements')).toBeInTheDocument();
+    expect(screen.queryByText('header')).not.toBeInTheDocument();
+  });
+
+  it('restores the full tree when the query is cleared', () => {
+    const input = renderPanel();
+    type(input, 'footer');
+    expect(screen.queryByText('header')).not.toBeInTheDocument();
+    type(input, '');
+    expect(screen.getByText('header')).toBeInTheDocument();
+    expect(screen.getByText('footer')).toBeInTheDocument();
+  });
+
+  it('re-enters the filtered view when arrowing from a selection the query pruned out', () => {
+    const onSelect = vi.fn<(id: number) => void>();
+    render(
+      <ElementTreePanel
+        tree={TREE}
+        truncated={false}
+        selectedId={2} // header — NOT a match for the query below, so it gets pruned
+        onSelect={onSelect}
+        onHover={() => {}}
+        projectPath="/tmp/project"
+        selectedSignature={null}
+      />
+    );
+    fireEvent.change(screen.getByLabelText('Search elements'), { target: { value: 'footer' } });
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+    // Nav would otherwise be dead; instead it re-enters at the filtered tree root (body, id 1).
+    expect(onSelect).toHaveBeenCalledWith(1);
+  });
+
+  it('shows a truncation-aware empty state when a search finds nothing in a truncated tree', () => {
+    render(
+      <ElementTreePanel
+        tree={TREE}
+        truncated={true}
+        selectedId={null}
+        onSelect={() => {}}
+        onHover={() => {}}
+        projectPath="/tmp/project"
+        selectedSignature={null}
+      />
+    );
+    fireEvent.change(screen.getByLabelText('Search elements'), { target: { value: 'zzz-nope' } });
+    expect(
+      screen.getByText('No matches in the loaded part of this large page.')
+    ).toBeInTheDocument();
+  });
+
+  it('keeps a filtering-aware truncation note visible while searching a truncated tree', () => {
+    render(
+      <ElementTreePanel
+        tree={TREE}
+        truncated={true}
+        selectedId={null}
+        onSelect={() => {}}
+        onHover={() => {}}
+        projectPath="/tmp/project"
+        selectedSignature={null}
+      />
+    );
+    fireEvent.change(screen.getByLabelText('Search elements'), { target: { value: 'footer' } });
+    expect(screen.getByText(/searched only the first part/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/edit/ElementTreePanel.tsx
+++ b/src/components/edit/ElementTreePanel.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { ChevronRightIcon } from '../icons';
 import { ElementHtmlEditor } from './ElementHtmlEditor';
 import type { ElementTreeNode } from '../../hooks/useElementTree';
+import { filterElementTree, isTreeQueryActive } from '../../lib/elementTreeFilter';
 import type { ElementSignature } from '../../lib/edit';
 
 interface Props {
@@ -63,6 +64,7 @@ export function ElementTreePanel({
   onViewChange,
 }: Props) {
   const [collapsed, setCollapsed] = useState<Set<number>>(new Set());
+  const [query, setQuery] = useState('');
   const [view, setView] = useState<'visual' | 'code'>('visual');
   const selectView = (next: 'visual' | 'code') => {
     setView(next);
@@ -70,7 +72,33 @@ export function ElementTreePanel({
   };
   const bodyRef = useRef<HTMLDivElement>(null);
 
-  const ancestors = useMemo(() => (tree ? buildAncestors(tree) : null), [tree]);
+  // When a query is active, render a pruned copy of the tree (matches plus their
+  // ancestor paths) via the borrowed Meno filter; a blank query is identity, so
+  // selection, reveal, and keyboard nav are unchanged in the common case.
+  const filtering = isTreeQueryActive(query);
+  const displayTree = useMemo(() => filterElementTree(tree, query), [tree, query]);
+
+  const ancestors = useMemo(
+    () => (displayTree ? buildAncestors(displayTree) : null),
+    [displayTree]
+  );
+
+  // Flat lookups for keyboard navigation: each node by id, and each node's
+  // parent id (null for the root). Built from the displayed (possibly filtered)
+  // tree so arrow nav stays consistent with what's on screen.
+  const navIndex = useMemo(() => {
+    const nodeById = new Map<number, ElementTreeNode>();
+    const parentById = new Map<number, number | null>();
+    if (displayTree) {
+      const walk = (node: ElementTreeNode, parent: number | null) => {
+        nodeById.set(node.id, node);
+        parentById.set(node.id, parent);
+        for (const child of node.children) walk(child, node.id);
+      };
+      walk(displayTree, null);
+    }
+    return { nodeById, parentById };
+  }, [displayTree]);
 
   // Selecting on the canvas should reveal the row: expand its ancestor chain
   // (presence in `collapsed` is depth-inverted — see collapsedState). Done as
@@ -108,6 +136,76 @@ export function ElementTreePanel({
     return () => cancelAnimationFrame(raf);
   }, [selectedId]);
 
+  // Arrow-key navigation from the selected element: Up/Down move between
+  // siblings (no wrap), Left selects the parent, Right dives into the first
+  // child. `onSelect` runs the same path as a click, so the canvas + edit panel
+  // follow and the target row auto-reveals + scrolls into view. The listener is
+  // document-level (the tree rows aren't focusable), but it never steals arrows
+  // from a focused text field or arrow-driven control in the edit panel.
+  useEffect(() => {
+    const NAV_KEYS = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'];
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (selectedId == null || !NAV_KEYS.includes(e.key)) return;
+
+      const el = document.activeElement;
+      const tag = el?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      if (el instanceof HTMLElement && el.isContentEditable) return;
+      const role = el?.getAttribute('role');
+      if (
+        role &&
+        ['combobox', 'listbox', 'menu', 'menuitem', 'slider', 'spinbutton', 'textbox'].includes(
+          role
+        )
+      ) {
+        return;
+      }
+
+      // While filtering, the selected element may have been pruned out of the
+      // visible tree (selection comes from the canvas/iframe, independent of the
+      // query). Nav would otherwise be dead, so re-enter the filtered view at
+      // its root and let the user navigate the matches from there.
+      if (filtering && !navIndex.nodeById.has(selectedId)) {
+        if (displayTree) {
+          e.preventDefault();
+          onSelect(displayTree.id);
+        }
+        return;
+      }
+
+      const parentId = navIndex.parentById.get(selectedId) ?? null;
+
+      if (e.key === 'ArrowRight') {
+        const first = navIndex.nodeById.get(selectedId)?.children[0];
+        if (first) {
+          e.preventDefault();
+          onSelect(first.id);
+        }
+        return;
+      }
+      if (e.key === 'ArrowLeft') {
+        if (parentId != null) {
+          e.preventDefault();
+          onSelect(parentId);
+        }
+        return;
+      }
+
+      // Up/Down: previous/next sibling. Root has no siblings; ends don't wrap.
+      if (parentId == null) return;
+      const siblings = navIndex.nodeById.get(parentId)?.children ?? [];
+      const idx = siblings.findIndex((s) => s.id === selectedId);
+      if (idx === -1) return;
+      const target = siblings[e.key === 'ArrowUp' ? idx - 1 : idx + 1];
+      if (target) {
+        e.preventDefault();
+        onSelect(target.id);
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [selectedId, navIndex, onSelect, displayTree, filtering]);
+
   const toggle = (id: number) => {
     setCollapsed((prev) => {
       const next = new Set(prev);
@@ -120,8 +218,10 @@ export function ElementTreePanel({
   // Presence in `collapsed` flips the depth-based default: shallow nodes
   // default open (presence = collapsed), deep nodes default closed
   // (presence = expanded).
-  const collapsedState = (id: number, depth: number) =>
-    depth < AUTO_EXPAND_DEPTH ? collapsed.has(id) : !collapsed.has(id);
+  const collapsedState = (id: number, depth: number) => {
+    if (filtering) return false; // a filtered view stays fully expanded so every match shows
+    return depth < AUTO_EXPAND_DEPTH ? collapsed.has(id) : !collapsed.has(id);
+  };
 
   const renderNode = (node: ElementTreeNode, depth: number) => {
     const hasChildren = node.children.length > 0;
@@ -146,6 +246,7 @@ export function ElementTreePanel({
                 e.stopPropagation();
                 toggle(node.id);
               }}
+              title={isCollapsed ? 'Expand' : 'Collapse'}
               aria-label={isCollapsed ? 'Expand' : 'Collapse'}
             >
               <ChevronRightIcon size={10} />
@@ -168,6 +269,16 @@ export function ElementTreePanel({
     <div className="ss-tree-panel" data-testid="element-tree-panel">
       <div className="ss-tree-panel__header">
         <span className="ss-tree-panel__title">Elements</span>
+        {view === 'visual' && (
+          <input
+            type="search"
+            className="ss-tree-panel__search"
+            placeholder="Search…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            aria-label="Search elements"
+          />
+        )}
         <div className="ss-tree-panel__modes" role="group" aria-label="Elements view">
           <button
             type="button"
@@ -189,14 +300,20 @@ export function ElementTreePanel({
       </div>
       {view === 'visual' ? (
         <div className="ss-tree-panel__body" ref={bodyRef} onMouseLeave={() => onHover(null)}>
-          {tree ? (
-            renderNode(tree, 0)
-          ) : (
-            <div className="ss-tree-panel__empty">Loading elements…</div>
+          {!tree && <div className="ss-tree-panel__empty">Loading elements…</div>}
+          {tree && displayTree && renderNode(displayTree, 0)}
+          {tree && !displayTree && (
+            <div className="ss-tree-panel__empty">
+              {truncated
+                ? 'No matches in the loaded part of this large page.'
+                : 'No matching elements'}
+            </div>
           )}
-          {truncated && (
+          {truncated && displayTree && (
             <div className="ss-tree-panel__note">
-              Large page — showing the first part of the tree.
+              {filtering
+                ? 'Large page — searched only the first part; some matches may be hidden.'
+                : 'Large page — showing the first part of the tree.'}
             </div>
           )}
         </div>

--- a/src/components/edit/ElementTreePanel.tsx
+++ b/src/components/edit/ElementTreePanel.tsx
@@ -86,10 +86,11 @@ export function ElementTreePanel({
   const filtering = isTreeQueryActive(query);
   const displayTree = useMemo(() => filterElementTree(tree, query), [tree, query]);
 
-  const ancestors = useMemo(
-    () => (displayTree ? buildAncestors(displayTree) : null),
-    [displayTree]
-  );
+  // Built from the FULL tree (not displayTree) so a canvas selection the active
+  // query prunes out still has its ancestor chain available to reveal; otherwise
+  // ancestors.get(selectedId) is undefined for the filtered-out node and the
+  // reveal state goes stale once the query clears.
+  const ancestors = useMemo(() => (tree ? buildAncestors(tree) : null), [tree]);
 
   // Flat lookups for keyboard navigation: each node by id, and each node's
   // parent id (null for the root). Built from the displayed (possibly filtered)
@@ -215,6 +216,10 @@ export function ElementTreePanel({
   }, [selectedId, navIndex, onSelect, displayTree, filtering]);
 
   const toggle = (id: number) => {
+    // During search the tree is force-expanded (see collapsedState), so a chevron
+    // click would mutate `collapsed` invisibly and surface as stale state once the
+    // query clears. Ignore toggles while filtering.
+    if (filtering) return;
     setCollapsed((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);

--- a/src/components/edit/ElementTreePanel.tsx
+++ b/src/components/edit/ElementTreePanel.tsx
@@ -42,6 +42,7 @@ function buildAncestors(root: ElementTreeNode): Map<number, number[]> {
   return out;
 }
 
+/** One tree row's label: the element's tag, its first class, and any text snippet. */
 function RowLabel({ node }: { node: ElementTreeNode }) {
   const firstClass = node.cls.split(/\s+/)[0] ?? '';
   return (
@@ -53,6 +54,13 @@ function RowLabel({ node }: { node: ElementTreeNode }) {
   );
 }
 
+/**
+ * The visual editor's element-tree panel: a searchable, keyboard-navigable tree
+ * of the previewed page's elements with a Visual/Code view toggle. Typing in the
+ * search box filters to matching nodes plus their ancestor path; Arrow
+ * Up/Down/Left/Right move the selection across siblings, to the parent, and into
+ * the first child.
+ */
 export function ElementTreePanel({
   tree,
   truncated,

--- a/src/components/edit/ElementTreePanel.tsx
+++ b/src/components/edit/ElementTreePanel.tsx
@@ -7,11 +7,12 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { ChevronRightIcon } from '../icons';
+import { ChevronRightIcon, SearchIcon } from '../icons';
 import { ElementHtmlEditor } from './ElementHtmlEditor';
 import type { ElementTreeNode } from '../../hooks/useElementTree';
 import { filterElementTree, isTreeQueryActive } from '../../lib/elementTreeFilter';
 import type { ElementSignature } from '../../lib/edit';
+import { useCommands } from '../../commands/useCommands';
 
 interface Props {
   tree: ElementTreeNode | null;
@@ -79,6 +80,28 @@ export function ElementTreePanel({
     onViewChange?.(next);
   };
   const bodyRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  useCommands(
+    () => [
+      {
+        id: 'elementTree.focusSearch',
+        title: 'Search elements',
+        icon: <SearchIcon size={14} />,
+        category: 'action',
+        when: 'project',
+        keywords: ['find', 'filter', 'tree', 'element', 'search'],
+        run: () => {
+          if (view !== 'visual') {
+            setView('visual');
+            onViewChange?.('visual');
+          }
+          requestAnimationFrame(() => searchRef.current?.focus());
+        },
+      },
+    ],
+    [view, onViewChange]
+  );
 
   // When a query is active, render a pruned copy of the tree (matches plus their
   // ancestor paths) via the borrowed Meno filter; a blank query is identity, so
@@ -284,6 +307,7 @@ export function ElementTreePanel({
         <span className="ss-tree-panel__title">Elements</span>
         {view === 'visual' && (
           <input
+            ref={searchRef}
             type="search"
             className="ss-tree-panel__search"
             placeholder="Search…"

--- a/src/lib/elementTreeFilter.test.ts
+++ b/src/lib/elementTreeFilter.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { filterElementTree, isTreeQueryActive } from './elementTreeFilter';
+import type { ElementTreeNode } from '../hooks/useElementTree';
+
+const node = (
+  id: number,
+  tag: string,
+  cls: string,
+  text: string,
+  children: ElementTreeNode[] = []
+): ElementTreeNode => ({ id, tag, cls, text, children });
+
+// body > [ header > h1("Welcome"), main > [ p("hello world"), button.cta("Buy now") ] ]
+const tree = node(0, 'body', '', '', [
+  node(1, 'header', 'site-header', '', [node(2, 'h1', 'title', 'Welcome')]),
+  node(3, 'main', '', '', [
+    node(4, 'p', 'lede', 'hello world'),
+    node(5, 'button', 'cta', 'Buy now'),
+  ]),
+]);
+
+const ids = (n: ElementTreeNode | null): number[] => (n ? [n.id, ...n.children.flatMap(ids)] : []);
+
+describe('isTreeQueryActive', () => {
+  it('is false for blank/whitespace, true otherwise', () => {
+    expect(isTreeQueryActive('')).toBe(false);
+    expect(isTreeQueryActive('   ')).toBe(false);
+    expect(isTreeQueryActive('p')).toBe(true);
+  });
+});
+
+describe('filterElementTree', () => {
+  it('returns the same tree reference for a blank query', () => {
+    expect(filterElementTree(tree, '')).toBe(tree);
+    expect(filterElementTree(tree, '   ')).toBe(tree);
+  });
+
+  it('returns null for a null tree', () => {
+    expect(filterElementTree(null, 'p')).toBeNull();
+  });
+
+  it('keeps a matching leaf and its ancestor path, dropping unrelated branches', () => {
+    // "Buy" matches button#5 text -> keep 0 (body) > 3 (main) > 5 (button)
+    const out = filterElementTree(tree, 'Buy');
+    expect(ids(out)).toEqual([0, 3, 5]);
+  });
+
+  it('matches on tag', () => {
+    expect(ids(filterElementTree(tree, 'h1'))).toEqual([0, 1, 2]);
+  });
+
+  it('matches on class', () => {
+    expect(ids(filterElementTree(tree, 'cta'))).toEqual([0, 3, 5]);
+  });
+
+  it('matches on text, case-insensitively', () => {
+    expect(ids(filterElementTree(tree, 'WELCOME'))).toEqual([0, 1, 2]);
+    expect(ids(filterElementTree(tree, 'hello'))).toEqual([0, 3, 4]);
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(filterElementTree(tree, 'zzz-nope')).toBeNull();
+  });
+
+  it('keeps multiple matches across branches and preserves sibling order', () => {
+    // "e" hits header(#1 tag), Welcome(#2 text) and lede(#4 class), but NOT
+    // button#5 ("button"/"cta"/"Buy now" have no "e"), so #5 is dropped.
+    const out = filterElementTree(tree, 'e');
+    expect(ids(out)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('a matched internal node with no matching descendants becomes a leaf', () => {
+    // "main" matches node#3's tag; its children (p, button) do not contain "main".
+    const out = filterElementTree(tree, 'main');
+    expect(ids(out)).toEqual([0, 3]);
+    expect(out?.children.find((c) => c.id === 3)?.children).toEqual([]);
+  });
+
+  it('does not mutate the original tree', () => {
+    const snapshot = JSON.stringify(tree);
+    filterElementTree(tree, 'Buy');
+    expect(JSON.stringify(tree)).toBe(snapshot);
+  });
+
+  it('tolerates malformed nodes with missing/non-string fields (untrusted iframe boundary)', () => {
+    const malformed = {
+      id: 9,
+      tag: 'div',
+      cls: undefined,
+      text: undefined,
+      children: [],
+    } as unknown as ElementTreeNode;
+    const root = node(0, 'body', '', '', [malformed, node(1, 'p', 'hit', 'x')]);
+    expect(() => filterElementTree(root, 'hit')).not.toThrow();
+    // The valid match is still found; the malformed node is simply pruned.
+    expect(ids(filterElementTree(root, 'hit'))).toEqual([0, 1]);
+    // And a query that matches the malformed node's (valid) tag still works.
+    expect(ids(filterElementTree(root, 'div'))).toEqual([0, 9]);
+  });
+});

--- a/src/lib/elementTreeFilter.ts
+++ b/src/lib/elementTreeFilter.ts
@@ -35,6 +35,11 @@ function selfMatches(node: ElementTreeNode, loweredQuery: string): boolean {
   );
 }
 
+/**
+ * Recursively keep `node` only when it self-matches or has a surviving
+ * descendant, returning a shallow copy carrying just the kept children. Returns
+ * `null` when the whole subtree is pruned away.
+ */
 function prune(node: ElementTreeNode, loweredQuery: string): ElementTreeNode | null {
   const keptChildren: ElementTreeNode[] = [];
   for (const child of node.children) {

--- a/src/lib/elementTreeFilter.ts
+++ b/src/lib/elementTreeFilter.ts
@@ -1,0 +1,65 @@
+/**
+ * Element-tree search — prunes the visual editor's element tree to the nodes
+ * matching a query, keeping the ancestor path to every match.
+ *
+ * This is the first consumer of the borrowed Meno filter engine
+ * ({@link module:lib/menoFilter}). A node "matches" when its `tag`, `cls`, or
+ * `text` contains the query (the engine's `$contains`, OR-ed across the three
+ * fields here). Case-insensitivity for the search box is provided by lower-casing
+ * both sides in this adapter, so the engine's `$contains` stays faithfully
+ * case-sensitive. A node is kept if it matches or if any descendant matches, so
+ * the tree still renders hierarchically with the path to each hit.
+ *
+ * Pure and dependency-free (no React, no DOM).
+ *
+ * @module lib/elementTreeFilter
+ */
+
+import type { ElementTreeNode } from '../hooks/useElementTree';
+import { matchesFilter } from './menoFilter';
+
+/** True when a non-blank query should drive filtering. */
+export function isTreeQueryActive(query: string): boolean {
+  return query.trim().length > 0;
+}
+
+/**
+ * Does this node itself match the (already lower-cased) query on tag/cls/text?
+ * Fields are coerced with `String(field ?? '')` because the tree crosses an
+ * untrusted boundary (the preview iframe's DOM snapshot) — a malformed node with
+ * a missing/non-string field must not throw and tear down the whole panel.
+ */
+function selfMatches(node: ElementTreeNode, loweredQuery: string): boolean {
+  return [node.tag, node.cls, node.text].some((field) =>
+    matchesFilter({ v: String(field ?? '').toLowerCase() }, { v: { $contains: loweredQuery } })
+  );
+}
+
+function prune(node: ElementTreeNode, loweredQuery: string): ElementTreeNode | null {
+  const keptChildren: ElementTreeNode[] = [];
+  for (const child of node.children) {
+    const kept = prune(child, loweredQuery);
+    if (kept) keptChildren.push(kept);
+  }
+  if (selfMatches(node, loweredQuery) || keptChildren.length > 0) {
+    return { ...node, children: keptChildren };
+  }
+  return null;
+}
+
+/**
+ * Return a pruned copy of the tree containing only nodes that match `query`
+ * (on tag/cls/text, case-insensitive) plus the ancestors of every match.
+ *
+ * - A blank query returns the original tree reference unchanged (no filtering).
+ * - `null` is returned when the tree is null, or when nothing matches.
+ * - Sibling order and the kept nodes' child structure are preserved.
+ */
+export function filterElementTree(
+  root: ElementTreeNode | null,
+  query: string
+): ElementTreeNode | null {
+  if (!root) return null;
+  if (!isTreeQueryActive(query)) return root;
+  return prune(root, query.trim().toLowerCase());
+}

--- a/src/lib/menoFilter.test.ts
+++ b/src/lib/menoFilter.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { matchesFilter, applyFilter, type Filter } from './menoFilter';
+
+const rec = (o: Record<string, unknown>) => o;
+
+describe('matchesFilter — implicit $eq and bypass', () => {
+  it('treats a raw value as $eq', () => {
+    expect(matchesFilter({ category: 'tech' }, { category: 'tech' })).toBe(true);
+    expect(matchesFilter({ category: 'news' }, { category: 'tech' })).toBe(false);
+  });
+
+  it('ANDs multiple fields', () => {
+    const f: Filter = { category: 'tech', published: true };
+    expect(matchesFilter({ category: 'tech', published: true }, f)).toBe(true);
+    expect(matchesFilter({ category: 'tech', published: false }, f)).toBe(false);
+  });
+
+  it('bypasses a field for "*", "", null, and undefined', () => {
+    for (const bypass of ['*', '', null, undefined]) {
+      expect(matchesFilter({ category: 'anything' }, { category: bypass })).toBe(true);
+    }
+  });
+
+  it('an empty filter matches every record', () => {
+    expect(matchesFilter({ a: 1 }, {})).toBe(true);
+  });
+
+  it('a missing field is undefined and fails a concrete $eq', () => {
+    expect(matchesFilter({}, { category: 'tech' })).toBe(false);
+  });
+});
+
+describe('matchesFilter — operators', () => {
+  it('$eq / $neq', () => {
+    expect(matchesFilter({ n: 5 }, { n: { $eq: 5 } })).toBe(true);
+    expect(matchesFilter({ n: 5 }, { n: { $neq: 5 } })).toBe(false);
+    expect(matchesFilter({ n: 6 }, { n: { $neq: 5 } })).toBe(true);
+  });
+
+  it('$gt / $gte / $lt / $lte on numbers', () => {
+    expect(matchesFilter({ price: 100 }, { price: { $gt: 100 } })).toBe(false);
+    expect(matchesFilter({ price: 101 }, { price: { $gt: 100 } })).toBe(true);
+    expect(matchesFilter({ price: 100 }, { price: { $gte: 100 } })).toBe(true);
+    expect(matchesFilter({ price: 100 }, { price: { $lt: 100 } })).toBe(false);
+    expect(matchesFilter({ price: 99 }, { price: { $lt: 100 } })).toBe(true);
+    expect(matchesFilter({ price: 100 }, { price: { $lte: 100 } })).toBe(true);
+  });
+
+  it('$gt / $lt work on strings (lexicographic)', () => {
+    expect(matchesFilter({ s: 'b' }, { s: { $gt: 'a' } })).toBe(true);
+    expect(matchesFilter({ s: 'a' }, { s: { $lt: 'b' } })).toBe(true);
+  });
+
+  it('comparisons across mismatched kinds are false', () => {
+    expect(matchesFilter({ x: 'a' }, { x: { $gt: 1 } })).toBe(false);
+    expect(matchesFilter({ x: undefined }, { x: { $gte: 0 } })).toBe(false);
+  });
+
+  it('ANDs multiple operators within one field', () => {
+    const f: Filter = { price: { $gt: 100, $lt: 500 } };
+    expect(matchesFilter({ price: 250 }, f)).toBe(true);
+    expect(matchesFilter({ price: 50 }, f)).toBe(false);
+    expect(matchesFilter({ price: 600 }, f)).toBe(false);
+  });
+
+  it('$contains on strings and arrays', () => {
+    expect(matchesFilter({ title: 'featured post' }, { title: { $contains: 'feature' } })).toBe(
+      true
+    );
+    expect(matchesFilter({ tags: ['a', 'b'] }, { tags: { $contains: 'b' } })).toBe(true);
+    expect(matchesFilter({ tags: ['a', 'b'] }, { tags: { $contains: 'c' } })).toBe(false);
+    expect(matchesFilter({ n: 5 }, { n: { $contains: '5' } })).toBe(false);
+  });
+
+  it('$notContains is the negation of $contains', () => {
+    expect(matchesFilter({ title: 'hello' }, { title: { $notContains: 'x' } })).toBe(true);
+    expect(matchesFilter({ title: 'hello' }, { title: { $notContains: 'ell' } })).toBe(false);
+  });
+
+  it('$startsWith / $endsWith are case-insensitive and string-only', () => {
+    expect(matchesFilter({ s: 'HelloWorld' }, { s: { $startsWith: 'hello' } })).toBe(true);
+    expect(matchesFilter({ s: 'HelloWorld' }, { s: { $endsWith: 'WORLD' } })).toBe(true);
+    expect(matchesFilter({ s: 'HelloWorld' }, { s: { $startsWith: 'world' } })).toBe(false);
+    expect(matchesFilter({ s: 42 }, { s: { $startsWith: '4' } })).toBe(false);
+  });
+
+  it('$in / $nin', () => {
+    expect(matchesFilter({ c: 'tech' }, { c: { $in: ['tech', 'news'] } })).toBe(true);
+    expect(matchesFilter({ c: 'sports' }, { c: { $in: ['tech', 'news'] } })).toBe(false);
+    expect(matchesFilter({ c: 'sports' }, { c: { $nin: ['tech', 'news'] } })).toBe(true);
+    expect(matchesFilter({ c: 'tech' }, { c: { $nin: ['tech', 'news'] } })).toBe(false);
+  });
+
+  it('$empty true/false covers null, undefined, "", and empty array', () => {
+    for (const empty of [null, undefined, '', [] as unknown[]]) {
+      expect(matchesFilter({ v: empty }, { v: { $empty: true } })).toBe(true);
+      expect(matchesFilter({ v: empty }, { v: { $empty: false } })).toBe(false);
+    }
+    expect(matchesFilter({ v: 'x' }, { v: { $empty: false } })).toBe(true);
+    expect(matchesFilter({ v: 0 }, { v: { $empty: true } })).toBe(false);
+  });
+
+  it('a plain object with non-operator keys is treated as a literal $eq', () => {
+    // Not an operator object -> compared by strict equality (reference), so a
+    // fresh literal never matches; this documents the disambiguation rule.
+    expect(matchesFilter({ meta: { a: 1 } }, { meta: { a: 1 } })).toBe(false);
+  });
+});
+
+describe('applyFilter', () => {
+  const rows = [
+    rec({ id: 1, category: 'tech', price: 100 }),
+    rec({ id: 2, category: 'tech', price: 300 }),
+    rec({ id: 3, category: 'news', price: 50 }),
+  ];
+
+  it('returns only matching records, order preserved', () => {
+    const out = applyFilter(rows, { category: 'tech', price: { $gte: 200 } });
+    expect(out.map((r) => r.id)).toEqual([2]);
+  });
+
+  it('returns all records for an all-bypass filter', () => {
+    expect(applyFilter(rows, { category: '*' })).toHaveLength(3);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(applyFilter(rows, { category: 'sports' })).toEqual([]);
+  });
+});

--- a/src/lib/menoFilter.ts
+++ b/src/lib/menoFilter.ts
@@ -73,6 +73,7 @@ const OPERATOR_KEYS: ReadonlySet<string> = new Set([
   '$empty',
 ]);
 
+/** True for a non-null, non-array object (an object literal / record). */
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
@@ -93,6 +94,7 @@ function isBypass(constraint: unknown): boolean {
   return constraint === '*' || constraint === '' || constraint === null || constraint === undefined;
 }
 
+/** Whether a value counts as empty for the `$empty` operator: null, undefined, '', or []. */
 function isEmptyValue(actual: unknown): boolean {
   return (
     actual === null ||
@@ -116,17 +118,24 @@ function gt(a: unknown, b: unknown): boolean {
   return false;
 }
 
+/** Strict less-than, defined only when both sides share a comparable kind (number or string). */
 function lt(a: unknown, b: unknown): boolean {
   if (typeof a === 'number' && typeof b === 'number') return a < b;
   if (typeof a === 'string' && typeof b === 'string') return a < b;
   return false;
 }
 
+/** Lower-case both sides for case-insensitive string ops; null when either side isn't a string. */
 function caseFold(a: unknown, b: unknown): { actual: string; expected: string } | null {
   if (typeof a !== 'string' || typeof b !== 'string') return null;
   return { actual: a.toLowerCase(), expected: b.toLowerCase() };
 }
 
+/**
+ * Evaluate a single operator against an `actual`/`expected` pair. Only known
+ * operators reach here (admitted by {@link isOperatorObject}); the default arm is
+ * unreachable and returns false.
+ */
 function evalOperator(op: string, actual: unknown, expected: unknown): boolean {
   switch (op) {
     case '$eq':

--- a/src/lib/menoFilter.ts
+++ b/src/lib/menoFilter.ts
@@ -1,0 +1,197 @@
+/**
+ * Meno-style declarative filter engine — pure and dependency-free.
+ *
+ * Borrowed capability from the Meno web builder's documented `meno-filter-api`
+ * (https://meno.so/docs/meno-filter-api): a small, declarative, data-in →
+ * data-out filter spec. Reimplemented here as pure functions with no DOM, no
+ * Meno runtime, and no coupling to Ship Studio's editor/proxy/framework
+ * detection — so it can safely back any in-app list. Its first consumer is the
+ * visual editor's element-tree search (see {@link module:lib/elementTreeFilter}).
+ *
+ * Spec implemented:
+ *  - Operators: `$eq $neq $gt $gte $lt $lte $contains $notContains $startsWith
+ *    $endsWith $in $nin $empty`.
+ *  - A field constraint is either a raw value (implicit `$eq`) or an operator
+ *    object `{ $op: value, … }` whose operators are AND-ed together. Multiple
+ *    fields in a filter are AND-ed together.
+ *  - Bypass values — `'*'`, `''`, `null`, `undefined` — mean "no constraint on
+ *    this field" (match everything for that field).
+ *
+ * Faithful-but-bounded choices: comparisons (`$gt`…`$lte`) apply only when both
+ * sides are the same comparable kind (number or string); `$startsWith` /
+ * `$endsWith` are case-insensitive (per the docs) and string-only; `$eq` is
+ * strict equality. Field access is flat (no nested dot-paths).
+ *
+ * Deliberately NOT implemented (see `.redline-loop/REVIEW_QUEUE.md`): sort,
+ * pagination, URL-sync, the `data-meno-*` DOM layer, and nested dot-path fields —
+ * none have a consumer yet.
+ *
+ * @module lib/menoFilter
+ */
+
+/** The thirteen documented filter operators. */
+export interface FilterOperators {
+  $eq?: unknown;
+  $neq?: unknown;
+  $gt?: number | string;
+  $gte?: number | string;
+  $lt?: number | string;
+  $lte?: number | string;
+  $contains?: unknown;
+  $notContains?: unknown;
+  $startsWith?: string;
+  $endsWith?: string;
+  $in?: unknown[];
+  $nin?: unknown[];
+  $empty?: boolean;
+}
+
+/**
+ * A per-field constraint: either an operator object ({@link FilterOperators}) or
+ * a raw value treated as an implicit `$eq`. Raw values can be anything, so this
+ * is `unknown`; {@link matchesFilter} disambiguates at runtime via the
+ * operator-object check.
+ */
+export type FieldConstraint = unknown;
+
+/** A filter maps field names to constraints; fields are AND-ed together. */
+export type Filter = Record<string, FieldConstraint>;
+
+const OPERATOR_KEYS: ReadonlySet<string> = new Set([
+  '$eq',
+  '$neq',
+  '$gt',
+  '$gte',
+  '$lt',
+  '$lte',
+  '$contains',
+  '$notContains',
+  '$startsWith',
+  '$endsWith',
+  '$in',
+  '$nin',
+  '$empty',
+]);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * A field constraint is an operator object only when it is a non-empty plain
+ * object whose every key is a known operator. Anything else (including a plain
+ * object with non-operator keys) is treated as a literal `$eq` value.
+ */
+function isOperatorObject(v: unknown): v is FilterOperators {
+  if (!isPlainObject(v)) return false;
+  const keys = Object.keys(v);
+  return keys.length > 0 && keys.every((k) => OPERATOR_KEYS.has(k));
+}
+
+/** `'*'`, `''`, `null`, `undefined` bypass the field (match everything). */
+function isBypass(constraint: unknown): boolean {
+  return constraint === '*' || constraint === '' || constraint === null || constraint === undefined;
+}
+
+function isEmptyValue(actual: unknown): boolean {
+  return (
+    actual === null ||
+    actual === undefined ||
+    actual === '' ||
+    (Array.isArray(actual) && actual.length === 0)
+  );
+}
+
+/** Substring test for strings; membership test for arrays; false otherwise. */
+function containsValue(actual: unknown, expected: unknown): boolean {
+  if (typeof actual === 'string') return actual.includes(String(expected));
+  if (Array.isArray(actual)) return actual.includes(expected);
+  return false;
+}
+
+/** Ordering comparison, defined only when both sides share a comparable kind. */
+function gt(a: unknown, b: unknown): boolean {
+  if (typeof a === 'number' && typeof b === 'number') return a > b;
+  if (typeof a === 'string' && typeof b === 'string') return a > b;
+  return false;
+}
+
+function lt(a: unknown, b: unknown): boolean {
+  if (typeof a === 'number' && typeof b === 'number') return a < b;
+  if (typeof a === 'string' && typeof b === 'string') return a < b;
+  return false;
+}
+
+function caseFold(a: unknown, b: unknown): { actual: string; expected: string } | null {
+  if (typeof a !== 'string' || typeof b !== 'string') return null;
+  return { actual: a.toLowerCase(), expected: b.toLowerCase() };
+}
+
+function evalOperator(op: string, actual: unknown, expected: unknown): boolean {
+  switch (op) {
+    case '$eq':
+      return actual === expected;
+    case '$neq':
+      return actual !== expected;
+    case '$gt':
+      return gt(actual, expected);
+    case '$gte':
+      return actual === expected || gt(actual, expected);
+    case '$lt':
+      return lt(actual, expected);
+    case '$lte':
+      return actual === expected || lt(actual, expected);
+    case '$contains':
+      return containsValue(actual, expected);
+    case '$notContains':
+      return !containsValue(actual, expected);
+    case '$startsWith': {
+      const f = caseFold(actual, expected);
+      return f !== null && f.actual.startsWith(f.expected);
+    }
+    case '$endsWith': {
+      const f = caseFold(actual, expected);
+      return f !== null && f.actual.endsWith(f.expected);
+    }
+    case '$in':
+      return Array.isArray(expected) && expected.includes(actual);
+    case '$nin':
+      return !Array.isArray(expected) || !expected.includes(actual);
+    case '$empty':
+      return expected ? isEmptyValue(actual) : !isEmptyValue(actual);
+    default:
+      // Unreachable: isOperatorObject only admits known operators.
+      return false;
+  }
+}
+
+/** Does `actual` satisfy every operator in `ops` (AND)? */
+function matchesOperators(actual: unknown, ops: FilterOperators): boolean {
+  for (const [op, expected] of Object.entries(ops)) {
+    if (!evalOperator(op, actual, expected)) return false;
+  }
+  return true;
+}
+
+/**
+ * Test one record against a filter. All fields must pass (AND). A field whose
+ * constraint is a bypass value imposes no constraint. A raw-value constraint is
+ * an implicit `$eq`; an operator object AND-s its operators.
+ */
+export function matchesFilter(record: Record<string, unknown>, filter: Filter): boolean {
+  for (const [field, constraint] of Object.entries(filter)) {
+    if (isBypass(constraint)) continue;
+    const actual = record[field];
+    if (isOperatorObject(constraint)) {
+      if (!matchesOperators(actual, constraint)) return false;
+    } else if (actual !== constraint) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Return the records that match the filter (order preserved). */
+export function applyFilter<T extends Record<string, unknown>>(records: T[], filter: Filter): T[] {
+  return records.filter((r) => matchesFilter(r, filter));
+}

--- a/src/styles/features/element-tree.css
+++ b/src/styles/features/element-tree.css
@@ -29,6 +29,28 @@
   font-size: var(--font-size-md);
 }
 
+.ss-tree-panel__search {
+  flex: 1;
+  min-width: 0;
+  margin-left: var(--spacing-md);
+  height: 22px;
+  padding: 0 var(--spacing-sm);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: var(--font-size-base);
+}
+
+.ss-tree-panel__search:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.ss-tree-panel__search::placeholder {
+  color: var(--text-muted);
+}
+
 /* Visual / Code toggle in the header. */
 .ss-tree-panel__modes {
   margin-left: auto;


### PR DESCRIPTION
## What

Two additions to the visual editor's element tree:

1. **Search** over the tree, powered by a small declarative filter engine (`menoFilter`). Typing filters to matching nodes plus their ancestor path; class and text both match; empty and truncated-tree states are handled.
2. **Arrow-key navigation** between elements: Up/Down move between siblings, Left selects the parent, Right dives into the first child. Keys are ignored while a text input is focused, so the edit panel keeps its own arrow behavior.

Both sit on top of the current Edit mode and coexist with the CSS / code editor.

## Why a fresh PR

This is the cleanly reviewable slice of my older #93. That PR predated the visual-editor rewrite and now conflicts with it wholesale. The search and keyboard-nav pieces, however, layer cleanly on top of the new editor, so I split them out here, rebased on current `main`, rather than asking you to untangle the 5k-line original.

## Tests

`menoFilter` (19), `elementTreeFilter` (12), `ElementTreePanel` search + nav (17): 48 tests, all green. `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Search elements” to the element tree with filtering by tag, class, and text, showing matches along with their ancestor path.
* **Bug Fixes**
  * Arrow-key navigation now follows the filtered/pruned tree view, including safe recovery when the selected node is hidden by the active query.
  * Clearing the search restores the full tree.
  * Updated empty-state and large/truncated messaging for “no matches in the loaded portion,” and keyboard shortcuts are ignored while typing in text inputs.
* **UI**
  * Improved styling for the element-tree search input and its focus/placeholder appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->