### PR TITLE
Fix remaining [object Object] error surfaces

### DIFF
--- a/src/components/branches/ConflictResolutionModal.tsx
+++ b/src/components/branches/ConflictResolutionModal.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../lib/conflicts';
 import { WarningIcon, CopyIcon, ChevronIcon, InfoIcon } from '../icons';
 import { trackEvent, trackError } from '../../lib/analytics';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { Spinner } from '../primitives/Spinner';
@@ -138,7 +139,7 @@ export function ConflictResolutionModal({
         }
       } catch (e) {
         trackError('conflict_resolve', e, 'Conflict Resolution');
-        onToast?.(e instanceof Error ? e.message : 'Failed to resolve conflict', 'error');
+        onToast?.(formatCommandError(asCommandError(e)) || 'Failed to resolve conflict', 'error');
       } finally {
         setIsApplying(false);
       }
@@ -170,7 +171,7 @@ export function ConflictResolutionModal({
       onClose();
     } catch (e) {
       trackError('merge_abort', e, 'Conflict Resolution');
-      onToast?.(e instanceof Error ? e.message : 'Failed to abort merge', 'error');
+      onToast?.(formatCommandError(asCommandError(e)) || 'Failed to abort merge', 'error');
     } finally {
       setIsApplying(false);
     }

--- a/src/components/dashboard/ImportProject.tsx
+++ b/src/components/dashboard/ImportProject.tsx
@@ -42,7 +42,7 @@ import {
   type WorkspacePick,
 } from '../import-project/steps/Step3WorkspacePicker';
 import { logger } from '../../lib/logger';
-import { asCommandError, formatCommandError } from '../../lib/errors';
+import { asCommandError, formatCommandError, friendlyProcessError } from '../../lib/errors';
 import { Spinner } from '../primitives/Spinner';
 
 /** Props for the ImportProject component */
@@ -164,23 +164,6 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
     });
   };
 
-  /** Map PTY exit codes to user-friendly error messages */
-  const getFriendlyError = (err: unknown): string => {
-    const msg = String(err);
-    const codeMatch = msg.match(/Process exited with code (\d+)/);
-    if (codeMatch) {
-      const code = parseInt(codeMatch[1]);
-      if (code === 243) {
-        return "npm couldn't access its cache directory (~/.npm). This usually happens when npm was previously run with sudo.\n\nTo fix, open a terminal and run:\nsudo chown -R $(whoami) ~/.npm";
-      }
-      if (code === 128) {
-        return "Git authentication failed. Make sure you're signed into GitHub.";
-      }
-    }
-    // Strip the "Error: " prefix that comes from Error.toString()
-    return msg.replace(/^Error:\s*/, '');
-  };
-
   /** Run package manager install via PTY, with a pre-check for permissions */
   const runPackageInstall = async (projectPath: string, packageManager: string) => {
     // Pre-check: verify npm cache is writable (relevant for npm/npx, and sometimes pnpm/yarn too)
@@ -224,7 +207,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       onComplete(importedProjectPath);
     } catch (err) {
       trackError('project_install_retry', err, 'Dashboard');
-      setError(getFriendlyError(err));
+      setError(friendlyProcessError(err));
     }
   };
 
@@ -250,7 +233,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       shipstudioDir = await ensureShipStudioDir();
     } catch (err) {
       trackError('project_import', err, 'Dashboard');
-      setError(getFriendlyError(err));
+      setError(friendlyProcessError(err));
       return;
     }
 
@@ -269,7 +252,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       }
     } catch (err) {
       trackError('project_import', err, 'Dashboard');
-      setError(getFriendlyError(err));
+      setError(friendlyProcessError(err));
       return;
     }
 
@@ -329,7 +312,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       await finishImport(projectPath);
     } catch (err) {
       trackError('project_import', err, 'Dashboard');
-      setError(getFriendlyError(err));
+      setError(friendlyProcessError(err));
     }
   };
 
@@ -358,7 +341,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       onComplete(projectPath);
     } catch (err) {
       trackError('project_import', err, 'Dashboard');
-      setError(getFriendlyError(err));
+      setError(friendlyProcessError(err));
     }
   };
 
