### PR TITLE
Branch create: sanitize names (spaces → dashes) instead of rejecting

### DIFF
--- a/src/components/branches/BranchesTab.tsx
+++ b/src/components/branches/BranchesTab.tsx
@@ -25,6 +25,7 @@ import {
   formatRelativeTime,
   getBranchPrefixPreference,
   setBranchPrefixPreference,
+  sanitizeBranchName,
 } from '../../lib/branches';
 import { gitPull } from '../../lib/git';
 import { BranchIcon, PlusIcon } from '../icons';
@@ -95,6 +96,8 @@ export function BranchesTab({
   const [newBranchName, setNewBranchName] = useState('');
   const [isCreatingBranch, setIsCreatingBranch] = useState(false);
   const [prefixUsername, setPrefixUsername] = useState(true);
+  // What the typed name becomes after sanitization (e.g. "adjust h2" → "adjust-h2")
+  const sanitizedNewBranchName = sanitizeBranchName(newBranchName);
   // Set when create fails because uncommitted changes would be overwritten by
   // the checkout — drives the commit-or-stash modal.
   const [createConflict, setCreateConflict] = useState<{
@@ -211,12 +214,13 @@ export function BranchesTab({
   };
 
   const handleCreateBranch = async () => {
-    if (!newBranchName.trim()) return;
+    // Sanitize instead of rejecting: "adjust h2" becomes "adjust-h2"
+    let branchName = sanitizeBranchName(newBranchName);
+    if (!branchName) return;
 
     setIsCreatingBranch(true);
     try {
       // Prefix with username if checkbox is checked
-      let branchName = newBranchName.trim();
       if (prefixUsername && githubUsername) {
         branchName = `${githubUsername}/${branchName}`;
       }
@@ -349,6 +353,15 @@ export function BranchesTab({
                 spellCheck={false}
               />
             </div>
+            {sanitizedNewBranchName && sanitizedNewBranchName !== newBranchName.trim() && (
+              <div className="branches-new-branch-hint">
+                will be created as:{' '}
+                <span className="branches-new-branch-hint-name">
+                  {prefixUsername && githubUsername ? `${githubUsername}/` : ''}
+                  {sanitizedNewBranchName}
+                </span>
+              </div>
+            )}
             <div className="branches-new-branch-footer">
               {githubUsername && (
                 <label className="branches-new-branch-checkbox">
@@ -375,7 +388,7 @@ export function BranchesTab({
                   variant="primary"
                   size="sm"
                   onClick={() => void handleCreateBranch()}
-                  disabled={!newBranchName.trim() || isCreatingBranch}
+                  disabled={!sanitizedNewBranchName || isCreatingBranch}
                 >
                   {isCreatingBranch ? 'Creating...' : 'Create'}
                 </Button>

--- a/src/lib/branches.test.ts
+++ b/src/lib/branches.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeBranchName } from './branches';
+
+describe('sanitizeBranchName', () => {
+  it('passes an already-valid name through unchanged', () => {
+    expect(sanitizeBranchName('adjust-h2')).toBe('adjust-h2');
+    expect(sanitizeBranchName('julian/feature-x')).toBe('julian/feature-x');
+    expect(sanitizeBranchName('release-1.2.3')).toBe('release-1.2.3');
+  });
+
+  it('converts a space to a dash', () => {
+    expect(sanitizeBranchName('adjust h2')).toBe('adjust-h2');
+  });
+
+  it('collapses runs of whitespace into a single dash', () => {
+    expect(sanitizeBranchName('fix   the   header')).toBe('fix-the-header');
+    expect(sanitizeBranchName('fix\tthe\theader')).toBe('fix-the-header');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(sanitizeBranchName('  adjust h2  ')).toBe('adjust-h2');
+  });
+
+  it('strips characters invalid in git refs', () => {
+    expect(sanitizeBranchName('what?is*this')).toBe('whatisthis');
+    expect(sanitizeBranchName('a~b^c:d')).toBe('abcd');
+    expect(sanitizeBranchName('a[b]c\\d')).toBe('abcd');
+  });
+
+  it('strips the invalid "@{" sequence', () => {
+    expect(sanitizeBranchName('foo@{bar')).toBe('foobar');
+  });
+
+  it('collapses ".." runs into a single dot', () => {
+    expect(sanitizeBranchName('release..notes')).toBe('release.notes');
+    expect(sanitizeBranchName('a...b')).toBe('a.b');
+  });
+
+  it('collapses repeated dashes and slashes', () => {
+    expect(sanitizeBranchName('a - b')).toBe('a-b');
+    expect(sanitizeBranchName('feat//thing')).toBe('feat/thing');
+  });
+
+  it('strips leading and trailing slashes and dots', () => {
+    expect(sanitizeBranchName('/feature/')).toBe('feature');
+    expect(sanitizeBranchName('.hidden.')).toBe('hidden');
+    expect(sanitizeBranchName('//a/b//')).toBe('a/b');
+  });
+
+  it('strips a trailing ".lock"', () => {
+    expect(sanitizeBranchName('mybranch.lock')).toBe('mybranch');
+    // exposed after collapsing ".." → "."
+    expect(sanitizeBranchName('mybranch..lock')).toBe('mybranch');
+  });
+
+  it('returns an empty string when nothing salvageable remains', () => {
+    expect(sanitizeBranchName('')).toBe('');
+    expect(sanitizeBranchName('   ')).toBe('');
+    expect(sanitizeBranchName('...')).toBe('');
+    expect(sanitizeBranchName('///')).toBe('');
+    expect(sanitizeBranchName('~^:?*')).toBe('');
+  });
+
+  it('handles the issue #166 repro', () => {
+    expect(sanitizeBranchName('adjust h2')).toBe('adjust-h2');
+  });
+});

--- a/src/lib/branches.ts
+++ b/src/lib/branches.ts
@@ -135,6 +135,48 @@ export async function discardChanges(projectPath: string): Promise<void> {
 }
 
 /**
+ * Sanitize user input into a valid git branch name.
+ *
+ * Rather than rejecting names like "adjust h2", we normalize them into
+ * something git accepts ("adjust-h2"):
+ * - trims and collapses whitespace runs into a single `-`
+ * - strips characters invalid in git refs (`~ ^ : ? * [ ] \` and `@{`)
+ * - collapses `..` runs into a single `.`
+ * - collapses repeated `-` / `/`
+ * - strips leading/trailing `/` and `.`, and a trailing `.lock`
+ *
+ * An input with nothing salvageable returns an empty string — callers must
+ * treat that the same as an empty input.
+ *
+ * @param name - Raw user input
+ * @returns A git-safe branch name, or an empty string
+ */
+export function sanitizeBranchName(name: string): string {
+  let sanitized = name
+    .trim()
+    .replace(/\s+/g, '-') // whitespace runs → single dash
+    // eslint-disable-next-line no-control-regex
+    .replace(/[~^:?*[\]\\\x00-\x1f\x7f]/g, '') // chars git forbids in refs
+    .replace(/@\{/g, '') // "@{" sequence is invalid in refs
+    .replace(/\.\.+/g, '.') // ".." is invalid in refs
+    .replace(/-+/g, '-') // collapse repeated dashes
+    .replace(/\/+/g, '/'); // collapse repeated slashes
+
+  // Stripping one thing can expose another (e.g. "name..lock" → "name.lock"
+  // → "name"), so repeat until stable.
+  for (;;) {
+    const next = sanitized
+      .replace(/^[/.]+/, '') // leading slashes/dots
+      .replace(/[/.]+$/, '') // trailing slashes/dots
+      .replace(/\.lock$/, ''); // git refuses refs ending in ".lock"
+    if (next === sanitized) break;
+    sanitized = next;
+  }
+
+  return sanitized;
+}
+
+/**
  * Create a new branch from a base branch.
  * @param projectPath - Absolute path to the project directory
  * @param branchName - Name for the new branch

--- a/src/styles/features/branches/pr-list.css
+++ b/src/styles/features/branches/pr-list.css
@@ -91,6 +91,19 @@
   color: var(--text-muted);
 }
 
+/* Shown when the typed name gets sanitized (e.g. "adjust h2" → "adjust-h2") */
+.branches-new-branch-hint {
+  margin: calc(-1 * var(--spacing-sm)) 0 var(--spacing-md);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  word-break: break-all;
+}
+
+.branches-new-branch-hint-name {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}
+
 .branches-new-branch-footer {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary

Creating a branch with a space in the name (e.g. `adjust h2`) was rejected with a raw "Invalid branch name" error. Non-technical users type natural phrases as branch names, so instead of rejecting, we now sanitize the input into a valid git ref: `adjust h2` → `adjust-h2`.

Reported in Slack: https://shipstudiocommunity.slack.com/archives/C0ABDL0GKHU/p1777488363499179

Fixes #166

## Changes

- **`src/lib/branches.ts`** — new `sanitizeBranchName()` helper: trims, collapses whitespace runs to a single `-`, strips characters git forbids in refs (`~ ^ : ? * [ ] \`, control chars, `@{`), collapses `..` runs and repeated `-`/`/`, strips leading/trailing `/` and `.` plus trailing `.lock`. Inputs with nothing salvageable return an empty string.
- **`src/components/branches/BranchesTab.tsx`** — sanitizes on submit, disables Create when nothing salvageable remains, and shows a live muted hint under the input (`will be created as: adjust-h2`) only when the sanitized name differs from what was typed.
- **`src/styles/features/branches/pr-list.css`** — hint styling using design tokens only.
- **`src/lib/branches.test.ts`** — 12 unit tests covering spaces, whitespace runs, invalid chars, dot/slash edge cases, `.lock`, and empty-result inputs.

Backend validation in `create_branch` is unchanged and remains the safety net.

## Testing

- `pnpm test:run` — 61 files, 907 passed / 4 skipped
- `pnpm typecheck`, `pnpm check:patterns`, eslint on touched files — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)