### PR TITLE
Fix "forbidden path" error when importing GitHub projects

### DIFF
--- a/src-tauri/src/commands/projects/detection.rs
+++ b/src-tauri/src/commands/projects/detection.rs
@@ -6,7 +6,7 @@
 use crate::cache::TtlCache;
 use crate::errors::CommandError;
 use crate::types::{PageInfo, ProjectType};
-use crate::utils::{resolve_workspace_path, validate_project_path};
+use crate::utils::{resolve_workspace_path, validate_project_file_path, validate_project_path};
 use std::sync::LazyLock;
 use std::time::{Duration, SystemTime};
 
@@ -342,6 +342,28 @@ pub async fn detect_project_type_command(
     let project = validate_project_path(&project_path)?;
     let workspace = resolve_workspace_path(&project);
     Ok(detect_project_type(&workspace))
+}
+
+/// Whether a file or directory already exists at `path`, restricted to paths
+/// inside an allowed projects root.
+///
+/// The import flow uses this to auto-suffix a colliding project name
+/// (`repo`, `repo-2`, …). It must see folders that physically exist on disk even
+/// when they aren't registered projects (e.g. a non-destructively removed
+/// project whose folder lingers), so it probes the filesystem rather than the
+/// project list.
+///
+/// Runs in the backend on purpose: the Tauri `fs` plugin scope only whitelists
+/// `$HOME/.nvm/**` for `exists`, so a frontend `exists()` on a `~/ShipStudio`
+/// path is rejected with "forbidden path". Validating here also covers custom
+/// project roots, which a static fs-plugin scope cannot express. Containment is
+/// enforced via `validate_project_file_path` (canonicalizes the parent, rejects
+/// `..`/symlink escapes) without requiring the target itself to exist yet.
+#[tauri::command]
+#[tracing::instrument]
+pub fn project_path_exists(path: String) -> Result<bool, CommandError> {
+    let resolved = validate_project_file_path(&path).map_err(CommandError::from)?;
+    Ok(resolved.exists())
 }
 
 /// Scan Next.js pages (app/ directory with page.tsx/js/jsx files)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -578,6 +578,7 @@ pub fn run() {
             commands::static_server::stop_static_server,
             // Project Type Detection
             commands::projects::detect_project_type_command,
+            commands::projects::project_path_exists,
             // Native Mobile Preview (iOS Simulator via serve-sim)
             commands::mobile::list_booted_simulators,
             commands::mobile::start_mobile_preview,

--- a/src/components/dashboard/ImportProject.tsx
+++ b/src/components/dashboard/ImportProject.tsx
@@ -14,7 +14,6 @@
 
 import { useState, useEffect } from 'react';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
-import { readTextFile } from '@tauri-apps/plugin-fs';
 import { trackError } from '../../lib/analytics';
 import {
   getGitHubUsername,
@@ -340,12 +339,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       // `npm install` exits ENOENT when there's no package.json, killing the
       // import after a successful clone — skip the install step instead, the
       // same way the zip-template path does.
-      let hasPackageJson = true;
-      try {
-        await readTextFile(`${projectPath}/package.json`);
-      } catch {
-        hasPackageJson = false;
-      }
+      const hasPackageJson = await projectPathExists(`${projectPath}/package.json`);
 
       if (hasPackageJson) {
         setCurrentStep('install');

--- a/src/components/dashboard/ImportProject.tsx
+++ b/src/components/dashboard/ImportProject.tsx
@@ -14,7 +14,7 @@
 
 import { useState, useEffect } from 'react';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
-import { exists, readTextFile } from '@tauri-apps/plugin-fs';
+import { readTextFile } from '@tauri-apps/plugin-fs';
 import { trackError } from '../../lib/analytics';
 import {
   getGitHubUsername,
@@ -26,6 +26,7 @@ import {
 } from '../../lib/github';
 import {
   ensureShipStudioDir,
+  projectPathExists,
   spawnPty,
   ensureGitignoreHasShipstudio,
   detectWorkspaces,
@@ -258,7 +259,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
     let safeName = baseName;
     let counter = 2;
     try {
-      while (await exists(`${shipstudioDir}/${safeName}`)) {
+      while (await projectPathExists(`${shipstudioDir}/${safeName}`)) {
         safeName = `${baseName}-${counter}`;
         counter += 1;
         if (counter > 50) {

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -82,6 +82,17 @@ export async function ensureShipStudioDir(): Promise<string> {
 }
 
 /**
+ * Whether a file or folder already exists at `path` inside an allowed projects
+ * root. Backend-validated — the Tauri `fs` plugin scope doesn't whitelist
+ * arbitrary `~/ShipStudio` paths for `exists`, and this also covers custom
+ * project roots. Used by the import flow's name-collision check.
+ * @param path - Absolute path to probe (inside the projects root)
+ */
+export async function projectPathExists(path: string): Promise<boolean> {
+  return invoke<boolean>('project_path_exists', { path });
+}
+
+/**
  * Spawn a pseudo-terminal process via the backend.
  * Used for running commands like git clone and npm install with progress events.
  * @param options - PTY options including cwd, command, args, and terminal size


### PR DESCRIPTION
## Problem

Importing any GitHub repo on v0.13.0 fails before the clone with:

> forbidden path: /Users/<you>/ShipStudio/<repo>, maybe it is not allowed on the scope for `allow-exists` permission in your capability file

The import flow's duplicate-name pre-check ([`ImportProject.tsx`](src/components/dashboard/ImportProject.tsx)) calls the Tauri **fs plugin's** `exists()` on `~/ShipStudio/<name>`, but the fs capability scope ([`capabilities/default.json`](src-tauri/capabilities/default.json)) only whitelists `$HOME/.nvm/**` for `fs:allow-exists`. Every out-of-scope path is rejected, so the check throws on its first iteration — before `gh repo clone` ever runs.

### Regression source

#141 swapped the old, path-validated `listProjects()` collision check for a frontend `exists()` (to also catch non-destructively-removed folders lingering on disk), without granting the fs scope. That shipped in v0.13.0 and breaks all GitHub imports.

## Fix

Replace the scope-blocked frontend `exists()` with a backend `project_path_exists` command that:

- validates containment via `validate_project_file_path` (canonicalizes the parent, rejects `..`/symlink escapes) without requiring the target to exist yet, then
- probes the filesystem directly.

This is independent of the fs-plugin scope and also covers **custom project roots**, which a static scope can't express. It preserves the original intent of #141 (seeing on-disk folders that aren't registered projects).

## Testing

- `cargo check`, `pnpm typecheck`, `pnpm lint`, `pnpm check:patterns`, and the frontend test suite (188 passed) all green.
- Manually verified: import of a previously-failing private repo now clones, installs deps, and syncs; the collision auto-suffix still works (`repo` → `repo-2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a safer project path check used during import, helping detect whether a project location already exists before proceeding.

* **Bug Fixes**
  * Improved import collision handling so existing project folders are identified more reliably, reducing accidental overwrites or duplicate project names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->