### PR TITLE
Setup installs: surface real errors, Windows npm + PATH robustness

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -184,6 +184,7 @@ To get an aggregate "any modal opened" count in PostHog, use a regex match on ev
 | `setup_step_skipped` | `step_id`, `step_index`, `reason: 'already_complete'` |
 | `setup_step_navigated_back` | `from_step`, `to_step` |
 | `setup_action_clicked` | `item_id`, `action` (`install`/`connect`), `step_id` |
+| `setup_action_failed` | `item_id`, `exit_code`, `error_excerpt` (extracted from terminal output, capped 200) |
 | `onboarding_completed` | `agents`, `entry_path` |
 | `default_agent_selected` | `agent_id`, `agent_count` |
 

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -123,6 +123,43 @@ fn get_login_shell_path() -> Option<String> {
     result
 }
 
+/// Parses the `path:` entry from an nvm-windows `settings.txt`. That entry is
+/// the symlink directory (e.g. `C:\Program Files\nodejs`) nvm-windows points
+/// at the currently-selected Node version. Conservative: returns None unless a
+/// non-empty `path:` line is present.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn parse_nvm_windows_symlink(settings: &str) -> Option<String> {
+    settings.lines().find_map(|line| {
+        let trimmed = line.trim();
+        let value = trimmed
+            .strip_prefix("path:")
+            .or_else(|| trimmed.strip_prefix("Path:"))?
+            .trim();
+        if value.is_empty() {
+            None
+        } else {
+            Some(value.to_string())
+        }
+    })
+}
+
+/// Returns the most recently modified subdirectory of `dir`, if any. Used to
+/// pick the newest fnm multishell link (fnm creates one per shell session).
+#[cfg_attr(not(windows), allow(dead_code))]
+fn most_recent_subdir(dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    std::fs::read_dir(dir)
+        .ok()?
+        .flatten()
+        .filter(|entry| entry.path().is_dir())
+        .max_by_key(|entry| {
+            entry
+                .metadata()
+                .and_then(|meta| meta.modified())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+        })
+        .map(|entry| entry.path())
+}
+
 /// Computes the extended PATH (uncached). Called by `get_extended_path()`.
 fn build_extended_path() -> String {
     let current_path = std::env::var("PATH").unwrap_or_default();
@@ -134,10 +171,53 @@ fn build_extended_path() -> String {
         // Add Windows-specific paths
         if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
             windows_paths.push(format!("{}\\Microsoft\\WindowsApps", local_app_data));
+
+            // Version-manager Node installs (issue #164): a GUI-launched app
+            // never sees the PATH entries these managers add in the user's
+            // shell profile, so node/npm from volta/fnm looked "not installed".
+            let volta_bin = format!("{}\\Volta\\bin", local_app_data);
+            if std::path::Path::new(&volta_bin).exists() {
+                windows_paths.push(volta_bin);
+            }
+
+            // fnm exposes node via per-shell symlink dirs under
+            // fnm_multishells; use the most recently created one. Fall back to
+            // the fnm install dir itself so at least `fnm` resolves.
+            let multishells = std::path::PathBuf::from(&local_app_data).join("fnm_multishells");
+            if let Some(latest) = most_recent_subdir(&multishells) {
+                windows_paths.push(latest.to_string_lossy().to_string());
+            } else {
+                let fnm_dir = format!("{}\\fnm", local_app_data);
+                if std::path::Path::new(&fnm_dir).exists() {
+                    windows_paths.push(fnm_dir);
+                }
+            }
+
+            // Node's per-user installer target (no-admin installs).
+            let user_nodejs = format!("{}\\Programs\\nodejs", local_app_data);
+            if std::path::Path::new(&user_nodejs).exists() {
+                windows_paths.push(user_nodejs);
+            }
         }
 
         if let Ok(app_data) = std::env::var("APPDATA") {
             windows_paths.push(format!("{}\\npm", app_data));
+
+            // nvm-windows: settings.txt's `path:` entry names the symlink dir
+            // that holds the currently-selected Node version. Parsing is
+            // conservative — if the file is missing or has no `path:` line we
+            // only add the nvm root itself (where nvm.exe lives).
+            let nvm_root = std::path::PathBuf::from(&app_data).join("nvm");
+            if nvm_root.exists() {
+                if let Ok(settings) = std::fs::read_to_string(nvm_root.join("settings.txt")) {
+                    if let Some(symlink) = parse_nvm_windows_symlink(&settings) {
+                        if std::path::Path::new(&symlink).exists() {
+                            windows_paths.push(symlink);
+                        }
+                    }
+                }
+                windows_paths.push(nvm_root.to_string_lossy().to_string());
+            }
         }
 
         if let Ok(program_files) = std::env::var("ProgramFiles") {
@@ -955,6 +1035,83 @@ mod tests {
             let now = 1000000u64;
             // Future timestamps should show "just now" (saturating subtraction)
             assert_eq!(format_relative_time_from_now(now + 60_000, now), "just now");
+        }
+    }
+
+    mod parse_nvm_windows_symlink {
+        use super::*;
+
+        #[test]
+        fn test_parses_typical_settings_file() {
+            let settings = "root: C:\\Users\\me\\AppData\\Roaming\\nvm\r\npath: C:\\Program Files\\nodejs\r\narch: 64\r\nproxy: none\r\n";
+            assert_eq!(
+                parse_nvm_windows_symlink(settings),
+                Some("C:\\Program Files\\nodejs".to_string())
+            );
+        }
+
+        #[test]
+        fn test_ignores_root_and_other_keys() {
+            // `root:` must not be mistaken for `path:`
+            let settings = "root: C:\\nvm\narch: 64\n";
+            assert_eq!(parse_nvm_windows_symlink(settings), None);
+        }
+
+        #[test]
+        fn test_handles_capitalized_key_and_extra_whitespace() {
+            let settings = "  Path:   C:\\nodejs-current  \n";
+            assert_eq!(
+                parse_nvm_windows_symlink(settings),
+                Some("C:\\nodejs-current".to_string())
+            );
+        }
+
+        #[test]
+        fn test_empty_value_returns_none() {
+            assert_eq!(parse_nvm_windows_symlink("path:\n"), None);
+            assert_eq!(parse_nvm_windows_symlink("path:   \n"), None);
+        }
+
+        #[test]
+        fn test_empty_file_returns_none() {
+            assert_eq!(parse_nvm_windows_symlink(""), None);
+        }
+    }
+
+    mod most_recent_subdir {
+        use super::*;
+
+        #[test]
+        fn test_missing_dir_returns_none() {
+            let dir = tempfile::tempdir().unwrap();
+            let missing = dir.path().join("does-not-exist");
+            assert_eq!(most_recent_subdir(&missing), None);
+        }
+
+        #[test]
+        fn test_empty_dir_returns_none() {
+            let dir = tempfile::tempdir().unwrap();
+            assert_eq!(most_recent_subdir(dir.path()), None);
+        }
+
+        #[test]
+        fn test_ignores_plain_files() {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::write(dir.path().join("a-file.txt"), "x").unwrap();
+            assert_eq!(most_recent_subdir(dir.path()), None);
+        }
+
+        #[test]
+        fn test_returns_newest_subdir() {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::create_dir(dir.path().join("older")).unwrap();
+            // Ensure a measurable mtime gap on filesystems with coarse timestamps
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            std::fs::create_dir(dir.path().join("newer")).unwrap();
+            std::fs::write(dir.path().join("noise.txt"), "x").unwrap();
+
+            let result = most_recent_subdir(dir.path()).unwrap();
+            assert_eq!(result, dir.path().join("newer"));
         }
     }
 

--- a/src/components/dashboard/AgentsPanel.tsx
+++ b/src/components/dashboard/AgentsPanel.tsx
@@ -40,6 +40,7 @@ import { useOptionalToast } from '../../contexts/ToastContext';
 import { useWorkspaceConnect } from '../../hooks/useWorkspaceConnect';
 import { logger } from '../../lib/logger';
 import { asCommandError, formatCommandError } from '../../lib/errors';
+import { extractTerminalError } from '../../lib/terminalDiagnostics';
 import {
   CheckIcon,
   ClaudeIcon,
@@ -498,7 +499,7 @@ export function AgentsPanel() {
   }, [openTerminal]);
 
   const handleTerminalExit = useCallback(
-    (exitCode: number | null) => {
+    (exitCode: number | null, outputTail = '') => {
       setTerminalTask(null);
       // Auth/install files (and newly-installed binaries) can land a beat after
       // the child process exits. Refresh immediately and then retry a few times
@@ -506,7 +507,10 @@ export function AgentsPanel() {
       void refresh();
       [600, 1500, 3000].forEach((delay) => setTimeout(() => void refresh(), delay));
       if (exitCode !== null && exitCode !== 0) {
-        logger.info('Agent terminal exited with non-zero code', { exitCode });
+        logger.info('Agent terminal exited with non-zero code', {
+          exitCode,
+          error: extractTerminalError(outputTail) ?? undefined,
+        });
       }
     },
     [refresh]

--- a/src/components/setup/OnboardingScreen.test.tsx
+++ b/src/components/setup/OnboardingScreen.test.tsx
@@ -55,7 +55,7 @@ vi.mock('./OnboardingTerminal', () => ({
   }: {
     command: string;
     args: string[];
-    onExit: (code: number | null) => void;
+    onExit: (code: number | null, outputTail?: string) => void;
   }) => (
     <div data-testid="mock-terminal">
       <button data-testid="terminal-exit-0" onClick={() => onExit(0)}>
@@ -69,6 +69,23 @@ vi.mock('./OnboardingTerminal', () => ({
       </button>
       <button data-testid="terminal-exit-127" onClick={() => onExit(127)}>
         Exit 127
+      </button>
+      <button
+        data-testid="terminal-exit-1-npm-err"
+        onClick={() => onExit(1, 'npm ERR! code EEXIST\nnpm ERR! EEXIST: file already exists\n')}
+      >
+        Exit 1 (npm ERR!)
+      </button>
+      <button
+        data-testid="terminal-exit-1-npm-missing"
+        onClick={() =>
+          onExit(
+            1,
+            "'npm' is not recognized as an internal or external command,\r\noperable program or batch file.\r\n"
+          )
+        }
+      >
+        Exit 1 (npm missing)
       </button>
     </div>
   ),
@@ -338,6 +355,74 @@ describe('OnboardingScreen', () => {
 
     expect(screen.getByText('Close')).toBeInTheDocument();
     expect(screen.getByTestId('mock-terminal')).toBeInTheDocument();
+  });
+
+  it('terminal failure surfaces the extracted error from the output tail', async () => {
+    // Step 3: installButtons[0] is Claude (a terminal item without a
+    // special-cased error message, unlike homebrew on step 1)
+    mockInvoke('get_full_setup_status', HAS_BASE_NO_AGENTS_STATUS);
+
+    render(<OnboardingScreen onComplete={onComplete} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Install at least one AI coding assistant')).toBeInTheDocument();
+    });
+
+    const installButtons = screen.getAllByText('Install');
+    act(() => {
+      fireEvent.click(installButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-terminal')).toBeInTheDocument();
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('terminal-exit-1-npm-err'));
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByText('Close'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('npm ERR! EEXIST: file already exists')).toBeInTheDocument();
+    });
+  });
+
+  it('terminal failure with npm-not-recognized shows the actionable Node.js message', async () => {
+    mockInvoke('get_full_setup_status', HAS_BASE_NO_AGENTS_STATUS);
+
+    render(<OnboardingScreen onComplete={onComplete} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Install at least one AI coding assistant')).toBeInTheDocument();
+    });
+
+    const installButtons = screen.getAllByText('Install');
+    act(() => {
+      fireEvent.click(installButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-terminal')).toBeInTheDocument();
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('terminal-exit-1-npm-missing'));
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByText('Close'));
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Node.js/npm wasn't found. Complete the Node.js step first, or restart Ship Studio if you just installed it."
+        )
+      ).toBeInTheDocument();
+    });
   });
 
   it('terminal cancel closes terminal', async () => {

--- a/src/components/setup/OnboardingScreen.tsx
+++ b/src/components/setup/OnboardingScreen.tsx
@@ -44,6 +44,7 @@ import {
 import { initDefaultAgent } from '../../lib/agent';
 import { checkGitHubCliStatus } from '../../lib/github';
 import { asCommandError, formatCommandError } from '../../lib/errors';
+import { extractTerminalError, isNodeMissingError } from '../../lib/terminalDiagnostics';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { SlackIcon } from '../icons';
 
@@ -202,7 +203,7 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
 
   // Handle terminal exit - process exit codes and check auth status
   const handleTerminalExit = useCallback(
-    async (exitCode: number | null) => {
+    async (exitCode: number | null, outputTail = '') => {
       const itemId = terminalConfig?.itemId;
       if (!itemId) return;
 
@@ -238,11 +239,22 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
       } else {
         setTerminalExitCode(exitCode);
 
-        let errorMessage = 'Command failed. Click to try again.';
+        // Surface the actual failure from the terminal output instead of a
+        // generic message (issue #164 — installs failed with zero diagnostics).
+        const extractedError = extractTerminalError(outputTail);
+        let errorMessage = extractedError ?? 'Command failed. Click to try again.';
         if (itemId === 'homebrew') {
           errorMessage =
             'Installation failed. Your macOS account may need administrator privileges.';
+        } else if (isNodeMissingError(outputTail)) {
+          errorMessage =
+            "Node.js/npm wasn't found. Complete the Node.js step first, or restart Ship Studio if you just installed it.";
         }
+        void trackEvent('setup_action_failed', {
+          item_id: itemId,
+          exit_code: exitCode,
+          error_excerpt: extractedError ?? undefined,
+        });
         updateItemStatus(itemId, {
           status: 'error',
           errorMessage,
@@ -649,7 +661,7 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
               <OnboardingTerminal
                 command={terminalConfig.command}
                 args={terminalConfig.args}
-                onExit={(exitCode) => void handleTerminalExit(exitCode)}
+                onExit={(exitCode, outputTail) => void handleTerminalExit(exitCode, outputTail)}
               />
               <div className="onboarding-terminal-hint">
                 <strong>If you're asked for a password</strong>, type it and press Enter. It stays

--- a/src/components/setup/OnboardingTerminal.tsx
+++ b/src/components/setup/OnboardingTerminal.tsx
@@ -21,6 +21,16 @@ import { logger } from '../../lib/logger';
 import { asCommandError, formatCommandError } from '../../lib/errors';
 import '@xterm/xterm/css/xterm.css';
 
+/**
+ * Maximum characters of raw PTY output retained for exit diagnostics.
+ * Enough to hold the tail of an npm/installer failure without growing
+ * unboundedly during long-running commands.
+ */
+const OUTPUT_TAIL_MAX_CHARS = 8192;
+
+/** Decodes PTY byte chunks for the diagnostics tail (output may be binary). */
+const OUTPUT_DECODER = new TextDecoder();
+
 /** Props for the OnboardingTerminal component */
 interface OnboardingTerminalProps {
   /** Command to run (e.g., "gh", "bash") */
@@ -29,8 +39,12 @@ interface OnboardingTerminalProps {
   args: string[];
   /** Working directory (defaults to home) */
   cwd?: string;
-  /** Callback fired when the process exits */
-  onExit: (exitCode: number | null) => void;
+  /**
+   * Callback fired when the process exits. `outputTail` is the last
+   * ~{@link OUTPUT_TAIL_MAX_CHARS} characters of raw output so callers can
+   * surface the actual error on failure (see lib/terminalDiagnostics).
+   */
+  onExit: (exitCode: number | null, outputTail: string) => void;
 }
 
 export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTerminalProps) {
@@ -38,6 +52,8 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
   const terminalRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const ptyRef = useRef<IPty | null>(null);
+  // Bounded tail of raw PTY output, handed to onExit for failure diagnostics.
+  const outputTailRef = useRef('');
   const [isReady, setIsReady] = useState(false);
 
   // Use ref for onExit to prevent effect re-runs when callback reference changes
@@ -177,6 +193,14 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
             `${programFiles}\\GitHub CLI`,
             `${programFiles}\\Git\\cmd`,
             `${programFiles}\\nodejs`,
+            // Version-manager Node installs — volta/fnm/nvm-windows users may
+            // have no %ProgramFiles%\nodejs, and their shell-profile PATH edits
+            // are invisible to a GUI-launched app. Without these, npm-based
+            // installs fail with "'npm' is not recognized" (issue #164).
+            // Nonexistent dirs on PATH are harmless.
+            `${localAppData}\\Volta\\bin`,
+            `${localAppData}\\fnm`,
+            `${localAppData}\\Programs\\nodejs`,
           ];
 
           const systemPath = systemEnv['PATH'] || '';
@@ -263,15 +287,22 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
         }
 
         ptyRef.current = pty;
+        outputTailRef.current = '';
 
-        // Handle PTY output -> terminal
+        // Handle PTY output -> terminal, keeping a bounded tail for diagnostics
         pty.onData((data) => {
           terminalRef.current?.write(data);
+          const text = typeof data === 'string' ? data : OUTPUT_DECODER.decode(data);
+          const combined = outputTailRef.current + text;
+          outputTailRef.current =
+            combined.length > OUTPUT_TAIL_MAX_CHARS
+              ? combined.slice(-OUTPUT_TAIL_MAX_CHARS)
+              : combined;
         });
 
         // Handle PTY exit
         pty.onExit(({ exitCode }) => {
-          onExitRef.current(exitCode);
+          onExitRef.current(exitCode, outputTailRef.current);
         });
 
         // Handle terminal input -> PTY
@@ -300,11 +331,10 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
         term.focus();
       } catch (err) {
         logger.warn(`Failed to spawn ${command}`);
-        term.write(
-          `\x1b[31mError starting command: ${formatCommandError(asCommandError(err))}\x1b[0m\r\n`
-        );
-        // Notify parent of failure
-        setTimeout(() => onExitRef.current(1), 1000);
+        const message = `Error starting command: ${formatCommandError(asCommandError(err))}`;
+        term.write(`\x1b[31m${message}\x1b[0m\r\n`);
+        // Notify parent of failure, passing the spawn error as the tail
+        setTimeout(() => onExitRef.current(1, message), 1000);
       }
     };
 

--- a/src/lib/ansi.test.ts
+++ b/src/lib/ansi.test.ts
@@ -14,6 +14,18 @@ describe('stripAnsi', () => {
     expect(stripAnsi('\x1b]0;my title\x07rest')).toBe('rest');
   });
 
+  it('removes ST-terminated OSC sequences (hyperlinks)', () => {
+    expect(stripAnsi('\x1b]8;;https://x.dev\x1b\\link')).toBe('link');
+  });
+
+  it('removes private-mode CSI sequences (cursor hide/show)', () => {
+    expect(stripAnsi('hello \x1b[?25lworld\x1b[?25h')).toBe('hello world');
+  });
+
+  it('removes single-character escapes', () => {
+    expect(stripAnsi('a\x1bMb')).toBe('ab');
+  });
+
   it('removes interleaved CSI and OSC families', () => {
     expect(stripAnsi('\x1b[31mred\x1b[0m \x1b]0;title\x07plain')).toBe('red plain');
   });

--- a/src/lib/ansi.ts
+++ b/src/lib/ansi.ts
@@ -3,11 +3,22 @@
  * a string so it can be displayed as plain text or sent to an agent
  * without the `\x1b[32mfoo\x1b[0m` noise.
  *
- * Covers two families:
- *   - CSI (Control Sequence Introducer): `ESC [ … letter`  — colors, cursor
- *   - OSC (Operating System Command):    `ESC ] … BEL`     — window titles
+ * Covers three families:
+ *   - CSI (Control Sequence Introducer): `ESC [ … final` — colors, cursor
+ *     (including intermediate bytes, e.g. `ESC [ ? 25 l`)
+ *   - OSC (Operating System Command): `ESC ] … BEL|ST` — window titles,
+ *     hyperlinks (terminated by BEL or `ESC \`)
+ *   - Single-character escapes in the `ESC @` … `ESC _` range — index,
+ *     next-line, string terminator, etc.
  */
 export function stripAnsi(input: string): string {
-  // eslint-disable-next-line no-control-regex
-  return input.replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, '').replace(/\x1b\][^\x07]*\x07/g, '');
+  return (
+    input
+      // eslint-disable-next-line no-control-regex
+      .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '')
+      // eslint-disable-next-line no-control-regex
+      .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?/g, '')
+      // eslint-disable-next-line no-control-regex
+      .replace(/\x1b[@-Z\\-_]/g, '')
+  );
 }

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -618,8 +618,10 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
         args: [],
       },
       codex: {
+        // --force clears EEXIST failures from stale/partial global installs,
+        // which npm otherwise reports opaquely (issue #164).
         command: 'npm',
-        args: ['install', '-g', '@openai/codex'],
+        args: ['install', '-g', '@openai/codex', '--force'],
       },
       codex_auth: {
         command: 'codex',
@@ -628,8 +630,9 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
       opencode: {
         // No clean PowerShell one-liner installer exists for Windows; install
         // via npm (Node is set up in step 1, same as Codex below).
+        // --force clears EEXIST failures from stale/partial global installs.
         command: 'npm',
-        args: ['install', '-g', 'opencode-ai'],
+        args: ['install', '-g', 'opencode-ai', '--force'],
       },
       opencode_auth: {
         command: 'opencode',
@@ -646,8 +649,9 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
         args: ['login'],
       },
       vercel: {
+        // --force clears EEXIST failures from stale/partial global installs.
         command: 'npm',
-        args: ['install', '-g', 'vercel'],
+        args: ['install', '-g', 'vercel', '--force'],
       },
       vercel_auth: {
         command: 'vercel',

--- a/src/lib/terminalDiagnostics.test.ts
+++ b/src/lib/terminalDiagnostics.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { extractTerminalError, isNodeMissingError } from './terminalDiagnostics';
+
+describe('extractTerminalError', () => {
+  it('returns null for an empty tail', () => {
+    expect(extractTerminalError('')).toBeNull();
+  });
+
+  it('returns null for whitespace/ANSI-only output', () => {
+    expect(extractTerminalError('  \r\n\x1b[2K\r\n   ')).toBeNull();
+  });
+
+  it("extracts the Windows 'npm is not recognized' line", () => {
+    const tail =
+      "'npm' is not recognized as an internal or external command,\r\n" +
+      'operable program or batch file.\r\n';
+    expect(extractTerminalError(tail)).toBe(
+      "'npm' is not recognized as an internal or external command,"
+    );
+  });
+
+  it('extracts the meaningful npm ERR! line, not the debug-log pointer', () => {
+    const tail = [
+      'npm ERR! code EEXIST',
+      'npm ERR! path C:\\Users\\me\\AppData\\Roaming\\npm\\vercel',
+      'npm ERR! EEXIST: file already exists, unlink C:\\Users\\me\\AppData\\Roaming\\npm\\vercel',
+      'npm ERR! A complete log of this run can be found in:',
+      'npm ERR!     C:\\Users\\me\\AppData\\Local\\npm-cache\\_logs\\2026-07-02.log',
+    ].join('\r\n');
+    expect(extractTerminalError(tail)).toBe(
+      'npm ERR! EEXIST: file already exists, unlink C:\\Users\\me\\AppData\\Roaming\\npm\\vercel'
+    );
+  });
+
+  it('strips ANSI codes from the extracted line', () => {
+    const tail = 'installing...\n\x1b[31mnpm ERR!\x1b[0m code EACCES\n';
+    expect(extractTerminalError(tail)).toBe('npm ERR! code EACCES');
+  });
+
+  it('collapses carriage-return progress redraws to the final segment', () => {
+    const tail = 'Downloading 10%\rDownloading 55%\rDownloading 100%\nerror: failed to fetch\n';
+    expect(extractTerminalError(tail)).toBe('error: failed to fetch');
+  });
+
+  it('falls back to the last non-empty line when nothing looks like an error', () => {
+    const tail = 'step one done\nstep two done\nexiting with status 7\n';
+    expect(extractTerminalError(tail)).toBe('exiting with status 7');
+  });
+
+  it('prefers the last error-ish line over later non-error lines', () => {
+    const tail = 'error: could not connect to registry\ncleaning up temp files\n';
+    expect(extractTerminalError(tail)).toBe('error: could not connect to registry');
+  });
+
+  it('caps very long lines at 200 characters', () => {
+    const longLine = `npm ERR! ${'x'.repeat(400)}`;
+    const result = extractTerminalError(longLine);
+    expect(result).not.toBeNull();
+    expect(result?.length).toBe(200);
+    expect(result?.endsWith('…')).toBe(true);
+  });
+});
+
+describe('isNodeMissingError', () => {
+  it('detects the cmd.exe not-recognized message for npm', () => {
+    expect(
+      isNodeMissingError(
+        "'npm' is not recognized as an internal or external command,\r\noperable program or batch file."
+      )
+    ).toBe(true);
+  });
+
+  it('detects the PowerShell not-recognized message', () => {
+    expect(
+      isNodeMissingError(
+        "npm : The term 'npm' is not recognized as the name of a cmdlet, function, script file, or operable program."
+      )
+    ).toBe(true);
+  });
+
+  it('detects the Unix command-not-found message for node', () => {
+    expect(isNodeMissingError('/bin/bash: node: command not found')).toBe(true);
+  });
+
+  it('sees through ANSI-colored output', () => {
+    expect(isNodeMissingError("\x1b[91m'node' is not recognized\x1b[0m")).toBe(true);
+  });
+
+  it('does not fire on unrelated failures', () => {
+    expect(isNodeMissingError('npm ERR! code EACCES')).toBe(false);
+    expect(isNodeMissingError("gh: command 'foo' not found")).toBe(false);
+    expect(isNodeMissingError('')).toBe(false);
+  });
+});

--- a/src/lib/terminalDiagnostics.ts
+++ b/src/lib/terminalDiagnostics.ts
@@ -1,0 +1,76 @@
+/**
+ * Terminal output diagnostics.
+ *
+ * Pure helpers that turn the raw output tail of a failed PTY command into a
+ * human-readable error message. Used by the onboarding wizard and the
+ * dashboard agents panel to surface *why* an install/auth command failed
+ * instead of a generic "Command failed" (see issue #164 — Windows installs
+ * failed with zero diagnostics).
+ *
+ * @module lib/terminalDiagnostics
+ */
+
+import { stripAnsi } from './ansi';
+
+/** Lines that look like they describe the failure. */
+const ERROR_LINE_PATTERN = /error|not recognized|not found|EACCES|EPERM|EEXIST|ENOENT|npm ERR!/i;
+
+/**
+ * npm's trailing pointer at its debug log (the sentence and the log-file path
+ * line that follows it) — present on every failure and says nothing about the
+ * cause, so never pick it as "the" error line.
+ */
+const NOISE_LINE_PATTERN = /complete log of this run|[\\/]_logs[\\/].*\.log\b/i;
+
+/**
+ * "npm/node isn't on PATH" — cmd.exe ("'npm' is not recognized as an internal
+ * or external command"), PowerShell ("The term 'npm' is not recognized…"),
+ * and Unix shells ("npm: command not found").
+ */
+const NODE_MISSING_PATTERN =
+  /'(npm|node)(\.cmd|\.exe)?' is not recognized|\b(npm|node): (command )?not found/i;
+
+/** Maximum length of an extracted error message shown in the UI / telemetry. */
+const MAX_ERROR_LENGTH = 200;
+
+/**
+ * Split terminal output into the lines a user actually saw: strips ANSI
+ * codes, collapses carriage-return redraws (spinners/progress bars rewrite
+ * the same line — only the last non-empty segment survives), and drops blank
+ * lines.
+ */
+function toVisibleLines(tail: string): string[] {
+  return stripAnsi(tail)
+    .split('\n')
+    .map((line) => {
+      const segments = line.split('\r').filter((segment) => segment.trim().length > 0);
+      return (segments[segments.length - 1] ?? '').trim();
+    })
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * Extract the most useful error line from the tail of a failed command's
+ * output. Prefers the last line that looks error-ish (error/not found/npm
+ * ERR!/EEXIST…), falls back to the last non-empty line, and returns null for
+ * an empty tail. Result is capped at {@link MAX_ERROR_LENGTH} characters.
+ */
+export function extractTerminalError(tail: string): string | null {
+  const lines = toVisibleLines(tail);
+  if (lines.length === 0) return null;
+
+  const errorLines = lines.filter(
+    (line) => ERROR_LINE_PATTERN.test(line) && !NOISE_LINE_PATTERN.test(line)
+  );
+  const best = errorLines.length > 0 ? errorLines[errorLines.length - 1] : lines[lines.length - 1];
+  return best.length > MAX_ERROR_LENGTH ? `${best.slice(0, MAX_ERROR_LENGTH - 1)}…` : best;
+}
+
+/**
+ * True when the output indicates npm/node itself wasn't found on PATH — the
+ * signature of an npm-based install attempted before Node.js is installed
+ * (or before a fresh install is visible to the app).
+ */
+export function isNodeMissingError(tail: string): boolean {
+  return NODE_MISSING_PATTERN.test(stripAnsi(tail));
+}


### PR DESCRIPTION
## Why

Addresses the CLI-install part of #164. Windows users reported "Failed to install Vercel CLI" in Slack with nothing to go on — the wizard's only signal on a failed install is the generic "Command failed. Click to try again." toast, because the PTY's output is written to xterm and discarded: only the exit code reaches the exit handler. On Windows the most common root cause (Node installed via nvm-windows/fnm/volta being invisible to a GUI-launched app's PATH → `'npm' is not recognized` → exit 1) was therefore indistinguishable from any other failure, and there was no failure telemetry either.

## What changed

**A. Output capture + real error messages**
- `OnboardingTerminal` keeps a bounded ~8KB tail of raw PTY output and extends the exit contract to `onExit(exitCode, outputTail)`. Edits are localized to the onData handler, the exit callback, and the spawn-failure catch — no reorganization (two open PRs touch this file).
- New `src/lib/terminalDiagnostics.ts`: `extractTerminalError(tail)` strips ANSI escapes and CR progress redraws, prefers error-ish lines (`error` / `not recognized` / `not found` / `EACCES` / `EPERM` / `EEXIST` / `ENOENT` / `npm ERR!`), skips npm's debug-log-pointer noise, caps at 200 chars; `isNodeMissingError(tail)` detects the cmd.exe/PowerShell/Unix "npm/node not found" signatures. `lib/ansi.ts`'s `stripAnsi` was extended (ST-terminated OSC, private-mode CSI, single-char escapes) and reused instead of duplicating a stripper.
- `OnboardingScreen` now shows the extracted error on failure, with actionable copy when npm/node itself is missing: "Node.js/npm wasn't found. Complete the Node.js step first, or restart Ship Studio if you just installed it." The homebrew special case is preserved. `AgentsPanel` (which reuses `OnboardingTerminal`) logs the extracted error too.
- New `setup_action_failed` telemetry event (`item_id`, `exit_code`, `error_excerpt`), documented in `docs/analytics.md` — future reports come with the actual error attached.

**B. Windows npm robustness**
- The Windows npm-based installs (vercel, codex, opencode) use `npm install -g <pkg> --force`, so stale/partial global installs no longer EEXIST-fail opaquely.

**C. Windows PATH discovery for version-manager Node**
- `build_extended_path` (Rust) now also adds, when present: `%LOCALAPPDATA%\Volta\bin`, the newest `%LOCALAPPDATA%\fnm_multishells` subdir (falling back to `%LOCALAPPDATA%\fnm`), the nvm-windows root plus the symlink dir parsed conservatively from `settings.txt`'s `path:` entry, and `%LOCALAPPDATA%\Programs\nodejs`.
- The PTY's `extraPaths` in `OnboardingTerminal` mirrors the static dirs (Volta\bin, fnm, Programs\nodejs) so the embedded terminal resolves npm the same way. The nvm current-version dir is backend-only (the frontend can't cheaply parse settings.txt).

## Windows-gated vs macOS

All PATH changes live inside the existing `#[cfg(windows)]` branch / `isWin` branch; the two new Rust helpers are cross-platform pure functions (unit-tested on all platforms, `allow(dead_code)` off-Windows). macOS command definitions and error copy are unchanged except that macOS failures now also surface the extracted error instead of the generic string — strictly more information.

## Test coverage

- `src/lib/terminalDiagnostics.test.ts` — 14 tests: npm ERR! extraction (skipping the log pointer), `'npm' is not recognized`, CR-redraw collapse, ANSI-wrapped errors, fallback line, 200-char cap, empty tails; node-missing detection for cmd.exe/PowerShell/Unix messages.
- `src/lib/ansi.test.ts` — new cases for ST-terminated OSC, private-mode CSI, single-char escapes.
- `OnboardingScreen.test.tsx` — two new integration tests: extracted error surfaces on the item after a failed install; npm-not-recognized shows the actionable Node.js message.
- `src-tauri/src/utils.rs` — 9 new unit tests for `parse_nvm_windows_symlink` (typical file, `root:` vs `path:`, whitespace/case, empty) and `most_recent_subdir` (missing/empty dir, files ignored, newest wins via tempfile).
- Full quality bar passes locally: `pnpm test:run` (63 files / 932 passed), `typecheck`, `lint:strict`, `format:check`, `check:patterns`, `check:loc`, `cargo test` (607 passed), `cargo clippy`, `cargo fmt --check` (no new diffs).

## Caveat: needs a Windows tester

The failure modes this fixes only reproduce on Windows with version-manager Node setups; CI's windows-check job compiles and runs the Rust tests on windows-latest, but the end-to-end wizard flow should be validated by a Windows tester (#79) before this is considered fully closed.

Addresses the CLI-install part of #164 (the connect-flow part remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)