### PR TITLE
Auto-respawn agent terminals that produce no output after 10s

### DIFF
--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -48,6 +48,7 @@ import { isWindows } from '../../lib/setup';
 import { logger } from '../../lib/logger';
 import { asCommandError, formatCommandError } from '../../lib/errors';
 import { getTerminalGpuEnabled } from '../../lib/settings';
+import { decideStartupTimeoutAction } from './startupWatchdog';
 import type { AgentConfig } from '../../lib/agent';
 import '@xterm/xterm/css/xterm.css';
 
@@ -520,6 +521,14 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     // per project open. Gating on disk-presence turns a ~1s miss into a
     // ~5ms file-exists check.
     let attemptResume = false;
+    // One automatic respawn per mount for the spawned-but-silent case
+    // (issue #158). Distinct from `maxRetries` (the spawn call threw) and
+    // the resume-failed retry (the process exited) — this covers a PTY
+    // that opened fine but never wrote a byte.
+    let autoRespawnUsed = false;
+    // Latest startup-watchdog / respawn-delay timers, cleared on unmount.
+    let startupTimer: ReturnType<typeof setTimeout> | null = null;
+    let respawnTimer: ReturnType<typeof setTimeout> | null = null;
 
     // Open (or re-attach to) the backend PTY session for this tab.
     // `retryCount` is used by the resume-failed-then-retry-fresh path.
@@ -698,22 +707,64 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           onExitRef.current?.(attach.exitCode ?? -1);
         }
 
