### PR TITLE
Visual editor: fix dropdowns closing instantly on open (WKWebView timing)

### DIFF
--- a/src/components/edit/AddMenu.tsx
+++ b/src/components/edit/AddMenu.tsx
@@ -13,6 +13,7 @@
 
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useDismissOnOutsidePointer } from '../../hooks/useDismissOnOutsidePointer';
 import { PlusIcon } from '../icons/utility';
 import { suggestProperties } from '../../lib/cssProperties';
 import {
@@ -216,16 +217,10 @@ export function AddMenu({ onAddProperty, onNest, mode = 'full', autoOpen = false
     };
   }, [open, anchor]);
 
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      const t = e.target as HTMLElement;
-      if (popRef.current?.contains(t) || btnRef.current?.contains(t)) return;
-      close();
-    };
-    document.addEventListener('mousedown', onDown, true);
-    return () => document.removeEventListener('mousedown', onDown, true);
-  }, [open]);
+  useDismissOnOutsidePointer(open, popRef, close, {
+    event: 'mousedown',
+    isOutside: (t) => !popRef.current?.contains(t) && !btnRef.current?.contains(t),
+  });
 
   const label = mode === 'keyframes' ? 'Add step' : mode === 'props' ? 'Add property' : 'Add';
   const placeholder =

--- a/src/components/edit/ClassBar.tsx
+++ b/src/components/edit/ClassBar.tsx
@@ -19,6 +19,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useDismissOnOutsidePointer } from '../../hooks/useDismissOnOutsidePointer';
 import { PlusIcon } from '../icons/utility';
 import { CheckIcon, SearchIcon } from '../icons/common';
 import type { CustomClass } from '../../lib/customClasses';
@@ -129,16 +130,9 @@ export function ClassBar({
     };
   }, [open, reposition]);
 
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: PointerEvent) => {
-      const t = e.target as Node;
-      if (triggerRef.current?.contains(t) || menuRef.current?.contains(t)) return;
-      close();
-    };
-    document.addEventListener('pointerdown', onDown, true);
-    return () => document.removeEventListener('pointerdown', onDown, true);
-  }, [open, close]);
+  useDismissOnOutsidePointer(open, menuRef, close, {
+    isOutside: (t) => !triggerRef.current?.contains(t) && !menuRef.current?.contains(t),
+  });
 
   const q = query.trim().toLowerCase();
   const matchedApplied = useMemo(

--- a/src/components/edit/ColorControls.tsx
+++ b/src/components/edit/ColorControls.tsx
@@ -8,6 +8,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useDismissOnOutsidePointer } from '../../hooks/useDismissOnOutsidePointer';
 import {
   arbitraryColorRaw,
   colorClassToken,
@@ -98,20 +99,14 @@ export function ColorField({
     };
   }, [open, reposition]);
 
+  useDismissOnOutsidePointer(open, popRef, () => setOpen(false), {
+    isOutside: (t) => !triggerRef.current?.contains(t) && !popRef.current?.contains(t),
+  });
   useEffect(() => {
     if (!open) return;
-    const onDown = (e: PointerEvent) => {
-      const t = e.target as Node;
-      if (triggerRef.current?.contains(t) || popRef.current?.contains(t)) return;
-      setOpen(false);
-    };
     const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setOpen(false);
-    document.addEventListener('pointerdown', onDown, true);
     document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('pointerdown', onDown, true);
-      document.removeEventListener('keydown', onKey);
-    };
+    return () => document.removeEventListener('keydown', onKey);
   }, [open]);
 
   const handlePick = useCallback(

--- a/src/components/edit/CssClassBar.tsx
+++ b/src/components/edit/CssClassBar.tsx
@@ -11,6 +11,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useDismissOnOutsidePointer } from '../../hooks/useDismissOnOutsidePointer';
 import { CSS_BREAKPOINTS } from '../../lib/cssControls';
 
 /** Breakpoint switcher — picks which `@media (min-width)` layer edits target. */