@@ -371,7 +354,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       await setWorkspaceSubpath(importedProjectPath, subpath);
     } catch (err) {
       trackError('project_import_workspace_save', err, 'Dashboard');
-      setError(getFriendlyError(err));
+      setError(friendlyProcessError(err));
       return;
     }
     setAwaitingWorkspacePick(false);

--- a/src/hooks/useAssetManagement.ts
+++ b/src/hooks/useAssetManagement.ts
@@ -105,7 +105,7 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
       onToast?.(`Assets folder set to ${saved}`, 'success');
     } catch (e) {
       trackError('assets_root_change', e, 'Workspace');
-      const msg = e instanceof Error ? e.message : 'Failed to change assets folder';
+      const msg = formatCommandError(asCommandError(e)) || 'Failed to change assets folder';
       setError(msg);
       onToast?.(msg, 'error');
     }
@@ -172,7 +172,7 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
       );
     } catch (e) {
       trackError('asset_upload', e, 'Workspace');
-      const msg = e instanceof Error ? e.message : 'Failed to upload';
+      const msg = formatCommandError(asCommandError(e)) || 'Failed to upload';
       setError(msg);
       onToast?.(msg, 'error');
     } finally {
@@ -203,7 +203,7 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
         onToast?.(`Deleted ${asset.name}`, 'success');
       } catch (e) {
         trackError('asset_delete', e, 'Workspace');
-        const msg = e instanceof Error ? e.message : 'Failed to delete';
+        const msg = formatCommandError(asCommandError(e)) || 'Failed to delete';
         setError(msg);
         onToast?.(msg, 'error');
       } finally {
@@ -248,7 +248,7 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
       onToast?.(`Renamed to ${renameValue.trim()}`, 'success');
     } catch (e) {
       trackError('asset_rename', e, 'Workspace');
-      const msg = e instanceof Error ? e.message : 'Failed to rename';
+      const msg = formatCommandError(asCommandError(e)) || 'Failed to rename';
       setError(msg);
       onToast?.(msg, 'error');
     } finally {
@@ -271,7 +271,7 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
       onToast?.(`Created folder ${newFolderName.trim()}`, 'success');
     } catch (e) {
       trackError('asset_folder_create', e, 'Workspace');
-      const msg = e instanceof Error ? e.message : 'Failed to create folder';
+      const msg = formatCommandError(asCommandError(e)) || 'Failed to create folder';
       setError(msg);
       onToast?.(msg, 'error');
     } finally {

--- a/src/hooks/useEnvEditor.test.ts
+++ b/src/hooks/useEnvEditor.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useEnvEditor } from './useEnvEditor';
+
+// Mock external dependencies
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('../lib/analytics', () => ({
+  trackEvent: vi.fn(),
+  trackError: vi.fn(),
+}));
+
+vi.mock('../lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('useEnvEditor', () => {
+  let core: typeof import('@tauri-apps/api/core');
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    core = await import('@tauri-apps/api/core');
+    vi.mocked(core.invoke).mockImplementation((cmd: string) => {
+      if (cmd === 'list_env_files') return Promise.resolve([]);
+      return Promise.resolve(undefined);
+    });
+  });
+
+  function renderEnvEditor() {
+    return renderHook(() =>
+      useEnvEditor({
+        projectPath: '/test/project',
+        isOpen: true,
+        onClose: vi.fn(),
+        onToast: vi.fn(),
+      })
+    );
+  }
+
+  describe('handleCreateFile error path', () => {
+    it('renders a CommandError rejection as a readable message, not "[object Object]"', async () => {
+      // invoke() rejections from migrated commands are plain CommandError
+      // objects — NOT instanceof Error.
+      vi.mocked(core.invoke).mockImplementation((cmd: string) => {
+        if (cmd === 'list_env_files') return Promise.resolve([]);
+        if (cmd === 'create_env_file') {
+          // Intentional non-Error rejection: this is exactly how Tauri
+          // surfaces CommandError values.
+          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+          return Promise.reject({ type: 'Io', message: 'permission denied' });
+        }
+        return Promise.resolve(undefined);
+      });
+
+      const { result } = renderEnvEditor();
+      await waitFor(() =>
+        expect(core.invoke).toHaveBeenCalledWith('list_env_files', expect.anything())
+      );
+
+      await act(async () => {
+        await result.current.handleCreateFile();
+      });
+
+      expect(result.current.error).toBe('I/O error: permission denied');
+      expect(result.current.error).not.toContain('[object Object]');
+    });
+
+    it('renders a legacy string rejection as-is', async () => {
+      vi.mocked(core.invoke).mockImplementation((cmd: string) => {
+        if (cmd === 'list_env_files') return Promise.resolve([]);
+        if (cmd === 'create_env_file') {
+          // Intentional string rejection: legacy commands reject with strings.
+          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+          return Promise.reject('file already exists');
+        }
+        return Promise.resolve(undefined);
+      });
+
+      const { result } = renderEnvEditor();
+
+      await act(async () => {
+        await result.current.handleCreateFile();
+      });
+
+      expect(result.current.error).toBe('file already exists');
+    });
+  });
+});

