### PR TITLE
Terminal: drag-drop no longer fans out to every agent; PTY write failures are logged

### DIFF
--- a/src/components/preview/DeviceMirror.tsx
+++ b/src/components/preview/DeviceMirror.tsx
@@ -41,7 +41,7 @@ import {
 } from '../../lib/mobile';
 import { usePolling } from '../../hooks/usePolling';
 import { checkDependenciesInstalled } from '../../lib/project';
-import { attachPtySession, writePtySession } from '../../lib/ptySession';
+import { attachPtySession, writePtySessionLogged } from '../../lib/ptySession';
 import { getWindowLabel } from '../../lib/window';
 import { ResetIcon, ChevronIcon } from '../icons';
 import { Button } from '../primitives/Button';
@@ -362,7 +362,7 @@ export function DeviceMirror({ projectName, projectPath, onSendToAgent }: Device
   // `react-native run-ios`) and `flutter run` all reload on an 'r' keystroke. We
   // write it straight to the build PTY the app is running in.
   const reloadApp = useCallback(() => {
-    void writePtySession(buildSessionId(projectPath), 'r');
+    writePtySessionLogged(buildSessionId(projectPath), 'r');
   }, [projectPath]);
 
   // Settle the build verdict. 'launched' is ground truth — the app is actually on

--- a/src/components/terminal/BuildTerminal.tsx
+++ b/src/components/terminal/BuildTerminal.tsx
@@ -26,7 +26,7 @@ import { createWebLinksAddon } from '../../lib/terminalLinks';
 import {
   openPtySession,
   attachPtySession,
-  writePtySession,
+  writePtySessionLogged,
   resizePtySession,
   onPtySessionData,
   onPtySessionExit,
@@ -157,7 +157,7 @@ export function BuildTerminal({
 
     // User keystrokes → PTY (this is what makes prompts answerable).
     const inputDisposable = term.onData((data) => {
-      void writePtySession(sessionId, data);
+      writePtySessionLogged(sessionId, data);
     });
     disposers.push(() => inputDisposable.dispose());
 

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -21,7 +21,7 @@ import { WebglAddon } from '@xterm/addon-webgl';
 import {
   openPtySession,
   attachPtySession,
-  writePtySession,
+  writePtySessionLogged,
   resizePtySession,
   killPtySession,
   onPtySessionData,
@@ -47,6 +47,7 @@ import { loadNerdFonts } from '../../lib/fonts';
 import { isWindows } from '../../lib/setup';
 import { logger } from '../../lib/logger';
 import { asCommandError, formatCommandError } from '../../lib/errors';
+import { isPointInRect, physicalToLogical } from '../../lib/dropTarget';
 import { getTerminalGpuEnabled } from '../../lib/settings';
 import { decideStartupTimeoutAction } from './startupWatchdog';
 import type { AgentConfig } from '../../lib/agent';
@@ -178,7 +179,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     if (!isActive || !isReady) return;
     const writer = (data: string) => {
       const sid = ptyRef.current?.sessionId;
-      if (sid) void writePtySession(sid, data);
+      if (sid) writePtySessionLogged(sid, data);
     };
     registerAgent(writer);
     return () => unregisterAgent(writer);
@@ -310,10 +311,29 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     let mounted = true;
 
     const setupDropListener = async () => {
-      // Listen for the tauri://drag-drop event
+      // Listen for the tauri://drag-drop event. It's window-global and every
+      // mounted Terminal registers one — including hidden tabs and background
+      // projects (kept mounted with `visibility: hidden` so their PTYs stay
+      // alive, see WorkspaceView) — so route the drop by position: only the
+      // visible pane under the cursor accepts it. Without this, one drop
+      // pastes the path into every open agent's PTY (issue #167).
       const unlistenFn = await listen<{ paths: string[]; position: { x: number; y: number } }>(
         'tauri://drag-drop',
         (event) => {
+          const container = containerRef.current;
+          // offsetParent is null for display:none subtrees; their rects are
+          // zero/stale and must never match.
+          if (!container || container.offsetParent === null) return;
+          // Hidden-but-mounted panes are absolutely positioned with
+          // `visibility: hidden`, so their rects still overlap the visible
+          // pane — computed visibility is the discriminator.
+          if (getComputedStyle(container).visibility !== 'visible') return;
+          // The payload position is in physical (device) pixels; DOM rects
+          // are logical CSS pixels — convert before hit-testing. In a split,
+          // this naturally routes the drop to the pane under the cursor.
+          const point = physicalToLogical(event.payload.position, window.devicePixelRatio);
+          if (!isPointInRect(point, container.getBoundingClientRect())) return;
+
           // Debounce - ignore duplicate events within 500ms
           const now = Date.now();
           if (now - lastDropTimeRef.current < 500) {
@@ -937,7 +957,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
             return;
           }
           const sid = ptyRef.current?.sessionId;
-          if (sid) void writePtySession(sid, data);
+          if (sid) writePtySessionLogged(sid, data);
           // When user sends input to an agent without title-based status detection,
           // assume it transitions to "thinking" (processing the request).
           if (!agent.supportsStatusDetection && data.includes('\r')) {
@@ -970,7 +990,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
               // Send a literal newline character (Ctrl+J / Line Feed)
               // This tells Claude Code to continue on a new line without submitting
               const sid = ptyRef.current?.sessionId;
-              if (sid) void writePtySession(sid, '\n');
+              if (sid) writePtySessionLogged(sid, '\n');
             }
             // Prevent both keydown and keypress from being processed
             event.preventDefault();
@@ -1085,7 +1105,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       },
       write: (data: string) => {
         const sid = ptyRef.current?.sessionId;
-        if (sid) void writePtySession(sid, data);
+        if (sid) writePtySessionLogged(sid, data);
       },
       paste: (data: string) => {
         if (terminalRef.current) {

--- a/src/lib/dropTarget.test.ts
+++ b/src/lib/dropTarget.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { physicalToLogical, isPointInRect } from './dropTarget';
+
+describe('physicalToLogical', () => {
+  it('divides physical coordinates by the device pixel ratio', () => {
+    expect(physicalToLogical({ x: 200, y: 100 }, 2)).toEqual({ x: 100, y: 50 });
+    expect(physicalToLogical({ x: 150, y: 300 }, 1.5)).toEqual({ x: 100, y: 200 });
+  });
+
+  it('is the identity at ratio 1', () => {
+    expect(physicalToLogical({ x: 42, y: 7 }, 1)).toEqual({ x: 42, y: 7 });
+  });
+
+  it('treats non-positive or non-finite ratios as 1', () => {
+    expect(physicalToLogical({ x: 10, y: 20 }, 0)).toEqual({ x: 10, y: 20 });
+    expect(physicalToLogical({ x: 10, y: 20 }, -2)).toEqual({ x: 10, y: 20 });
+    expect(physicalToLogical({ x: 10, y: 20 }, NaN)).toEqual({ x: 10, y: 20 });
+    expect(physicalToLogical({ x: 10, y: 20 }, Infinity)).toEqual({ x: 10, y: 20 });
+  });
+});
+
+describe('isPointInRect', () => {
+  const rect = { left: 100, top: 50, right: 300, bottom: 250 };
+
+  it('accepts a point inside the rect', () => {
+    expect(isPointInRect({ x: 200, y: 150 }, rect)).toBe(true);
+  });
+
+  it('accepts the top-left edge and rejects the bottom-right edge (half-open)', () => {
+    expect(isPointInRect({ x: 100, y: 50 }, rect)).toBe(true);
+    expect(isPointInRect({ x: 300, y: 250 }, rect)).toBe(false);
+    expect(isPointInRect({ x: 299.9, y: 249.9 }, rect)).toBe(true);
+  });
+
+  it('rejects points outside on each side', () => {
+    expect(isPointInRect({ x: 99, y: 150 }, rect)).toBe(false); // left
+    expect(isPointInRect({ x: 301, y: 150 }, rect)).toBe(false); // right
+    expect(isPointInRect({ x: 200, y: 49 }, rect)).toBe(false); // above
+    expect(isPointInRect({ x: 200, y: 251 }, rect)).toBe(false); // below
+  });
+
+  it('never matches zero- or negative-area rects (hidden elements)', () => {
+    expect(isPointInRect({ x: 0, y: 0 }, { left: 0, top: 0, right: 0, bottom: 0 })).toBe(false);
+    expect(isPointInRect({ x: 10, y: 10 }, { left: 10, top: 0, right: 10, bottom: 20 })).toBe(
+      false
+    );
+    expect(isPointInRect({ x: 5, y: 5 }, { left: 10, top: 10, right: 0, bottom: 0 })).toBe(false);
+  });
+
+  it('routes a drop to the correct pane of a side-by-side split', () => {
+    const leftPane = { left: 0, top: 40, right: 400, bottom: 600 };
+    const rightPane = { left: 400, top: 40, right: 800, bottom: 600 };
+    const dropInRight = physicalToLogical({ x: 1200, y: 400 }, 2); // -> (600, 200)
+    expect(isPointInRect(dropInRight, leftPane)).toBe(false);
+    expect(isPointInRect(dropInRight, rightPane)).toBe(true);
+  });
+});

--- a/src/lib/dropTarget.ts
+++ b/src/lib/dropTarget.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure geometry helpers for routing window-global Tauri `drag-drop` events
+ * to the pane under the cursor.
+ *
+ * Tauri's `tauri://drag-drop` event is window-global, and every mounted
+ * Terminal registers a listener — including hidden tabs and background
+ * projects, which stay mounted (`visibility: hidden`) so their PTYs keep
+ * running. Each instance must therefore decide from the drop position
+ * whether the drop belongs to it, or a single drop fans out to every
+ * agent's PTY (issue #167).
+ *
+ * The payload's `position` is a Tauri `PhysicalPosition` (device pixels);
+ * DOM rects are in logical CSS pixels — convert before hit-testing.
+ */
+
+/** An x/y point. Physical or logical depending on context. */
+export interface DropPoint {
+  x: number;
+  y: number;
+}
+
+/** The subset of `DOMRect` needed for hit-testing (keeps tests DOM-free). */
+export interface DropRect {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/**
+ * Convert a physical (device-pixel) drop position to logical CSS pixels.
+ * A non-positive or non-finite ratio (headless webviews, defensive) is
+ * treated as 1.
+ */
+export function physicalToLogical(position: DropPoint, devicePixelRatio: number): DropPoint {
+  const scale = Number.isFinite(devicePixelRatio) && devicePixelRatio > 0 ? devicePixelRatio : 1;
+  return { x: position.x / scale, y: position.y / scale };
+}
+
+/**
+ * True when `point` (logical px) falls inside `rect`. Zero- and
+ * negative-area rects — what hidden or `display: none` elements report —
+ * never match.
+ */
+export function isPointInRect(point: DropPoint, rect: DropRect): boolean {
+  if (rect.right - rect.left <= 0 || rect.bottom - rect.top <= 0) return false;
+  return (
+    point.x >= rect.left && point.x < rect.right && point.y >= rect.top && point.y < rect.bottom
+  );
+}

--- a/src/lib/ptySession.ts
+++ b/src/lib/ptySession.ts
@@ -15,6 +15,8 @@
 
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { logger } from './logger';
+import { asCommandError, formatCommandError } from './errors';
 
 export interface OpenPtySessionArgs {
   /** Stable id for this PTY session. Usually the tab's `sessionId` UUID
@@ -79,11 +81,27 @@ export async function openPtySession(args: OpenPtySessionArgs): Promise<OpenPtyS
   });
 }
 
-/** Write bytes to a session's PTY. */
+/** Write bytes to a session's PTY. Rejects on failure — awaiting callers
+ *  see the error. Fire-and-forget input paths (keystrokes) should use
+ *  {@link writePtySessionLogged} instead so failures don't vanish. */
 export async function writePtySession(sessionId: string, data: string): Promise<void> {
   const encoder = new TextEncoder();
   const bytes = Array.from(encoder.encode(data));
   await invoke('pty_session_write', { sessionId, data: bytes });
+}
+
+/** Fire-and-forget variant of {@link writePtySession} for input paths where
+ *  nothing awaits the write (keystrokes, injected prompts). A rejected
+ *  write means the input was silently dropped (#167) — log it so there's a
+ *  trace. Deliberately no toast: one per lost keystroke would spam. */
+export function writePtySessionLogged(sessionId: string, data: string): void {
+  writePtySession(sessionId, data).catch((err: unknown) => {
+    logger.warn('[ptySession] write failed — input dropped', {
+      sessionId,
+      length: data.length,
+      error: formatCommandError(asCommandError(err)),
+    });
+  });
 }
 
 /** Resize the PTY backing a session. */


### PR DESCRIPTION
Addresses the drag-drop mirroring and silent input loss from #167. Part (a) — apostrophe doubling on dead-key layouts — is not covered here; it needs a Windows/international-keyboard repro.

## Bug: one drop pasted into every agent's PTY

The fan-out mechanism:

- WorkspaceView keeps **every tab of every open project mounted** (hidden with `position: absolute` + `visibility: hidden` so xterm keeps its dimensions and background PTYs stay alive).
- Each mounted `Terminal` registers a **window-global** `tauri://drag-drop` listener with no visibility/position check — it only checked `pty && term && paths`, then `term.focus()` + `term.paste(paths)`.
- The 500ms debounce is **per-instance** (`lastDropTimeRef`), so it can't dedupe across instances.

Net: dropping a file into one pane typed its path into every open agent's PTY, across tabs and projects.

### Fix: route the drop by position

Each instance now decides whether the drop belongs to it before pasting:

1. Bail if the container's `offsetParent` is null (`display: none` subtrees — zero/stale rects).
2. Bail if computed `visibility !== 'visible'` — hidden panes are absolutely positioned, so their rects still **overlap** the visible pane; a rect test alone can't tell them apart.
3. Convert the payload's `position` (Tauri `PhysicalPosition`, device pixels) to logical CSS pixels via `devicePixelRatio`, then hit-test against `getBoundingClientRect()`.

In a side-by-side split the hit-test naturally routes the drop to the pane under the cursor. The debounce is kept, now after routing.

The pure helpers (`physicalToLogical`, `isPointInRect`) live in `src/lib/dropTarget.ts`; zero-area rects never match, and non-finite/non-positive pixel ratios fall back to 1.

## Bug: silent input loss on failed PTY writes

Every input path did `void writePtySession(...)` with no `.catch` anywhere (onData keystrokes, Shift+Enter newline, the imperative `write()`, the agent-bridge writer). If `pty_session_write` rejected, the keystroke vanished with zero log.

New `writePtySessionLogged` in `src/lib/ptySession.ts` catches and `logger.warn`s with the session id and formatted `CommandError`. All fire-and-forget call sites (Terminal, BuildTerminal, DeviceMirror) use it. Deliberately no toast — one per lost keystroke would spam. `writePtySession` itself still rejects, so awaiting callers keep seeing errors.

## Tests

- `src/lib/dropTarget.test.ts`: physical→logical conversion (incl. degenerate ratios), half-open rect containment, per-side rejection, zero/negative-area rects never matching (hidden elements), and split-pane routing.
- Full suite: 63 files, 919 passed / 4 skipped. `typecheck`, `lint:strict`, `format:check`, `check:patterns`, `check:loc` all green.

Note: hunks were deliberately kept clear of open PRs #184 (custom key handler paste branch) and #187 (spawn/attach restructure) — the drag-drop block and the write-site one-liners are outside both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)