### PR TITLE
CI: restore green main (rustfmt drift + dialog plugin version mismatch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@lezer/highlight": "^1.2.3",
     "@sentry/react": "^10.48.0",
     "@tauri-apps/api": "^2",
-    "@tauri-apps/plugin-dialog": "^2.7.1",
+    "@tauri-apps/plugin-dialog": "~2.6.0",
     "@tauri-apps/plugin-fs": "^2.4.5",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^2
         version: 2.9.1
       '@tauri-apps/plugin-dialog':
-        specifier: ^2.7.1
-        version: 2.7.1
+        specifier: ~2.6.0
+        version: 2.6.0
       '@tauri-apps/plugin-fs':
         specifier: ^2.4.5
         version: 2.4.5
@@ -872,8 +872,8 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@tauri-apps/plugin-dialog@2.7.1':
-    resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
+  '@tauri-apps/plugin-dialog@2.6.0':
+    resolution: {integrity: sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==}
 
   '@tauri-apps/plugin-fs@2.4.5':
     resolution: {integrity: sha512-dVxWWGE6VrOxC7/jlhyE+ON/Cc2REJlM35R3PJX3UvFw2XwYhLGQVAIyrehenDdKjotipjYEVc4YjOl3qq90fA==}
@@ -3248,7 +3248,7 @@ snapshots:
       '@tauri-apps/cli-win32-ia32-msvc': 2.9.6
       '@tauri-apps/cli-win32-x64-msvc': 2.9.6
 
-  '@tauri-apps/plugin-dialog@2.7.1':
+  '@tauri-apps/plugin-dialog@2.6.0':
     dependencies:
       '@tauri-apps/api': 2.11.1
 

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -130,9 +130,9 @@ async fn get_uncommitted_count(project_path: &Path) -> Option<u32> {
 /// order.
 async fn scan_git_info(paths: Vec<PathBuf>) -> Vec<(Option<String>, Option<u32>)> {
     stream::iter(paths)
-        .map(|path| async move {
-            tokio::join!(get_git_branch(&path), get_uncommitted_count(&path))
-        })
+        .map(
+            |path| async move { tokio::join!(get_git_branch(&path), get_uncommitted_count(&path)) },
+        )
         .buffered(GIT_SCAN_CONCURRENCY)
         .collect()
         .await
@@ -1494,7 +1494,9 @@ mod tests {
         // Neither project is a git repo — both must degrade gracefully
         // rather than erroring or being dropped.
         assert_eq!(info.len(), 2);
-        assert!(info.iter().all(|(branch, count)| branch.is_none() && count.is_none()));
+        assert!(info
+            .iter()
+            .all(|(branch, count)| branch.is_none() && count.is_none()));
     }
 
     #[test]


### PR DESCRIPTION
main's CI is red on two mechanical issues, both bypassed by admin-merges last week:

1. **Backend Checks — `cargo fmt --check`**: formatting drift in `src-tauri/src/commands/projects/mod.rs` (from #176). Fixed by running rustfmt; no semantic change.
2. **Windows Checks — `pnpm tauri build --no-bundle`**: tauri's version guard rejects the build because the Rust crate `tauri-plugin-dialog` is locked at **2.6.0** while npm `@tauri-apps/plugin-dialog` was **^2.7.1**. Pinned the npm package to `~2.6.0` to match. (Upgrading the crate to 2.7 instead would pull the entire tauri/wry stack forward — not appropriate in a CI-health fix; if we want that upgrade it should be its own PR with a real smoke test.)

Verified locally: typecheck, 911 frontend tests, `cargo fmt --check`, and `tauri build --no-bundle` passes the version guard.

Every open PR currently inherits these failures; this should land first so the queue gets clean CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)