@@ -69,17 +70,12 @@ function ClassCombobox({
     .slice(0, 50);
   const canCreate = q !== '' && !allClasses.includes(q) && !taken.has(q);
 
+  // The combobox is only mounted while open, so `open` is simply `true` here.
+  useDismissOnOutsidePointer(true, popRef, onClose);
   useEffect(() => {
-    const onDown = (e: PointerEvent) => {
-      if (!popRef.current?.contains(e.target as Node)) onClose();
-    };
     const onKey = (e: KeyboardEvent) => e.key === 'Escape' && onClose();
-    document.addEventListener('pointerdown', onDown, true);
     document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('pointerdown', onDown, true);
-      document.removeEventListener('keydown', onKey);
-    };
+    return () => document.removeEventListener('keydown', onKey);
   }, [onClose]);
 
   const left = Math.min(anchor.left, window.innerWidth - 240);

--- a/src/components/edit/CssControls.tsx
+++ b/src/components/edit/CssControls.tsx
@@ -20,6 +20,7 @@ import {
   type ReactNode,
 } from 'react';
 import { createPortal } from 'react-dom';
+import { useDismissOnOutsidePointer } from '../../hooks/useDismissOnOutsidePointer';
 import { Button } from '../primitives/Button';
 import { EnumDropdown } from './EnumDropdown';
 import { ColorPicker } from './ColorPicker';
@@ -62,20 +63,16 @@ function ResettableCcLabel({
   const btnRef = useRef<HTMLButtonElement>(null);
   const popRef = useRef<HTMLButtonElement>(null);
 
+  useDismissOnOutsidePointer(pop !== null, popRef, () => setPop(null), {
+    isOutside: (t) => !popRef.current?.contains(t) && !btnRef.current?.contains(t),
+  });
   useEffect(() => {
     if (!pop) return;
-    const onDown = (e: PointerEvent) => {
-      const t = e.target as Node;
-      if (popRef.current?.contains(t) || btnRef.current?.contains(t)) return;
-      setPop(null);
-    };
     const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setPop(null);
     const onScroll = () => setPop(null);
-    document.addEventListener('pointerdown', onDown, true);
     document.addEventListener('keydown', onKey);
     window.addEventListener('scroll', onScroll, true);
     return () => {
-      document.removeEventListener('pointerdown', onDown, true);
       document.removeEventListener('keydown', onKey);
       window.removeEventListener('scroll', onScroll, true);
     };
@@ -324,20 +321,14 @@ function ColorControl({
     };
   }, [open, reposition]);
 
+  useDismissOnOutsidePointer(open, popRef, close, {
+    isOutside: (t) => !triggerRef.current?.contains(t) && !popRef.current?.contains(t),
+  });
   useEffect(() => {
     if (!open) return;
-    const onDown = (e: PointerEvent) => {
-      const t = e.target as Node;
-      if (triggerRef.current?.contains(t) || popRef.current?.contains(t)) return;
-      close();
-    };
     const onKey = (e: KeyboardEvent) => e.key === 'Escape' && close();
-    document.addEventListener('pointerdown', onDown, true);
     document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('pointerdown', onDown, true);
-      document.removeEventListener('keydown', onKey);
-    };
+    return () => document.removeEventListener('keydown', onKey);
   }, [open, close]);
 
   const commitText = () => {

--- a/src/components/edit/DeclarationRow.tsx
+++ b/src/components/edit/DeclarationRow.tsx
@@ -7,6 +7,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useDismissOnOutsidePointer } from '../../hooks/useDismissOnOutsidePointer';
 import { CloseIcon } from '../icons/common';
 import { PlusIcon } from '../icons/utility';
 import { EditPopover } from './EditPopover';
@@ -203,12 +204,9 @@ function NestControl({
   // Dismiss on Escape (returning focus to the trigger) or an outside click — a
   // keyboard user can't reach an onMouseLeave, so both are required to close it.
   // Mirrors the mousedown-capture click-outside pattern used by AddMenu.
+  useDismissOnOutsidePointer(open, wrapRef, () => setOpen(false), { event: 'mousedown' });
   useEffect(() => {
     if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (wrapRef.current?.contains(e.target as Node)) return;
-      setOpen(false);
-    };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
@@ -216,12 +214,8 @@ function NestControl({
         btnRef.current?.focus();
       }
     };
-    document.addEventListener('mousedown', onDown, true);
     document.addEventListener('keydown', onKey, true);
-    return () => {
-      document.removeEventListener('mousedown', onDown, true);
-      document.removeEventListener('keydown', onKey, true);
-    };
+    return () => document.removeEventListener('keydown', onKey, true);
   }, [open]);
 
   return (

--- a/src/components/edit/EditPopover.tsx
+++ b/src/components/edit/EditPopover.tsx
@@ -11,6 +11,7 @@
 
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useDismissOnOutsidePointer } from '../../hooks/useDismissOnOutsidePointer';
 import { ColorPicker } from './ColorPicker';
 import { colorSwatch, parseNumericValue, formatNumericValue } from '../../lib/cssProperties';
 
@@ -84,6 +85,26 @@ export function EditPopover({ anchor, initial, options, placeholder, onCommit, o
 
   // Escape cancels; click-away commits the current value. Clicks inside the popover
   // or its portaled sub-menus (the color format dropdown) don't dismiss.
+  // The popover is only mounted while open, so `open` is simply `true` here.
+  useDismissOnOutsidePointer(
+    true,
+    popRef,
+    () => {
+      onCommit(textRef.current);
+      onClose();
+    },
+    {
+      event: 'mousedown',
+      isOutside: (target) => {
+        const t = target as HTMLElement;
+        if (popRef.current?.contains(t)) return false;
+        // Clicking the anchor again is a toggle — let its own onClick close us.
+        if (anchor?.contains(t)) return false;
+        if (t.closest?.('.ss-enum__menu, .ss-color-popover')) return false;
+        return true;
+      },
+    }
+  );
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -91,22 +112,9 @@ export function EditPopover({ anchor, initial, options, placeholder, onCommit, o
         onClose();
       }
     };
-    const onDown = (e: MouseEvent) => {
-      const t = e.target as HTMLElement;
-      if (popRef.current?.contains(t)) return;
-      // Clicking the anchor again is a toggle — let its own onClick close us.
-      if (anchor?.contains(t)) return;
-      if (t.closest?.('.ss-enum__menu, .ss-color-popover')) return;
-      onCommit(textRef.current);
-      onClose();
-    };
     document.addEventListener('keydown', onKey, true);
-    document.addEventListener('mousedown', onDown, true);
-    return () => {
-      document.removeEventListener('keydown', onKey, true);
-      document.removeEventListener('mousedown', onDown, true);
-    };
-  }, [onClose, onCommit, anchor]);
+    return () => document.removeEventListener('keydown', onKey, true);
+  }, [onClose]);
 
   if (!pos) return null;
   return createPortal(

--- a/src/components/edit/EnumDropdown.tsx
+++ b/src/components/edit/EnumDropdown.tsx
@@ -8,6 +8,7 @@
 
 import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useDismissOnOutsidePointer } from '../../hooks/useDismissOnOutsidePointer';
 
 interface Option {
   label: string;
@@ -52,21 +53,16 @@ export function EnumDropdown({ label, options, value, onChange }: Props) {
     };
   }, [open, reposition]);
 
-  // Close on outside pointer / Escape.
+  // Close on outside pointer (menu is portaled, so the trigger is a second
+  // "inside" root) / Escape.
+  useDismissOnOutsidePointer(open, menuRef, () => setOpen(false), {
+    isOutside: (t) => !triggerRef.current?.contains(t) && !menuRef.current?.contains(t),
+  });
   useEffect(() => {
     if (!open) return;
-    const onDown = (e: PointerEvent) => {
-      const t = e.target as Node;
-      if (triggerRef.current?.contains(t) || menuRef.current?.contains(t)) return;
-      setOpen(false);
-    };
     const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setOpen(false);
-    document.addEventListener('pointerdown', onDown, true);
     document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('pointerdown', onDown, true);
-      document.removeEventListener('keydown', onKey);
-    };
+    return () => document.removeEventListener('keydown', onKey);
   }, [open]);
 
   return (

--- a/src/components/edit/ResettableLabel.tsx
+++ b/src/components/edit/ResettableLabel.tsx
@@ -8,6 +8,7 @@
 
 import { useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react';
 import { createPortal } from 'react-dom';
+import { useDismissOnOutsidePointer } from '../../hooks/useDismissOnOutsidePointer';
 import { LayerDot } from './LayerDot';
 import { type Breakpoint } from '../../lib/edit';
 
@@ -29,20 +30,18 @@ export function ResettableLabel({ label, definedAt, active, onReset }: Props) {
   const btnRef = useRef<HTMLButtonElement>(null);
 
   // Dismiss the floating Reset on outside click / Escape / scroll.
+  useDismissOnOutsidePointer(pop !== null, popRef, () => setPop(null), {
+    isOutside: (t) => !popRef.current?.contains(t) && !btnRef.current?.contains(t),
+  });
   useEffect(() => {
     if (!pop) return;
-    const onDown = (e: PointerEvent) => {
-      const t = e.target as Node;
-      if (popRef.current?.contains(t) || btnRef.current?.contains(t)) return;
-      setPop(null);
-    };
     const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setPop(null);
-    document.addEventListener('pointerdown', onDown, true);
+    const onScroll = () => setPop(null);
     document.addEventListener('keydown', onKey);
-    window.addEventListener('scroll', () => setPop(null), true);
+    window.addEventListener('scroll', onScroll, true);
     return () => {
-      document.removeEventListener('pointerdown', onDown, true);
       document.removeEventListener('keydown', onKey);
+      window.removeEventListener('scroll', onScroll, true);
     };
   }, [pop]);
 

--- a/src/hooks/useDismissOnOutsidePointer.test.ts
+++ b/src/hooks/useDismissOnOutsidePointer.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for useDismissOnOutsidePointer — the rAF-deferred capture-phase
+ * outside-pointer dismissal used by the visual editor's popovers (issue #172).
+ *
+ * requestAnimationFrame is stubbed with a manually-flushed queue so the tests
+ * can observe the window BETWEEN the effect running and the listener attaching
+ * — exactly where the WKWebView instant-close bug lived.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { RefObject } from 'react';
+import { useDismissOnOutsidePointer } from './useDismissOnOutsidePointer';
+
+let rafCallbacks: Map<number, FrameRequestCallback>;
+let nextRafId: number;
+
+/** Run every queued animation-frame callback (one "frame"). */
+function flushAnimationFrame() {
+  const pending = Array.from(rafCallbacks.values());
+  rafCallbacks.clear();
+  pending.forEach((cb) => cb(0));
+}
+
+function dispatch(el: Element, type: string) {
+  el.dispatchEvent(new Event(type, { bubbles: true }));
+}
+
+describe('useDismissOnOutsidePointer', () => {
+  let container: HTMLDivElement;
+  let inside: HTMLButtonElement;
+  let outside: HTMLDivElement;
+  let containerRef: RefObject<HTMLElement | null>;
+
+  beforeEach(() => {
+    rafCallbacks = new Map();
+    nextRafId = 1;
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      const id = nextRafId++;
+      rafCallbacks.set(id, cb);
+      return id;
+    });
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      rafCallbacks.delete(id);
+    });
+
+    container = document.createElement('div');
+    inside = document.createElement('button');
+    container.appendChild(inside);
+    outside = document.createElement('div');
+    document.body.append(container, outside);
+    containerRef = { current: container };
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  it('ignores a pointerdown dispatched in the same frame the popover opened (the opening gesture)', () => {
+    const onDismiss = vi.fn();
+    renderHook(() => useDismissOnOutsidePointer(true, containerRef, onDismiss));
+
+    // The opening gesture's pointerdown arrives after the effect ran but
+    // before the next frame — it must never reach the listener.
+    dispatch(outside, 'pointerdown');
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('dismisses on an outside pointerdown after a frame has passed', () => {
+    const onDismiss = vi.fn();
+    renderHook(() => useDismissOnOutsidePointer(true, containerRef, onDismiss));
+
+    flushAnimationFrame();
+    dispatch(outside, 'pointerdown');
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not dismiss on a pointerdown inside the container', () => {
+    const onDismiss = vi.fn();
+    renderHook(() => useDismissOnOutsidePointer(true, containerRef, onDismiss));
+
+    flushAnimationFrame();
+    dispatch(inside, 'pointerdown');
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('does nothing while closed', () => {
+    const onDismiss = vi.fn();
+    renderHook(() => useDismissOnOutsidePointer(false, containerRef, onDismiss));
+
+    expect(rafCallbacks.size).toBe(0);
+    flushAnimationFrame();
+    dispatch(outside, 'pointerdown');
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('removes the listener when open flips back to false', () => {
+    const onDismiss = vi.fn();
+    const { rerender } = renderHook(
+      ({ open }) => useDismissOnOutsidePointer(open, containerRef, onDismiss),
+      { initialProps: { open: true } }
+    );
+
+    flushAnimationFrame();
+    rerender({ open: false });
+    dispatch(outside, 'pointerdown');
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('cancels the pending frame if closed before the listener attached', () => {
+    const onDismiss = vi.fn();
+    const { rerender } = renderHook(
+      ({ open }) => useDismissOnOutsidePointer(open, containerRef, onDismiss),
+      { initialProps: { open: true } }
+    );
+
+    rerender({ open: false });
+    expect(rafCallbacks.size).toBe(0); // rAF was cancelled, not just orphaned
+    flushAnimationFrame();
+    dispatch(outside, 'pointerdown');
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('removes the listener on unmount', () => {
+    const onDismiss = vi.fn();
+    const { unmount } = renderHook(() => useDismissOnOutsidePointer(true, containerRef, onDismiss));
+
+    flushAnimationFrame();
+    unmount();
+    dispatch(outside, 'pointerdown');
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('listens for mousedown instead when configured', () => {
+    const onDismiss = vi.fn();
+    renderHook(() =>
+      useDismissOnOutsidePointer(true, containerRef, onDismiss, { event: 'mousedown' })
+    );
+
+    flushAnimationFrame();
+    dispatch(outside, 'pointerdown');
+    expect(onDismiss).not.toHaveBeenCalled();
+    dispatch(outside, 'mousedown');
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects an isOutside override (e.g. a separate trigger counts as inside)', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    const onDismiss = vi.fn();
+    renderHook(() =>
+      useDismissOnOutsidePointer(true, containerRef, onDismiss, {
+        isOutside: (t) => !container.contains(t) && !trigger.contains(t),
+      })
+    );
+
+    flushAnimationFrame();
+    dispatch(trigger, 'pointerdown');
+    dispatch(inside, 'pointerdown');
+    expect(onDismiss).not.toHaveBeenCalled();
+    dispatch(outside, 'pointerdown');
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the latest onDismiss without re-deferring the listener', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(
+      ({ cb }) => useDismissOnOutsidePointer(true, containerRef, cb),
+      { initialProps: { cb: first } }
+    );
+
+    flushAnimationFrame();
+    rerender({ cb: second });
+    // No new rAF was scheduled — the listener stayed attached.
+    expect(rafCallbacks.size).toBe(0);
+    dispatch(outside, 'pointerdown');
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useDismissOnOutsidePointer.ts
+++ b/src/hooks/useDismissOnOutsidePointer.ts
@@ -1,0 +1,75 @@
+/**
+ * Dismiss-on-outside-pointer for hand-rolled popovers (visual editor).
+ *
+ * Registers a CAPTURE-phase document listener while `open` is true, and calls
+ * `onDismiss` when the event lands outside the popover. Registration is
+ * deferred by one animation frame: on some engines (WKWebView on macOS
+ * Sequoia, issue #172) the opening gesture's pointerdown can be dispatched
+ * AFTER the effect that registers the listener runs, so a listener attached
+ * synchronously sees the very gesture that opened the popover and closes it
+ * instantly. Deferring one frame guarantees the opening gesture's events can
+ * never reach the listener, regardless of engine event/effect ordering.
+ *
+ * This deliberately does NOT replace `useClickOutside` (bubble-phase `click`
+ * semantics) — it's the shared home for the capture-phase
+ * `pointerdown`/`mousedown` pattern the edit-panel popovers use.
+ *
+ * @module hooks/useDismissOnOutsidePointer
+ */
+
+import { useEffect, useRef, type RefObject } from 'react';
+
+interface Options {
+  /** Which pointer event to dismiss on (default `'pointerdown'`). */
+  event?: 'pointerdown' | 'mousedown';
+  /**
+   * Override the containment check for popovers whose "inside" spans more than
+   * `containerRef` (e.g. a separate trigger, an anchor element, or portaled
+   * sub-menus). Return true when the target counts as outside. When provided,
+   * this fully replaces the default `containerRef.contains` check.
+   */
+  isOutside?: (target: Node) => boolean;
+}
+
+/**
+ * Call `onDismiss` on a capture-phase outside `pointerdown`/`mousedown` while
+ * `open` is true. The listener attaches one animation frame after `open`
+ * flips true so the opening gesture can never dismiss the popover.
+ */
+export function useDismissOnOutsidePointer(
+  open: boolean,
+  containerRef: RefObject<HTMLElement | null>,
+  onDismiss: () => void,
+  opts: Options = {}
+): void {
+  const { event = 'pointerdown' } = opts;
+
+  // Keep the latest callbacks in refs so the listener effect only re-runs when
+  // `open` (or the event type) changes — re-registering would re-defer it.
+  const onDismissRef = useRef(onDismiss);
+  const isOutsideRef = useRef(opts.isOutside);
+  useEffect(() => {
+    onDismissRef.current = onDismiss;
+    isOutsideRef.current = opts.isOutside;
+  });
+
+  useEffect(() => {
+    if (!open) return;
+
+    const onDown = (e: Event) => {
+      const target = e.target as Node;
+      const outside = isOutsideRef.current
+        ? isOutsideRef.current(target)
+        : !containerRef.current?.contains(target);
+      if (outside) onDismissRef.current();
+    };
+
+    const raf = requestAnimationFrame(() => {
+      document.addEventListener(event, onDown, true);
+    });
+    return () => {
+      cancelAnimationFrame(raf);
+      document.removeEventListener(event, onDown, true);
+    };
+  }, [open, event, containerRef]);
+}


### PR DESCRIPTION
## Root cause

The visual editor's ~10 hand-rolled popovers (enum dropdowns, color pickers, class menus, reset popovers, add/nest menus) all open via `onClick → setOpen(true)` and close via a **capture-phase document `pointerdown`/`mousedown` listener registered synchronously in a `useEffect` keyed on `[open]`**.

The only thing preventing the *opening* gesture from closing the menu was the assumption that the opening pointerdown finishes dispatching before the effect registers the listener. That ordering is not guaranteed — on WKWebView under macOS Sequoia the opening gesture's pointerdown can be dispatched **after** the effect runs, so it hits the just-registered listener, lands "outside" the (portaled, just-mounted) menu, and closes the popover instantly.

## Fix

New shared hook `src/hooks/useDismissOnOutsidePointer.ts`: same capture-phase outside-pointer dismissal, but listener registration is **deferred by one animation frame** (`requestAnimationFrame` inside the effect, cancelled on cleanup). The opening gesture's events can never reach the listener regardless of engine event/effect ordering.

- Event type is configurable (`pointerdown` default, `mousedown` for the menus that used it) — each popover keeps its exact prior semantics.
- An `isOutside` override preserves each popover's extra "inside" roots (separate trigger buttons, the EditPopover's anchor element and portaled sub-menus like `.ss-enum__menu` / `.ss-color-popover`).
- Escape / scroll dismissal stays in the components, unchanged.
- Deliberately does **not** touch `primitives/Dropdown` or `useClickOutside` (different semantics; migrating these popovers to the primitive is a bigger refactor, out of scope).

## Popovers migrated (10)

| File | Popover | Event |
|---|---|---|
| `EnumDropdown.tsx` | main enum select (breakpoint picker, CSS enum controls, ColorPicker format, EnumControls) | pointerdown |
| `CssControls.tsx` | ResettableCcLabel reset popover | pointerdown |
| `CssControls.tsx` | ColorControl swatch popover | pointerdown |
| `ColorControls.tsx` | color swatch popover | pointerdown |
| `ClassBar.tsx` | class-suggestion menu | pointerdown |
| `CssClassBar.tsx` | class combobox | pointerdown |
| `ResettableLabel.tsx` | floating Reset | pointerdown |
| `AddMenu.tsx` | add property/rule menu | mousedown |
| `EditPopover.tsx` | value edit popover (commit-on-click-away) | mousedown |
| `DeclarationRow.tsx` | NestControl menu | mousedown |

## Tests

`src/hooks/useDismissOnOutsidePointer.test.ts` (10 tests) stubs `requestAnimationFrame` with a manually-flushed queue to observe the exact window where the bug lived:

- a pointerdown dispatched in the same frame the popover opened (the opening gesture) is ignored
- after a frame, outside pointerdown dismisses; inside does not
- listener removed on close and unmount; pending rAF cancelled if closed before it fired
- `mousedown` option and `isOutside` override respected
- latest `onDismiss` used without re-deferring the listener

All gates green: `pnpm test:run` (921 passed), `typecheck`, `lint:strict`, `format:check`, `check:patterns`, `check:loc`.

## Verification note

The fix targets a timing race that doesn't reproduce on every machine — it needs a quick smoke test on macOS Sequoia by the reporter: enter edit mode, open the breakpoint picker / any enum dropdown / a color swatch, and confirm the menu stays open after the opening click.

Fixes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)