### PR TITLE
Fix "[object Object]" shown for failed Tauri commands

### DIFF
--- a/src/commands/useShopifyCommands.tsx
+++ b/src/commands/useShopifyCommands.tsx
@@ -8,6 +8,7 @@ import {
   shopifyAdminUrl,
 } from '../lib/shopify';
 import type { ProjectType } from '../lib/static-server';
+import { asCommandError, formatCommandError } from '../lib/errors';
 
 /**
  * Palette commands for Shopify theme projects. Called from `WorkspaceView`
@@ -78,7 +79,7 @@ export function useShopifyCommands({
             onSendToAgent(buildPushPrompt(store));
             showToast('Prompt pasted — press Enter in the terminal to run it', 'success');
           } catch (err) {
-            showToast(err instanceof Error ? err.message : String(err), 'error');
+            showToast(formatCommandError(asCommandError(err)), 'error');
           }
         },
       },
@@ -107,7 +108,7 @@ export function useShopifyCommands({
             }
             await openUrl(shopifyAdminUrl(store));
           } catch (err) {
-            showToast(err instanceof Error ? err.message : String(err), 'error');
+            showToast(formatCommandError(asCommandError(err)), 'error');
           }
         },
       },

--- a/src/components/accounts/AccountSelectScreen.tsx
+++ b/src/components/accounts/AccountSelectScreen.tsx
@@ -20,6 +20,7 @@ import {
   setActiveAccountId,
   type Account,
 } from '../../lib/accounts';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import '../../styles/features/account-select.css';
 
 interface AccountSelectScreenProps {
@@ -56,7 +57,7 @@ export function AccountSelectScreen({ onContinue }: AccountSelectScreenProps) {
       setAccounts(list);
       setActiveId(active);
     } catch (e) {
-      showToast(`Failed to load workspaces: ${String(e)}`, 'error');
+      showToast(`Failed to load workspaces: ${formatCommandError(asCommandError(e))}`, 'error');
     } finally {
       setIsLoading(false);
     }
@@ -72,7 +73,7 @@ export function AccountSelectScreen({ onContinue }: AccountSelectScreenProps) {
       await setActiveAccountId(account.id);
       onContinue();
     } catch (e) {
-      showToast(`Failed to switch workspace: ${String(e)}`, 'error');
+      showToast(`Failed to switch workspace: ${formatCommandError(asCommandError(e))}`, 'error');
     } finally {
       setIsSwitching(false);
     }

--- a/src/components/accounts/AccountSettingsModal.tsx
+++ b/src/components/accounts/AccountSettingsModal.tsx
@@ -27,6 +27,7 @@ import {
   type AccountCredentialStatus,
   type CredentialKey,
 } from '../../lib/accounts';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import '../../styles/features/account-select.css';
 
 interface EditingCred {
@@ -105,7 +106,7 @@ export function AccountSettingsModal({
       onUpdated(updated);
       showToast('Workspace updated', 'success');
     } catch (e) {
-      showToast(`Failed to update: ${String(e)}`, 'error');
+      showToast(`Failed to update: ${formatCommandError(asCommandError(e))}`, 'error');
     } finally {
       setIsSaving(false);
     }
@@ -121,7 +122,7 @@ export function AccountSettingsModal({
       onDeleted(account.id);
       showToast('Workspace deleted', 'success');
     } catch (e) {
-      showToast(`Failed to delete: ${String(e)}`, 'error');
+      showToast(`Failed to delete: ${formatCommandError(asCommandError(e))}`, 'error');
       setIsDeleting(false);
     }
   };
@@ -135,7 +136,7 @@ export function AccountSettingsModal({
       await loadCredStatus(account.id);
       showToast('Credential saved', 'success');
     } catch (e) {
-      showToast(`Failed to save: ${String(e)}`, 'error');
+      showToast(`Failed to save: ${formatCommandError(asCommandError(e))}`, 'error');
     } finally {
       setIsSavingCred(false);
     }
@@ -147,7 +148,7 @@ export function AccountSettingsModal({
       await loadCredStatus(account.id);
       showToast('Credential removed', 'success');
     } catch (e) {
-      showToast(`Failed to clear: ${String(e)}`, 'error');
+      showToast(`Failed to clear: ${formatCommandError(asCommandError(e))}`, 'error');
     }
   };
 

--- a/src/components/accounts/NewAccountModal.tsx
+++ b/src/components/accounts/NewAccountModal.tsx
@@ -10,6 +10,7 @@ import { Button } from '../primitives/Button';
 import { Spinner } from '../primitives/Spinner';
 import { useOptionalToast } from '../../contexts/ToastContext';
 import { createAccount, ACCOUNT_COLORS, type Account } from '../../lib/accounts';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 interface NewAccountModalProps {
   isOpen: boolean;
@@ -37,7 +38,7 @@ export function NewAccountModal({ isOpen, onClose, onCreated }: NewAccountModalP
       onCreated(created);
       handleClose();
     } catch (e) {
-      showToast(`Failed to create workspace: ${String(e)}`, 'error');
+      showToast(`Failed to create workspace: ${formatCommandError(asCommandError(e))}`, 'error');
     } finally {
       setIsSaving(false);
     }

--- a/src/components/branches/BranchIndicator.tsx
+++ b/src/components/branches/BranchIndicator.tsx
@@ -21,6 +21,7 @@ import { ChangedFile, ChangeStatus } from '../../lib/git';
 import { discardChanges } from '../../lib/branches';
 import { DiffModal } from './DiffModal';
 import { useOptionalToast } from '../../contexts/ToastContext';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 interface BranchIndicatorProps {
   /** Current branch name */
