### PR TITLE
Add non-destructive project removal

### DIFF
--- a/src-tauri/src/commands/external_projects.rs
+++ b/src-tauri/src/commands/external_projects.rs
@@ -123,9 +123,9 @@ pub async fn register_external_project(app: AppHandle) -> Result<Option<String>,
         None => return Ok(None), // User cancelled
     };
 
-    // Validate project has package.json or HTML files
-    let is_valid_project = folder_path.join("package.json").exists()
-        || crate::commands::projects::has_html_files(&folder_path);
+    // Use the same predicate as dashboard discovery so removed projects can be
+    // restored even when they were blank, git-only, or Ship Studio metadata-only.
+    let is_valid_project = crate::commands::projects::is_valid_project(&folder_path);
 
     if !is_valid_project {
         // Check one level deep for a nested project
@@ -142,9 +142,7 @@ pub async fn register_external_project(app: AppHandle) -> Result<Option<String>,
                     {
                         continue;
                     }
-                    if sub.join("package.json").exists()
-                        || crate::commands::projects::has_html_files(&sub)
-                    {
+                    if crate::commands::projects::is_valid_project(&sub) {
                         if let Some(name) = entry.file_name().to_str() {
                             nested_projects.push(name.to_string());
                         }

--- a/src-tauri/src/commands/external_projects.rs
+++ b/src-tauri/src/commands/external_projects.rs
@@ -182,6 +182,10 @@ pub async fn register_external_project(app: AppHandle) -> Result<Option<String>,
         .iter()
         .any(|root| canonical.starts_with(root))
     {
+        if crate::commands::projects::restore_removed_project(&canonical)? {
+            return Ok(Some(canonical_str));
+        }
+
         return Err(
             "This project is already inside your projects folder. It will appear automatically."
                 .to_string()

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -32,6 +32,8 @@ use super::git::get_current_branch_sync;
 use crate::errors::CommandError;
 use crate::types::{DashboardProject, PageInfo, ProjectInfo, ProjectMetadata, ProjectType};
 use crate::utils::{create_command, validate_project_path};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
 
 // ============ Helper Functions ============
 
@@ -124,6 +126,129 @@ fn project_visible_for_account(
     ui_state::effective_account_id_in(metadata, accounts) == active_account_id
 }
 
+const REMOVED_PROJECTS_CONFIG_SCHEMA_VERSION: u32 = 1;
+
+#[cfg(test)]
+static REMOVED_PROJECTS_CONFIG_PATH_OVERRIDE: std::sync::LazyLock<
+    std::sync::Mutex<Option<PathBuf>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+
+#[derive(Serialize, Deserialize, Clone)]
+struct RemovedProject {
+    path: String,
+    removed_at: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct RemovedProjectsConfig {
+    schema_version: u32,
+    #[serde(default)]
+    projects: Vec<RemovedProject>,
+}
+
+impl Default for RemovedProjectsConfig {
+    fn default() -> Self {
+        Self {
+            schema_version: REMOVED_PROJECTS_CONFIG_SCHEMA_VERSION,
+            projects: Vec::new(),
+        }
+    }
+}
+
+impl RemovedProjectsConfig {
+    fn contains_path(&self, canonical_path: &Path) -> bool {
+        self.projects
+            .iter()
+            .any(|project| stored_path_matches(&project.path, canonical_path))
+    }
+}
+
+fn removed_projects_config_path() -> Result<PathBuf, String> {
+    #[cfg(test)]
+    if let Some(path) = REMOVED_PROJECTS_CONFIG_PATH_OVERRIDE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+    {
+        return Ok(path);
+    }
+
+    Ok(crate::utils::default_projects_root()?
+        .join(".shipstudio")
+        .join("removed-projects.json"))
+}
+
+fn load_removed_projects_config() -> Result<RemovedProjectsConfig, String> {
+    let config_path = removed_projects_config_path()?;
+
+    if !config_path.exists() {
+        return Ok(RemovedProjectsConfig::default());
+    }
+
+    let contents = std::fs::read_to_string(&config_path)
+        .map_err(|e| format!("Failed to read removed projects config: {e}"))?;
+
+    serde_json::from_str(&contents)
+        .map_err(|e| format!("Failed to parse removed projects config: {e}"))
+}
+
+fn save_removed_projects_config(config: &RemovedProjectsConfig) -> Result<(), String> {
+    let config_path = removed_projects_config_path()?;
+
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
+    }
+
+    let contents = serde_json::to_string_pretty(config)
+        .map_err(|e| format!("Failed to serialize removed projects config: {e}"))?;
+
+    std::fs::write(&config_path, contents)
+        .map_err(|e| format!("Failed to write removed projects config: {e}"))
+}
+
+fn canonical_or_original(path: &Path) -> PathBuf {
+    dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn stored_path_matches(stored_path: &str, canonical_path: &Path) -> bool {
+    canonical_or_original(Path::new(stored_path)) == canonical_path
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn mark_project_removed(canonical: &Path) -> Result<(), CommandError> {
+    let mut config = load_removed_projects_config()?;
+    if !config.contains_path(canonical) {
+        config.projects.push(RemovedProject {
+            path: canonical.to_string_lossy().to_string(),
+            removed_at: now_ms(),
+        });
+    }
+    save_removed_projects_config(&config)?;
+    Ok(())
+}
+
+pub(crate) fn restore_removed_project(canonical: &Path) -> Result<bool, CommandError> {
+    let mut config = load_removed_projects_config()?;
+    let initial_len = config.projects.len();
+    config
+        .projects
+        .retain(|project| !stored_path_matches(&project.path, canonical));
+
+    let restored = config.projects.len() != initial_len;
+    if restored {
+        save_removed_projects_config(&config)?;
+    }
+
+    Ok(restored)
+}
+
 // ============ Tauri Commands ============
 
 #[tauri::command]
@@ -135,6 +260,7 @@ pub async fn list_projects() -> Result<Vec<ProjectInfo>, CommandError> {
     let active_account_id = crate::commands::accounts::get_active_account_id().unwrap_or_default();
     // Live workspace list, read once so the visibility check stays IO-free per project.
     let accounts = crate::commands::setup::read_app_state().accounts;
+    let removed_projects = load_removed_projects_config().unwrap_or_default();
 
     if !shipstudio_dir.exists() {
         return Ok(Vec::new());
@@ -147,6 +273,11 @@ pub async fn list_projects() -> Result<Vec<ProjectInfo>, CommandError> {
         let entry = entry.map_err(|e| e.to_string())?;
         let path = entry.path();
         if is_valid_project(&path) {
+            let canonical = canonical_or_original(&path);
+            if removed_projects.contains_path(&canonical) {
+                continue;
+            }
+
             let thumbnail_path = path.join(".shipstudio").join("thumbnail.png");
             let thumbnail = if thumbnail_path.exists() {
                 Some(thumbnail_path.to_string_lossy().to_string())
@@ -242,6 +373,7 @@ pub async fn get_dashboard_projects() -> Result<Vec<DashboardProject>, CommandEr
     let active_account_id = crate::commands::accounts::get_active_account_id().unwrap_or_default();
     // Live workspace list, read once so the visibility check stays IO-free per project.
     let accounts = crate::commands::setup::read_app_state().accounts;
+    let removed_projects = load_removed_projects_config().unwrap_or_default();
 
     if !shipstudio_dir.exists() {
         return Ok(Vec::new());
@@ -254,6 +386,11 @@ pub async fn get_dashboard_projects() -> Result<Vec<DashboardProject>, CommandEr
         let entry = entry.map_err(|e| e.to_string())?;
         let path = entry.path();
         if is_valid_project(&path) {
+            let canonical = canonical_or_original(&path);
+            if removed_projects.contains_path(&canonical) {
+                continue;
+            }
+
             let thumbnail_path = path.join(".shipstudio").join("thumbnail.png");
             let thumbnail = if thumbnail_path.exists() {
                 Some(thumbnail_path.to_string_lossy().to_string())
@@ -587,7 +724,7 @@ pub async fn delete_project(path: String) -> Result<(), CommandError> {
     // Check if this is an external project
     if crate::commands::external_projects::is_registered_external_path(&canonical)? {
         return Err(
-            "Cannot delete external projects. Use 'Remove from list' instead."
+            "Cannot delete external projects. Use 'Remove from Ship Studio' instead."
                 .to_string()
                 .into(),
         );
@@ -601,6 +738,45 @@ pub async fn delete_project(path: String) -> Result<(), CommandError> {
     }
 
     std::fs::remove_dir_all(&canonical).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Removes a project from Ship Studio's dashboard without deleting its files.
+///
+/// Projects inside a configured projects folder are discovered automatically, so
+/// this records the exact project path in Ship Studio's app config and list
+/// scans skip it afterward. External projects keep using their existing
+/// registry removal path.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn remove_project_from_app(path: String) -> Result<(), CommandError> {
+    let canonical = dunce::canonicalize(&path).map_err(|_| "Project not found".to_string())?;
+
+    if crate::commands::external_projects::is_registered_external_path(&canonical)? {
+        let canonical_str = canonical.to_string_lossy().to_string();
+        crate::commands::external_projects::unregister_external_project(path).await?;
+        crate::commands::folders::move_project_to_folder(canonical_str.clone(), None).await?;
+        crate::commands::projects::unpin_project(canonical_str).await?;
+        return Ok(());
+    }
+
+    if !crate::utils::allowed_project_roots()
+        .iter()
+        .any(|root| canonical.starts_with(root))
+    {
+        return Err(
+            "Can only remove projects that live in a Ship Studio projects folder."
+                .to_string()
+                .into(),
+        );
+    }
+
+    mark_project_removed(&canonical)?;
+
+    let canonical_str = canonical.to_string_lossy().to_string();
+    crate::commands::folders::move_project_to_folder(canonical_str.clone(), None).await?;
+    crate::commands::projects::unpin_project(canonical_str).await?;
+
     Ok(())
 }
 
@@ -970,6 +1146,32 @@ pub async fn move_projects_to_root(from: String, to: String) -> Result<MoveRepor
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{LazyLock, Mutex};
+
+    static REMOVED_PROJECTS_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    struct RemovedProjectsConfigOverride {
+        _tmp: tempfile::TempDir,
+    }
+
+    impl RemovedProjectsConfigOverride {
+        fn install() -> Self {
+            let tmp = tempfile::tempdir().unwrap();
+            let path = tmp.path().join("removed-projects.json");
+            *REMOVED_PROJECTS_CONFIG_PATH_OVERRIDE
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()) = Some(path);
+            Self { _tmp: tmp }
+        }
+    }
+
+    impl Drop for RemovedProjectsConfigOverride {
+        fn drop(&mut self) {
+            *REMOVED_PROJECTS_CONFIG_PATH_OVERRIDE
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()) = None;
+        }
+    }
 
     #[test]
     fn validate_project_name_accepts_normal_names() {
@@ -1034,5 +1236,45 @@ mod tests {
             std::fs::read_to_string(dst.join("nested").join("file.txt")).unwrap(),
             "hello"
         );
+    }
+
+    #[test]
+    fn removed_projects_registry_marks_and_restores_path_without_deleting_files() {
+        let _guard = REMOVED_PROJECTS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _override = RemovedProjectsConfigOverride::install();
+        let tmp = tempfile::tempdir().unwrap();
+        make_project(tmp.path(), "alpha");
+        let project = dunce::canonicalize(tmp.path().join("alpha")).unwrap();
+
+        mark_project_removed(&project).unwrap();
+
+        let config = load_removed_projects_config().unwrap();
+        assert!(config.contains_path(&project));
+        assert!(project.exists());
+
+        assert!(restore_removed_project(&project).unwrap());
+
+        let config = load_removed_projects_config().unwrap();
+        assert!(!config.contains_path(&project));
+        assert!(project.exists());
+    }
+
+    #[test]
+    fn removed_projects_registry_is_idempotent() {
+        let _guard = REMOVED_PROJECTS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _override = RemovedProjectsConfigOverride::install();
+        let tmp = tempfile::tempdir().unwrap();
+        make_project(tmp.path(), "alpha");
+        let project = dunce::canonicalize(tmp.path().join("alpha")).unwrap();
+
+        mark_project_removed(&project).unwrap();
+        mark_project_removed(&project).unwrap();
+
+        let config = load_removed_projects_config().unwrap();
+        assert_eq!(config.projects.len(), 1);
     }
 }

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -128,20 +128,31 @@ fn project_visible_for_account(
 
 const REMOVED_PROJECTS_CONFIG_SCHEMA_VERSION: u32 = 1;
 
+/// Guards removed-project registry read/mutate/write cycles so simultaneous
+/// remove and restore actions cannot overwrite each other's changes.
+static REMOVED_PROJECTS_CONFIG_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
 #[cfg(test)]
 static REMOVED_PROJECTS_CONFIG_PATH_OVERRIDE: std::sync::LazyLock<
     std::sync::Mutex<Option<PathBuf>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
 
-#[derive(Serialize, Deserialize, Clone)]
+/// One dashboard-hidden project entry in the app-level removal registry.
+#[derive(Serialize, Deserialize, Clone, Debug)]
 struct RemovedProject {
+    /// Canonical project directory path recorded at removal time.
     path: String,
+    /// Millisecond Unix timestamp used for audit/debugging.
     removed_at: u64,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+/// Persistent app-level registry for local projects hidden from the dashboard.
+#[derive(Serialize, Deserialize, Clone, Debug)]
 struct RemovedProjectsConfig {
+    /// Schema version for future migrations.
     schema_version: u32,
+    /// Canonical project paths hidden from automatic local project scans.
     #[serde(default)]
     projects: Vec<RemovedProject>,
 }
@@ -156,6 +167,7 @@ impl Default for RemovedProjectsConfig {
 }
 
 impl RemovedProjectsConfig {
+    /// Returns true when the registry already hides the canonical project path.
     fn contains_path(&self, canonical_path: &Path) -> bool {
         self.projects
             .iter()
@@ -163,6 +175,7 @@ impl RemovedProjectsConfig {
     }
 }
 
+/// Returns the app-level path for the removed-projects registry.
 fn removed_projects_config_path() -> Result<PathBuf, String> {
     #[cfg(test)]
     if let Some(path) = REMOVED_PROJECTS_CONFIG_PATH_OVERRIDE
@@ -178,6 +191,8 @@ fn removed_projects_config_path() -> Result<PathBuf, String> {
         .join("removed-projects.json"))
 }
 
+/// Loads the removed-projects registry, returning an empty config only when it
+/// has not been created yet.
 fn load_removed_projects_config() -> Result<RemovedProjectsConfig, String> {
     let config_path = removed_projects_config_path()?;
 
@@ -192,6 +207,7 @@ fn load_removed_projects_config() -> Result<RemovedProjectsConfig, String> {
         .map_err(|e| format!("Failed to parse removed projects config: {e}"))
 }
 
+/// Persists the removed-projects registry to disk.
 fn save_removed_projects_config(config: &RemovedProjectsConfig) -> Result<(), String> {
     let config_path = removed_projects_config_path()?;
 
@@ -207,14 +223,18 @@ fn save_removed_projects_config(config: &RemovedProjectsConfig) -> Result<(), St
         .map_err(|e| format!("Failed to write removed projects config: {e}"))
 }
 
+/// Canonicalizes a path when possible, preserving the original path if it no
+/// longer exists.
 fn canonical_or_original(path: &Path) -> PathBuf {
     dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
+/// Compares a stored registry path to the current canonical project path.
 fn stored_path_matches(stored_path: &str, canonical_path: &Path) -> bool {
     canonical_or_original(Path::new(stored_path)) == canonical_path
 }
 
+/// Returns the current wall-clock time in milliseconds since the Unix epoch.
 fn now_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -222,7 +242,11 @@ fn now_ms() -> u64 {
         .unwrap_or(0)
 }
 
+/// Records a canonical local project path as hidden from dashboard scans.
 fn mark_project_removed(canonical: &Path) -> Result<(), CommandError> {
+    let _guard = REMOVED_PROJECTS_CONFIG_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     let mut config = load_removed_projects_config()?;
     if !config.contains_path(canonical) {
         config.projects.push(RemovedProject {
@@ -234,7 +258,11 @@ fn mark_project_removed(canonical: &Path) -> Result<(), CommandError> {
     Ok(())
 }
 
+/// Removes a canonical path from the hidden-project registry.
 pub(crate) fn restore_removed_project(canonical: &Path) -> Result<bool, CommandError> {
+    let _guard = REMOVED_PROJECTS_CONFIG_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     let mut config = load_removed_projects_config()?;
     let initial_len = config.projects.len();
     config
@@ -260,7 +288,7 @@ pub async fn list_projects() -> Result<Vec<ProjectInfo>, CommandError> {
     let active_account_id = crate::commands::accounts::get_active_account_id().unwrap_or_default();
     // Live workspace list, read once so the visibility check stays IO-free per project.
     let accounts = crate::commands::setup::read_app_state().accounts;
-    let removed_projects = load_removed_projects_config().unwrap_or_default();
+    let removed_projects = load_removed_projects_config()?;
 
     if !shipstudio_dir.exists() {
         return Ok(Vec::new());
@@ -373,7 +401,7 @@ pub async fn get_dashboard_projects() -> Result<Vec<DashboardProject>, CommandEr
     let active_account_id = crate::commands::accounts::get_active_account_id().unwrap_or_default();
     // Live workspace list, read once so the visibility check stays IO-free per project.
     let accounts = crate::commands::setup::read_app_state().accounts;
-    let removed_projects = load_removed_projects_config().unwrap_or_default();
+    let removed_projects = load_removed_projects_config()?;
 
     if !shipstudio_dir.exists() {
         return Ok(Vec::new());
@@ -741,6 +769,30 @@ pub async fn delete_project(path: String) -> Result<(), CommandError> {
     Ok(())
 }
 
+/// Clears path-keyed dashboard references after a project has already been
+/// removed from the visible project set.
+async fn clear_project_dashboard_references(canonical: &Path) {
+    let canonical_str = canonical.to_string_lossy().to_string();
+
+    if let Err(err) =
+        crate::commands::folders::move_project_to_folder(canonical_str.clone(), None).await
+    {
+        tracing::warn!(
+            project = %canonical.display(),
+            error = %err,
+            "Failed to clear project folder assignment after removal"
+        );
+    }
+
+    if let Err(err) = crate::commands::projects::unpin_project(canonical_str).await {
+        tracing::warn!(
+            project = %canonical.display(),
+            error = %err,
+            "Failed to unpin project after removal"
+        );
+    }
+}
+
 /// Removes a project from Ship Studio's dashboard without deleting its files.
 ///
 /// Projects inside a configured projects folder are discovered automatically, so
@@ -750,13 +802,11 @@ pub async fn delete_project(path: String) -> Result<(), CommandError> {
 #[tauri::command]
 #[tracing::instrument]
 pub async fn remove_project_from_app(path: String) -> Result<(), CommandError> {
-    let canonical = dunce::canonicalize(&path).map_err(|_| "Project not found".to_string())?;
+    let canonical = validate_project_path(&path)?;
 
     if crate::commands::external_projects::is_registered_external_path(&canonical)? {
-        let canonical_str = canonical.to_string_lossy().to_string();
         crate::commands::external_projects::unregister_external_project(path).await?;
-        crate::commands::folders::move_project_to_folder(canonical_str.clone(), None).await?;
-        crate::commands::projects::unpin_project(canonical_str).await?;
+        clear_project_dashboard_references(&canonical).await;
         return Ok(());
     }
 
@@ -772,10 +822,7 @@ pub async fn remove_project_from_app(path: String) -> Result<(), CommandError> {
     }
 
     mark_project_removed(&canonical)?;
-
-    let canonical_str = canonical.to_string_lossy().to_string();
-    crate::commands::folders::move_project_to_folder(canonical_str.clone(), None).await?;
-    crate::commands::projects::unpin_project(canonical_str).await?;
+    clear_project_dashboard_references(&canonical).await;
 
     Ok(())
 }
@@ -1276,5 +1323,19 @@ mod tests {
 
         let config = load_removed_projects_config().unwrap();
         assert_eq!(config.projects.len(), 1);
+    }
+
+    #[test]
+    fn removed_projects_registry_reports_invalid_json() {
+        let _guard = REMOVED_PROJECTS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _override = RemovedProjectsConfigOverride::install();
+        let path = removed_projects_config_path().unwrap();
+        std::fs::write(&path, "{not valid json").unwrap();
+
+        let err = load_removed_projects_config().expect_err("invalid registry should fail closed");
+
+        assert!(err.contains("Failed to parse removed projects config"));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -361,6 +361,7 @@ pub fn run() {
             commands::projects::create_blank_project,
             commands::projects::remove_git_history,
             commands::projects::delete_project,
+            commands::projects::remove_project_from_app,
             commands::projects::rename_project,
             commands::projects::clear_project_cache,
             commands::projects::get_auto_accept_mode,

--- a/src/components/dashboard/ImportProject.tsx
+++ b/src/components/dashboard/ImportProject.tsx
@@ -14,7 +14,7 @@
 
 import { useState, useEffect } from 'react';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
-import { readTextFile } from '@tauri-apps/plugin-fs';
+import { exists, readTextFile } from '@tauri-apps/plugin-fs';
 import { trackError } from '../../lib/analytics';
 import {
   getGitHubUsername,
@@ -25,7 +25,6 @@ import {
   GitHubRepo,
 } from '../../lib/github';
 import {
-  listProjects,
   ensureShipStudioDir,
   spawnPty,
   ensureGitignoreHasShipstudio,
@@ -245,23 +244,26 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       return;
     }
 
+    let shipstudioDir: string;
+    try {
+      shipstudioDir = await ensureShipStudioDir();
+    } catch (err) {
+      trackError('project_import', err, 'Dashboard');
+      setError(getFriendlyError(err));
+      return;
+    }
+
     // Auto-suffix on collision so re-importing a monorepo for a different
     // workspace doesn't error out (`sugar-shark`, `sugar-shark-2`, ...).
     let safeName = baseName;
-    try {
-      const existingProjects = await listProjects();
-      const existingNames = new Set(existingProjects.map((p) => p.name.toLowerCase()));
-      let counter = 2;
-      while (existingNames.has(safeName.toLowerCase())) {
-        safeName = `${baseName}-${counter}`;
-        counter += 1;
-        if (counter > 50) {
-          setError(`Too many copies of "${baseName}" already exist`);
-          return;
-        }
+    let counter = 2;
+    while (await exists(`${shipstudioDir}/${safeName}`).catch(() => false)) {
+      safeName = `${baseName}-${counter}`;
+      counter += 1;
+      if (counter > 50) {
+        setError(`Too many copies of "${baseName}" already exist`);
+        return;
       }
-    } catch {
-      // If we can't check, proceed with the base name
     }
 
     setIsImporting(true);
@@ -272,8 +274,6 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
     setAwaitingWorkspacePick(false);
 
     try {
-      // Ensure ShipStudio directory exists
-      const shipstudioDir = await ensureShipStudioDir();
       const projectPath = `${shipstudioDir}/${safeName}`;
 
       // Clone repository using gh CLI (uses GitHub CLI authentication)

--- a/src/components/dashboard/ImportProject.tsx
+++ b/src/components/dashboard/ImportProject.tsx
@@ -257,13 +257,19 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
     // workspace doesn't error out (`sugar-shark`, `sugar-shark-2`, ...).
     let safeName = baseName;
     let counter = 2;
-    while (await exists(`${shipstudioDir}/${safeName}`).catch(() => false)) {
-      safeName = `${baseName}-${counter}`;
-      counter += 1;
-      if (counter > 50) {
-        setError(`Too many copies of "${baseName}" already exist`);
-        return;
+    try {
+      while (await exists(`${shipstudioDir}/${safeName}`)) {
+        safeName = `${baseName}-${counter}`;
+        counter += 1;
+        if (counter > 50) {
+          setError(`Too many copies of "${baseName}" already exist`);
+          return;
+        }
       }
+    } catch (err) {
+      trackError('project_import', err, 'Dashboard');
+      setError(getFriendlyError(err));
+      return;
     }
 
     setIsImporting(true);

--- a/src/components/dashboard/ProjectActionConfirmModal.tsx
+++ b/src/components/dashboard/ProjectActionConfirmModal.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from 'react';
+import { ModalFrame } from '../primitives/ModalFrame';
+import { Button } from '../primitives/Button';
+
+interface ProjectActionConfirmModalProps {
+  title: string;
+  body: ReactNode;
+  hint: string;
+  loading: boolean;
+  confirmLabel: string;
+  loadingLabel: string;
+  confirmVariant: 'primary' | 'danger';
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+/** Shared confirmation dialog for project and folder actions. */
+export function ProjectActionConfirmModal({
+  title,
+  body,
+  hint,
+  loading,
+  confirmLabel,
+  loadingLabel,
+  confirmVariant,
+  onCancel,
+  onConfirm,
+}: ProjectActionConfirmModalProps) {
+  return (
+    <ModalFrame isOpen onClose={onCancel} title={title} showCloseButton={false}>
+      <div style={{ padding: 'var(--spacing-xl)' }}>
+        <p>{body}</p>
+        <p className="hint">{hint}</p>
+        <div className="modal-actions">
+          <Button variant="secondary" onClick={onCancel} disabled={loading}>
+            Cancel
+          </Button>
+          <Button variant={confirmVariant} onClick={onConfirm} disabled={loading}>
+            {loading ? loadingLabel : confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </ModalFrame>
+  );
+}

--- a/src/components/dashboard/ProjectCard.tsx
+++ b/src/components/dashboard/ProjectCard.tsx
@@ -21,7 +21,7 @@ interface ProjectCardProps {
   thumbnailData: string | null;
   /** Callback when the card is clicked to open the project */
   onSelect: () => void;
-  /** Callback when delete button is clicked */
+  /** Callback when deleting project files from disk is clicked */
   onDelete: () => void;
   /** Callback when main branch warning is toggled */
   onToggleMainBranchWarning: (hidden: boolean) => void;
@@ -37,12 +37,12 @@ interface ProjectCardProps {
   onUploadThumbnail?: () => void;
   /** Whether this is an external project */
   isExternal?: boolean;
-  /** Callback when remove from list is clicked (for external projects) */
+  /** Callback when remove from Ship Studio is clicked */
   onRemove?: () => void;
   /** Whether the project is currently pinned to the rail. */
   isPinned?: boolean;
   /** Toggle pin state. Receives the desired new state. */
-  onTogglePin?: (pinned: boolean) => void;
+  onTogglePin?: (pinned: boolean) => void | Promise<void>;
 }
 
 export const ProjectCard = memo(function ProjectCard({

--- a/src/components/dashboard/ProjectCardMenu.tsx
+++ b/src/components/dashboard/ProjectCardMenu.tsx
@@ -4,7 +4,7 @@
  * Provides options for:
  * - Toggling main branch warning
  * - Moving to folder / exporting as template
- * - Deleting the project
+ * - Removing the project from Ship Studio or deleting local files
  *
  * @module components/ProjectCardMenu
  */
@@ -38,17 +38,17 @@ interface ProjectCardMenuProps {
   /** Callback to upload a custom thumbnail image. When set, shows the
    *  "Upload new thumbnail" item; the parent owns the file picker. */
   onUploadThumbnail?: () => void;
-  /** Callback when delete is clicked */
+  /** Callback when deleting files from disk is clicked */
   onDelete: () => void;
-  /** Whether this is an external project (shows "Remove from list" instead of delete) */
+  /** Whether this is an external project */
   isExternal?: boolean;
-  /** Callback when remove from list is clicked (for external projects) */
+  /** Callback when remove from Ship Studio is clicked */
   onRemove?: () => void;
   /** Whether the project is currently pinned to the rail. Optional — when
    *  omitted, the pin/unpin row is hidden entirely (legacy callers). */
   isPinned?: boolean;
   /** Toggle pin state. Receives the desired new state. */
-  onTogglePin?: (pinned: boolean) => void;
+  onTogglePin?: (pinned: boolean) => void | Promise<void>;
 }
 
 export function ProjectCardMenu({
@@ -124,19 +124,22 @@ export function ProjectCardMenu({
                 {isPinned ? '○' : '●'}
               </span>
             }
-            onSelect={() => onTogglePin(!isPinned)}
+            onSelect={() => {
+              void onTogglePin(!isPinned);
+            }}
           >
             <span>{isPinned ? 'Unpin from sidebar' : 'Pin to sidebar'}</span>
           </DropdownItem>
         )}
         <DropdownDivider />
-        {isExternal && onRemove ? (
-          <DropdownItem variant="danger" icon={<CloseIcon size={14} />} onSelect={onRemove}>
-            <span>Remove from list</span>
+        {onRemove && (
+          <DropdownItem icon={<CloseIcon size={14} />} onSelect={onRemove}>
+            <span>Remove from Ship Studio</span>
           </DropdownItem>
-        ) : (
+        )}
+        {!isExternal && (
           <DropdownItem variant="danger" icon={<TrashIcon size={14} />} onSelect={onDelete}>
-            <span>Delete project</span>
+            <span>Delete files from computer</span>
           </DropdownItem>
         )}
       </Dropdown>

--- a/src/components/dashboard/ProjectGridView.tsx
+++ b/src/components/dashboard/ProjectGridView.tsx
@@ -31,7 +31,7 @@ export interface ProjectGridViewProps {
   onOpenMoveWorkspaceModal: (project: DashboardProject) => void;
   onExportAsTemplate: (projectPath: string) => void;
   onUploadThumbnail: (project: DashboardProject) => void;
-  onRemoveExternal: (project: DashboardProject) => void;
+  onRemoveProject: (project: DashboardProject) => void;
 
   onOpenFolder: (folderId: string) => void;
   onRenameFolder: (folder: FolderInfo) => void;
@@ -40,7 +40,7 @@ export interface ProjectGridViewProps {
   /** Set of currently pinned project paths (for menu state). */
   pinnedSet?: ReadonlySet<string>;
   /** Toggle pin state for a project. */
-  onTogglePin?: (projectPath: string, pinned: boolean) => void;
+  onTogglePin?: (projectPath: string, pinned: boolean) => void | Promise<void>;
   /** Start the create-project flow (drives the zero-projects empty-state CTA). */
   onCreateProject?: () => void;
 }
@@ -59,7 +59,7 @@ export function ProjectGridView({
   onOpenMoveWorkspaceModal,
   onExportAsTemplate,
   onUploadThumbnail,
-  onRemoveExternal,
+  onRemoveProject,
   onOpenFolder,
   onRenameFolder,
   onDeleteFolder,
@@ -122,7 +122,7 @@ export function ProjectGridView({
           onExportAsTemplate={() => onExportAsTemplate(project.path)}
           onUploadThumbnail={() => onUploadThumbnail(project)}
           isExternal={project.is_external}
-          onRemove={project.is_external ? () => onRemoveExternal(project) : undefined}
+          onRemove={() => onRemoveProject(project)}
           isPinned={pinnedSet?.has(project.path) ?? false}
           onTogglePin={onTogglePin ? (pinned) => onTogglePin(project.path, pinned) : undefined}
         />

--- a/src/components/dashboard/ProjectList.tsx
+++ b/src/components/dashboard/ProjectList.tsx
@@ -22,10 +22,10 @@ import {
   getProjectThumbnail,
   uploadProjectThumbnail,
   deleteProject,
+  removeProjectFromApp,
   renameProject,
   exportProjectAsTemplate,
 } from '../../lib/project';
-import { unregisterExternalProject } from '../../lib/external-projects';
 import { asCommandError, formatCommandError } from '../../lib/errors';
 import { logger } from '../../lib/logger';
 import { trackEvent, trackError } from '../../lib/analytics';
@@ -52,8 +52,7 @@ import { FolderBreadcrumb } from './FolderBreadcrumb';
 import { MoveFolderModal } from './MoveFolderModal';
 import { MoveWorkspaceModal } from './MoveWorkspaceModal';
 import { SettingsModal } from './SettingsModal';
-import { ModalFrame } from '../primitives/ModalFrame';
-import { Button } from '../primitives/Button';
+import { ProjectActionConfirmModal } from './ProjectActionConfirmModal';
 import { Spinner } from '../primitives/Spinner';
 import { GitHubCalendar } from './GitHubCalendar';
 import { useModal } from '../../contexts/ModalContext';
@@ -107,7 +106,7 @@ interface ProjectListProps {
   /** Set of currently pinned project paths. */
   pinnedSet?: ReadonlySet<string>;
   /** Toggle pin state for a project. */
-  onTogglePin?: (projectPath: string, pinned: boolean) => void;
+  onTogglePin?: (projectPath: string, pinned: boolean) => void | Promise<void>;
   /** Open the workspace switcher (shown as a chip beside "All Projects"). */
   onSwitchAccount?: () => void;
 }
@@ -141,7 +140,9 @@ export function ProjectList({
   const activeAccountId = activeAccount?.id;
   const hasMultipleWorkspaces = accounts.length > 1;
   const [deleteConfirm, setDeleteConfirm] = useState<DashboardProject | null>(null);
+  const [removeConfirm, setRemoveConfirm] = useState<DashboardProject | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [removing, setRemoving] = useState(false);
   const [renameTarget, setRenameTarget] = useState<DashboardProject | null>(null);
 
   // Folder navigation state
@@ -436,15 +437,28 @@ export function ProjectList({
     }
   };
 
-  const handleRemoveExternal = async (project: DashboardProject) => {
+  const handleRemoveFromApp = async (project: DashboardProject) => {
+    setRemoving(true);
     try {
-      await unregisterExternalProject(project.path);
+      await removeProjectFromApp(project.path);
+      if (pinnedSet?.has(project.path)) {
+        await onTogglePin?.(project.path, false);
+      }
+      void trackEvent('project_removed_from_app', {
+        is_external: project.is_external,
+        $screen_name: 'Dashboard',
+      });
+      setRemoveConfirm(null);
       await loadAll();
+      showToast(`${project.name} was removed from Ship Studio`, 'success');
     } catch (error) {
-      logger.error('Failed to remove external project', {
+      trackError('project_remove_from_app', error, 'Dashboard');
+      logger.error('Failed to remove project from Ship Studio', {
         error: error instanceof Error ? error.message : String(error),
       });
-      alert('Failed to remove project: ' + String(error));
+      alert('Failed to remove project: ' + formatCommandError(asCommandError(error)));
+    } finally {
+      setRemoving(false);
     }
   };
 
@@ -671,7 +685,7 @@ export function ProjectList({
           onOpenMoveWorkspaceModal={(project) => void handleOpenMoveWorkspaceModal(project)}
           onExportAsTemplate={(path) => void handleExportAsTemplate(path)}
           onUploadThumbnail={(project) => handleUploadThumbnail(project)}
-          onRemoveExternal={(project) => void handleRemoveExternal(project)}
+          onRemoveProject={(project) => setRemoveConfirm(project)}
           onOpenFolder={(folderId) => setCurrentFolderId(folderId)}
           onRenameFolder={(folder) => setRenamingFolder(folder)}
           onDeleteFolder={(folder) => setDeleteFolderConfirm(folder)}
@@ -803,25 +817,58 @@ export function ProjectList({
 
         {/* Delete Project Confirmation Modal */}
         {deleteConfirm && (
-          <DeleteConfirmModal
-            title="Delete Project?"
-            name={deleteConfirm.name}
-            hint="This will delete the local copy from your computer. If this project is connected to GitHub, your code will remain there and you can reimport it at any time."
-            deleting={deleting}
+          <ProjectActionConfirmModal
+            title="Delete Files From Computer?"
+            body={
+              <>
+                Permanently delete <strong>{deleteConfirm.name}</strong> from this computer?
+              </>
+            }
+            hint="This removes the local project folder and its files. Use Remove from Ship Studio if you only want to hide it from the app."
+            loading={deleting}
+            confirmLabel="Delete files"
+            loadingLabel="Deleting..."
+            confirmVariant="danger"
             onCancel={() => setDeleteConfirm(null)}
-            onDelete={() => void handleDelete(deleteConfirm)}
+            onConfirm={() => void handleDelete(deleteConfirm)}
+          />
+        )}
+
+        {/* Remove Project Confirmation Modal */}
+        {removeConfirm && (
+          <ProjectActionConfirmModal
+            title="Remove From Ship Studio?"
+            body={
+              <>
+                Remove <strong>{removeConfirm.name}</strong> from Ship Studio?
+              </>
+            }
+            hint="Your project folder and files will stay on this computer. You can add it back later with Import Project, Local Folder."
+            loading={removing}
+            confirmLabel="Remove from Ship Studio"
+            loadingLabel="Removing..."
+            confirmVariant="primary"
+            onCancel={() => setRemoveConfirm(null)}
+            onConfirm={() => void handleRemoveFromApp(removeConfirm)}
           />
         )}
 
         {/* Delete Folder Confirmation Modal */}
         {deleteFolderConfirm && (
-          <DeleteConfirmModal
+          <ProjectActionConfirmModal
             title="Delete Folder?"
-            name={deleteFolderConfirm.name}
+            body={
+              <>
+                Delete the folder <strong>{deleteFolderConfirm.name}</strong>?
+              </>
+            }
             hint="Projects in this folder will not be deleted. They will appear at the root level."
-            deleting={deletingFolder}
+            loading={deletingFolder}
+            confirmLabel="Delete"
+            loadingLabel="Deleting..."
+            confirmVariant="danger"
             onCancel={() => setDeleteFolderConfirm(null)}
-            onDelete={() => void handleDeleteFolder(deleteFolderConfirm)}
+            onConfirm={() => void handleDeleteFolder(deleteFolderConfirm)}
           />
         )}
 
@@ -838,41 +885,5 @@ export function ProjectList({
         {/* ChangelogModal is mounted globally in <AppGlobalModals>. */}
       </div>
     </div>
-  );
-}
-
-/** Shared delete-confirmation dialog for projects and folders. */
-function DeleteConfirmModal({
-  title,
-  name,
-  hint,
-  deleting,
-  onCancel,
-  onDelete,
-}: {
-  title: string;
-  name: string;
-  hint: string;
-  deleting: boolean;
-  onCancel: () => void;
-  onDelete: () => void;
-}) {
-  return (
-    <ModalFrame isOpen onClose={onCancel} title={title} showCloseButton={false}>
-      <div style={{ padding: 'var(--spacing-xl)' }}>
-        <p>
-          Are you sure you want to delete <strong>{name}</strong>?
-        </p>
-        <p className="hint">{hint}</p>
-        <div className="modal-actions">
-          <Button variant="secondary" onClick={onCancel} disabled={deleting}>
-            Cancel
-          </Button>
-          <Button variant="danger" onClick={onDelete} disabled={deleting}>
-            {deleting ? 'Deleting...' : 'Delete'}
-          </Button>
-        </div>
-      </div>
-    </ModalFrame>
   );
 }

--- a/src/components/dashboard/ProjectList.tsx
+++ b/src/components/dashboard/ProjectList.tsx
@@ -456,7 +456,7 @@ export function ProjectList({
       logger.error('Failed to remove project from Ship Studio', {
         error: error instanceof Error ? error.message : String(error),
       });
-      alert('Failed to remove project: ' + formatCommandError(asCommandError(error)));
+      showToast(`Failed to remove project: ${formatCommandError(asCommandError(error))}`, 'error');
     } finally {
       setRemoving(false);
     }

--- a/src/lib/project.test.ts
+++ b/src/lib/project.test.ts
@@ -19,6 +19,7 @@ import {
   ensureGitignoreHasShipstudio,
   getProjectThumbnail,
   deleteProject,
+  removeProjectFromApp,
   exportProjectAsTemplate,
   openProjectInNewWindow,
   getCustomDevCommand,
@@ -242,6 +243,25 @@ describe('lib/project', () => {
     it('propagates errors from invoke', async () => {
       vi.mocked(core.invoke).mockRejectedValue(new Error('permission denied'));
       await expect(deleteProject('/abs/project')).rejects.toThrow('permission denied');
+    });
+  });
+
+  // ============ removeProjectFromApp ============
+
+  describe('removeProjectFromApp', () => {
+    it('invokes "remove_project_from_app" with path', async () => {
+      vi.mocked(core.invoke).mockResolvedValue(undefined);
+
+      await removeProjectFromApp('/abs/project');
+
+      expect(core.invoke).toHaveBeenCalledWith('remove_project_from_app', {
+        path: '/abs/project',
+      });
+    });
+
+    it('propagates errors from invoke', async () => {
+      vi.mocked(core.invoke).mockRejectedValue(new Error('not found'));
+      await expect(removeProjectFromApp('/abs/project')).rejects.toThrow('not found');
     });
   });
 

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -138,6 +138,14 @@ export async function deleteProject(path: string): Promise<void> {
 }
 
 /**
+ * Remove a project from Ship Studio without deleting its files.
+ * @param path - Absolute path to the project directory to hide from the dashboard
+ */
+export async function removeProjectFromApp(path: string): Promise<void> {
+  return invoke<void>('remove_project_from_app', { path });
+}
+
+/**
  * Rename a project's folder on disk and rekey path-keyed stores (pins, folders,
  * sessions). Only works for ~/ShipStudio projects, and is rejected by the
  * backend if the project is currently open or has an active session.


### PR DESCRIPTION
## Summary
- Add a non-destructive `Remove from Ship Studio` action for project tiles so users can hide projects without deleting local files.
- Keep `Delete files from computer` as the explicit destructive path with clearer confirmation copy.
- Track hidden local projects in an app-level removed-projects registry and restore them when users re-add the folder.
- Address CodeRabbit review feedback around registry integrity, path validation, restore detection, cleanup behavior, and import collision checks.

## Test plan
- [x] Manually verified removing a project from Ship Studio hides it while leaving files untouched.
- [x] Manually verified the project can be re-added through Import Project -> Local Folder.
- [x] Added backend registry coverage for mark/restore/idempotency/invalid JSON behavior.
- [x] Added frontend wrapper coverage for `removeProjectFromApp`.

## CI gates
- [x] `pnpm check:all && pnpm test:run && pnpm rust:test` passes locally
  - `pnpm check:all`
  - `pnpm test:run`
  - `HOME=/private/tmp/ship-studio-rust-test-home CARGO_HOME=/Users/benjackson/.cargo RUSTUP_HOME=/Users/benjackson/.rustup pnpm rust:test`

<details>
<summary><strong>Patterns checklist</strong> (only relevant if you changed code)</summary>

We use a small set of shared primitives so the codebase stays consistent.
Tick the ones that apply; cross out ones that do not. Full reference:
[CLAUDE.md -> How to Do Things in Ship Studio](../CLAUDE.md#how-to-do-things-in-ship-studio).

**Frontend**
- [x] New modals use `<ModalFrame>` (no hand-rolled overlays / ESC handling)
- [x] New buttons use `<Button variant=...>` (no new `foo-btn` classes)
- [x] New async state uses `useAsyncState` / `useInvoke` (not applicable; no new async state abstraction added)
- [x] New polling uses `usePolling` (not applicable; no polling added)
- [x] Modal state uses `useModal(id)` from `ModalContext` (not applicable; dashboard confirmation state follows the existing local confirm pattern)

**CSS**
- [x] No raw hex colors, raw `px` spacing, raw z-index numbers, or raw transition durations - use design tokens from `src/styles/global/base.css`
- [x] New CSS files placed under `src/styles/{global,features,modes,components}/` (not applicable; no new CSS files)

**Rust**
- [x] New `#[tauri::command]`s return `Result<T, CommandError>` and have `#[tracing::instrument]`
- [x] User-supplied paths validated with `validate_project_path`
- [x] External CLI calls go through `run_with_timeout` (`src-tauri/src/external_command.rs`) (not applicable; no new external CLI calls)

**Tests**
- [x] Added tests for non-trivial logic (or noted why not)

</details>