-        // Startup timeout: if no output is received within 10s, the agent
-        // likely failed to launch (binary not found, permission error, etc.).
-        // Show an error instead of hanging on "Starting..." forever.
+        // Startup watchdog: if no output is received within 10s, the agent
+        // likely failed to launch (binary not found, permission error, or a
+        // wedged first spawn — issue #158). The manual fix users found is
+        // "create a new agent tab", i.e. a fresh PTY — so kill the silent
+        // session and respawn once with the same config. Only if the
+        // respawn is also silent do we surface the error text.
         let receivedOutput = false;
         const startupTimeout = setTimeout(() => {
-          if (!receivedOutput && mounted) {
-            logger.error('[Terminal] Startup timeout - no output after 10s', {
+          const action = decideStartupTimeoutAction({ receivedOutput, mounted, autoRespawnUsed });
+          if (action === 'none') return;
+
+          if (action === 'respawn') {
+            autoRespawnUsed = true;
+            logger.warn('[Terminal] No output after 10s - killing silent PTY and respawning', {
               agent: agent.id,
               binary: agent.binaryName,
+              sessionId: backendSessionId,
             });
             terminalRef.current?.write(
-              `\r\n\x1b[31m${agent.displayName} did not produce any output after 10 seconds.\x1b[0m\r\n` +
-                `\x1b[33mThe process may have failed to start. Check that "${agent.binaryName}" is installed and accessible.\x1b[0m\r\n`
+              `\r\n\x1b[33mNo output — restarting ${agent.displayName}…\x1b[0m\r\n`
             );
+            // Unsubscribe from the silent session BEFORE killing it so the
+            // kill-induced exit event can't trigger the "[Process exited]"
+            // prompt or the resume-retry path.
+            for (const d of ptyDisposablesRef.current) {
+              try {
+                d.dispose();
+              } catch {
+                /* ignore */
+              }
+            }
+            ptyDisposablesRef.current = [];
+            ptyRef.current = null;
+            void killPtySession(backendSessionId)
+              .catch(() => {
+                /* already dead — open will spawn fresh either way */
+              })
+              .then(() => {
+                // Grace period so the killed PTY's exit event (same session
+                // id) is delivered before the respawned run subscribes —
+                // otherwise it would look like the new process exiting.
+                respawnTimer = setTimeout(() => {
+                  if (mounted) void setupPty(0);
+                }, 500);
+              });
+            return;
           }
+
+          logger.error('[Terminal] Startup timeout - no output after 10s', {
+            agent: agent.id,
+            binary: agent.binaryName,
+          });
+          terminalRef.current?.write(
+            `\r\n\x1b[31m${agent.displayName} did not produce any output after 10 seconds.\x1b[0m\r\n` +
+              `\x1b[33mThe process may have failed to start. Check that "${agent.binaryName}" is installed and accessible.\x1b[0m\r\n`
+          );
         }, 10_000);
+        startupTimer = startupTimeout;
 
         // Buffer early output to detect resume failures on exit
         let outputBuffer = '';
@@ -991,6 +1042,8 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       mounted = false;
       resizeObserver.disconnect();
       if (resizeRaf) cancelAnimationFrame(resizeRaf);
+      if (startupTimer) clearTimeout(startupTimer);
+      if (respawnTimer) clearTimeout(respawnTimer);
       if (textarea) {
         textarea.removeEventListener('focus', onTextareaFocus);
         textarea.removeEventListener('blur', onTextareaBlur);

--- a/src/components/terminal/startupWatchdog.test.ts
+++ b/src/components/terminal/startupWatchdog.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tests for the agent-terminal startup watchdog policy (issue #158).
+ *
+ * The behaviour that matters: a spawned-but-silent PTY gets exactly one
+ * automatic respawn; a second silent run surfaces the error; output or
+ * unmount disarms the watchdog entirely.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { decideStartupTimeoutAction } from './startupWatchdog';
+
+describe('decideStartupTimeoutAction', () => {
+  it('does nothing once output has been received', () => {
+    expect(
+      decideStartupTimeoutAction({ receivedOutput: true, mounted: true, autoRespawnUsed: false })
+    ).toBe('none');
+    // Output wins even if the respawn budget is already spent.
+    expect(
+      decideStartupTimeoutAction({ receivedOutput: true, mounted: true, autoRespawnUsed: true })
+    ).toBe('none');
+  });
+
+  it('does nothing after unmount', () => {
+    expect(
+      decideStartupTimeoutAction({ receivedOutput: false, mounted: false, autoRespawnUsed: false })
+    ).toBe('none');
+    expect(
+      decideStartupTimeoutAction({ receivedOutput: false, mounted: false, autoRespawnUsed: true })
+    ).toBe('none');
+  });
+
+  it('respawns once when the first spawn is silent', () => {
+    expect(
+      decideStartupTimeoutAction({ receivedOutput: false, mounted: true, autoRespawnUsed: false })
+    ).toBe('respawn');
+  });
+
+  it('shows the error when the respawn is also silent (no retry loop)', () => {
+    expect(
+      decideStartupTimeoutAction({ receivedOutput: false, mounted: true, autoRespawnUsed: true })
+    ).toBe('error');
+  });
+});

--- a/src/components/terminal/startupWatchdog.ts
+++ b/src/components/terminal/startupWatchdog.ts
@@ -1,0 +1,37 @@
+/**
+ * Decision logic for the agent-terminal startup watchdog.
+ *
+ * When a PTY spawns but never produces output within the startup window,
+ * the agent process is wedged (issue #158: seen on first app launch with
+ * Claude Code on macOS and Codex on Windows). The manual workaround users
+ * found — create a new agent tab, delete the old one — amounts to "kill
+ * the silent PTY and spawn a fresh one". `decideStartupTimeoutAction`
+ * drives the automatic version of that, capped at one respawn per
+ * terminal mount so a genuinely-broken binary can't respawn in a loop.
+ *
+ * Kept as a pure function so the retry policy is unit-testable without
+ * mounting the xterm-heavy Terminal component.
+ */
+
+export interface StartupTimeoutState {
+  /** True once any PTY output arrived for the current spawn. */
+  receivedOutput: boolean;
+  /** True while the owning effect instance is still mounted. */
+  mounted: boolean;
+  /** True once the single allowed automatic respawn has been used. */
+  autoRespawnUsed: boolean;
+}
+
+export type StartupTimeoutAction = 'none' | 'respawn' | 'error';
+
+/**
+ * What to do when the no-output startup timeout fires.
+ *
+ * - `'none'`    — output arrived or the component unmounted; do nothing.
+ * - `'respawn'` — silent first spawn: kill the PTY and respawn once.
+ * - `'error'`   — the respawn was also silent: surface the error text.
+ */
+export function decideStartupTimeoutAction(state: StartupTimeoutState): StartupTimeoutAction {
+  if (state.receivedOutput || !state.mounted) return 'none';
+  return state.autoRespawnUsed ? 'error' : 'respawn';
+}


### PR DESCRIPTION
Fixes #158

## Problem

On first app launch, opening a project sometimes shows **"Claude Code did not produce any output after 10 seconds. The process may have failed to start…"** (also reported for Codex on Windows). The PTY spawns fine but the agent process is wedged and never writes a byte. The manual workaround users found — create a new agent tab with "+" and delete the old one — works because it kills the silent PTY and spawns a fresh one; a plain remount would not help since `pty_session_open` reattaches to a still-alive session.

## Fix

Reproduce the workaround automatically. When the 10s startup watchdog fires with no output:

1. Print `No output — restarting <agent>…` in the terminal.
2. Unsubscribe the data/exit listeners **before** killing, so the kill-induced exit event can't trigger the "[Process exited]" prompt or the `--resume` retry path.
3. `killPtySession` the silent session (drops the backend registry entry so re-open spawns fresh instead of reattaching).
4. After a 500ms grace period (so the killed PTY's stale exit event — same session id — can't be mistaken for the new process exiting), call `setupPty(0)` again with the same agent config.

Only if the respawn is **also** silent do we show the original error text.

## One-retry guard

The retry decision is a pure helper, `decideStartupTimeoutAction` in `src/components/terminal/startupWatchdog.ts`: `receivedOutput || !mounted` → `none`; first silent timeout → `respawn` (sets a per-effect `autoRespawnUsed` flag); silent timeout with the flag set → `error`. The flag lives in the setup effect's scope, so the cap is one automatic respawn per terminal mount — no loops — and it composes with (rather than stacks on) the existing spawn-exception `maxRetries` and the resume-failed fresh-session retry. Watchdog and respawn-delay timers are cleared on unmount.

## Testing

- `pnpm test:run` — 61 files, 899 passed / 4 skipped, including 4 new unit tests for the watchdog policy (`startupWatchdog.test.ts`)
- `pnpm typecheck` — clean
- `pnpm exec eslint` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal startup handling now automatically retries once if a session starts silently, helping recover from transient launch issues.
  * Users will see a clear “No output — restarting …” message when the automatic retry happens.

* **Bug Fixes**
  * Reduced false startup failures by better distinguishing between a real error, an unmounted terminal, and a temporarily silent session.
  * Prevented repeated restart loops after the single automatic retry is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->