### PR TITLE
Fix "path not found" error opening the raw Terminal tab on Windows

### DIFF
--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -47,7 +47,7 @@ import { loadNerdFonts } from '../../lib/fonts';
 import { isWindows } from '../../lib/setup';
 import { logger } from '../../lib/logger';
 import { getTerminalGpuEnabled } from '../../lib/settings';
-import type { AgentConfig } from '../../lib/agent';
+import { getSpawnCommand, type AgentConfig } from '../../lib/agent';
 import '@xterm/xterm/css/xterm.css';
 
 /** Agent status based on terminal title */
@@ -647,9 +647,9 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           agentArgs.push(agent.autoAcceptFlag);
         }
 
-        // On Windows, agent may be a .cmd script - must run through cmd.exe
-        const spawnCmd = isWin ? 'cmd.exe' : agent.binaryName;
-        const spawnArgs = isWin ? ['/C', agent.binaryName, ...agentArgs] : agentArgs;
+        // On Windows, agent may be a .cmd script - must run through cmd.exe.
+        // See getSpawnCommand for the raw "Terminal" tab exception.
+        const { command: spawnCmd, args: spawnArgs } = getSpawnCommand(agent, agentArgs, isWin);
 
         // The backend session id is the tab's sessionName UUID — it survives
         // component unmount/remount and project switches, so attach is

--- a/src/lib/agent.test.ts
+++ b/src/lib/agent.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   getAgentById,
+  getSpawnCommand,
   initDefaultAgent,
   getDefaultAgentId,
   getActiveAgent,
@@ -168,5 +169,35 @@ describe('AgentConfig fields', () => {
       expect(agent.notFoundMessage).toBeTruthy();
       expect(agent.installHint).toBeTruthy();
     }
+  });
+});
+
+// ============ getSpawnCommand ============
+
+describe('getSpawnCommand', () => {
+  it('on macOS/Linux, spawns the agent binary directly with its args', () => {
+    const result = getSpawnCommand(CLAUDE_CODE, ['--resume', 'abc'], false);
+    expect(result).toEqual({ command: 'claude', args: ['--resume', 'abc'] });
+  });
+
+  it('on macOS/Linux, spawns the terminal shell directly', () => {
+    const result = getSpawnCommand(TERMINAL, [], false);
+    expect(result).toEqual({ command: '/bin/zsh', args: [] });
+  });
+
+  it('on Windows, wraps a regular agent through cmd.exe /C', () => {
+    const result = getSpawnCommand(CLAUDE_CODE, ['--resume', 'abc'], true);
+    expect(result).toEqual({ command: 'cmd.exe', args: ['/C', 'claude', '--resume', 'abc'] });
+  });
+
+  it('on Windows, wraps Codex through cmd.exe /C', () => {
+    const result = getSpawnCommand(CODEX, ['--yolo'], true);
+    expect(result).toEqual({ command: 'cmd.exe', args: ['/C', 'codex', '--yolo'] });
+  });
+
+  it('on Windows, launches cmd.exe directly for the raw Terminal tab (regression: previously ran `cmd.exe /C /bin/zsh`, which cmd.exe cannot resolve)', () => {
+    const result = getSpawnCommand(TERMINAL, [], true);
+    expect(result).toEqual({ command: 'cmd.exe', args: [] });
+    expect(result.args).not.toContain('/bin/zsh');
   });
 });

--- a/src/lib/agent.ts
+++ b/src/lib/agent.ts
@@ -143,6 +143,29 @@ export function getAgentById(id: string): AgentConfig {
 }
 
 /**
+ * Resolve the actual PTY command + args to spawn for a given agent.
+ *
+ * On Windows, most agents are `.cmd` batch scripts that CreateProcessW can't
+ * exec directly, so they're wrapped through `cmd.exe /C <binary> <args>`.
+ * The raw "Terminal" tab is the exception: its `binaryName` ('/bin/zsh') is
+ * a Unix shell path that only makes sense on macOS/Linux, so on Windows it
+ * must launch cmd.exe directly as the shell itself, unwrapped.
+ */
+export function getSpawnCommand(
+  agent: AgentConfig,
+  agentArgs: string[],
+  isWin: boolean
+): { command: string; args: string[] } {
+  if (!isWin) {
+    return { command: agent.binaryName, args: agentArgs };
+  }
+  if (agent.id === TERMINAL.id) {
+    return { command: 'cmd.exe', args: [] };
+  }
+  return { command: 'cmd.exe', args: ['/C', agent.binaryName, ...agentArgs] };
+}
+
+/**
  * Returns the currently active (default) agent configuration.
  *
  * Reads from the in-memory cache. Falls back to CLAUDE_CODE if unset.


### PR DESCRIPTION
## Summary
- The raw "Terminal" tab's `binaryName` (`/bin/zsh`) is a Unix shell path. On Windows every agent gets wrapped as `cmd.exe /C <binaryName>`, so the Terminal tab ran `cmd.exe /C /bin/zsh`, which cmd.exe can't resolve — surfaces to the user as "The system cannot find the path specified."
- Extracted the spawn decision into a pure, exported `getSpawnCommand()` (`src/lib/agent.ts`) so it's independently testable, and made Windows launch `cmd.exe` directly (unwrapped) for this one case instead of double-wrapping it.
- Frontend-only change — no Rust/backend code touched.

## Test plan
- [x] `pnpm test:run` — 900/900 passing, including 5 new unit tests on `getSpawnCommand` (`src/lib/agent.test.ts`) covering Windows + macOS/Linux for both regular agents and the raw Terminal tab, including a regression test pinned to the exact broken case (`cmd.exe /C /bin/zsh`)
- [x] `tsc --noEmit` clean
- [x] `pnpm lint-staged` (eslint --fix, prettier) + `tsc --noEmit` + `vitest run` — ran automatically via this repo's husky pre-commit/pre-push hooks
- [ ] `pnpm check:all` (full lint:strict + rustfmt + clippy + pattern/LOC checks) and `pnpm rust:test` — **not run locally**, no Rust toolchain available in this environment. Change doesn't touch any `.rs` files, so risk is low, but I haven't confirmed clippy/rustfmt/pattern checks pass — deferring to CI for that.
- [ ] **Not verified against a live Windows build** — no local Rust toolchain to run `tauri dev` end-to-end. Reported by a user on Windows 11 hitting this exact error; logic verified via the unit tests above, but someone with a working Windows dev build should confirm the Terminal tab actually opens before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)