### PR TITLE
Fix inline text editing not saving in vanilla-CSS / Astro projects

### DIFF
--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -40,6 +40,7 @@ import { BrowserTools } from './BrowserTools';
 import { HealthTabPanel, type HealthTabPanelRef } from '../code/HealthTabPanel';
 import { BrowserDropdown } from './BrowserDropdown';
 import { useVisualEditor } from '../../hooks/useVisualEditor';
+import { useTextEditing } from '../../hooks/useTextEditing';
 import { useCssCascadeEditor } from '../../hooks/useCssCascadeEditor';
 import { useElementSettings } from '../../hooks/useElementSettings';
 import { useCssVariables } from '../../hooks/useCssVariables';
@@ -617,6 +618,15 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
       ? 'css'
       : null;
   const activeEditMode = editor.editMode || cssEditor.editMode;
+  // Inline text editing (double-click copy) is shared by both styling editors —
+  // mounted once here, active whenever either editor's edit mode is on, so it
+  // works for vanilla-CSS/Astro projects (cssEditor) as well as Tailwind.
+  const textEditing = useTextEditing({
+    iframeRef,
+    projectPath,
+    enabled: activeEditMode,
+    onToast,
+  });
   const toggleActiveEditor =
     editorMode === 'css' ? cssEditor.toggleEditMode : editor.toggleEditMode;
 
@@ -1288,10 +1298,10 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
               selection={editor.selection}
               projectPath={projectPath}
               currentClass={editor.currentClass}
-              textResolution={editor.textResolution}
+              textResolution={textEditing.textResolution}
               imageResolution={editor.imageResolution}
               onReplaceImage={editor.replaceImage}
-              textBlockedNonce={editor.textBlockedNonce}
+              textBlockedNonce={textEditing.textBlockedNonce}
               breakpoints={breakpoints}
               activeBreakpoint={activeBreakpoint}
               breakpointTooWide={breakpointTooWide}

