### PR TITLE
Fix per-workspace GitHub repo owner + Claude token capture

### DIFF
--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -220,6 +220,54 @@ pub fn clear_claude_token(account_id: &str) {
     delete_from_keychain(account_id, CLAUDE_EXPIRES_KEY);
 }
 
+/// Best-effort check that a freshly-captured Claude token actually
+/// authenticates, run once at connect time before we persist it.
+///
+/// It mirrors the exact request Claude Code makes — `POST /v1/messages` with the
+/// OAuth bearer + `oauth-2025-04-20` beta header — so a token that passes here is
+/// genuinely usable by the agent terminal (same endpoint, same scope). We send
+/// `max_tokens: 1` so a *valid* token costs a negligible one-token completion.
+///
+/// Returns `true` ONLY on a definitive auth rejection (HTTP 401) — the signature
+/// of a truncated/garbage capture or a revoked token. Network errors, timeouts,
+/// rate limits, and server errors all return `false`, so a transient blip never
+/// blocks a real login (we'd rather store a token and let normal use surface a
+/// problem than reject a good login offline).
+fn claude_token_is_rejected(token: &str) -> bool {
+    let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    else {
+        return false;
+    };
+    rt.block_on(async {
+        let Ok(client) = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+        else {
+            return false;
+        };
+        let body = serde_json::json!({
+            "model": "claude-haiku-4-5-20251001",
+            "max_tokens": 1,
+            "messages": [{ "role": "user", "content": "hi" }],
+        });
+        match client
+            .post("https://api.anthropic.com/v1/messages")
+            .header("authorization", format!("Bearer {token}"))
+            .header("anthropic-version", "2023-06-01")
+            .header("anthropic-beta", "oauth-2025-04-20")
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+        {
+            Ok(resp) => resp.status() == reqwest::StatusCode::UNAUTHORIZED,
+            Err(_) => false,
+        }
+    })
+}
+
 /// Current wall-clock time in unix seconds (0 if the clock is before the epoch).
 fn unix_now() -> u64 {
     SystemTime::now()
@@ -1001,8 +1049,22 @@ const TOKEN_MIN_LEN: usize = 20;
 /// What the user sees in the terminal where the token would have printed.
 const TOKEN_PLACEHOLDER: &[u8] = b"sk-ant-[redacted by Ship Studio]";
 
+/// Minimum column width for the `claude setup-token` PTY. The CLI renders its
+/// output (via Ink) wrapped to the terminal width, so a narrow terminal inserts
+/// a real newline into the middle of the ~108-char token — and the scraper,
+/// which stops at the first non-token byte, then captures only the pre-wrap
+/// fragment and stores a truncated, invalid token (the "shows connected but
+/// every call is 401" bug). We force the PTY wide enough that the token always
+/// prints on one line, regardless of how small the connect modal is. The
+/// on-screen terminal reflows for display, so widening costs nothing visible.
+const CLAUDE_CONNECT_MIN_COLS: u16 = 400;
+
 fn is_token_byte(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.')
+    // Token charset is base64url (`-`/`_`), but accept standard base64 (`+`/`/`/`=`)
+    // too so a format change can never silently truncate capture at one of those
+    // bytes. The token's real boundary is whitespace / ESC / EOF, none of which
+    // are in this set.
+    b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'+' | b'/' | b'=')
 }
 
 /// First index of `needle` within `haystack`, if present.
@@ -1144,6 +1206,10 @@ pub fn claude_connect_start(
         }
     }
 