@@ -113,7 +114,7 @@ export function BranchIndicator({
       onDiscard?.();
       setShowDropdown(false);
     } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
+      const message = formatCommandError(asCommandError(e));
       onToast?.(`Failed to discard changes: ${message}`, 'error');
     } finally {
       setIsDiscarding(false);

--- a/src/components/branches/GitHubButton.tsx
+++ b/src/components/branches/GitHubButton.tsx
@@ -24,6 +24,7 @@ import { openUrl } from '@tauri-apps/plugin-opener';
 import { Button } from '../primitives/Button';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { useOptionalToast } from '../../contexts/ToastContext';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 /** Props for the GitHubButton component */
 interface GitHubButtonProps {
@@ -316,7 +317,7 @@ export function GitHubButton({
                     setIsCreatingRepo(false);
                   }, 3000);
                 } catch (e) {
-                  setError(String(e));
+                  setError(formatCommandError(asCommandError(e)));
                   onToast?.('Failed to create repository', 'error');
                   setIsLoading(false);
                   setIsCreatingRepo(false);

--- a/src/components/branches/PublishBranchDropdown.tsx
+++ b/src/components/branches/PublishBranchDropdown.tsx
@@ -16,6 +16,7 @@ import { useClickOutside } from '../../hooks/useClickOutside';
 import { logger } from '../../lib/logger';
 import { trackEvent, trackError } from '../../lib/analytics';
 import { useOptionalToast } from '../../contexts/ToastContext';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 // Module-scoped so the metric spans dropdown re-mounts. Per-project would be
 // better but cross-project publish cadence is also useful and far simpler.
@@ -164,7 +165,7 @@ export function PublishBranchDropdown({
       onStatusChange();
       setPublishState({ status: 'success' });
     } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
+      const message = formatCommandError(asCommandError(e));
       let errorType: 'push_rejected' | 'auth_error' | 'merge_conflict' | 'generic' = 'generic';
 
       if (message.includes('MERGE_CONFLICT')) {

--- a/src/components/branches/PullRequestsTab.tsx
+++ b/src/components/branches/PullRequestsTab.tsx
@@ -24,6 +24,7 @@ import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { Spinner } from '../primitives/Spinner';
 import { useOptionalToast } from '../../contexts/ToastContext';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 interface PullRequestsTabProps {
   /** Project path for PR operations */
@@ -126,7 +127,7 @@ export function PullRequestsTab({
       setPostMergeInfo({ branchName: headRef, baseBranch: baseRef });
     } catch (e) {
       trackError('pr_merge', e, 'Workspace');
-      onToast?.(`Failed to merge: ${String(e)}`, 'error');
+      onToast?.(`Failed to merge: ${formatCommandError(asCommandError(e))}`, 'error');
     } finally {
       setMergingPr(null);
     }
@@ -156,7 +157,7 @@ export function PullRequestsTab({
       }
     } catch (e) {
       trackError('pr_post_merge_cleanup', e, 'Workspace');
-      onToast?.(`Cleanup failed: ${String(e)}`, 'error');
+      onToast?.(`Cleanup failed: ${formatCommandError(asCommandError(e))}`, 'error');
     } finally {
       setIsCleaningUp(false);
       setPostMergeInfo(null);
@@ -173,7 +174,7 @@ export function PullRequestsTab({
       onToast?.(`Checked out branch ${headRef}`, 'success');
     } catch (e) {
       trackError('pr_checkout', e, 'Workspace');
-      onToast?.(`Failed to checkout: ${String(e)}`, 'error');
+      onToast?.(`Failed to checkout: ${formatCommandError(asCommandError(e))}`, 'error');
     } finally {
       setCheckingOutPr(null);
     }
@@ -189,7 +190,7 @@ export function PullRequestsTab({
       onRefresh();
     } catch (e) {
       trackError('pr_close', e, 'Workspace');
-      onToast?.(`Failed to close PR: ${String(e)}`, 'error');
+      onToast?.(`Failed to close PR: ${formatCommandError(asCommandError(e))}`, 'error');
     } finally {
       setClosingPr(null);
     }

--- a/src/components/branches/UnsavedChangesModal.tsx
+++ b/src/components/branches/UnsavedChangesModal.tsx
@@ -15,6 +15,7 @@ import { publishBranch, discardChanges, switchBranch } from '../../lib/branches'
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { useOptionalToast } from '../../contexts/ToastContext';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 interface UnsavedChangesModalProps {
   /** Current branch name */
@@ -54,7 +55,7 @@ export function UnsavedChangesModal({
         onToast?.(result.error || 'Failed to switch branch', 'error');
       }
     } catch (e) {
-      onToast?.(`Failed to publish: ${String(e)}`, 'error');
+      onToast?.(`Failed to publish: ${formatCommandError(asCommandError(e))}`, 'error');
     } finally {
       setIsPublishing(false);
     }
@@ -73,7 +74,7 @@ export function UnsavedChangesModal({
         onToast?.(result.error || 'Failed to switch branch', 'error');
       }
     } catch (e) {
-      onToast?.(`Failed to discard changes: ${String(e)}`, 'error');
+      onToast?.(`Failed to discard changes: ${formatCommandError(asCommandError(e))}`, 'error');
     } finally {
       setIsDiscarding(false);
     }

--- a/src/components/dashboard/AgentsPanel.tsx
+++ b/src/components/dashboard/AgentsPanel.tsx
@@ -39,6 +39,7 @@ import { Spinner } from '../primitives/Spinner';
 import { useOptionalToast } from '../../contexts/ToastContext';
 import { useWorkspaceConnect } from '../../hooks/useWorkspaceConnect';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import {
   CheckIcon,
   ClaudeIcon,
@@ -292,7 +293,10 @@ export function AgentsPanel() {
       setAgents(data);
     } catch (err) {
       logger.warn('Failed to load agent status');
-      showToastRef.current(`Failed to load agents: ${String(err)}`, 'error');
+      showToastRef.current(
+        `Failed to load agents: ${formatCommandError(asCommandError(err))}`,
+        'error'
+      );
     } finally {
       setLoading(false);
     }
@@ -397,7 +401,7 @@ export function AgentsPanel() {
         // the new default without intermediate states.
         setAgents((current) => current.map((a) => ({ ...a, isDefault: a.id === agentId })));
       } catch (err) {
-        showToast(`Failed to set default: ${String(err)}`, 'error');
+        showToast(`Failed to set default: ${formatCommandError(asCommandError(err))}`, 'error');
       } finally {
         setBusy(null);
       }
@@ -421,7 +425,7 @@ export function AgentsPanel() {
         showToast(`Signed out of ${agent.displayName}`, 'success');
         await refresh();
       } catch (err) {
-        showToast(`Sign out failed: ${String(err)}`, 'error');
+        showToast(`Sign out failed: ${formatCommandError(asCommandError(err))}`, 'error');
       } finally {
         setBusy(null);
       }
@@ -462,7 +466,7 @@ export function AgentsPanel() {
         showToast(`Uninstalled ${displayName}`, 'success');
         await refresh();
       } catch (err) {
-        showToast(`Uninstall failed: ${String(err)}`, 'error');
+        showToast(`Uninstall failed: ${formatCommandError(asCommandError(err))}`, 'error');
       } finally {
         setBusy(null);
       }

--- a/src/components/dashboard/Changelog.tsx
+++ b/src/components/dashboard/Changelog.tsx
@@ -13,6 +13,7 @@ import { listen } from '@tauri-apps/api/event';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { WarningIcon } from '../icons';
 import { trackEvent, trackError } from '../../lib/analytics';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import { installVersion } from '../../lib/updater';
 import { Button } from '../primitives/Button';
 
@@ -637,7 +638,7 @@ export function Changelog({ className = '' }: ChangelogProps) {
     } catch (err: unknown) {
       trackError('version_rewind', err, 'Dashboard');
       setRewindStage('error');
-      setRewindError(err instanceof Error ? err.message : String(err));
+      setRewindError(formatCommandError(asCommandError(err)));
     }
   }, [rewindVersion]);
 

--- a/src/components/dashboard/ClaudeConnectTerminal.tsx
+++ b/src/components/dashboard/ClaudeConnectTerminal.tsx
@@ -19,6 +19,7 @@ import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { createWebLinksAddon } from '../../lib/terminalLinks';
 import { loadNerdFonts } from '../../lib/fonts';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import {
   claudeConnectStart,
   claudeConnectWrite,
@@ -150,7 +151,9 @@ export function ClaudeConnectTerminal({
         });
       } catch (err) {
         logger.warn('[ClaudeConnectTerminal] failed to start connect', { error: String(err) });
-        term.write(`\r\n\x1b[31mCouldn't start Claude login: ${String(err)}\x1b[0m\r\n`);
+        term.write(
+          `\r\n\x1b[31mCouldn't start Claude login: ${formatCommandError(asCommandError(err))}\x1b[0m\r\n`
+        );
         return;
       }
 

--- a/src/components/dashboard/ImportProject.tsx
+++ b/src/components/dashboard/ImportProject.tsx
@@ -42,6 +42,7 @@ import {
   type WorkspacePick,
 } from '../import-project/steps/Step3WorkspacePicker';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import { Spinner } from '../primitives/Spinner';
 
 /** Props for the ImportProject component */
@@ -116,7 +117,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       setRepos(repoList);
     } catch (e) {
       trackError('github_repos_load', e, 'Dashboard');
-      setError(`Failed to load repositories: ${String(e)}`);
+      setError(`Failed to load repositories: ${formatCommandError(asCommandError(e))}`);
     } finally {
       setLoadingRepos(false);
     }

--- a/src/components/dashboard/NewFolderModal.tsx
+++ b/src/components/dashboard/NewFolderModal.tsx
@@ -9,6 +9,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 /** Props for the NewFolderModal component */
 interface NewFolderModalProps {
@@ -66,7 +67,7 @@ export function NewFolderModal({
       await onCreate(trimmedName);
       onClose();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(formatCommandError(asCommandError(err)));
     } finally {
       setLoading(false);
     }

--- a/src/components/dashboard/ProjectList.tsx
+++ b/src/components/dashboard/ProjectList.tsx
@@ -383,7 +383,7 @@ export function ProjectList({
       logger.error('Failed to toggle main branch warning', {
         error: error instanceof Error ? error.message : String(error),
       });
-      alert('Failed to update main branch warning: ' + String(error));
+      alert('Failed to update main branch warning: ' + formatCommandError(asCommandError(error)));
     }
   };
 
@@ -417,7 +417,7 @@ export function ProjectList({
       logger.error('Failed to upload thumbnail', {
         error: error instanceof Error ? error.message : String(error),
       });
-      alert('Failed to upload thumbnail: ' + String(error));
+      alert('Failed to upload thumbnail: ' + formatCommandError(asCommandError(error)));
     }
   };
 
@@ -433,7 +433,7 @@ export function ProjectList({
       logger.error('Failed to export template', {
         error: error instanceof Error ? error.message : String(error),
       });
-      alert('Failed to export template: ' + String(error));
+      alert('Failed to export template: ' + formatCommandError(asCommandError(error)));
     }
   };
 
@@ -485,7 +485,7 @@ export function ProjectList({
       logger.error('Failed to delete folder', {
         error: error instanceof Error ? error.message : String(error),
       });
-      alert('Failed to delete folder: ' + String(error));
+      alert('Failed to delete folder: ' + formatCommandError(asCommandError(error)));
     } finally {
       setDeletingFolder(false);
     }

--- a/src/components/dashboard/VercelTokenModal.tsx
+++ b/src/components/dashboard/VercelTokenModal.tsx
@@ -13,6 +13,7 @@ import { openUrl } from '@tauri-apps/plugin-opener';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { setAccountCredential } from '../../lib/accounts';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import { useOptionalToast } from '../../contexts/ToastContext';
 
 const VERCEL_TOKENS_URL = 'https://vercel.com/account/tokens';
@@ -40,7 +41,7 @@ export function VercelTokenModal({
       await setAccountCredential(accountId, 'vercel_token', trimmed);
       onSaved();
     } catch (err) {
-      showToast(`Couldn't save Vercel token: ${String(err)}`, 'error');
+      showToast(`Couldn't save Vercel token: ${formatCommandError(asCommandError(err))}`, 'error');
     } finally {
       setSaving(false);
     }

--- a/src/components/dashboard/WorkspaceConnectTerminal.tsx
+++ b/src/components/dashboard/WorkspaceConnectTerminal.tsx
@@ -18,6 +18,7 @@ import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { createWebLinksAddon } from '../../lib/terminalLinks';
 import { loadNerdFonts } from '../../lib/fonts';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import {
   workspaceConnectStart,
   workspaceConnectWrite,
@@ -139,7 +140,9 @@ export function WorkspaceConnectTerminal({
         });
       } catch (err) {
         logger.warn('[WorkspaceConnectTerminal] failed to start connect', { error: String(err) });
-        term.write(`\r\n\x1b[31mCouldn't start login: ${String(err)}\x1b[0m\r\n`);
+        term.write(
+          `\r\n\x1b[31mCouldn't start login: ${formatCommandError(asCommandError(err))}\x1b[0m\r\n`
+        );
         return;
       }
 

--- a/src/components/plugins/McpModal.tsx
+++ b/src/components/plugins/McpModal.tsx
@@ -15,6 +15,7 @@ import { Spinner } from '../primitives/Spinner';
 import { type McpServer, listMcpServers, addMcpServer, removeMcpServer } from '../../lib/mcp';
 import { trackEvent, trackSearch } from '../../lib/analytics';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import { useModal } from '../../contexts/ModalContext';
 
 type Tab = 'connected' | 'add';
@@ -118,7 +119,7 @@ export function McpModal({
       logger.error('Failed to add MCP server', {
         error: err instanceof Error ? err.message : String(err),
       });
-      setAddError(err instanceof Error ? err.message : String(err));
+      setAddError(formatCommandError(asCommandError(err)));
     } finally {
       setIsAdding(false);
     }

--- a/src/components/plugins/PluginManager.tsx
+++ b/src/components/plugins/PluginManager.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { CloseIcon, SearchIcon } from '../icons';
 import { trackEvent, trackError } from '../../lib/analytics';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import {
   listPlugins,
   installPlugin,
@@ -256,7 +257,7 @@ export function PluginManager({
       logger.error('Failed to install plugin', {
         error: err instanceof Error ? err.message : String(err),
       });
-      setError(err instanceof Error ? err.message : String(err));
+      setError(formatCommandError(asCommandError(err)));
       setInstallingId(null);
     }
   };
@@ -283,7 +284,7 @@ export function PluginManager({
       logger.error('Failed to install plugin from URL', {
         error: err instanceof Error ? err.message : String(err),
       });
-      setError(err instanceof Error ? err.message : String(err));
+      setError(formatCommandError(asCommandError(err)));
     } finally {
       setIsInstallingUrl(false);
     }
@@ -310,7 +311,7 @@ export function PluginManager({
       logger.error('Failed to link dev plugin', {
         error: err instanceof Error ? err.message : String(err),
       });
-      setError(err instanceof Error ? err.message : String(err));
+      setError(formatCommandError(asCommandError(err)));
     } finally {
       setIsLinkingDev(false);
     }

--- a/src/components/plugins/SkillsModal.tsx
+++ b/src/components/plugins/SkillsModal.tsx
@@ -23,6 +23,7 @@ import {
 import { listAgentSkills } from '../../lib/claude';
 import { trackEvent, trackSearch } from '../../lib/analytics';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import { useModal } from '../../contexts/ModalContext';
 
 /** Format install count as compact string (e.g., 98500 → "98.5K") */
@@ -158,7 +159,7 @@ export function SkillsModal({
       logger.error('Failed to search skills', {
         error: err instanceof Error ? err.message : String(err),
       });
-      setSearchError(err instanceof Error ? err.message : 'Search failed');
+      setSearchError(formatCommandError(asCommandError(err)));
     } finally {
       setIsSearching(false);
     }
@@ -178,7 +179,7 @@ export function SkillsModal({
       await fetchSkills();
       setActiveTab('installed');
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      const msg = formatCommandError(asCommandError(err));
       logger.error('Failed to install skill', { error: msg });
       setSearchError(msg);
     } finally {

--- a/src/components/preview/DeviceMirror.tsx
+++ b/src/components/preview/DeviceMirror.tsx
@@ -48,6 +48,7 @@ import { Button } from '../primitives/Button';
 import { Spinner } from '../primitives/Spinner';
 import { BuildTerminal } from '../terminal/BuildTerminal';
 import { AndroidMirrorStage } from './AndroidMirrorStage';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 interface DeviceMirrorProps {
   /** Project name, for guidance copy. */
@@ -286,7 +287,7 @@ export function DeviceMirror({ projectName, projectPath, onSendToAgent }: Device
         logger.error('[DeviceMirror] failed', {
           error: err instanceof Error ? err.message : String(err),
         });
-        setErrorMsg(err instanceof Error ? err.message : String(err));
+        setErrorMsg(formatCommandError(asCommandError(err)));
         setStatus('error');
       }
     };

--- a/src/components/setup/OnboardingTerminal.tsx
+++ b/src/components/setup/OnboardingTerminal.tsx
@@ -18,6 +18,7 @@ import { readDir, exists } from '@tauri-apps/plugin-fs';
 import { loadNerdFonts } from '../../lib/fonts';
 import { isWindows } from '../../lib/setup';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import '@xterm/xterm/css/xterm.css';
 
 /** Props for the OnboardingTerminal component */
@@ -299,7 +300,9 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
         term.focus();
       } catch (err) {
         logger.warn(`Failed to spawn ${command}`);
-        term.write(`\x1b[31mError starting command: ${String(err)}\x1b[0m\r\n`);
+        term.write(
+          `\x1b[31mError starting command: ${formatCommandError(asCommandError(err))}\x1b[0m\r\n`
+        );
         // Notify parent of failure
         setTimeout(() => onExitRef.current(1), 1000);
       }

--- a/src/components/shopify/ShopifySetup.tsx
+++ b/src/components/shopify/ShopifySetup.tsx
@@ -25,6 +25,7 @@ import { useOptionalToast } from '../../contexts/ToastContext';
 import { Button } from '../primitives/Button';
 import { ResetIcon } from '../icons';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 type GateStep = 'checking' | 'cli-missing' | 'store-missing';
 
@@ -102,7 +103,7 @@ export function ShopifySetup({
       onConnected();
     } catch (err) {
       logger.error('[ShopifySetup] Failed to save store', { error: String(err) });
-      setInputError(err instanceof Error ? err.message : String(err));
+      setInputError(formatCommandError(asCommandError(err)));
     } finally {
       setIsSaving(false);
     }

--- a/src/components/shopify/ShopifyStoreModal.tsx
+++ b/src/components/shopify/ShopifyStoreModal.tsx
@@ -13,6 +13,7 @@ import { useModal } from '../../contexts/ModalContext';
 import { useOptionalToast } from '../../contexts/ToastContext';
 import { getShopifyStore, setShopifyStore, normalizeStoreDomain } from '../../lib/shopify';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 interface ShopifyStoreModalProps {
   projectPath: string;
@@ -59,7 +60,7 @@ export function ShopifyStoreModal({ projectPath, onStoreSaved }: ShopifyStoreMod
       onStoreSaved();
     } catch (err) {
       logger.error('[ShopifyStoreModal] Failed to save store', { error: String(err) });
-      setError(err instanceof Error ? err.message : String(err));
+      setError(formatCommandError(asCommandError(err)));
     } finally {
       setIsSaving(false);
     }

--- a/src/components/support/ConversationView.tsx
+++ b/src/components/support/ConversationView.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../lib/support';
 import type { WidgetMessage } from '../../lib/support';
 import { trackEvent } from '../../lib/analytics';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 interface ConversationViewProps {
   ticketId: string;
@@ -54,7 +55,7 @@ export function ConversationView({ ticketId }: ConversationViewProps) {
       })
       .catch((e) => {
         if (!cancelled) {
-          setError(e instanceof Error ? e.message : String(e));
+          setError(formatCommandError(asCommandError(e)));
           setLoading(false);
         }
       });
@@ -80,7 +81,7 @@ export function ConversationView({ ticketId }: ConversationViewProps) {
       void trackEvent('support_ticket_replied', { $screen_name: 'Support' });
       setTimeout(scrollToBottom, 50);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(formatCommandError(asCommandError(e)));
     } finally {
       setSending(false);
     }

--- a/src/components/support/NewTicketForm.tsx
+++ b/src/components/support/NewTicketForm.tsx
@@ -11,6 +11,7 @@ import { trackEvent } from '../../lib/analytics';
 import { getVersion } from '@tauri-apps/api/app';
 import { getCurrentBranch } from '../../lib/branches';
 import { detectProjectType } from '../../lib/static-server';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 const TICKET_TYPES = [
   { id: 'bug', icon: '🐛', label: 'Bug' },
@@ -124,7 +125,7 @@ export function NewTicketForm({
 
       onSuccess(conversation);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(formatCommandError(asCommandError(e)));
       setSubmitting(false);
     }
   };

--- a/src/components/support/TicketList.tsx
+++ b/src/components/support/TicketList.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect } from 'react';
 import { listTickets, formatRelativeTime } from '../../lib/support';
 import type { Conversation } from '../../lib/support';
 import type { SupportView } from './SupportPanel';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 interface TicketListProps {
   onNavigate: (view: SupportView) => void;
@@ -25,7 +26,7 @@ export function TicketList({ onNavigate }: TicketListProps) {
         if (!cancelled) setTickets(result);
       })
       .catch((e) => {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+        if (!cancelled) setError(formatCommandError(asCommandError(e)));
       })
       .finally(() => {
         if (!cancelled) setLoading(false);

--- a/src/components/terminal/BuildTerminal.tsx
+++ b/src/components/terminal/BuildTerminal.tsx
@@ -34,6 +34,7 @@ import {
 import { getTerminalGpuEnabled } from '../../lib/settings';
 import { loadNerdFonts } from '../../lib/fonts';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import '@xterm/xterm/css/xterm.css';
 
 interface BuildTerminalProps {
@@ -200,7 +201,9 @@ export function BuildTerminal({
           logger.error('[BuildTerminal] failed to start build session', {
             error: err instanceof Error ? err.message : String(err),
           });
-          term.write(`\r\n\x1b[31mFailed to start build: ${String(err)}\x1b[0m\r\n`);
+          term.write(
+            `\r\n\x1b[31mFailed to start build: ${formatCommandError(asCommandError(err))}\x1b[0m\r\n`
+          );
         }
       }
     })();

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -46,6 +46,7 @@ import { getShellPath, getSystemEnv } from '../../lib/project';
 import { loadNerdFonts } from '../../lib/fonts';
 import { isWindows } from '../../lib/setup';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import { getTerminalGpuEnabled } from '../../lib/settings';
 import type { AgentConfig } from '../../lib/agent';
 import '@xterm/xterm/css/xterm.css';
@@ -943,7 +944,9 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           );
           setTimeout(() => void setupPty(retryCount + 1), 1000);
         } else {
-          term.write(`\x1b[31m${agent.notFoundMessage}: ${String(err)}\x1b[0m\r\n`);
+          term.write(
+            `\x1b[31m${agent.notFoundMessage}: ${formatCommandError(asCommandError(err))}\x1b[0m\r\n`
+          );
           term.write(`\x1b[33m${agent.installHint}\x1b[0m\r\n`);
         }
       }

--- a/src/components/workspace/BackupsModal.tsx
+++ b/src/components/workspace/BackupsModal.tsx
@@ -17,6 +17,7 @@ import { useAsyncState } from '../../hooks/useAsyncState';
 import { EmptyState } from '../primitives/EmptyState';
 import { Spinner } from '../primitives/Spinner';
 import { useModal } from '../../contexts/ModalContext';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 interface BackupsModalProps {
   projectPath: string;
@@ -81,7 +82,7 @@ export function BackupsModal({ projectPath, onRestore, onCreatePR }: BackupsModa
       setModalState({ type: 'success', result });
       onRestore?.();
     } catch (err) {
-      setError(String(err));
+      setError(formatCommandError(asCommandError(err)));
       setModalState({ type: 'list' });
     }
   };

--- a/src/hooks/useAsyncState.ts
+++ b/src/hooks/useAsyncState.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { asCommandError, formatCommandError } from '../lib/errors';
 
 export interface UseAsyncStateReturn<T, Args extends unknown[]> {
   data: T | null;
@@ -72,14 +73,10 @@ export function useAsyncState<T, Args extends unknown[] = []>(
       }
       return result;
     } catch (e) {
-      const err =
-        e instanceof Error
-          ? e
-          : new Error(
-              typeof e === 'object' && e !== null && 'message' in e
-                ? String((e as { message: unknown }).message)
-                : String(e)
-            );
+      // A rejected Tauri command is a `CommandError` object, not an Error —
+      // route it through the formatter so variants without a `message` field
+      // (Process, Timeout, …) render properly instead of "[object Object]".
+      const err = e instanceof Error ? e : new Error(formatCommandError(asCommandError(e)));
       if (mountedRef.current) {
         setError(err);
         onErrorRef.current?.(err);

--- a/src/hooks/useBranchManagement.ts
+++ b/src/hooks/useBranchManagement.ts
@@ -21,6 +21,7 @@ import {
 import { getChangedFiles, ChangedFile } from '../lib/git';
 import { invoke } from '@tauri-apps/api/core';
 import { logger } from '../lib/logger';
+import { asCommandError, formatCommandError } from '../lib/errors';
 import { trackEvent } from '../lib/analytics';
 import type { PreviewHandle } from '../components/preview/Preview';
 import type { HealthTabPanelRef } from '../components/code/HealthTabPanel';
@@ -249,7 +250,7 @@ export function useBranchManagement({
             void fetchBranchInfo(currentProject.path);
             return;
           } catch (e) {
-            const errorMsg = e instanceof Error ? e.message : String(e);
+            const errorMsg = formatCommandError(asCommandError(e));
             if (errorMsg.includes('MERGE_CONFLICT')) {
               // Conflicts created locally - show the UI
               setShowConflictResolution(true);
@@ -258,7 +259,7 @@ export function useBranchManagement({
             }
           }
         } catch (e) {
-          const errorMsg = e instanceof Error ? e.message : String(e);
+          const errorMsg = formatCommandError(asCommandError(e));
           showToast(`Error: ${errorMsg}`, 'error');
         }
       } else {

--- a/src/hooks/useCodeHealth.ts
+++ b/src/hooks/useCodeHealth.ts
@@ -18,6 +18,7 @@ import {
   getFixPrompt,
 } from '../lib/health';
 import { logger } from '../lib/logger';
+import { asCommandError, formatCommandError } from '../lib/errors';
 
 export type CheckStatus = 'idle' | 'running' | 'pass' | 'fail' | 'missing';
 
@@ -197,7 +198,7 @@ export function useCodeHealth({
           return 'fail';
         }
       } catch (e) {
-        const message = e instanceof Error ? e.message : String(e);
+        const message = formatCommandError(asCommandError(e));
         emitOutput(`\x1b[31m✕\x1b[0m ${CATEGORY_LABELS[category]} error: ${message}\r\n`);
         setCheckStates((prev) => ({
           ...prev,

--- a/src/hooks/useFileTree.ts
+++ b/src/hooks/useFileTree.ts
@@ -18,6 +18,7 @@ import {
   type FileContent,
 } from '../lib/code';
 import { logger } from '../lib/logger';
+import { asCommandError, formatCommandError } from '../lib/errors';
 import { trackEvent } from '../lib/analytics';
 import { useAsyncState } from './useAsyncState';
 
@@ -326,7 +327,7 @@ export function useFileTree(projectPath: string): UseFileTreeResult {
       });
       return 'saved';
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      const msg = formatCommandError(asCommandError(err));
       logger.error('Failed to save file', { path, error: msg });
       setSaveError(msg);
       return 'error';

--- a/src/hooks/useInvoke.ts
+++ b/src/hooks/useInvoke.ts
@@ -2,6 +2,7 @@ import { invoke } from '@tauri-apps/api/core';
 import type { InvokeArgs } from '@tauri-apps/api/core';
 import { useCallback, useMemo } from 'react';
 import { logger } from '../lib/logger';
+import { asCommandError, formatCommandError } from '../lib/errors';
 import { useAsyncState, type UseAsyncStateReturn } from './useAsyncState';
 
 interface Options<T> {
@@ -31,7 +32,9 @@ export function useInvoke<T>(
       try {
         return await invoke<T>(command, args);
       } catch (e) {
-        const err = e instanceof Error ? e : new Error(String(e));
+        // A rejected Tauri command is a `CommandError` object, not an Error —
+        // `String(e)` would yield "[object Object]". Format it to its message.
+        const err = e instanceof Error ? e : new Error(formatCommandError(asCommandError(e)));
         logger.error(`invoke '${command}' failed`, { error: err.message });
         throw err;
       }

--- a/src/hooks/usePluginState.ts
+++ b/src/hooks/usePluginState.ts
@@ -7,6 +7,7 @@
 
 import { useState, useCallback } from 'react';
 import { installPlugin, listPlugins, VERCEL_PLUGIN_REPO } from '../lib/plugins';
+import { asCommandError, formatCommandError } from '../lib/errors';
 import { invoke } from '@tauri-apps/api/core';
 
 interface PluginTerminalState {
@@ -108,7 +109,7 @@ export function usePluginState() {
         setPluginSuggestion(null);
         onSuccess(`${name} plugin installed`);
       } catch (err) {
-        onError(`Failed to install plugin: ${err instanceof Error ? err.message : String(err)}`);
+        onError(`Failed to install plugin: ${formatCommandError(asCommandError(err))}`);
       } finally {
         setPluginSuggestionInstalling(false);
       }

--- a/src/hooks/useSnapshots.ts
+++ b/src/hooks/useSnapshots.ts
@@ -10,6 +10,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import * as snapshots from '../lib/snapshots';
 import { logger } from '../lib/logger';
+import { asCommandError, formatCommandError } from '../lib/errors';
 import { usePolling } from './usePolling';
 import type { ToastType } from './useToasts';
 
@@ -94,7 +95,7 @@ export function useSnapshots(
       const summary = summarize('Undid', next.files_changed);
       showToast(summary ?? 'Nothing to undo', summary ? 'success' : 'info');
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      const msg = formatCommandError(asCommandError(err));
       showToast(`Undo failed: ${msg}`, 'error');
     }
   }, [projectPath, showToast]);
@@ -107,7 +108,7 @@ export function useSnapshots(
       const summary = summarize('Redid', next.files_changed);
       showToast(summary ?? 'Nothing to redo', summary ? 'success' : 'info');
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      const msg = formatCommandError(asCommandError(err));
       showToast(`Redo failed: ${msg}`, 'error');
     }
   }, [projectPath, showToast]);

--- a/src/hooks/useTextEditing.test.ts
+++ b/src/hooks/useTextEditing.test.ts
@@ -118,7 +118,7 @@ describe('useTextEditing', () => {
     await dispatch({ type: 'ss:select', signature: SIG, leafText: true }, src);
     await dispatch({ type: 'ss:textCommit', text: 'New copy' }, src);
     expect(posts(iframeRef)).toContainEqual({ type: 'ss:textRevert' });
-    expect(onToast).toHaveBeenCalledWith('Error: boom', 'error');
+    expect(onToast).toHaveBeenCalledWith('boom', 'error');
   });
 
   it('does not write when the text is unchanged (just re-baselines)', async () => {

--- a/src/hooks/useTextEditing.ts
+++ b/src/hooks/useTextEditing.ts
@@ -38,6 +38,7 @@ import {
 } from '../lib/edit';
 import { logger } from '../lib/logger';
 import { trackEvent } from '../lib/analytics';
+import { asCommandError, formatCommandError } from '../lib/errors';
 
 interface Params {
   iframeRef: React.RefObject<HTMLIFrameElement | null>;
@@ -151,7 +152,7 @@ export function useTextEditing({ iframeRef, projectPath, enabled, onToast }: Par
             onToast?.('Saved to source', 'success');
           } catch (err) {
             logger.error('[TextEditing] text write-back failed', { error: String(err) });
-            onToast?.(String(err), 'error');
+            onToast?.(formatCommandError(asCommandError(err)), 'error');
             // Couldn't save — put the original text back in the preview.
             post({ type: 'ss:textRevert' });
           }

--- a/src/hooks/useVisualEditor.ts
+++ b/src/hooks/useVisualEditor.ts
@@ -75,6 +75,7 @@ import {
 } from '../lib/customClasses';
 import { logger } from '../lib/logger';
 import { trackEvent } from '../lib/analytics';
+import { asCommandError, formatCommandError } from '../lib/errors';
 
 /**
  * What the style controls currently edit:
@@ -357,7 +358,7 @@ export function useVisualEditor({
           }
         } catch (err) {
           logger.error('[VisualEditor] resolve failed', { error: String(err) });
-          onToast?.(String(err), 'error');
+          onToast?.(formatCommandError(asCommandError(err)), 'error');
           setSelection({
             signature: sig,
             resolution: {
@@ -536,7 +537,7 @@ export function useVisualEditor({
           if (!opts?.silent) onToast?.('Class saved', 'success');
         } catch (err) {
           logger.error('[VisualEditor] class write-back failed', { error: String(err) });
-          onToast?.(String(err), 'error');
+          onToast?.(formatCommandError(asCommandError(err)), 'error');
         }
         return;
       }
@@ -584,7 +585,7 @@ export function useVisualEditor({
         if (!opts?.silent) onToast?.('Saved to source', 'success');
       } catch (err) {
         logger.error('[VisualEditor] write-back failed', { error: String(err) });
-        onToast?.(String(err), 'error');
+        onToast?.(formatCommandError(asCommandError(err)), 'error');
       }
     },
     [selection, projectPath, onToast, post, setEditTarget, recordCommit]
@@ -651,7 +652,7 @@ export function useVisualEditor({
         await writeElementClass([...current, name].join(' '));
         recordCommit('custom_class_applied');
       } catch (err) {
-        onToast?.(String(err), 'error');
+        onToast?.(formatCommandError(asCommandError(err)), 'error');
       }
     },
     [currentElementClass, writeElementClass, onToast, recordCommit]
@@ -673,7 +674,7 @@ export function useVisualEditor({
         if (ok && wasEditing) editElement();
         recordCommit('custom_class_unapplied');
       } catch (err) {
-        onToast?.(String(err), 'error');
+        onToast?.(formatCommandError(asCommandError(err)), 'error');
       }
     },
     [currentElementClass, writeElementClass, editElement, onToast, recordCommit]
@@ -715,7 +716,7 @@ export function useVisualEditor({
           onToast?.(`Kept ${[...unsafe].join(', ')} on the element (not a utility).`, 'success');
         }
       } catch (err) {
-        onToast?.(String(err), 'error');
+        onToast?.(formatCommandError(asCommandError(err)), 'error');
       }
     },
     [
@@ -769,7 +770,7 @@ export function useVisualEditor({
         onToast?.('Image replaced', 'success');
       } catch (err) {
         logger.error('[VisualEditor] image write-back failed', { error: String(err) });
-        onToast?.(String(err), 'error');
+        onToast?.(formatCommandError(asCommandError(err)), 'error');
         throw err;
       }
     },

--- a/src/hooks/useWorkspaceConnect.tsx
+++ b/src/hooks/useWorkspaceConnect.tsx
@@ -30,6 +30,7 @@ import {
   type WorkspaceConnectService,
 } from '../lib/accounts';
 import { useOptionalToast } from '../contexts/ToastContext';
+import { asCommandError, formatCommandError } from '../lib/errors';
 
 /** Every login this hook can connect. (`vercel` is token-based, the rest are PTY.) */
 export type ConnectServiceId = WorkspaceConnectService | 'vercel';
@@ -106,7 +107,10 @@ export function useWorkspaceConnect({
         showToast(`Disconnected ${SERVICE_LABEL[service]}`, 'success');
         onChanged?.();
       } catch (err) {
-        showToast(`Couldn't disconnect ${SERVICE_LABEL[service]}: ${String(err)}`, 'error');
+        showToast(
+          `Couldn't disconnect ${SERVICE_LABEL[service]}: ${formatCommandError(asCommandError(err))}`,
+          'error'
+        );
       }
     },
     [accountId, showToast, onChanged]


### PR DESCRIPTION
## Summary

Tauri commands reject with a structured `CommandError` **object**, not a JS `Error`. Anywhere we did `String(err)` or `err instanceof Error ? err.message : String(err)` at a user-facing sink, the object got coerced to the literal text `"[object Object]"` — swallowing the real failure message. This is the recurring "[object Object]" error several flows have hit (e.g. plugin install failing on Windows).

This routes user-facing caught errors through the existing canonical helper `formatCommandError(asCommandError(err))` from [`src/lib/errors.ts`](src/lib/errors.ts).

**The upshot:** user-facing error messages are now accurate — they show the real underlying error instead of `"[object Object]"`, which makes future cases far easier to debug (the actual stderr / failure reason now surfaces in the UI instead of being hidden).

## Changes

- **Core hooks (highest impact):** `useInvoke` and `useAsyncState` wrapped errors as `new Error(String(e))`, so every consumer rendering `error.message` showed `"[object Object]"`; `useAsyncState` additionally dropped the message for `Process`/`Timeout` variants (no `.message` field). Fixing these two fixes all canonical consumers at once.
- **~38 direct sinks** — `setError` / `showToast` / `onToast` / `onError` / `alert` / terminal `term.write` across plugins, accounts, support, dashboard, branches, shopify, and preview.

## Deliberately not changed

- `logger.*` calls keep the `err instanceof Error ? err.message : String(err)` form (the pattern CONTRIBUTING.md documents for logging).
- `trackError(...)` keeps the raw object.
- The `getFriendlyError` PTY exit-code parsers and the WebCodecs decoder errors in `androidMirror.ts` are a different concern (real `Error` instances, not `CommandError`).

## Testing

- `pnpm check:all` ✓ (typecheck, eslint, prettier, rustfmt, clippy, patterns, loc)
- `pnpm test:run` ✓ (895 passed, 4 skipped)
- Updated one test that asserted the old `String(Error)` `"Error: "` prefix — the helper now yields the clean message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages across the app so failed actions now show clearer, more consistent details in toasts, terminals, dialogs, and alerts.
  * Updated several workspace, account, branch, plugin, support, Shopify, terminal, and editor flows to display formatted command errors instead of raw or generic strings.
* **Tests**
  * Adjusted an existing test to match the updated error message format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->