--- a/src/hooks/useEnvEditor.ts
+++ b/src/hooks/useEnvEditor.ts
@@ -11,6 +11,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { trackEvent, trackError } from '../lib/analytics';
+import { asCommandError, formatCommandError } from '../lib/errors';
 import { logger } from '../lib/logger';
 
 /** Represents an environment file in the project */
@@ -438,7 +439,7 @@ export function useEnvEditor({
       onToast?.(`Created ${fileName}`, 'success');
     } catch (e) {
       trackError('env_file_create', e, 'Workspace');
-      setError(e as string);
+      setError(formatCommandError(asCommandError(e)));
       onToast?.(`Failed to create ${fileName}`, 'error');
     }
   };

--- a/src/hooks/useProjectCreation.ts
+++ b/src/hooks/useProjectCreation.ts
@@ -35,6 +35,7 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
 import { trackError } from '../lib/analytics';
+import { friendlyProcessError } from '../lib/errors';
 import { getWindowLabel } from '../lib/window';
 import { checkNpmCachePermissions } from '../lib/setup';
 import { installPlugin, VERCEL_PLUGIN_REPO } from '../lib/plugins';
@@ -42,6 +43,11 @@ import { installPlugin, VERCEL_PLUGIN_REPO } from '../lib/plugins';
 // ---------------------------------------------------------------------------
 // Types & Constants
 // ---------------------------------------------------------------------------
+
+/** Extra PTY exit-code mappings specific to the creation flow (template scaffolds). */
+const CREATE_FLOW_EXIT_MESSAGES: Record<number, string> = {
+  69: 'Xcode Command Line Tools license has not been accepted. Open Terminal and run:\nsudo xcodebuild -license accept\n\nThen try creating the project again.',
+};
 
 /** Grouping for the template picker, so the grid isn't an undifferentiated list. */
 export type TemplateCategory = 'web' | 'mobile' | 'other';
@@ -310,26 +316,6 @@ export function useProjectCreation({ onComplete, onCancel }: UseProjectCreationP
     });
   };
 
-  /** Map PTY exit codes to user-friendly error messages */
-  const getFriendlyError = (err: unknown): string => {
-    const msg = String(err);
-    const codeMatch = msg.match(/Process exited with code (\d+)/);
-    if (codeMatch) {
-      const code = parseInt(codeMatch[1]);
-      if (code === 243) {
-        return "npm couldn't access its cache directory (~/.npm). This usually happens when npm was previously run with sudo.\n\nTo fix, open a terminal and run:\nsudo chown -R $(whoami) ~/.npm";
-      }
-      if (code === 128) {
-        return "Git authentication failed. Make sure you're signed into GitHub.";
-      }
-      if (code === 69) {
-        return 'Xcode Command Line Tools license has not been accepted. Open Terminal and run:\nsudo xcodebuild -license accept\n\nThen try creating the project again.';
-      }
-    }
-    // Strip the "Error: " prefix that comes from Error.toString()
-    return msg.replace(/^Error:\s*/, '');
-  };
-
   /** Run npm install via PTY, with a pre-check for permissions */
   const runNpmInstall = async (projectPath: string) => {
     // Pre-check: verify npm cache is writable
@@ -371,7 +357,7 @@ export function useProjectCreation({ onComplete, onCancel }: UseProjectCreationP
       onComplete(createdProjectPath);
     } catch (err) {
       trackError('project_install_retry', err, 'Dashboard');
-      setError(getFriendlyError(err));
+      setError(friendlyProcessError(err, CREATE_FLOW_EXIT_MESSAGES));
     }
   };
 
