### PR TITLE
Assets panel: download/export assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@lezer/highlight": "^1.2.3",
     "@sentry/react": "^10.48.0",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-fs": "^2.4.5",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.9.1
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.7.1
+        version: 2.7.1
       '@tauri-apps/plugin-fs':
         specifier: ^2.4.5
         version: 2.4.5
@@ -792,6 +795,9 @@ packages:
     peerDependencies:
       react: ^16.14.0 || 17.x || 18.x || 19.x
 
+  '@tauri-apps/api@2.11.1':
+    resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
+
   '@tauri-apps/api@2.9.1':
     resolution: {integrity: sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw==}
 
@@ -865,6 +871,9 @@ packages:
     resolution: {integrity: sha512-3xDdXL5omQ3sPfBfdC8fCtDKcnyV7OqyzQgfyT5P3+zY6lcPqIYKQBvUasNvppi21RSdfhy44ttvJmftb0PCDw==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-dialog@2.7.1':
+    resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
 
   '@tauri-apps/plugin-fs@2.4.5':
     resolution: {integrity: sha512-dVxWWGE6VrOxC7/jlhyE+ON/Cc2REJlM35R3PJX3UvFw2XwYhLGQVAIyrehenDdKjotipjYEVc4YjOl3qq90fA==}
@@ -3188,6 +3197,8 @@ snapshots:
       '@sentry/core': 10.48.0
       react: 19.2.3
 
+  '@tauri-apps/api@2.11.1': {}
+
   '@tauri-apps/api@2.9.1': {}
 
   '@tauri-apps/cli-darwin-arm64@2.9.6':
@@ -3236,6 +3247,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.9.6
       '@tauri-apps/cli-win32-ia32-msvc': 2.9.6
       '@tauri-apps/cli-win32-x64-msvc': 2.9.6
+
+  '@tauri-apps/plugin-dialog@2.7.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-fs@2.4.5':
     dependencies:

--- a/src-tauri/src/commands/assets.rs
+++ b/src-tauri/src/commands/assets.rs
@@ -425,6 +425,91 @@ pub async fn create_asset_folder(
     Ok(())
 }
 
+/// Core of `export_asset`, factored out so it can be unit-tested against a
+/// temp directory (the command wrapper requires a real ShipStudio project
+/// path). Copies `asset_path` (relative to `root_dir`) to `destination`.
+fn export_asset_to(
+    root_dir: &Path,
+    asset_path: &str,
+    destination: &str,
+    overwrite: bool,
+) -> Result<String, CommandError> {
+    let source = validate_asset_path(root_dir, asset_path)?;
+
+    if !source.is_file() {
+        return Err(CommandError::Validation {
+            field: "asset_path".to_string(),
+            reason: "Only files can be downloaded".to_string(),
+        });
+    }
+
+    let dest = PathBuf::from(destination);
+    if !dest.is_absolute() {
+        return Err(CommandError::Validation {
+            field: "destination".to_string(),
+            reason: "Destination must be an absolute path".to_string(),
+        });
+    }
+
+    if dest.exists() {
+        // Never silently replace a file: the caller must opt in (the native
+        // save dialog has already asked the user to confirm replacement).
+        if !overwrite {
+            return Err(CommandError::Validation {
+                field: "destination".to_string(),
+                reason: "A file already exists at the destination".to_string(),
+            });
+        }
+        if dest.is_dir() {
+            return Err(CommandError::Validation {
+                field: "destination".to_string(),
+                reason: "Destination is a folder".to_string(),
+            });
+        }
+        // Copying a file onto itself truncates it — refuse instead.
+        let canonical_dest =
+            dunce::canonicalize(&dest).map_err(|e| format!("Invalid destination: {e}"))?;
+        if canonical_dest == source {
+            return Err(CommandError::Validation {
+                field: "destination".to_string(),
+                reason: "Destination is the same file as the asset".to_string(),
+            });
+        }
+    } else {
+        let parent = dest
+            .parent()
+            .ok_or("Invalid destination: no parent directory")?;
+        if !parent.exists() {
+            return Err(CommandError::Validation {
+                field: "destination".to_string(),
+                reason: "Destination folder does not exist".to_string(),
+            });
+        }
+    }
+
+    fs::copy(&source, &dest).map_err(|e| format!("Failed to export asset: {e}"))?;
+
+    Ok(dest.to_string_lossy().to_string())
+}
+
+/// Export (download) an asset: copy it out of the project's assets folder to a
+/// caller-supplied absolute destination path (chosen via a native save dialog).
+/// Returns the destination path that was written.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn export_asset(
+    project_path: String,
+    asset_path: String,
+    destination: String,
+    overwrite: bool,
+) -> Result<String, CommandError> {
+    let repo_root = validate_project_path(&project_path)?;
+    let project = resolve_workspace_path(&repo_root);
+    let root_dir = assets_root_dir(&repo_root, &project);
+
+    export_asset_to(&root_dir, &asset_path, &destination, overwrite)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -495,5 +580,75 @@ mod tests {
 
         let dir = assets_root_dir(tmp.path(), tmp.path());
         assert_eq!(dir, tmp.path().join("public"));
+    }
+
+    /// Temp assets root containing `logo.png`, plus an empty output dir.
+    fn export_fixture() -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("public");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("logo.png"), b"png-bytes").unwrap();
+        let out = tmp.path().join("out");
+        std::fs::create_dir_all(&out).unwrap();
+        (tmp, root, out)
+    }
+
+    #[test]
+    fn export_asset_copies_file_to_destination() {
+        let (_tmp, root, out) = export_fixture();
+        let dest = out.join("logo.png");
+
+        let written = export_asset_to(&root, "logo.png", &dest.to_string_lossy(), false).unwrap();
+
+        assert_eq!(written, dest.to_string_lossy());
+        assert_eq!(std::fs::read(&dest).unwrap(), b"png-bytes");
+        // Source is untouched.
+        assert_eq!(std::fs::read(root.join("logo.png")).unwrap(), b"png-bytes");
+    }
+
+    #[test]
+    fn export_asset_rejects_path_traversal() {
+        let (tmp, root, out) = export_fixture();
+        std::fs::write(tmp.path().join("secret.txt"), b"secret").unwrap();
+        let dest = out.join("secret.txt");
+
+        let err = export_asset_to(&root, "../secret.txt", &dest.to_string_lossy(), false)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("traversal"), "unexpected error: {err}");
+        assert!(!dest.exists());
+    }
+
+    #[test]
+    fn export_asset_refuses_existing_destination_without_overwrite() {
+        let (_tmp, root, out) = export_fixture();
+        let dest = out.join("logo.png");
+        std::fs::write(&dest, b"pre-existing").unwrap();
+
+        let err = export_asset_to(&root, "logo.png", &dest.to_string_lossy(), false).unwrap_err();
+        assert!(matches!(err, CommandError::Validation { .. }));
+        // Untouched without overwrite…
+        assert_eq!(std::fs::read(&dest).unwrap(), b"pre-existing");
+
+        // …replaced with overwrite.
+        export_asset_to(&root, "logo.png", &dest.to_string_lossy(), true).unwrap();
+        assert_eq!(std::fs::read(&dest).unwrap(), b"png-bytes");
+    }
+
+    #[test]
+    fn export_asset_rejects_relative_destination() {
+        let (_tmp, root, _out) = export_fixture();
+        let err = export_asset_to(&root, "logo.png", "relative/logo.png", false).unwrap_err();
+        assert!(matches!(err, CommandError::Validation { .. }));
+    }
+
+    #[test]
+    fn export_asset_rejects_directories() {
+        let (_tmp, root, out) = export_fixture();
+        std::fs::create_dir_all(root.join("images")).unwrap();
+        let dest = out.join("images");
+
+        let err = export_asset_to(&root, "images", &dest.to_string_lossy(), false).unwrap_err();
+        assert!(matches!(err, CommandError::Validation { .. }));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -653,6 +653,7 @@ pub fn run() {
             commands::assets::delete_asset,
             commands::assets::rename_asset,
             commands::assets::create_asset_folder,
+            commands::assets::export_asset,
             // Code Health
             commands::health::detect_health_scripts,
             commands::health::run_health_script,

--- a/src/components/workspace/AssetsPanel.tsx
+++ b/src/components/workspace/AssetsPanel.tsx
@@ -7,6 +7,7 @@
  * - Rename and delete assets
  * - Create new folders
  * - Copy asset paths for use in code
+ * - Download assets to disk via a native save dialog
  *
  * The modal body is exported separately as `AssetsModal` with explicit
  * open/close props plus an optional pick mode, so other features (the visual
@@ -27,6 +28,7 @@ import { useModal } from '../../contexts/ModalContext';
 import {
   CloseIcon,
   CopyIcon,
+  DownloadIcon,
   TrashIcon,
   EditIcon,
   UploadIcon,
@@ -150,6 +152,7 @@ export function AssetsModal({ projectPath, isOpen, onClose, pick }: AssetsModalP
     handleRename,
     handleCreateFolder,
     handleCopyPath,
+    handleDownload,
     navigateToFolder,
     handleDragEnter,
     handleDragLeave,
@@ -494,6 +497,18 @@ export function AssetsModal({ projectPath, isOpen, onClose, pick }: AssetsModalP
                       )}
                     </div>
                     <div className="assets-item-actions">
+                      {!asset.isDirectory && (
+                        <button
+                          className="assets-action-btn"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void handleDownload(asset);
+                          }}
+                          title="Download"
+                        >
+                          <DownloadIcon size={12} />
+                        </button>
+                      )}
                       <button
                         className="assets-action-btn"
                         onClick={(e) => {
@@ -579,6 +594,18 @@ export function AssetsModal({ projectPath, isOpen, onClose, pick }: AssetsModalP
                       )}
                     </div>
                     <div className="assets-grid-actions">
+                      {!asset.isDirectory && (
+                        <button
+                          className="assets-action-btn"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void handleDownload(asset);
+                          }}
+                          title="Download"
+                        >
+                          <DownloadIcon size={12} />
+                        </button>
+                      )}
                       <button
                         className="assets-action-btn"
                         onClick={(e) => {

--- a/src/hooks/useAssetManagement.ts
+++ b/src/hooks/useAssetManagement.ts
@@ -8,17 +8,20 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { save } from '@tauri-apps/plugin-dialog';
 import {
   listAssets,
   uploadAsset,
   deleteAsset,
   renameAsset,
   createAssetFolder,
+  exportAsset,
   getAssetsRoot,
   setAssetsRoot,
   DEFAULT_ASSETS_ROOT,
   type Asset,
 } from '../lib/assets';
+import { asCommandError, formatCommandError } from '../lib/errors';
 import { trackEvent, trackError, trackSearch } from '../lib/analytics';
 import { logger } from '../lib/logger';
 
@@ -293,6 +296,27 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
     }
   };
 
+  // Handle download: pick a destination via the native save dialog, then copy
+  // the asset there. The dialog already confirms replacement of an existing
+  // file, so the export runs with overwrite enabled.
+  const handleDownload = async (asset: Asset) => {
+    try {
+      const destination = await save({
+        defaultPath: asset.name,
+        title: `Download ${asset.name}`,
+      });
+      if (!destination) return; // user cancelled
+      const saved = await exportAsset(projectPath, asset.path, destination, true);
+      void trackEvent('asset_downloaded', { $screen_name: 'Workspace' });
+      onToast?.(`Saved to ${saved}`, 'success');
+    } catch (e) {
+      trackError('asset_download', e, 'Workspace');
+      const msg = formatCommandError(asCommandError(e));
+      setError(msg);
+      onToast?.(msg, 'error');
+    }
+  };
+
   // Navigate into folder
   const navigateToFolder = (asset: Asset) => {
     if (asset.isDirectory) {
@@ -385,6 +409,7 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
     handleRename,
     handleCreateFolder,
     handleCopyPath,
+    handleDownload,
     navigateToFolder,
     handleDragEnter,
     handleDragLeave,

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -145,6 +145,25 @@ export async function renameAsset(
 }
 
 /**
+ * Export (download) an asset: copy it out of the assets folder to an absolute
+ * destination path on disk (typically chosen via a native save dialog).
+ * @param projectPath - Path to the project
+ * @param assetPath - Relative path of the asset within the assets folder
+ * @param destination - Absolute path to write the copy to
+ * @param overwrite - Replace an existing file at the destination (the save
+ *   dialog has already asked the user to confirm)
+ * @returns The destination path that was written
+ */
+export async function exportAsset(
+  projectPath: string,
+  assetPath: string,
+  destination: string,
+  overwrite = false
+): Promise<string> {
+  return invoke<string>('export_asset', { projectPath, assetPath, destination, overwrite });
+}
+
+/**
  * Create a folder in /public
  * @param projectPath - Path to the project
  * @param folderPath - Path for the new folder within /public


### PR DESCRIPTION
## Summary

The Assets panel had no way to get a file back out of the project — you could upload, rename, and delete, but not download. This adds a per-asset **Download** action (list and grid views, files only) next to "Copy path" that opens a native save dialog (default filename = asset name) and copies the asset to the chosen destination, confirming with a toast showing where it was saved.

Fixes #170
(Slack report: https://shipstudiocommunity.slack.com/archives/C0ABDL0GKHU/p1776467132013799)

## Implementation

**Backend** (`src-tauri/src/commands/assets.rs`)
- New `export_asset` command following the four Rust rules: `Result<String, CommandError>`, `validate_project_path()` on the project, `validate_asset_path()` keeps the source inside the assets root, `#[tracing::instrument]`.
- Destination must be absolute; an existing destination fails with a `Validation` error unless `overwrite: true` is passed (the native save dialog has already asked the user to confirm replacement). Also rejects directories, a missing destination folder, and copying a file onto itself.
- Core logic factored into a testable `export_asset_to` helper; command registered in `lib.rs`.

**Frontend**
- `exportAsset` wrapper in `src/lib/assets.ts` matching the existing style.
- `handleDownload` in `useAssetManagement` uses `save()` from `@tauri-apps/plugin-dialog` — the Rust plugin (`tauri-plugin-dialog`) and `dialog:default` capability were already wired up; this adds the official JS binding. Errors surface via the existing toast pattern using `formatCommandError(asCommandError(e))`.
- Download buttons in `AssetsPanel.tsx` follow the existing `assets-action-btn` icon-row convention (raw ≤28px icon buttons per CLAUDE.md), using the existing `DownloadIcon`.

## Testing

- `cargo test` — 595 passed (5 new: happy path, path-traversal rejection, existing-destination refusal + overwrite, relative destination, directory rejection)
- `pnpm test:run` — 895 passed, 4 skipped
- `pnpm typecheck`, `pnpm lint`, `pnpm check:patterns`, `pnpm check:loc`, `cargo fmt --check` all pass; clippy warning count unchanged from main

🤖 Generated with [Claude Code](https://claude.com/claude-code)