--- a/src/hooks/useTextEditing.test.ts
+++ b/src/hooks/useTextEditing.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Inline text-editing bridge for both styling editors.
+ *
+ * Focus: the regression that shipped text editing broken for vanilla-CSS / Astro
+ * projects — a confirmed `ss:textCommit` must write to source (`applyTextEdit`)
+ * and re-baseline (`ss:commit`). Also covers the select-time editability gating
+ * (`ss:textInfo`), the failure-revert path, and the iframe-source security guard.
+ * Only the two Tauri-backed calls (resolve + write-back) are mocked.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+vi.mock('../lib/edit', async (importActual) => {
+  const actual = await importActual<typeof import('../lib/edit')>();
+  return {
+    ...actual,
+    resolveTextSource: vi.fn(),
+    applyTextEdit: vi.fn(),
+  };
+});
+
+// trackEvent would otherwise reach for a real Tauri IPC on a saved edit.
+vi.mock('../lib/analytics', () => ({ trackEvent: vi.fn().mockResolvedValue(undefined) }));
+
+import { useTextEditing } from './useTextEditing';
+import { resolveTextSource, applyTextEdit } from '../lib/edit';
+
+type Fn = ReturnType<typeof vi.fn>;
+
+function fakeIframeRef() {
+  return {
+    current: { contentWindow: { postMessage: vi.fn() } },
+  } as unknown as React.RefObject<HTMLIFrameElement | null>;
+}
+
+function setup(enabled = true) {
+  const iframeRef = fakeIframeRef();
+  const onToast = vi.fn();
+  const hook = renderHook(() =>
+    useTextEditing({ iframeRef, projectPath: '/proj', enabled, onToast })
+  );
+  return { ...hook, iframeRef, onToast };
+}
+
+/** Calls posted back to the iframe, as `{type}` objects. */
+function posts(iframeRef: React.RefObject<HTMLIFrameElement | null>) {
+  // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the postMessage mock's calls, not invoking it bound
+  const fn = iframeRef.current!.contentWindow!.postMessage as Fn;
+  return (fn.mock.calls as Array<[{ type?: string; editable?: boolean }]>).map((c) => c[0]);
+}
+
+/** Dispatch a window message as if from the given source, then flush microtasks. */
+async function dispatch(data: unknown, source: MessageEventSource) {
+  await act(async () => {
+    window.dispatchEvent(new MessageEvent('message', { source, data }));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+const SIG = { className: 'lead', tagName: 'p', ancestorClasses: [] };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (resolveTextSource as Fn).mockResolvedValue({
+    status: 'resolved',
+    file: 'src/pages/index.astro',
+    line: 7,
+    column: 3,
+    text: 'Old copy',
+  });
+  (applyTextEdit as Fn).mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('useTextEditing', () => {
+  it('writes a confirmed text edit to source and re-baselines (the CSS-editor regression)', async () => {
+    const { iframeRef, onToast } = setup();
+    const src = iframeRef.current!.contentWindow!;
+
+    // A leaf-text selection resolves and the iframe is told editing is allowed.
+    await dispatch({ type: 'ss:select', signature: SIG, leafText: true }, src);
+    expect(posts(iframeRef)).toContainEqual({ type: 'ss:textInfo', editable: true });
+
+    // Confirm an edit → the new text is written to the resolved source location.
+    await dispatch({ type: 'ss:textCommit', text: 'New copy' }, src);
+    expect(applyTextEdit).toHaveBeenCalledTimes(1);
+    expect((applyTextEdit as Fn).mock.calls[0]).toEqual([
+      '/proj',
+      'src/pages/index.astro',
+      7,
+      3,
+      'Old copy',
+      'New copy',
+    ]);
+    expect(posts(iframeRef)).toContainEqual({ type: 'ss:commit' });
+    expect(onToast).toHaveBeenCalledWith('Saved to source', 'success');
+  });
+
+  it('posts editable:false for a non-leaf selection and never resolves text', async () => {
+    const { iframeRef } = setup();
+    await dispatch(
+      { type: 'ss:select', signature: SIG, leafText: false },
+      iframeRef.current!.contentWindow!
+    );
+    expect(resolveTextSource).not.toHaveBeenCalled();
+    expect(posts(iframeRef)).toContainEqual({ type: 'ss:textInfo', editable: false });
+  });
+
+  it('reverts the preview when the source write fails', async () => {
+    (applyTextEdit as Fn).mockRejectedValueOnce(new Error('boom'));
+    const { iframeRef, onToast } = setup();
+    const src = iframeRef.current!.contentWindow!;
+    await dispatch({ type: 'ss:select', signature: SIG, leafText: true }, src);
+    await dispatch({ type: 'ss:textCommit', text: 'New copy' }, src);
+    expect(posts(iframeRef)).toContainEqual({ type: 'ss:textRevert' });
+    expect(onToast).toHaveBeenCalledWith('Error: boom', 'error');
+  });
+
+  it('does not write when the text is unchanged (just re-baselines)', async () => {
+    const { iframeRef } = setup();
+    const src = iframeRef.current!.contentWindow!;
+    await dispatch({ type: 'ss:select', signature: SIG, leafText: true }, src);
+    await dispatch({ type: 'ss:textCommit', text: 'Old copy' }, src);
+    expect(applyTextEdit).not.toHaveBeenCalled();
+    expect(posts(iframeRef)).toContainEqual({ type: 'ss:commit' });
+  });
+
+  it('ignores messages that do not originate from the preview iframe', async () => {
+    setup(); // registers the listener; the forged message below must be rejected
+    // A forged commit from another frame must not write to the user's files.
+    await dispatch({ type: 'ss:textCommit', text: 'Injected' }, {} as MessageEventSource);
+    expect(applyTextEdit).not.toHaveBeenCalled();
+  });
+
+  it('is inert when no editor is in edit mode', async () => {
+    const { iframeRef } = setup(false);
+    await dispatch(
+      { type: 'ss:select', signature: SIG, leafText: true },
+      iframeRef.current!.contentWindow!
+    );
+    expect(resolveTextSource).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useTextEditing.ts
+++ b/src/hooks/useTextEditing.ts
@@ -1,0 +1,195 @@
+/**
+ * Inline text editing — owns the double-click-to-edit-copy flow shared by BOTH
+ * styling editors (Tailwind `useVisualEditor` and vanilla-CSS
+ * `useCssCascadeEditor`). Text editing is an edit-mode capability, not a
+ * styling-editor one: the iframe selection script gates and commits text the
+ * same way regardless of project type, so the handler lives here and is mounted
+ * once in Preview.tsx, active whenever EITHER editor's edit mode is on.
+ *
+ * Flow: an `ss:select` resolves the clicked leaf's text to source and posts the
+ * editability verdict back (`ss:textInfo`) — the iframe gates double-click
+ * editing on it. On confirm the iframe posts `ss:textCommit`; we write the new
+ * text to source (`applyTextEdit`) and post `ss:commit` to re-baseline, or
+ * `ss:textRevert` on failure so the optimistic edit is undone.
+ *
+ * Exposes `textResolution` (drives the Tailwind panel's read-only hint) and
+ * `textBlockedNonce` (pulses the dynamic-text hand-off). The CSS cascade panel
+ * has no text UI — it just benefits from the working commit path.
+ *
+ * Boundaries: lib/edit wrappers (`resolveTextSource`/`applyTextEdit`) over the
+ * Rust edit backend; the iframe `ss:*` message protocol.
+ *
+ * Gotchas: incoming messages are trusted only when `e.source` is the preview
+ * iframe's contentWindow — the iframe hosts untrusted project content, and a
+ * forged `ss:textCommit` would otherwise write to the user's files. Writes arm
+ * `ss:suppressReload` BEFORE touching disk: Astro's full reload can beat the
+ * post-write `ss:commit`, briefly reverting the preview. The resolved target is
+ * mirrored into a ref so the commit handler reads fresh state without
+ * re-subscribing, and the select-time resolve is guarded by its own staleness
+ * token so a fast click-through can't post a stale `ss:textInfo`.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  resolveTextSource,
+  applyTextEdit,
+  type ElementSignature,
+  type TextResolution,
+} from '../lib/edit';
+import { logger } from '../lib/logger';
+import { trackEvent } from '../lib/analytics';
+
+interface Params {
+  iframeRef: React.RefObject<HTMLIFrameElement | null>;
+  projectPath: string;
+  /** Active whenever either styling editor's edit mode is on. */
+  enabled: boolean;
+  onToast?: (message: string, type?: 'success' | 'error') => void;
+}
+
+export function useTextEditing({ iframeRef, projectPath, enabled, onToast }: Params) {
+  // The resolved text target for the current selection (null when the element's
+  // text isn't a plain editable literal). Mirrored into a ref so the ss:textCommit
+  // handler reads the latest without re-subscribing. `text` is the source baseline
+  // used as the drift guard on write-back.
+  const [textResolution, setTextResolution] = useState<TextResolution | null>(null);
+  // Bumps each time a double-click lands on dynamic text the iframe bounced out of
+  // — drives a one-shot pulse on the DynamicTextHelp hand-off so the user notices it.
+  const [textBlockedNonce, setTextBlockedNonce] = useState(0);
+  const textTargetRef = useRef<{ file: string; line: number; column: number; text: string } | null>(
+    null
+  );
+  const setTextTarget = useCallback((res: TextResolution | null) => {
+    textTargetRef.current =
+      res?.status === 'resolved'
+        ? { file: res.file, line: res.line, column: res.column, text: res.text }
+        : null;
+    setTextResolution(res);
+  }, []);
+  // The signature of the current selection, mirrored for on-demand text resolution
+  // if a commit arrives before the (async) select-time resolve has landed.
+  const selectedSigRef = useRef<ElementSignature | null>(null);
+  // Staleness guard for the select-time resolve — bumped on each new selection so a
+  // fast click-through can't let an older resolve post the wrong ss:textInfo.
+  const selectTokenRef = useRef(0);
+
+  const post = useCallback(
+    (msg: unknown) => iframeRef.current?.contentWindow?.postMessage(msg, '*'),
+    [iframeRef]
+  );
+
+  // Drop any stale selection state when edit mode closes, so a target from a prior
+  // session can't bleed into the next one.
+  useEffect(() => {
+    if (enabled) return;
+    selectedSigRef.current = null;
+    textTargetRef.current = null;
+    setTextResolution(null);
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: MessageEvent) => {
+      // SECURITY: only trust messages from the actual preview iframe. The iframe
+      // hosts untrusted project content; a forged `ss:textCommit` from another
+      // frame would otherwise write to the user's source files.
+      if (e.source !== iframeRef.current?.contentWindow) return;
+      const d = e.data as {
+        type?: string;
+        signature?: ElementSignature;
+        leafText?: boolean;
+        text?: string;
+      } | null;
+      if (!d) return;
+
+      // The element turned out not to be editable (dynamic text) — the iframe bounced
+      // out of the optimistic edit. No toast: the Tailwind panel shows the "copy a
+      // request for your agent" hand-off (DynamicTextHelp) for the still-selected element.
+      if (d.type === 'ss:textBlocked') {
+        setTextBlockedNonce((n) => n + 1);
+        return;
+      }
+
+      // Inline text edit was confirmed in the iframe — write the new text to source.
+      if (d.type === 'ss:textCommit' && typeof d.text === 'string') {
+        const next = d.text;
+        const sig = selectedSigRef.current;
+        // Arm reload suppression before writing (same reasoning as a class commit).
+        post({ type: 'ss:suppressReload' });
+        void (async () => {
+          try {
+            // The select-time resolve may not have landed yet (fast double-click →
+            // type → commit); resolve on demand so the edit is never dropped silently.
+            let target = textTargetRef.current;
+            if (!target) {
+              if (!sig) throw new Error('Lost track of this element — reselect it and try again.');
+              const res = await resolveTextSource(projectPath, sig);
+              if (res.status !== 'resolved')
+                throw new Error(res.reason || 'This text isn’t editable.');
+              target = { file: res.file, line: res.line, column: res.column, text: res.text };
+              textTargetRef.current = target;
+            }
+            if (next === target.text) {
+              post({ type: 'ss:commit' }); // unchanged — just re-baseline, no write
+              return;
+            }
+            await applyTextEdit(
+              projectPath,
+              target.file,
+              target.line,
+              target.column,
+              target.text,
+              next
+            );
+            // Advance the drift baseline so consecutive text edits keep working.
+            target.text = next;
+            setTextResolution((prev) =>
+              prev?.status === 'resolved' ? { ...prev, text: next } : prev
+            );
+            post({ type: 'ss:commit' });
+            void trackEvent('visual_text_saved');
+            onToast?.('Saved to source', 'success');
+          } catch (err) {
+            logger.error('[TextEditing] text write-back failed', { error: String(err) });
+            onToast?.(String(err), 'error');
+            // Couldn't save — put the original text back in the preview.
+            post({ type: 'ss:textRevert' });
+          }
+        })();
+        return;
+      }
+
+      // A fresh selection: resolve its text-editability and post the verdict back.
+      // The iframe gates inline editing on it (single-text-node leaves only).
+      if (d.type !== 'ss:select' || !d.signature) return;
+      const sig = d.signature;
+      selectedSigRef.current = sig;
+      setTextTarget(null); // optimistic; iframe allows editing until told otherwise
+      const token = ++selectTokenRef.current;
+      if (d.leafText) {
+        void (async () => {
+          try {
+            const textRes = await resolveTextSource(projectPath, sig);
+            // Ignore if the selection changed underneath us.
+            if (selectTokenRef.current !== token) return;
+            setTextTarget(textRes);
+            post({ type: 'ss:textInfo', editable: textRes.status === 'resolved' });
+          } catch {
+            if (selectTokenRef.current === token) post({ type: 'ss:textInfo', editable: false });
+          }
+        })();
+      } else {
+        post({ type: 'ss:textInfo', editable: false });
+      }
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, [enabled, projectPath, onToast, post, iframeRef, setTextTarget]);
+
+  return {
+    /** Text-editability of the current selection (drives the panel's hint). */
+    textResolution,
+    /** Bumps when a double-click hits dynamic text — pulses the hand-off block. */
+    textBlockedNonce,
+  };
+}

--- a/src/hooks/useVisualEditor.ts
+++ b/src/hooks/useVisualEditor.ts
@@ -5,29 +5,30 @@
  *
  * Lifecycle: toggle on → post `ss:activate` (re-posted on every iframe `load`,
  * since the script re-initializes inert on each HMR reload) → an `ss:select`
- * click resolves to source via the backend (class resolution, plus parallel
- * text/image resolutions guarded by a staleness token) → edits (`applyToken`,
+ * click resolves to source via the backend (class resolution, plus a parallel
+ * image resolution guarded by a staleness token) → edits (`applyToken`,
  * `setBoxSide`, `stepSpacing`, `reset`) twMerge the live class and post
  * `ss:mutate` with breakpoint-scoped preview rules (instant DOM feedback, no
  * write) → `commit` writes the merged className back to source and advances
- * the drift baseline so consecutive edits keep working. Text and image edits
- * (`ss:textCommit`, `replaceImage`) write immediately on confirm.
+ * the drift baseline so consecutive edits keep working. Image edits
+ * (`replaceImage`) write immediately on confirm. Inline TEXT editing lives in
+ * the shared `useTextEditing` hook (mounted alongside this one in Preview.tsx).
  *
- * Exposes `editMode`, `selection`, `currentClass`, text/image resolutions,
+ * Exposes `editMode`, `selection`, `currentClass`, image resolution,
  * `multiTarget`, auto-save, and the edit/commit callbacks — consumed by
  * Preview.tsx, which threads them into VisualEditorPanel.
  *
  * Boundaries: lib/edit wrappers (`resolveClassnameSource`, `applyClassnameEdit
- * [Multi]`, `resolveTextSource`/`applyTextEdit`, `resolveImageSource`/
- * `applySrcEdit`, `findComponentUsage`) over the Rust edit backend; the iframe
- * `ss:*` message protocol; localStorage for the auto-save opt-in.
+ * [Multi]`, `resolveImageSource`/`applySrcEdit`, `findComponentUsage`) over the
+ * Rust edit backend; the iframe `ss:*` message protocol; localStorage for the
+ * auto-save opt-in.
  *
  * Gotchas: incoming messages are trusted only when `e.source` is the preview
  * iframe's contentWindow — the iframe hosts untrusted project content, and a
- * forged `ss:textCommit` would otherwise write to the user's files. Every
+ * forged `ss:mutate` would otherwise drive edits on the user's behalf. Every
  * write arms `ss:suppressReload` BEFORE touching disk: Astro's full reload can
  * beat the post-write `ss:commit`, briefly reverting the preview. Live values
- * (`currentClass`, text/image targets) are mirrored into refs so the commit
+ * (`currentClass`, image target) are mirrored into refs so the commit
  * callbacks read fresh state without re-subscribing the message handler.
  */
 
@@ -37,8 +38,6 @@ import {
   resolveClassnameSource,
   applyClassnameEdit,
   applyClassnameEditMulti,
-  resolveTextSource,
-  applyTextEdit,
   resolveImageSource,
   applySrcEdit,
   findComponentUsage,
@@ -63,7 +62,6 @@ import {
   type ResetSpec,
   type ElementSignature,
   type Resolution,
-  type TextResolution,
   type ImageResolution,
   type UsageReport,
 } from '../lib/edit';
@@ -211,26 +209,12 @@ export function useVisualEditor({
     setMultiTargetState(t);
   }, []);
 
-  // Inline text editing: the resolved text target for the current selection (null
-  // when the element's text isn't a plain editable literal). Mirrored into a ref so
-  // the ss:textCommit handler reads the latest without re-subscribing. `text` is the
-  // source baseline used as the drift guard on write-back.
-  const [textResolution, setTextResolution] = useState<TextResolution | null>(null);
-  // Bumps each time a double-click lands on dynamic text the iframe bounced out of
-  // — drives a one-shot pulse on the DynamicTextHelp hand-off so the user notices it.
-  const [textBlockedNonce, setTextBlockedNonce] = useState(0);
-  const textTargetRef = useRef<{ file: string; line: number; column: number; text: string } | null>(
-    null
-  );
-  const setTextTarget = useCallback((res: TextResolution | null) => {
-    textTargetRef.current =
-      res?.status === 'resolved'
-        ? { file: res.file, line: res.line, column: res.column, text: res.text }
-        : null;
-    setTextResolution(res);
-  }, []);
-  // The signature of the current selection, mirrored for on-demand text resolution if
-  // a commit arrives before the (async) select-time resolve has landed.
+  // Inline text editing lives in the shared `useTextEditing` hook (mounted once in
+  // Preview.tsx, active for either styling editor) — it owns the ss:textInfo gating
+  // and ss:textCommit write-back. This hook keeps only the class/image concerns.
+
+  // The signature of the current selection, mirrored so the class commit/structural
+  // gestures read the live source-className baseline without re-subscribing.
   const selectedSigRef = useRef<ElementSignature | null>(null);
 
   // Image src editing: the resolved src target for the current selection (null when
@@ -328,67 +312,11 @@ export function useVisualEditor({
         signature?: ElementSignature;
         count?: number;
         leafText?: boolean;
-        text?: string;
       } | null;
       if (!d) return;
 
-      // The element turned out not to be editable (dynamic text) — the iframe bounced
-      // out of the optimistic edit. No toast: the panel shows the "copy a request for
-      // your agent" hand-off (DynamicTextHelp) for the still-selected element.
-      if (d.type === 'ss:textBlocked') {
-        setTextBlockedNonce((n) => n + 1);
-        return;
-      }
-
-      // Inline text edit was confirmed in the iframe — write the new text to source.
-      if (d.type === 'ss:textCommit' && typeof d.text === 'string') {
-        const next = d.text;
-        const sig = selectedSigRef.current;
-        // Arm reload suppression before writing (same reasoning as a class commit).
-        post({ type: 'ss:suppressReload' });
-        void (async () => {
-          try {
-            // The select-time resolve may not have landed yet (fast double-click →
-            // type → commit); resolve on demand so the edit is never dropped silently.
-            let target = textTargetRef.current;
-            if (!target) {
-              if (!sig) throw new Error('Lost track of this element — reselect it and try again.');
-              const res = await resolveTextSource(projectPath, sig);
-              if (res.status !== 'resolved')
-                throw new Error(res.reason || 'This text isn’t editable.');
-              target = { file: res.file, line: res.line, column: res.column, text: res.text };
-              textTargetRef.current = target;
-            }
-            if (next === target.text) {
-              post({ type: 'ss:commit' }); // unchanged — just re-baseline, no write
-              return;
-            }
-            await applyTextEdit(
-              projectPath,
-              target.file,
-              target.line,
-              target.column,
-              target.text,
-              next
-            );
-            // Advance the drift baseline so consecutive text edits keep working.
-            target.text = next;
-            setTextResolution((prev) =>
-              prev?.status === 'resolved' ? { ...prev, text: next } : prev
-            );
-            post({ type: 'ss:commit' });
-            recordCommit('visual_text_saved');
-            onToast?.('Saved to source', 'success');
-          } catch (err) {
-            logger.error('[VisualEditor] text write-back failed', { error: String(err) });
-            onToast?.(String(err), 'error');
-            // Couldn't save — put the original text back in the preview.
-            post({ type: 'ss:textRevert' });
-          }
-        })();
-        return;
-      }
-
+      // Text-edit messages (ss:textBlocked / ss:textCommit) are handled by the
+      // shared useTextEditing hook, not here.
       if (d.type !== 'ss:select' || !d.signature) return;
       const sig = d.signature;
       const instanceCount = d.count ?? 1;
@@ -408,7 +336,6 @@ export function useVisualEditor({
       post({ type: 'ss:clearClassPreview' });
       setMultiTarget('all'); // a fresh selection defaults to editing all occurrences
       setUsage(null);
-      setTextTarget(null); // optimistic; iframe allows editing until told otherwise
       setImageTarget(null);
       const usageToken = ++usageTokenRef.current;
       void (async () => {
@@ -441,24 +368,6 @@ export function useVisualEditor({
           });
         }
       })();
-      // Text-editability runs in parallel: only for single-text-node leaves. The
-      // iframe gates inline editing on the verdict we post back (ss:textInfo).
-      if (leafText) {
-        void (async () => {
-          try {
-            const textRes = await resolveTextSource(projectPath, sig);
-            // Ignore if the selection changed underneath us.
-            if (usageTokenRef.current !== usageToken) return;
-            setTextTarget(textRes);
-            post({ type: 'ss:textInfo', editable: textRes.status === 'resolved' });
-          } catch {
-            if (usageTokenRef.current === usageToken)
-              post({ type: 'ss:textInfo', editable: false });
-          }
-        })();
-      } else {
-        post({ type: 'ss:textInfo', editable: false });
-      }
       // Image src resolution runs in parallel for <img> elements — drives the
       // panel's Image section (current asset + Replace).
       if (sig.tagName === 'img') {
@@ -488,10 +397,8 @@ export function useVisualEditor({
     iframeRef,
     setLiveClass,
     setMultiTarget,
-    setTextTarget,
     setImageTarget,
     setEditTarget,
-    recordCommit,
   ]);
 
   // Load the project's custom classes when edit mode opens; refresh helper lets
@@ -512,6 +419,7 @@ export function useVisualEditor({
 
   useEffect(() => {
     if (!editMode) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: load custom classes + entry-CSS check on edit-mode open
     void refreshCustomClasses();
     void detectTailwindSetup(projectPath)
       .then((setup) => setClassEntryReady(setup.entryCss != null))
@@ -910,14 +818,13 @@ export function useVisualEditor({
       if (prev) {
         setSelection(null);
         setLiveClass('');
-        setTextTarget(null);
         setImageTarget(null);
         setEditTarget({ kind: 'element' });
         selectedSigRef.current = null;
       }
       return !prev;
     });
-  }, [setLiveClass, setTextTarget, setImageTarget, setEditTarget]);
+  }, [setLiveClass, setImageTarget, setEditTarget]);
 
   return {
     editMode,
@@ -925,14 +832,10 @@ export function useVisualEditor({
     selection,
     currentClass,
     usage,
-    /** Text-editability of the current selection (drives the panel's hint). */
-    textResolution,
     /** Image-src editability of the current selection (drives the Image section). */
     imageResolution,
     /** Write a new src to source and swap the preview (immediate save). */
     replaceImage,
-    /** Bumps when a double-click hits dynamic text — pulses the hand-off block. */
-    textBlockedNonce,
     multiTarget,
     setMultiTarget,
     autoSave,


### PR DESCRIPTION
## Problem

Double-clicking text to edit copy in the preview worked visually but was **silently dropped** for vanilla-CSS projects (Astro without Tailwind, static HTML). The change reverted on reload, and the sync status stayed **"All changes synced"** because nothing was ever written to source — so there was nothing to publish.

This affected **every** vanilla-CSS / static-HTML project, not a single user.

## Root cause

Text editing was handled only inside `useVisualEditor` (the Tailwind path), which listens for `ss:textCommit` and calls `resolveTextSource` + `applyTextEdit`. `useCssCascadeEditor` (the vanilla-CSS path) only listened for `ss:select` / `ss:cascade` and never wired up text commits. The iframe optimistically allows editing until told otherwise via `ss:textInfo`, which the CSS path never posted — so editing looked enabled but no write ever happened.

## Fix

Text editing is an **edit-mode** capability, not a styling-editor one — the iframe protocol (`select_script.html`) and backend (`resolve_text_source` / `apply_text_edit`) are already project-agnostic. This extracts text editing into a shared `useTextEditing` hook, mounted once in `Preview.tsx` and active whenever **either** editor's edit mode is on.

- **New `src/hooks/useTextEditing.ts`** — owns `ss:select` editability gating (`ss:textInfo`), `ss:textCommit` write-back, and `ss:textBlocked`, with its own staleness guard and the iframe-source security check.
- **`useVisualEditor.ts`** — drops all text logic (keeps `selectedSigRef` for class editing). The Tailwind path runs the **same code, relocated** → no behavioural change.
- **`Preview.tsx`** — mounts `useTextEditing` (gated on `editor.editMode || cssEditor.editMode`); `VisualEditorPanel` now sources `textResolution` / `textBlockedNonce` from the shared hook.
- **`useTextEditing.test.ts`** — 6 tests including the regression (a confirmed commit must write to source), which **fails against the pre-fix code**.

## Testing

- `pnpm check:all`, `pnpm lint:strict`, `pnpm test:run` (885 passed), `pnpm rust:test` (588 passed) — all green.
- Manually verified in a native-CSS Astro project: edit text → saves to the `.astro` source, persists across reload, sync status flips to unsynced.
- Manually verified no regression in a Tailwind project: text editing, the read-only/dynamic-text hint, image replace, and class/spacing edits all still work.

## Patterns checklist

- No banned patterns (`check:patterns` clean) — no hand-rolled modals, no `Result<T, String>`, no raw hex/spacing.
- Reuses the existing `visual_text_saved` analytics event (already documented in `docs/analytics.md`); no new event.
- No new Tauri commands or CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added inline text editing support in the preview, with clearer handling for editable and non-editable text selections.
  - Improved edit-mode behavior so text editing works consistently across supported editor modes.

- **Bug Fixes**
  - Text edits now commit more reliably and recover cleanly if an update fails.
  - Prevented unintended text-edit actions from unrelated messages or inactive editing sessions.

- **Tests**
  - Added coverage for text editing workflows, including success, failure, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->