### PR TITLE
PTY: fix first-output race behind 'stuck at Starting…' + ConPTY 0-size wedge

### DIFF
--- a/src-tauri/plugins/tauri-plugin-pty/src/lib.rs
+++ b/src-tauri/plugins/tauri-plugin-pty/src/lib.rs
@@ -30,6 +30,17 @@ struct Session {
 
 type PtyHandler = u32;
 
+/// Minimum PTY dimension. Windows ConPTY wedges (produces no output, or
+/// hangs the client) when created or resized at 0 rows/cols — which a
+/// caller can request when it spawns before its terminal widget has been
+/// measured. Clamp to a small sane floor; the real size follows via resize.
+const MIN_PTY_DIMENSION: u16 = 2;
+
+/// Clamp a requested PTY size to the minimum ConPTY tolerates.
+fn clamp_pty_size(rows: u16, cols: u16) -> (u16, u16) {
+    (rows.max(MIN_PTY_DIMENSION), cols.max(MIN_PTY_DIMENSION))
+}
+
 #[tauri::command]
 async fn spawn<R: Runtime>(
     file: String,
@@ -53,6 +64,7 @@ async fn spawn<R: Runtime>(
     let _ = flow_control_pause;
     let _ = flow_control_resume;
 
+    let (rows, cols) = clamp_pty_size(rows, cols);
     let pty_system = native_pty_system();
     let pair = pty_system
         .openpty(PtySize {
@@ -152,6 +164,7 @@ async fn resize(
     rows: u16,
     state: tauri::State<'_, PluginState>,
 ) -> Result<(), String> {
+    let (rows, cols) = clamp_pty_size(rows, cols);
     let session = state
         .sessions
         .read()
@@ -219,6 +232,21 @@ async fn exitstatus(pid: PtyHandler, state: tauri::State<'_, PluginState>) -> Re
     })
     .await
     .map_err(|e: tokio::task::JoinError| e.to_string())?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::clamp_pty_size;
+
+    #[test]
+    fn clamp_pty_size_floors_zero_and_one() {
+        assert_eq!(clamp_pty_size(0, 0), (2, 2));
+        assert_eq!(clamp_pty_size(1, 0), (2, 2));
+        assert_eq!(clamp_pty_size(0, 120), (2, 120));
+        assert_eq!(clamp_pty_size(24, 1), (24, 2));
+        assert_eq!(clamp_pty_size(24, 80), (24, 80));
+        assert_eq!(clamp_pty_size(u16::MAX, u16::MAX), (u16::MAX, u16::MAX));
+    }
 }
 
 /// Initializes the plugin.

--- a/src-tauri/src/commands/pty_session.rs
+++ b/src-tauri/src/commands/pty_session.rs
@@ -30,13 +30,67 @@ use tauri::{AppHandle, Emitter};
 /// without becoming a memory burden across dozens of background sessions.
 const RING_BUFFER_MAX: usize = 128 * 1024;
 
+/// Minimum PTY dimension. Windows ConPTY wedges (produces no output, or
+/// hangs the client) when created or resized at 0 rows/cols — which the
+/// frontend can request when it spawns before xterm has measured its
+/// container. Clamp to a small sane floor; the real size follows via resize.
+const MIN_PTY_DIMENSION: u16 = 2;
+
+/// Clamp a requested PTY size to the minimum ConPTY tolerates.
+fn clamp_pty_size(rows: u16, cols: u16) -> (u16, u16) {
+    (rows.max(MIN_PTY_DIMENSION), cols.max(MIN_PTY_DIMENSION))
+}
+
+/// Ring buffer + cumulative-offset accounting, guarded by ONE mutex so that
+/// appending a chunk and advancing the offset are atomic with respect to an
+/// attach snapshot.
+///
+/// `total_offset` counts every byte ever read from the PTY — ring trimming
+/// does NOT decrease it. Each emitted `pty-session-data` event carries the
+/// chunk's start offset, and `pty_session_attach` returns `total_offset` at
+/// snapshot time as `end_offset`. Because append + offset increment happen
+/// under the same lock as the snapshot, an event chunk either lies entirely
+/// before the snapshot (`offset + len <= end_offset`) or entirely at/after
+/// it (`offset >= end_offset`) — it can never straddle the boundary. That's
+/// what lets the frontend subscribe *before* attaching and drop exactly the
+/// chunks the snapshot already covers.
+struct SessionBuffer {
+    ring: VecDeque<u8>,
+    total_offset: u64,
+}
+
+impl SessionBuffer {
+    fn new() -> Self {
+        Self {
+            ring: VecDeque::with_capacity(8192),
+            total_offset: 0,
+        }
+    }
+
+    /// Append a chunk, returning its start offset (the cumulative byte
+    /// count before this chunk).
+    fn append(&mut self, bytes: &[u8]) -> u64 {
+        let start = self.total_offset;
+        append_to_ring(&mut self.ring, bytes);
+        self.total_offset = start.saturating_add(bytes.len() as u64);
+        // No-straddle invariant: the offset advances by exactly the chunk
+        // length in the same critical section as the ring append, so any
+        // snapshot end_offset (also read under this mutex) coincides with a
+        // chunk boundary — never the middle of a chunk. Also: we can never
+        // retain more bytes than were ever produced.
+        debug_assert_eq!(self.total_offset, start + bytes.len() as u64);
+        debug_assert!(self.ring.len() as u64 <= self.total_offset);
+        start
+    }
+}
+
 struct Session {
     pid: u32,
     project_path: Option<String>,
     tab_session_id: Option<String>,
     alive: AtomicBool,
     exit_code: Mutex<Option<i32>>,
-    buffer: Mutex<VecDeque<u8>>,
+    buffer: Mutex<SessionBuffer>,
     writer: Mutex<Box<dyn std::io::Write + Send>>,
     child_killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
     master: Mutex<Box<dyn portable_pty::MasterPty + Send>>,
@@ -52,6 +106,22 @@ fn now_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+/// Windows system vars that cmd.exe / ConPTY / Node require. Mirrors the
+/// critical subset of `get_system_env` in `commands/pty/mod.rs` — injected
+/// server-side in `pty_session_open` so a frontend env map that lost them
+/// (the PTY env replaces, not merges, the parent env) can't produce a
+/// wedged, output-less session.
+#[cfg_attr(not(windows), allow(dead_code))]
+const CRITICAL_WINDOWS_ENV_VARS: [&str; 5] =
+    ["SystemRoot", "COMSPEC", "PATHEXT", "windir", "SYSTEMDRIVE"];
+
+/// Case-insensitive key lookup — Windows env var names are case-insensitive,
+/// and the frontend may send e.g. `SYSTEMROOT` where we check `SystemRoot`.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn env_has_key(env: &BTreeMap<String, String>, key: &str) -> bool {
+    env.keys().any(|k| k.eq_ignore_ascii_case(key))
 }
 
 fn append_to_ring(ring: &mut VecDeque<u8>, bytes: &[u8]) {
@@ -78,14 +148,19 @@ pub struct OpenSessionResult {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AttachResult {
     /// Recent output bytes (the ring buffer tail) — xterm should write these
-    /// immediately to restore the visible scrollback before subscribing to
-    /// the live data event stream.
+    /// immediately to restore the visible scrollback.
     pub buffer: Vec<u8>,
     pub pid: u32,
     pub alive: bool,
     pub exit_code: Option<i32>,
+    /// Cumulative byte offset at snapshot time (total bytes ever read from
+    /// the PTY, independent of ring trimming). Live `pty-session-data`
+    /// events whose `offset` is `< end_offset` are already contained in
+    /// `buffer` and must be dropped by the subscriber.
+    pub end_offset: u64,
 }
 
 #[derive(Serialize)]
@@ -135,6 +210,7 @@ pub async fn pty_session_open(
         }
     }
 
+    let (rows, cols) = clamp_pty_size(rows, cols);
     let pty_system = native_pty_system();
     let pair = pty_system
         .openpty(PtySize {
@@ -163,6 +239,20 @@ pub async fn pty_session_open(
         cmd.env(std::ffi::OsString::from(k), std::ffi::OsString::from(v));
     }
 
+    // Windows safety net: the provided env REPLACES the parent environment,
+    // so if the frontend's map is missing critical system vars, cmd.exe /
+    // ConPTY / Node fail in silent, confusing ways (a PTY that never
+    // produces a byte). Backfill them from the app's own environment when
+    // absent — the frontend-supplied values still win when present.
+    #[cfg(windows)]
+    for key in CRITICAL_WINDOWS_ENV_VARS {
+        if !env_has_key(&env, key) {
+            if let Ok(val) = std::env::var(key) {
+                cmd.env(std::ffi::OsString::from(key), std::ffi::OsString::from(val));
+            }
+        }
+    }
+
     // Inject the project's Workspace credentials/config dirs SERVER-SIDE, so
     // secret token values (Vercel/Figma/OpenAI/Anthropic-base-url) never have to
     // cross the IPC boundary into the webview's JS. The backend wins over any
@@ -189,7 +279,7 @@ pub async fn pty_session_open(
         tab_session_id: tab_session_id.clone(),
         alive: AtomicBool::new(true),
         exit_code: Mutex::new(None),
-        buffer: Mutex::new(VecDeque::with_capacity(8192)),
+        buffer: Mutex::new(SessionBuffer::new()),
         writer: Mutex::new(writer),
         child_killer: Mutex::new(child_killer),
         master: Mutex::new(pair.master),
@@ -215,14 +305,23 @@ pub async fn pty_session_open(
                     Err(_) => break,
                 };
                 let chunk = &buf[..n];
-                if let Ok(mut ring) = session_for_reader.buffer.lock() {
-                    append_to_ring(&mut ring, chunk);
-                }
+                // Capture the chunk's start offset under the SAME lock that
+                // appends it to the ring — this atomicity is what guarantees
+                // an attach snapshot's end_offset always lands on a chunk
+                // boundary (see `SessionBuffer`).
+                let Ok(chunk_start_offset) = session_for_reader
+                    .buffer
+                    .lock()
+                    .map(|mut b| b.append(chunk))
+                else {
+                    break; // poisoned — registry is unusable for this session
+                };
                 let _ = app_for_reader.emit(
                     "pty-session-data",
                     serde_json::json!({
                         "sessionId": session_id_for_reader,
                         "data": chunk,
+                        "offset": chunk_start_offset,
                     }),
                 );
             }
@@ -302,6 +401,7 @@ pub fn pty_session_resize(session_id: String, cols: u16, rows: u16) -> Result<()
     let Some(session) = session else {
         return Err("unknown session".to_string().into());
     };
+    let (rows, cols) = clamp_pty_size(rows, cols);
     let master = session
         .master
         .lock()
@@ -354,12 +454,15 @@ pub fn pty_session_attach(session_id: String) -> Result<AttachResult, CommandErr
     let Some(session) = session else {
         return Err("unknown session".to_string().into());
     };
-    let buffer: Vec<u8> = {
-        let ring = session
+    // Snapshot bytes AND end offset under one lock acquisition: the pair
+    // must be consistent for the frontend's offset filter to be exact.
+    let (buffer, end_offset): (Vec<u8>, u64) = {
+        let b = session
             .buffer
             .lock()
             .map_err(|e| format!("buffer lock poisoned: {e}"))?;
-        ring.iter().copied().collect()
+        debug_assert!(b.ring.len() as u64 <= b.total_offset);
+        (b.ring.iter().copied().collect(), b.total_offset)
     };
     let alive = session.alive.load(Ordering::Relaxed);
     let exit_code = *session
@@ -371,6 +474,7 @@ pub fn pty_session_attach(session_id: String) -> Result<AttachResult, CommandErr
         pid: session.pid,
         alive,
         exit_code,
+        end_offset,
     })
 }
 
@@ -438,5 +542,103 @@ mod tests {
         append_to_ring(&mut ring, &huge);
         assert_eq!(ring.len(), RING_BUFFER_MAX);
         assert!(ring.iter().all(|&b| b == b'q'));
+    }
+
+    #[test]
+    fn offset_accounting_across_appends() {
+        let mut buf = SessionBuffer::new();
+        assert_eq!(buf.append(b"hello"), 0);
+        assert_eq!(buf.append(b" world"), 5);
+        assert_eq!(buf.append(b""), 11);
+        assert_eq!(buf.append(b"!"), 11);
+        assert_eq!(buf.total_offset, 12);
+        let out: Vec<u8> = buf.ring.iter().copied().collect();
+        assert_eq!(&out, b"hello world!");
+    }
+
+    #[test]
+    fn offset_keeps_counting_past_ring_trim() {
+        let mut buf = SessionBuffer::new();
+        let big = vec![b'a'; RING_BUFFER_MAX];
+        assert_eq!(buf.append(&big), 0);
+        // This append trims the ring's front, but offsets are cumulative:
+        // they count bytes ever produced, not bytes retained.
+        assert_eq!(buf.append(b"XYZ"), RING_BUFFER_MAX as u64);
+        assert_eq!(buf.total_offset, RING_BUFFER_MAX as u64 + 3);
+        assert_eq!(buf.ring.len(), RING_BUFFER_MAX);
+
+        // Oversized single write: ring keeps only the tail; offset counts it all.
+        let huge = vec![b'q'; RING_BUFFER_MAX + 5000];
+        let start = buf.append(&huge);
+        assert_eq!(start, RING_BUFFER_MAX as u64 + 3);
+        assert_eq!(buf.total_offset, start + huge.len() as u64);
+        assert_eq!(buf.ring.len(), RING_BUFFER_MAX);
+    }
+
+    #[test]
+    fn attach_end_offset_matches_snapshot_even_after_trim() {
+        let mut buf = SessionBuffer::new();
+        let big = vec![b'z'; RING_BUFFER_MAX + 100];
+        buf.append(&big);
+        buf.append(b"tail");
+        // What pty_session_attach snapshots under the lock:
+        let snapshot: Vec<u8> = buf.ring.iter().copied().collect();
+        let end_offset = buf.total_offset;
+        assert_eq!(end_offset, big.len() as u64 + 4);
+        assert_eq!(snapshot.len(), RING_BUFFER_MAX);
+        // The snapshot always covers exactly the bytes with offsets in
+        // [end_offset - snapshot.len(), end_offset) — the math holds even
+        // though the ring dropped older bytes.
+        assert!(snapshot.len() as u64 <= end_offset);
+        assert_eq!(&snapshot[snapshot.len() - 4..], b"tail");
+    }
+
+    #[test]
+    fn snapshot_end_offset_never_straddles_a_chunk() {
+        // Simulate the reader thread appending chunks while attaches take
+        // snapshots at every possible interleaving point. Since append and
+        // snapshot both run under the buffer mutex, the only observable
+        // end_offsets are the total_offset values between appends — assert
+        // none of them falls strictly inside any chunk's [start, start+len).
+        let chunks: [&[u8]; 4] = [b"first", b"", b"second-chunk", b"x"];
+        let mut buf = SessionBuffer::new();
+        let mut chunk_ranges: Vec<(u64, u64)> = Vec::new();
+        let mut snapshot_points = vec![buf.total_offset];
+        for chunk in chunks {
+            let start = buf.append(chunk);
+            chunk_ranges.push((start, start + chunk.len() as u64));
+            snapshot_points.push(buf.total_offset);
+        }
+        for &end_offset in &snapshot_points {
+            for &(start, end) in &chunk_ranges {
+                let straddles = end_offset > start && end_offset < end;
+                assert!(
+                    !straddles,
+                    "end_offset {end_offset} straddles chunk [{start}, {end})"
+                );
+                // The frontend's filter is total: each chunk is either fully
+                // covered by the snapshot or fully after it.
+                assert!(end <= end_offset || start >= end_offset);
+            }
+        }
+    }
+
+    #[test]
+    fn clamp_pty_size_floors_zero_and_one() {
+        assert_eq!(clamp_pty_size(0, 0), (2, 2));
+        assert_eq!(clamp_pty_size(1, 0), (2, 2));
+        assert_eq!(clamp_pty_size(0, 120), (2, 120));
+        assert_eq!(clamp_pty_size(24, 1), (24, 2));
+        assert_eq!(clamp_pty_size(24, 80), (24, 80));
+        assert_eq!(clamp_pty_size(u16::MAX, u16::MAX), (u16::MAX, u16::MAX));
+    }
+
+    #[test]
+    fn env_has_key_is_case_insensitive() {
+        let mut env = BTreeMap::new();
+        env.insert("SYSTEMROOT".to_string(), "C:\\Windows".to_string());
+        assert!(env_has_key(&env, "SystemRoot"));
+        assert!(env_has_key(&env, "systemroot"));
+        assert!(!env_has_key(&env, "COMSPEC"));
     }
 }

--- a/src/components/terminal/BuildTerminal.tsx
+++ b/src/components/terminal/BuildTerminal.tsx
@@ -30,6 +30,7 @@ import {
   resizePtySession,
   onPtySessionData,
   onPtySessionExit,
+  createAttachGate,
 } from '../../lib/ptySession';
 import { getTerminalGpuEnabled } from '../../lib/settings';
 import { loadNerdFonts } from '../../lib/fonts';
@@ -161,7 +162,12 @@ export function BuildTerminal({
     });
     disposers.push(() => inputDisposable.dispose());
 
-    // Open (idempotent) → attach (replay ring buffer) → subscribe to live feed.
+    // Open (idempotent) → subscribe to live feed → attach (replay ring
+    // buffer, then flush the gate). Subscribing BEFORE attaching matters:
+    // Tauri drops events with no registered listener, so the old
+    // attach-then-subscribe order could lose a chunk emitted between the
+    // snapshot and the subscription (issue #156). The offset gate drops the
+    // chunks the snapshot already covers, so nothing double-writes either.
     void (async () => {
       try {
         await openPtySession({
@@ -170,11 +176,40 @@ export function BuildTerminal({
           args: ['-lic', command],
           cwd,
           env: {},
-          cols: term.cols,
-          rows: term.rows,
+          // Clamp: spawning before layout settles can report 0-size, and a
+          // 0-size ConPTY produces no output at all (the backend clamps
+          // too; this keeps xterm and the PTY in agreement).
+          cols: Math.max(term.cols, 2),
+          rows: Math.max(term.rows, 2),
           projectPath: cwd,
         });
         if (cancelled) return;
+
+        const gate = createAttachGate((bytes) => {
+          term.write(bytes);
+          emitOutput(bytes);
+        });
+        const unlistenData = await onPtySessionData(sessionId, (bytes, offset) => {
+          if (cancelled) return;
+          gate.push(offset, bytes);
+        });
+        disposers.push(() => void unlistenData());
+
+        // Exit is parked until the snapshot replay so onOutput consumers see
+        // the build's final output before its exit classification.
+        let gateOpen = false;
+        let pendingExit: number | null = null;
+        let exitEventSeen = false;
+        const unlistenExit = await onPtySessionExit(sessionId, (exitCode) => {
+          if (cancelled) return;
+          exitEventSeen = true;
+          if (!gateOpen) {
+            pendingExit = exitCode;
+            return;
+          }
+          onExitRef.current?.(exitCode);
+        });
+        disposers.push(() => void unlistenExit());
 
         const attach = await attachPtySession(sessionId);
         if (cancelled) return;
@@ -182,20 +217,14 @@ export function BuildTerminal({
           term.write(attach.buffer);
           emitOutput(attach.buffer);
         }
-        // If it already exited before we attached, surface that immediately.
-        if (!attach.alive && attach.exitCode !== null) onExitRef.current?.(attach.exitCode);
-
-        const unlistenData = await onPtySessionData(sessionId, (bytes) => {
-          if (cancelled) return;
-          term.write(bytes);
-          emitOutput(bytes);
-        });
-        disposers.push(() => void unlistenData());
-
-        const unlistenExit = await onPtySessionExit(sessionId, (exitCode) => {
-          if (!cancelled) onExitRef.current?.(exitCode);
-        });
-        disposers.push(() => void unlistenExit());
+        gateOpen = true;
+        gate.open(attach.endOffset);
+        if (pendingExit !== null) {
+          onExitRef.current?.(pendingExit);
+        } else if (!attach.alive && attach.exitCode !== null && !exitEventSeen) {
+          // It exited before we even subscribed — surface that immediately.
+          onExitRef.current?.(attach.exitCode);
+        }
       } catch (err) {
         if (!cancelled) {
           logger.error('[BuildTerminal] failed to start build session', {

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -26,6 +26,7 @@ import {
   killPtySession,
   onPtySessionData,
   onPtySessionExit,
+  createAttachGate,
 } from '../../lib/ptySession';
 import type { UnlistenFn } from '@tauri-apps/api/event';
 import { useAgentBridge } from '../../contexts/AgentBridgeContext';
@@ -665,17 +666,22 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         // component unmount/remount and project switches, so attach is
         // idempotent. `openPtySession` is a no-op if the session is already
         // alive; it evicts-and-respawns if a previous run exited (retry
-        // path below). `attachPtySession` returns the ring-buffer tail for
-        // xterm to replay before the live stream takes over.
+        // path below). `attachPtySession` (called after subscribing, below)
+        // returns the ring-buffer tail for xterm to replay plus the offset
+        // the live stream is de-duplicated against.
         const backendSessionId = sessionName || `tab-${Date.now()}`;
+        // Clamp dimensions: the zero-guard above gives up after 3s and can
+        // reach this point with cols/rows ≤ 1, and a 0-size ConPTY produces
+        // no output at all on Windows (issue #156). The backend clamps too;
+        // this keeps xterm and the PTY in agreement.
         const opened = await openPtySession({
           sessionId: backendSessionId,
           command: spawnCmd,
           args: spawnArgs,
           cwd: projectPath,
           env,
-          cols: term.cols,
-          rows: term.rows,
+          cols: Math.max(term.cols, 2),
+          rows: Math.max(term.rows, 2),
           projectPath,
           tabSessionId: sessionName ?? null,
         });
@@ -694,77 +700,22 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         });
         onSpawnRef.current?.(opened.pid);
 
-        const attach = await attachPtySession(backendSessionId);
-        if (!mounted) return;
-        if (attach.buffer.length > 0) {
-          // Replay ring-buffer tail so a newly-attached xterm shows prior
-          // output (critical for project switches back to a background tab).
-          terminalRef.current?.write(attach.buffer);
-        }
-        if (!attach.alive) {
-          // Session already exited between open and attach. Treat as a
-          // normal exit so the retry-on-resume-fail path can kick in.
-          onExitRef.current?.(attach.exitCode ?? -1);
-        }
+        // Subscribe BEFORE attaching. Tauri drops events that fire with no
+        // registered listener, so the old attach-then-subscribe order lost
+        // any chunk emitted between the attach snapshot and the
+        // subscription going live — for a single-paint TUI (Codex) that
+        // could be its only paint, leaving the tab stuck on the loading
+        // message forever (issue #156). With subscribe-first, every byte is
+        // either in the snapshot or delivered as an event; the offset gate
+        // below drops the overlap exactly.
 
-        // Startup watchdog: if no output is received within 10s, the agent
-        // likely failed to launch (binary not found, permission error, or a
-        // wedged first spawn — issue #158). The manual fix users found is
-        // "create a new agent tab", i.e. a fresh PTY — so kill the silent
-        // session and respawn once with the same config. Only if the
-        // respawn is also silent do we surface the error text.
+        // Set once any live PTY event arrives for this spawn — the process
+        // demonstrably produced output even if the chunk itself is dropped
+        // as snapshot-covered. (The replayed attach snapshot does NOT count
+        // as output, matching the pre-gate behavior.)
         let receivedOutput = false;
-        const startupTimeout = setTimeout(() => {
-          const action = decideStartupTimeoutAction({ receivedOutput, mounted, autoRespawnUsed });
-          if (action === 'none') return;
-
-          if (action === 'respawn') {
-            autoRespawnUsed = true;
-            logger.warn('[Terminal] No output after 10s - killing silent PTY and respawning', {
-              agent: agent.id,
-              binary: agent.binaryName,
-              sessionId: backendSessionId,
-            });
-            terminalRef.current?.write(
-              `\r\n\x1b[33mNo output — restarting ${agent.displayName}…\x1b[0m\r\n`
-            );
-            // Unsubscribe from the silent session BEFORE killing it so the
-            // kill-induced exit event can't trigger the "[Process exited]"
-            // prompt or the resume-retry path.
-            for (const d of ptyDisposablesRef.current) {
-              try {
-                d.dispose();
-              } catch {
-                /* ignore */
-              }
-            }
-            ptyDisposablesRef.current = [];
-            ptyRef.current = null;
-            void killPtySession(backendSessionId)
-              .catch(() => {
-                /* already dead — open will spawn fresh either way */
-              })
-              .then(() => {
-                // Grace period so the killed PTY's exit event (same session
-                // id) is delivered before the respawned run subscribes —
-                // otherwise it would look like the new process exiting.
-                respawnTimer = setTimeout(() => {
-                  if (mounted) void setupPty(0);
-                }, 500);
-              });
-            return;
-          }
-
-          logger.error('[Terminal] Startup timeout - no output after 10s', {
-            agent: agent.id,
-            binary: agent.binaryName,
-          });
-          terminalRef.current?.write(
-            `\r\n\x1b[31m${agent.displayName} did not produce any output after 10 seconds.\x1b[0m\r\n` +
-              `\x1b[33mThe process may have failed to start. Check that "${agent.binaryName}" is installed and accessible.\x1b[0m\r\n`
-          );
-        }, 10_000);
-        startupTimer = startupTimeout;
+        // Startup watchdog handle — armed after the snapshot replay below.
+        let startupTimeout: ReturnType<typeof setTimeout> | null = null;
 
         // Buffer early output to detect resume failures on exit
         let outputBuffer = '';
@@ -779,49 +730,51 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           terminalRef.current?.write(normalized);
         };
 
-        // Handle PTY output -> terminal
         // Store disposables so cleanup() can remove IPC listeners and prevent CPU leak.
-        // For agents without title-based detection, add idle-detection:
-        // when output stops flowing for 1.5s after "thinking" state, transition to "waiting".
         const pushDisposable = (unlisten: UnlistenFn) => {
           ptyDisposablesRef.current.push({ dispose: () => unlisten() });
         };
 
-        if (!agent.supportsStatusDetection) {
-          let idleTimer: ReturnType<typeof setTimeout> | null = null;
-          const unlistenData = await onPtySessionData(backendSessionId, (bytes) => {
-            receivedOutput = true;
-            if (outputBuffer.length < 2000) {
-              outputBuffer += new TextDecoder().decode(bytes);
-            }
-            clearTimeout(startupTimeout);
-            writeToTerminal(bytes);
-            if (lastStatusRef.current === 'thinking') {
-              if (idleTimer) clearTimeout(idleTimer);
-              idleTimer = setTimeout(() => {
-                if (lastStatusRef.current === 'thinking') {
-                  lastStatusRef.current = 'waiting';
-                  onStatusChangeRef.current?.('waiting', '');
-                }
-              }, 1500);
-            }
-          });
-          pushDisposable(unlistenData);
-        } else {
-          const unlistenData = await onPtySessionData(backendSessionId, (bytes) => {
-            receivedOutput = true;
-            if (outputBuffer.length < 2000) {
-              outputBuffer += new TextDecoder().decode(bytes);
-            }
-            clearTimeout(startupTimeout);
-            writeToTerminal(bytes);
-          });
-          pushDisposable(unlistenData);
-        }
+        // Gate: queues live chunks until the attach snapshot is written,
+        // then flushes only the chunks the snapshot doesn't already cover.
+        // For agents without title-based detection it also drives
+        // idle-detection: when output stops flowing for 1.5s after
+        // "thinking", transition to "waiting".
+        let idleTimer: ReturnType<typeof setTimeout> | null = null;
+        const gate = createAttachGate((bytes) => {
+          if (outputBuffer.length < 2000) {
+            outputBuffer += new TextDecoder().decode(bytes);
+          }
+          writeToTerminal(bytes);
+          if (!agent.supportsStatusDetection && lastStatusRef.current === 'thinking') {
+            if (idleTimer) clearTimeout(idleTimer);
+            idleTimer = setTimeout(() => {
+              if (lastStatusRef.current === 'thinking') {
+                lastStatusRef.current = 'waiting';
+                onStatusChangeRef.current?.('waiting', '');
+              }
+            }, 1500);
+          }
+        });
 
-        // Handle PTY exit — subscribe to the backend event stream.
-        const unlistenExit = await onPtySessionExit(backendSessionId, (exitCode) => {
-          clearTimeout(startupTimeout);
+        // Handle PTY output -> terminal (through the gate).
+        const unlistenData = await onPtySessionData(backendSessionId, (bytes, offset) => {
+          receivedOutput = true;
+          if (startupTimeout) clearTimeout(startupTimeout);
+          gate.push(offset, bytes);
+        });
+        pushDisposable(unlistenData);
+
+        // Handle PTY exit — subscribe to the backend event stream. An exit
+        // that fires before the snapshot replay is parked so the
+        // "[Process exited]" prompt can't render above the scrollback it
+        // belongs after.
+        let gateOpen = false;
+        let pendingExit: number | null = null;
+        let exitEventSeen = false;
+
+        const handleExit = (exitCode: number) => {
+          if (startupTimeout) clearTimeout(startupTimeout);
           logger.info('[Terminal] PTY process exited', {
             agent: agent.id,
             exitCode,
@@ -904,8 +857,98 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
 
           offerRestart();
           onExitRef.current?.(exitCode);
+        };
+
+        const unlistenExit = await onPtySessionExit(backendSessionId, (exitCode) => {
+          exitEventSeen = true;
+          if (!gateOpen) {
+            pendingExit = exitCode;
+            return;
+          }
+          handleExit(exitCode);
         });
         pushDisposable(unlistenExit);
+
+        const attach = await attachPtySession(backendSessionId);
+        if (!mounted) return;
+        if (attach.buffer.length > 0) {
+          // Replay ring-buffer tail so a newly-attached xterm shows prior
+          // output (critical for project switches back to a background tab).
+          terminalRef.current?.write(attach.buffer);
+        }
+        // Open the gate: flush queued live chunks, dropping the ones the
+        // snapshot already covers (offset < endOffset).
+        gateOpen = true;
+        gate.open(attach.endOffset);
+
+        // Startup watchdog: if no output is received within 10s, the agent
+        // likely failed to launch (binary not found, permission error, or a
+        // wedged first spawn — issue #158). The manual fix users found is
+        // "create a new agent tab", i.e. a fresh PTY — so kill the silent
+        // session and respawn once with the same config. Only if the
+        // respawn is also silent do we surface the error text.
+        startupTimeout = setTimeout(() => {
+          const action = decideStartupTimeoutAction({ receivedOutput, mounted, autoRespawnUsed });
+          if (action === 'none') return;
+
+          if (action === 'respawn') {
+            autoRespawnUsed = true;
+            logger.warn('[Terminal] No output after 10s - killing silent PTY and respawning', {
+              agent: agent.id,
+              binary: agent.binaryName,
+              sessionId: backendSessionId,
+            });
+            terminalRef.current?.write(
+              `\r\n\x1b[33mNo output — restarting ${agent.displayName}…\x1b[0m\r\n`
+            );
+            // Unsubscribe from the silent session BEFORE killing it so the
+            // kill-induced exit event can't trigger the "[Process exited]"
+            // prompt or the resume-retry path.
+            for (const d of ptyDisposablesRef.current) {
+              try {
+                d.dispose();
+              } catch {
+                /* ignore */
+              }
+            }
+            ptyDisposablesRef.current = [];
+            ptyRef.current = null;
+            void killPtySession(backendSessionId)
+              .catch(() => {
+                /* already dead — open will spawn fresh either way */
+              })
+              .then(() => {
+                // Grace period so the killed PTY's exit event (same session
+                // id) is delivered before the respawned run subscribes —
+                // otherwise it would look like the new process exiting.
+                respawnTimer = setTimeout(() => {
+                  if (mounted) void setupPty(0);
+                }, 500);
+              });
+            return;
+          }
+
+          logger.error('[Terminal] Startup timeout - no output after 10s', {
+            agent: agent.id,
+            binary: agent.binaryName,
+          });
+          terminalRef.current?.write(
+            `\r\n\x1b[31m${agent.displayName} did not produce any output after 10 seconds.\x1b[0m\r\n` +
+              `\x1b[33mThe process may have failed to start. Check that "${agent.binaryName}" is installed and accessible.\x1b[0m\r\n`
+          );
+        }, 10_000);
+        startupTimer = startupTimeout;
+
+        if (pendingExit !== null) {
+          // The process exited while the snapshot was in flight — run the
+          // full exit path now that the scrollback is on screen.
+          handleExit(pendingExit);
+        } else if (!attach.alive && !exitEventSeen) {
+          // Session already exited before we subscribed (the exit event
+          // predates this attach cycle and was dropped by Tauri). Treat as
+          // a normal exit so the retry-on-resume-fail path can kick in.
+          onExitRef.current?.(attach.exitCode ?? -1);
+        }
 
         // Dismiss the first-run hint on the user's first real keystroke — and
         // broadcast so sibling terminals (split panes / tabs) clear theirs too.

--- a/src/lib/ptySession.test.ts
+++ b/src/lib/ptySession.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the attach gate — the de-duplication half of the
+ * subscribe-first PTY attach protocol (issue #156).
+ *
+ * The backend guarantees a data chunk never straddles an attach snapshot's
+ * `endOffset` (append + offset increment are atomic under the ring-buffer
+ * mutex), so the gate's filter can be a plain `offset >= endOffset`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createAttachGate } from './ptySession';
+
+const bytes = (s: string): Uint8Array => new TextEncoder().encode(s);
+const text = (b: Uint8Array): string => new TextDecoder().decode(b);
+
+function gateWithLog() {
+  const delivered: string[] = [];
+  const gate = createAttachGate((b) => delivered.push(text(b)));
+  return { gate, delivered };
+}
+
+describe('createAttachGate', () => {
+  it('queues events while the snapshot end is unknown', () => {
+    const deliver = vi.fn();
+    const gate = createAttachGate(deliver);
+    gate.push(0, bytes('early'));
+    gate.push(5, bytes('also early'));
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it('flush drops chunks the snapshot covers and keeps the rest, in order', () => {
+    const { gate, delivered } = gateWithLog();
+    // Chunks at offsets 0..5, 5..10 are inside the snapshot (endOffset 10);
+    // 10..14 and 14..15 arrived while attaching but are NOT in the snapshot.
+    gate.push(0, bytes('AAAAA'));
+    gate.push(5, bytes('BBBBB'));
+    gate.push(10, bytes('CCCC'));
+    gate.push(14, bytes('D'));
+    gate.open(10);
+    expect(delivered).toEqual(['CCCC', 'D']);
+  });
+
+  it('a chunk starting exactly at endOffset is delivered (no-straddle boundary)', () => {
+    const { gate, delivered } = gateWithLog();
+    gate.push(10, bytes('at-boundary'));
+    gate.open(10);
+    expect(delivered).toEqual(['at-boundary']);
+  });
+
+  it('delivers everything when the snapshot is empty (fresh spawn, endOffset 0)', () => {
+    const { gate, delivered } = gateWithLog();
+    gate.push(0, bytes('first paint'));
+    gate.open(0);
+    gate.push(11, bytes('more'));
+    expect(delivered).toEqual(['first paint', 'more']);
+  });
+
+  it('applies the same filter to live events after opening', () => {
+    const { gate, delivered } = gateWithLog();
+    gate.open(20);
+    // A straggler event for snapshot-covered bytes (e.g. delayed IPC
+    // delivery) must not double-write.
+    gate.push(0, bytes('stale'));
+    gate.push(20, bytes('live-1'));
+    gate.push(26, bytes('live-2'));
+    expect(delivered).toEqual(['live-1', 'live-2']);
+  });
+
+  it('preserves arrival order across the flush boundary', () => {
+    const { gate, delivered } = gateWithLog();
+    gate.push(3, bytes('queued-1'));
+    gate.push(11, bytes('queued-2'));
+    gate.open(3); // nothing covered — both queued chunks pass
+    gate.push(19, bytes('live'));
+    expect(delivered).toEqual(['queued-1', 'queued-2', 'live']);
+  });
+
+  it('ignores a second open (already-open gate keeps its snapshot end)', () => {
+    const { gate, delivered } = gateWithLog();
+    gate.push(0, bytes('covered'));
+    gate.open(5);
+    gate.open(0); // must not re-flush or move the boundary
+    gate.push(5, bytes('after'));
+    expect(delivered).toEqual(['after']);
+  });
+
+  it('does not re-deliver queued chunks on later pushes', () => {
+    const { gate, delivered } = gateWithLog();
+    gate.push(0, bytes('a'));
+    gate.open(0);
+    expect(delivered).toEqual(['a']);
+    gate.push(1, bytes('b'));
+    expect(delivered).toEqual(['a', 'b']);
+  });
+});

--- a/src/lib/ptySession.ts
+++ b/src/lib/ptySession.ts
@@ -36,12 +36,16 @@ export interface OpenPtySessionResult {
 }
 
 export interface AttachPtySessionResult {
-  /** Buffered output (raw bytes). xterm should `write()` this before
-   *  subscribing to live data so the replay + live feed don't overlap. */
+  /** Buffered output (raw bytes). xterm should `write()` this to restore
+   *  the visible scrollback. */
   buffer: Uint8Array;
   pid: number;
   alive: boolean;
   exitCode: number | null;
+  /** Cumulative byte offset at snapshot time (total bytes the PTY ever
+   *  produced). Live data events with `offset < endOffset` are already
+   *  contained in `buffer` and must be dropped — see `createAttachGate`. */
+  endOffset: number;
 }
 
 export interface PtySessionListItem {
@@ -57,6 +61,10 @@ export interface PtySessionListItem {
 interface DataEventPayload {
   sessionId: string;
   data: number[];
+  /** Cumulative byte offset of this chunk's first byte (total bytes the
+   *  PTY produced before it). Compare against an attach snapshot's
+   *  `endOffset` to drop chunks the snapshot already covers. */
+  offset: number;
 }
 
 interface ExitEventPayload {
@@ -101,19 +109,23 @@ export async function killPtySession(sessionId: string): Promise<void> {
 }
 
 /** Fetch the session's buffered tail + liveness. Called on mount to replay
- *  recent output before subscribing to the live data stream. */
+ *  recent output. Subscribe to the live data stream BEFORE calling this and
+ *  gate the events with `createAttachGate(...)` + the returned `endOffset`
+ *  so no chunk emitted around the snapshot is lost or double-written. */
 export async function attachPtySession(sessionId: string): Promise<AttachPtySessionResult> {
   const raw = await invoke<{
     buffer: number[];
     pid: number;
     alive: boolean;
     exitCode: number | null;
+    endOffset: number;
   }>('pty_session_attach', { sessionId });
   return {
     buffer: new Uint8Array(raw.buffer),
     pid: raw.pid,
     alive: raw.alive,
     exitCode: raw.exitCode,
+    endOffset: raw.endOffset,
   };
 }
 
@@ -127,15 +139,16 @@ export async function listPtySessions(projectPath?: string | null): Promise<PtyS
 /**
  * Subscribe to live data chunks for a specific session. Returns an async
  * unlisten fn. The callback receives raw bytes — hand them to xterm's
- * `write(Uint8Array)`.
+ * `write(Uint8Array)` — plus the chunk's cumulative start offset for
+ * de-duplication against an attach snapshot (see `createAttachGate`).
  */
 export async function onPtySessionData(
   sessionId: string,
-  handler: (bytes: Uint8Array) => void
+  handler: (bytes: Uint8Array, offset: number) => void
 ): Promise<UnlistenFn> {
   return listen<DataEventPayload>('pty-session-data', (event) => {
     if (event.payload.sessionId !== sessionId) return;
-    handler(new Uint8Array(event.payload.data));
+    handler(new Uint8Array(event.payload.data), event.payload.offset);
   });
 }
 
@@ -152,4 +165,50 @@ export async function onPtySessionExit(
     if (event.payload.sessionId !== sessionId) return;
     handler(event.payload.exitCode);
   });
+}
+
+/**
+ * De-duplication gate for the subscribe-first attach protocol.
+ *
+ * Tauri drops events that fire while no listener is registered, so a
+ * component must subscribe to `onPtySessionData` BEFORE calling
+ * `attachPtySession` — otherwise a chunk emitted between the snapshot and
+ * the subscription is lost forever (a single-paint TUI then looks dead:
+ * issue #156). Subscribing first inverts the problem into duplication:
+ * chunks that arrive before/around the snapshot may already be inside the
+ * snapshot buffer. This gate resolves it exactly, using the backend's
+ * cumulative byte offsets:
+ *
+ * - `push(offset, bytes)` — feed every live event through. Before the
+ *   snapshot end is known, chunks are queued. Afterwards, a chunk is
+ *   delivered iff `offset >= endOffset` (the backend guarantees a chunk
+ *   never straddles the snapshot boundary).
+ * - `open(endOffset)` — call after writing the snapshot. Flushes the queue
+ *   in arrival order, dropping chunks the snapshot already covers.
+ */
+export interface AttachGate {
+  push(offset: number, bytes: Uint8Array): void;
+  open(endOffset: number): void;
+}
+
+export function createAttachGate(deliver: (bytes: Uint8Array) => void): AttachGate {
+  let snapshotEnd: number | null = null;
+  const pending: Array<{ offset: number; bytes: Uint8Array }> = [];
+  return {
+    push(offset: number, bytes: Uint8Array): void {
+      if (snapshotEnd === null) {
+        pending.push({ offset, bytes });
+        return;
+      }
+      if (offset >= snapshotEnd) deliver(bytes);
+    },
+    open(endOffset: number): void {
+      if (snapshotEnd !== null) return; // already open — ignore
+      snapshotEnd = endOffset;
+      for (const chunk of pending) {
+        if (chunk.offset >= endOffset) deliver(chunk.bytes);
+      }
+      pending.length = 0;
+    },
+  };
 }


### PR DESCRIPTION
Fixes #156. Should also reduce the 'Starting…' hangs reported in #164, alongside PR #180.

## Root cause 1 — the first-output event race (primary, OS-independent)

When a `pty_session` opens, the Rust reader thread starts emitting `pty-session-data` events **immediately**. But the frontend's order was:

1. `openPtySession` (PTY spawns, output starts flowing)
2. `attachPtySession` (snapshot of the ring buffer, replayed into xterm)
3. `onPtySessionData` (subscribe to live events)

Tauri **drops** events that fire while no listener is registered. Any chunk emitted after the attach snapshot but before step 3 was lost forever. For a TUI that paints once and then waits (Codex is the canonical case), that lost chunk was its *only* paint — the PTY is perfectly healthy, but the tab shows "starting terminal…" until the heat death of the universe. The intermittency is pure IPC timing, which is also why it reproduces on macOS occasionally and not just Windows.

### The fix: an offset-cursor protocol

- The backend now tracks a **cumulative byte offset** per session (total bytes ever read from the PTY; ring-buffer trimming never decreases it). Each `pty-session-data` event carries its chunk's start `offset`, captured under the **same mutex** that appends the chunk to the ring buffer.
- `pty_session_attach` returns `endOffset` — the cumulative offset at snapshot time, read under that same mutex. Because append + offset increment are atomic with respect to the snapshot, a chunk can never straddle the boundary: it's either entirely covered by the snapshot (`offset + len <= endOffset`) or entirely after it (`offset >= endOffset`).
- `Terminal.tsx` and `BuildTerminal.tsx` now **subscribe first, then attach**. Live events are queued by an attach gate (`createAttachGate` in `src/lib/ptySession.ts`) until the snapshot is written, then flushed with the filter `offset >= endOffset` — nothing lost, nothing double-written. This holds for *every* attach cycle, including hot-session re-attach when switching back to a background project.
- Exit events are parked the same way so "[Process exited]" can't render above the scrollback it belongs after, and the exit-before-subscribe case is de-duplicated against the attach result's `alive`/`exitCode`.

Behavior preserved: the 10s startup watchdog + single auto-respawn, `receivedOutput` semantics (a replayed attach snapshot still does not count as live output; any live event — even one the gate drops as snapshot-covered — does), and the resume-failed retry path.

## Root cause 2 — 0-size ConPTY (contributing)

`rows`/`cols` went to `openpty()` and `resize()` unclamped in both the `pty_session` registry and the forked `tauri-plugin-pty` (the poll-based plugin the onboarding terminal uses — which explains the onboarding wedge without touching `OnboardingTerminal.tsx`). A 0×0 ConPTY produces no output at all. Both backends now clamp to a 2×2 floor at spawn and resize; the frontend clamps at its spawn call sites too — `Terminal.tsx`'s zero-dimension guard has a 3s give-up fallback that could previously proceed at 1×1.

## Windows env safety net

`pty_session_open`'s env map **replaces** the parent environment. If the frontend-built map is ever missing critical Windows system vars, cmd.exe/ConPTY/Node fail in silent, no-output ways. The backend now backfills `SystemRoot`, `COMSPEC`, `PATHEXT`, `windir`, `SYSTEMDRIVE` from its own environment when absent (case-insensitive check; frontend values still win when present).

## Tests

- **Rust (`pty_session.rs`)**: offset accounting across appends + ring trim, attach `endOffset` consistency after trimming, a no-straddle invariant test over all snapshot interleavings, size-clamp floors, case-insensitive env-key lookup. Plugin crate gets its own clamp tests.
- **TS (`src/lib/ptySession.test.ts`)**: attach-gate queueing before the snapshot, flush dropping snapshot-covered chunks while preserving arrival order, exact boundary behavior (`offset === endOffset` delivered), stale-event de-dup after open, fresh-spawn (`endOffset === 0`) pass-through.
- Full suites green: `pnpm test:run` (63 files / 919 passed), `typecheck`, `lint:strict`, `format:check`, `check:patterns`, `check:loc`, `cargo test` (604 passed, incl. 9 pty_session tests), `cargo clippy` with CI flags, plugin `cargo test`.

## Caveat

The ConPTY + env portions are Windows-targeted and verified here by compilation, unit tests, and the CI `windows-check` job — a hands-on confirmation on a real Windows machine would be great (see #79 for the Windows-tester ask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)