@@ -466,7 +452,7 @@ export function useProjectCreation({ onComplete, onCancel }: UseProjectCreationP
       onComplete(projectPath);
     } catch (err) {
       trackError('project_create', err, 'Dashboard');
-      setError(getFriendlyError(err));
+      setError(friendlyProcessError(err, CREATE_FLOW_EXIT_MESSAGES));
     }
   };
 
@@ -554,7 +540,7 @@ export function useProjectCreation({ onComplete, onCancel }: UseProjectCreationP
       onComplete(projectPath);
     } catch (err) {
       trackError('project_create_zip', err, 'Dashboard');
-      setError(getFriendlyError(err));
+      setError(friendlyProcessError(err, CREATE_FLOW_EXIT_MESSAGES));
     }
   };
 

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   asCommandError,
   formatCommandError,
+  friendlyProcessError,
   isMergeConflictError,
   type CommandError,
 } from './errors';
@@ -45,6 +46,52 @@ describe('formatCommandError', () => {
       "Pull request #7 can't be merged cleanly: conflict"
     );
     expect(formatCommandError({ type: 'Other', message: 'just a message' })).toBe('just a message');
+  });
+});
+
+describe('friendlyProcessError', () => {
+  it('formats a CommandError object instead of "[object Object]"', () => {
+    const err: CommandError = { type: 'Process', cmd: 'git', exit_code: 1, stderr: 'fatal: nope' };
+    expect(friendlyProcessError(err)).toBe('`git` exited with status 1: fatal: nope');
+    expect(friendlyProcessError({ type: 'Io', message: 'disk full' })).toBe('I/O error: disk full');
+    expect(friendlyProcessError({ type: 'Io', message: 'disk full' })).not.toContain(
+      '[object Object]'
+    );
+  });
+
+  it('maps "Process exited with code 243" to the npm cache advice', () => {
+    const result = friendlyProcessError(new Error('Process exited with code 243\n\nnpm ERR!'));
+    expect(result).toContain('~/.npm');
+    expect(result).toContain('sudo chown');
+  });
+
+  it('maps "Process exited with code 128" to git auth advice', () => {
+    expect(friendlyProcessError('Process exited with code 128')).toBe(
+      "Git authentication failed. Make sure you're signed into GitHub."
+    );
+  });
+
+  it('passes an Error instance message through unchanged', () => {
+    expect(friendlyProcessError(new Error('clone failed'))).toBe('clone failed');
+  });
+
+  it('strips the "Error: " prefix from stringified errors', () => {
+    expect(friendlyProcessError('Error: clone failed')).toBe('clone failed');
+  });
+
+  it('supports caller-provided extra exit-code mappings', () => {
+    const extra = { 69: 'Accept the Xcode license first.' };
+    expect(friendlyProcessError(new Error('Process exited with code 69'), extra)).toBe(
+      'Accept the Xcode license first.'
+    );
+    // Without the extra map, unknown codes fall through to the raw message
+    expect(friendlyProcessError(new Error('Process exited with code 69'))).toBe(
+      'Process exited with code 69'
+    );
+    // Shared mappings still apply when an extra map is provided
+    expect(friendlyProcessError('Process exited with code 128', extra)).toBe(
+      "Git authentication failed. Make sure you're signed into GitHub."
+    );
   });
 });
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -59,3 +59,42 @@ export function formatCommandError(err: CommandError): string {
 export function isMergeConflictError(value: unknown): boolean {
   return asCommandError(value).type === 'MergeConflict';
 }
+
+/**
+ * Exit-code → actionable-message mappings shared by the PTY-driven flows
+ * (project creation, GitHub import) that run `git clone` / package installs.
+ */
+const PROCESS_EXIT_MESSAGES: Record<number, string> = {
+  243: "npm couldn't access its cache directory (~/.npm). This usually happens when npm was previously run with sudo.\n\nTo fix, open a terminal and run:\nsudo chown -R $(whoami) ~/.npm",
+  128: "Git authentication failed. Make sure you're signed into GitHub.",
+};
+
+/**
+ * Map a caught error from a PTY-driven process (clone, install, …) to a
+ * user-friendly message.
+ *
+ * Handles Error instances, plain strings, and CommandError objects from
+ * `invoke()` rejections — the latter are plain objects (NOT `instanceof
+ * Error`), so naive `String(err)` renders them as "[object Object]".
+ * "Process exited with code N" messages are mapped to actionable advice;
+ * callers can extend the exit-code map for flow-specific codes.
+ */
+export function friendlyProcessError(
+  err: unknown,
+  extraExitCodeMessages?: Record<number, string>
+): string {
+  const msg =
+    err instanceof Error
+      ? err.message
+      : typeof err === 'string'
+        ? err
+        : formatCommandError(asCommandError(err));
+  const codeMatch = msg.match(/Process exited with code (\d+)/);
+  if (codeMatch) {
+    const code = parseInt(codeMatch[1], 10);
+    const mapped = extraExitCodeMessages?.[code] ?? PROCESS_EXIT_MESSAGES[code];
+    if (mapped) return mapped;
+  }
+  // Strip the "Error: " prefix that comes from Error.toString()
+  return msg.replace(/^Error:\s*/, '');
+}


### PR DESCRIPTION
## Why

Follow-up to #150. Tauri `invoke()` rejections from migrated commands are `CommandError` **plain objects** — they are not `instanceof Error` — so any error path that used `String(err)`, `err as string`, or an `instanceof Error` check with a generic fallback rendered the literal text `[object Object]` (or silently dropped the backend detail). An audit found the remaining offenders; the canonical safe formatter is `formatCommandError(asCommandError(e))` from `src/lib/errors.ts`.

## Confirmed user-facing "[object Object]" bugs

1. **`src/hooks/useEnvEditor.ts`** — `setError(e as string)` in the `create_env_file` catch (rendered raw in `EnvEditor.tsx`) now formats through `formatCommandError(asCommandError(e))`.
2. **`src/components/dashboard/ImportProject.tsx`** — local `getFriendlyError` started with `const msg = String(err)`; the try blocks also await invoke wrappers (`ensureShipStudioDir`, `projectPathExists`, `detectPackageManager`, …) whose CommandError rejections became `[object Object]`.
3. **`src/hooks/useProjectCreation.ts`** — identical duplicated helper, same bug at its 3 `setError` sites.

For 2 + 3 the two near-identical helpers were extracted into one shared **`friendlyProcessError(err, extraExitCodeMessages?)`** in `src/lib/errors.ts`: it coerces Error instances / strings / CommandError objects safely, keeps the "Process exited with code N" mapping (243 npm cache, 128 git auth) unchanged, and the creation-flow-only code 69 (Xcode license) message is passed via the caller map so behavior is preserved exactly.

## Secondary (silently dropped backend detail)

4. **`src/hooks/useAssetManagement.ts`** (5 sites) — `e instanceof Error ? e.message : '<generic>'` now formats the CommandError via `formatCommandError(asCommandError(e))`, keeping the generic string as fallback for empty messages.
5. **`src/components/branches/ConflictResolutionModal.tsx`** (2 toast sites) — same pattern, same fix.

## Test coverage

- `src/lib/errors.test.ts` — new `friendlyProcessError` suite: CommandError object in → readable message out (never `[object Object]`), exit-code 243/128 mapping, caller-provided extra map (69) with shared mappings still applying, Error-instance passthrough, `Error: ` prefix stripping.
- `src/hooks/useEnvEditor.test.ts` (new) — proves `handleCreateFile`'s error path renders a CommandError rejection as readable text and a legacy string rejection as-is, using the repo's hook-test conventions.

All CI checks pass locally: `typecheck`, `lint:strict`, `format:check`, `test:run` (919 passed, 4 skipped), `check:patterns`, `check:loc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer, friendlier error messages across project creation, import, asset management, environment file creation, and conflict resolution.
  * Some common process failures now show actionable guidance, such as permission or authentication help.

* **Bug Fixes**
  * Improved handling of non-standard errors so messages no longer appear as `"[object Object]"`.
  * Standardized fallback error text for failed merge, import, and asset actions.

* **Tests**
  * Added coverage for the new error formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->