+    // Force a wide terminal so `claude setup-token` never wraps the token across
+    // a newline (which would truncate the scraped token — see
+    // CLAUDE_CONNECT_MIN_COLS). The frontend xterm reflows for display.
+    let cols = cols.max(CLAUDE_CONNECT_MIN_COLS);
     let pair = native_pty_system()
         .openpty(PtySize {
             rows,
@@ -1209,10 +1275,30 @@ pub fn claude_connect_start(
             let mut buf = [0u8; 4096];
             let mut carry: Vec<u8> = Vec::new();
             let store_and_signal = |token: String| {
+                // We've scraped a token; stop scanning regardless of outcome.
+                session.captured.store(true, Ordering::Relaxed);
+
+                // Validate before persisting. Storing a token that the API
+                // rejects is the exact trap that made a workspace read
+                // "connected" on the dashboard while every agent call returned
+                // 401 — so a rejected token is dropped, not saved.
+                if claude_token_is_rejected(&token) {
+                    tracing::warn!(
+                        account_id = %account_id,
+                        "captured Claude token was rejected by the API (401); not storing"
+                    );
+                    let msg = "\r\n\x1b[31mThat login didn't work — the API rejected the token. \
+                               Please start over and run the login again.\x1b[0m\r\n";
+                    emit_connect_data(&app, &session_id, msg.as_bytes());
+                    // No `claude-connect-captured`: the workspace stays
+                    // disconnected, and the connect modal's exit handler shows
+                    // its "Login didn't finish / Start over" affordance.
+                    return;
+                }
+
                 if let Err(e) = store_claude_token(&account_id, &token, email.as_deref()) {
                     tracing::warn!("failed to store captured Claude token: {e}");
                 }
-                session.captured.store(true, Ordering::Relaxed);
                 let _ = app.emit(
                     "claude-connect-captured",
                     serde_json::json!({ "sessionId": session_id }),
@@ -1318,6 +1404,10 @@ pub fn claude_connect_resize(session_id: String, cols: u16, rows: u16) -> Result
         .master
         .lock()
         .map_err(|e| format!("master lock poisoned: {e}"))?;
+    // Keep the floor from claude_connect_start: a later fit-resize from the
+    // (narrow) modal must not shrink the PTY back down and let the token wrap
+    // before it's printed and captured. See CLAUDE_CONNECT_MIN_COLS.
+    let cols = cols.max(CLAUDE_CONNECT_MIN_COLS);
     master
         .resize(PtySize {
             rows,
@@ -1764,6 +1854,23 @@ mod tests {
         // Surrounding text is preserved verbatim.
         assert!(shown.contains("Long-lived token created!"));
         assert!(shown.contains("Store it."));
+    }
+
+    #[test]
+    fn redact_captures_token_with_base64_chars() {
+        // Defensive: if the token format ever includes standard base64 (`+`/`/`/`=`)
+        // instead of base64url, the scan must not stop at one of those bytes and
+        // store a truncated token. The run still terminates at the trailing space.
+        let out = b"sk-ant-oat01-AbC+dEf/123=ghIJKlmnopQRstuvWXyz456 trailing";
+        let (emit, token) = redact_once(out);
+        assert_eq!(
+            token.as_deref(),
+            Some("sk-ant-oat01-AbC+dEf/123=ghIJKlmnopQRstuvWXyz456")
+        );
+        let shown = String::from_utf8_lossy(&emit);
+        assert!(!shown.contains("AbC+dEf"), "token leaked: {shown}");
+        assert!(shown.contains("sk-ant-[redacted by Ship Studio]"));
+        assert!(shown.contains("trailing"));
     }
 
     #[test]

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -1661,6 +1661,7 @@ pub fn workspace_connect_start(
     {
         let app = app.clone();
         let session_id = session_id.clone();
+        let is_github = matches!(svc, ConnectService::Github);
         std::thread::spawn(move || {
             let code = match child.wait() {
                 Ok(status) if status.success() => 0,
@@ -1669,6 +1670,12 @@ pub fn workspace_connect_start(
             };
             if let Ok(mut map) = CONNECT_REGISTRY.lock() {
                 map.remove(&session_id);
+            }
+            // A GitHub login just finished — the identity for this workspace may
+            // have changed without an active-account switch, so drop any cached
+            // username (keyed per-workspace) to avoid showing a stale owner.
+            if is_github {
+                crate::commands::github::invalidate_github_username_cache();
             }
             let _ = app.emit(
                 "workspace-connect-exit",
@@ -1787,6 +1794,11 @@ pub fn workspace_disconnect_service(id: String, service: String) -> Result<(), C
     }
     // Best-effort: failures (e.g. "not logged in") are fine.
     let _ = command.output();
+    // Logging out changes this workspace's GitHub identity — drop any cached
+    // username so a subsequent lookup doesn't return the signed-out account.
+    if matches!(svc, ConnectService::Github) {
+        crate::commands::github::invalidate_github_username_cache();
+    }
     Ok(())
 }
 

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -152,17 +152,20 @@ pub async fn check_github_cli_status() -> GitHubCliStatus {
 /// created under); without one, they fall back to the globally-active
 /// workspace. The account id is returned so callers can key per-workspace
 /// caches — see [`GITHUB_USERNAME_CACHE`].
-fn gh_command_and_account(project_path: Option<&str>) -> (Command, String) {
+fn gh_command_and_account(project_path: Option<&str>) -> Result<(Command, String), CommandError> {
     match project_path {
         Some(p) => {
-            let path = Path::new(p);
-            let account_id = crate::commands::projects::project_account_id_sync(path);
-            (get_gh_command_for_project(path), account_id)
+            // Validate the caller-supplied path (rejects traversal / out-of-sandbox
+            // paths, allows registered external projects) before we read its
+            // workspace config — parity with the other project-scoped commands.
+            let path = validate_project_path(p).map_err(CommandError::from)?;
+            let account_id = crate::commands::projects::project_account_id_sync(&path);
+            Ok((get_gh_command_for_project(&path), account_id))
         }
         None => {
             let account_id = crate::commands::accounts::get_active_account_id()
                 .unwrap_or_else(|_| "default".to_string());
-            (get_gh_command(), account_id)
+            Ok((get_gh_command(), account_id))
         }
     }
 }
@@ -170,7 +173,7 @@ fn gh_command_and_account(project_path: Option<&str>) -> (Command, String) {
 #[tauri::command]
 #[tracing::instrument]
 pub async fn get_github_username(project_path: Option<String>) -> Result<String, CommandError> {
-    let (mut cmd, account_id) = gh_command_and_account(project_path.as_deref());
+    let (mut cmd, account_id) = gh_command_and_account(project_path.as_deref())?;
 
     if let Some(cached) = GITHUB_USERNAME_CACHE.get(&account_id) {
         return Ok(cached);
@@ -195,7 +198,7 @@ pub async fn get_github_username(project_path: Option<String>) -> Result<String,
 pub async fn get_github_orgs(project_path: Option<String>) -> Result<Vec<String>, CommandError> {
     // Get orgs where user can create repos, scoped to the project's workspace
     // login so org choices match the account the repo will be created under.
-    let (mut cmd, _account_id) = gh_command_and_account(project_path.as_deref());
+    let (mut cmd, _account_id) = gh_command_and_account(project_path.as_deref())?;
     cmd.args(["api", "user/orgs", "--jq", ".[].login"]);
     let output = run_command_with_timeout(cmd, GITHUB_CLI_TIMEOUT_SECS).await?;
 

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -17,15 +17,20 @@ use std::sync::LazyLock;
 use std::time::Duration;
 use tracing::{debug, warn};
 
-/// 10-minute TTL cache for `gh api user --jq .login`. The username rarely
-/// changes during a session; the uncached call adds ~200ms and hits the
-/// network, so caching is a meaningful perf win.
-static GITHUB_USERNAME_CACHE: LazyLock<TtlCache<(), String>> =
+/// 10-minute TTL cache for `gh api user --jq .login`, keyed by the workspace
+/// (account) id the lookup ran under. The username rarely changes during a
+/// session; the uncached call adds ~200ms and hits the network, so caching is a
+/// meaningful perf win. Keying by account id is essential: the same call
+/// resolves to a *different* GitHub identity per workspace, so a single
+/// unit-keyed cache would hand one workspace's login to another (the
+/// "Create Repo defaulted to the wrong owner" bug).
+static GITHUB_USERNAME_CACHE: LazyLock<TtlCache<String, String>> =
     LazyLock::new(|| TtlCache::new(Duration::from_secs(600)));
 
-/// Invalidate the cached GitHub username. Call after auth changes.
+/// Invalidate every cached GitHub username. Call after auth changes or a
+/// workspace switch — both can change which login any account resolves to.
 pub fn invalidate_github_username_cache() {
-    GITHUB_USERNAME_CACHE.invalidate(&());
+    GITHUB_USERNAME_CACHE.clear();
 }
 
 /// Default timeout for GitHub CLI commands (15 seconds)
@@ -141,14 +146,36 @@ pub async fn check_github_cli_status() -> GitHubCliStatus {
     }
 }
 
+/// Resolves the gh command + workspace (account) id for an optional project.
+/// With a project path, both are scoped to that *project's* workspace login (so
+/// the owner shown for a repo matches the account the repo will actually be
+/// created under); without one, they fall back to the globally-active
+/// workspace. The account id is returned so callers can key per-workspace
+/// caches — see [`GITHUB_USERNAME_CACHE`].
+fn gh_command_and_account(project_path: Option<&str>) -> (Command, String) {
+    match project_path {
+        Some(p) => {
+            let path = Path::new(p);
+            let account_id = crate::commands::projects::project_account_id_sync(path);
+            (get_gh_command_for_project(path), account_id)
+        }
+        None => {
+            let account_id = crate::commands::accounts::get_active_account_id()
+                .unwrap_or_else(|_| "default".to_string());
+            (get_gh_command(), account_id)
+        }
+    }
+}
+
 #[tauri::command]
 #[tracing::instrument]
-pub async fn get_github_username() -> Result<String, CommandError> {
-    if let Some(cached) = GITHUB_USERNAME_CACHE.get(&()) {
+pub async fn get_github_username(project_path: Option<String>) -> Result<String, CommandError> {
+    let (mut cmd, account_id) = gh_command_and_account(project_path.as_deref());
+
+    if let Some(cached) = GITHUB_USERNAME_CACHE.get(&account_id) {
         return Ok(cached);
     }
 
-    let mut cmd = get_gh_command();
     cmd.args(["api", "user", "--jq", ".login"]);
     let output = run_command_with_timeout(cmd, GITHUB_CLI_TIMEOUT_SECS).await?;
 
@@ -159,15 +186,16 @@ pub async fn get_github_username() -> Result<String, CommandError> {
     }
 
     let username = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    GITHUB_USERNAME_CACHE.insert((), username.clone());
+    GITHUB_USERNAME_CACHE.insert(account_id, username.clone());
     Ok(username)
 }
 
 #[tauri::command]
 #[tracing::instrument]
-pub async fn get_github_orgs() -> Result<Vec<String>, CommandError> {
-    // Get orgs where user can create repos
-    let mut cmd = get_gh_command();
+pub async fn get_github_orgs(project_path: Option<String>) -> Result<Vec<String>, CommandError> {
+    // Get orgs where user can create repos, scoped to the project's workspace
+    // login so org choices match the account the repo will be created under.
+    let (mut cmd, _account_id) = gh_command_and_account(project_path.as_deref());
     cmd.args(["api", "user/orgs", "--jq", ".[].login"]);
     let output = run_command_with_timeout(cmd, GITHUB_CLI_TIMEOUT_SECS).await?;
 
@@ -593,6 +621,11 @@ mod tests {
     use super::*;
     use crate::types::GitHubRepo;
 
+    /// Serializes the tests that touch the process-global GITHUB_USERNAME_CACHE.
+    /// `invalidate_github_username_cache` clears the whole cache, so without this
+    /// these tests race under cargo's default multi-threaded runner.
+    static CACHE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn parse_github_repo_https_with_git_suffix() {
         assert_eq!(
@@ -735,15 +768,17 @@ mod tests {
     /// We prime the cache manually (no network), invalidate, and check miss.
     #[test]
     fn github_username_cache_invalidation_clears_entry() {
-        GITHUB_USERNAME_CACHE.insert((), "alice".to_string());
+        let _guard = CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        invalidate_github_username_cache();
+        GITHUB_USERNAME_CACHE.insert("default".to_string(), "alice".to_string());
         assert_eq!(
-            GITHUB_USERNAME_CACHE.get(&()),
+            GITHUB_USERNAME_CACHE.get("default"),
             Some("alice".to_string()),
             "cache should be primed"
         );
         invalidate_github_username_cache();
         assert_eq!(
-            GITHUB_USERNAME_CACHE.get(&()),
+            GITHUB_USERNAME_CACHE.get("default"),
             None,
             "invalidate must clear the cached username"
         );
@@ -752,15 +787,37 @@ mod tests {
     /// Verify the cache survives repeated reads within TTL (stability check).
     #[test]
     fn github_username_cache_stable_across_reads() {
+        let _guard = CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Clean slate before asserting.
         invalidate_github_username_cache();
-        GITHUB_USERNAME_CACHE.insert((), "bob".to_string());
-        let first = GITHUB_USERNAME_CACHE.get(&());
-        let second = GITHUB_USERNAME_CACHE.get(&());
+        GITHUB_USERNAME_CACHE.insert("default".to_string(), "bob".to_string());
+        let first = GITHUB_USERNAME_CACHE.get("default");
+        let second = GITHUB_USERNAME_CACHE.get("default");
         assert_eq!(first, second);
         assert_eq!(first.as_deref(), Some("bob"));
         // Cleanup so we don't pollute other tests (test-threads=1 means tests
         // run sequentially but global state still bleeds between cases).
+        invalidate_github_username_cache();
+    }
+
+    /// Regression: two workspaces resolve to two different GitHub logins, so the
+    /// cache must hold both independently. A single unit-keyed cache returned
+    /// one workspace's identity for the other (Create Repo wrong-owner bug).
+    #[test]
+    fn github_username_cache_is_keyed_per_workspace() {
+        let _guard = CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        invalidate_github_username_cache();
+        GITHUB_USERNAME_CACHE.insert("default".to_string(), "adambwhitten".to_string());
+        GITHUB_USERNAME_CACHE.insert("circa".to_string(), "circa-brand-agency".to_string());
+        assert_eq!(
+            GITHUB_USERNAME_CACHE.get("default").as_deref(),
+            Some("adambwhitten")
+        );
+        assert_eq!(
+            GITHUB_USERNAME_CACHE.get("circa").as_deref(),
+            Some("circa-brand-agency"),
+            "each workspace must keep its own cached login"
+        );
         invalidate_github_username_cache();
     }
 

--- a/src/components/branches/GitHubButton.tsx
+++ b/src/components/branches/GitHubButton.tsx
@@ -14,7 +14,12 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { GitHubState } from '../../hooks/useIntegrationStatus';
-import { ProjectGitHubStatus, pushToGitHub, getGitHubOrgs } from '../../lib/github';
+import {
+  ProjectGitHubStatus,
+  pushToGitHub,
+  getGitHubOrgs,
+  getGitHubUsername,
+} from '../../lib/github';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { Button } from '../primitives/Button';
 import { ModalFrame } from '../primitives/ModalFrame';
@@ -57,9 +62,17 @@ export function GitHubButton({
   const [error, setError] = useState<string | null>(null);
   const [orgs, setOrgs] = useState<string[]>([]);
   const [selectedOwner, setSelectedOwner] = useState<string | null>(null);
+  // GitHub login for *this project's* workspace, which can differ from the
+  // globally-active workspace login carried by `githubState.username`. The
+  // repo is created under the project's workspace (push_to_github is
+  // project-scoped), so the owner we show must come from the same place — else
+  // the dropdown defaults to the active workspace's account (the wrong-owner bug).
+  const [projectUsername, setProjectUsername] = useState<string | null>(null);
   const createRepoTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const { cliStatus, username } = githubState;
+  const { cliStatus, username: activeUsername } = githubState;
+  // Prefer the project-scoped login; fall back to the active one until it loads.
+  const username = projectUsername ?? activeUsername;
 
   const closeCreateModal = () => {
     setShowCreateModal(false);
@@ -75,14 +88,34 @@ export function GitHubButton({
     };
   }, []);
 
-  // Fetch orgs when modal opens
+  // Fetch the owner (this project's workspace login) and its orgs when the
+  // modal opens. Both are scoped to `projectPath` so they match the account the
+  // repo will be created under, not whichever workspace is globally active.
   useEffect(() => {
-    if (showCreateModal && cliStatus.authenticated) {
-      void getGitHubOrgs()
-        .then(setOrgs)
-        .catch(() => setOrgs([]));
-    }
-  }, [showCreateModal, cliStatus.authenticated]);
+    if (!showCreateModal || !cliStatus.authenticated) return;
+    let cancelled = false;
+    void getGitHubUsername(projectPath)
+      .then((name) => {
+        if (cancelled) return;
+        setProjectUsername(name);
+        // Default the dropdown to the project's account unless the user already
+        // picked an owner this session.
+        setSelectedOwner((prev) => prev ?? name);
+      })
+      .catch(() => {
+        /* fall back to the active-workspace username already in state */
+      });
+    void getGitHubOrgs(projectPath)
+      .then((list) => {
+        if (!cancelled) setOrgs(list);
+      })
+      .catch(() => {
+        if (!cancelled) setOrgs([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [showCreateModal, cliStatus.authenticated, projectPath]);
 
   // Clear isCreatingRepo when status becomes connected
   // This synchronizes local loading state with external status - a valid pattern
@@ -161,7 +194,9 @@ export function GitHubButton({
         className="github-button github-create"
         onClick={() => {
           setRepoName(projectName);
-          setSelectedOwner(username); // Default to personal account
+          // Clear so the modal's effect can default the owner to this project's
+          // workspace login once it resolves (see the fetch effect above).
+          setSelectedOwner(null);
           setShowCreateModal(true);
           setError(null);
         }}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -42,19 +42,24 @@ export async function checkGitHubCliStatus(): Promise<GitHubCliStatus> {
 
 /**
  * Get the authenticated GitHub username.
+ * @param projectPath - Optional project path; when given, resolves the username
+ *   for that project's workspace login rather than the globally-active one, so
+ *   it matches the account a repo created from that project lands under.
  * @returns GitHub username
  * @throws If not authenticated
  */
-export async function getGitHubUsername(): Promise<string> {
-  return invoke<string>('get_github_username');
+export async function getGitHubUsername(projectPath?: string): Promise<string> {
+  return invoke<string>('get_github_username', { projectPath });
 }
 
 /**
  * Get list of GitHub organizations the user belongs to.
+ * @param projectPath - Optional project path; scopes the org list to that
+ *   project's workspace login (see {@link getGitHubUsername}).
  * @returns Array of organization names
  */
-export async function getGitHubOrgs(): Promise<string[]> {
-  return invoke<string[]>('get_github_orgs');
+export async function getGitHubOrgs(projectPath?: string): Promise<string[]> {
+  return invoke<string[]>('get_github_orgs', { projectPath });
 }
 
 /**


### PR DESCRIPTION
Two follow-up bugs in the per-workspace logins feature (the five-tool per-workspace auth from #132).

## 1. "Create Repo" defaulted to the wrong GitHub owner

The Create Repo dialog's owner dropdown read `get_github_username` / `get_github_orgs`, which ran under the **globally-active** workspace (`get_gh_command`). But the repo is actually created under the **project's** workspace (`push_to_github` → `get_gh_command_for_project`). So opening Create Repo from a project tagged to workspace B while workspace A was active showed A's account/orgs — and could create the repo somewhere other than what the dropdown showed.

- Both lookups now take an optional `project_path` and resolve the **project's** workspace login, matching where the repo lands.
- The username cache was a single unit-keyed entry, so it could hand one workspace's login to another; it's now keyed per-workspace and cleared on auth/workspace change.
- `GitHubButton` fetches the project-scoped owner + orgs when the modal opens and defaults the dropdown to them.

## 2. Claude showed "connected" but every agent call returned 401

The per-workspace token captured via `claude setup-token` was being stored **truncated**, so the API rejected it (`401 Invalid bearer token`) even though the dashboard read "connected". Root cause: the CLI renders its output wrapped to the connect terminal's width, so a narrow PTY split the ~108-char token across a newline, and the scraper (which stops at the first non-token byte) stored only the pre-wrap fragment.

- Force the `setup-token` PTY to a wide minimum (`CLAUDE_CONNECT_MIN_COLS`) at open **and** resize, so the token never wraps. The on-screen terminal reflows for display, so nothing visible changes.
- Broaden `is_token_byte` to accept base64 `+` `/` `=` defensively.
- **Validate the captured token before persisting**: it makes the same `POST /v1/messages` call Claude Code makes (`max_tokens: 1`). A token the API rejects with 401 is dropped with an error shown in the connect terminal instead of being saved and read back as "connected". Network errors/timeouts/rate-limits never block a real login.

## Testing

- `cargo check` + backend unit tests (github, accounts/redact) pass; added regression tests for per-workspace cache keying and base64 token capture.
- `tsc` clean; frontend tests pass.
- Manually verified in-app: Create Repo now defaults to the project workspace's GitHub account; reconnecting Claude in a non-default workspace captures a full-length token and the agent terminal works (no 401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub account and organization details now respect the current project workspace, improving accuracy in the Create Repo flow.
  * Token setup now verifies login more reliably before saving credentials.

* **Bug Fixes**
  * Fixed cases where GitHub identity or org results could come from the wrong workspace.
  * Prevented token capture from being cut off by terminal wrapping or certain token characters.
  * Improved feedback when a Claude login token is invalid, so failed setup is clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->