### PR TITLE
Mount ToastProvider: useOptionalToast now actually shows toasts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@
  * ## State Architecture
  *
  * State has been extracted into custom hooks for better organization:
- * - `useToasts` - Toast notification state
+ * - `ToastProvider` / `useToast` - Toast notification state (app-root context)
  * - `useTerminalManagement` - Terminal tabs and session state
  * - `useIntegrationStatus` - GitHub/Claude integration state
  * - `useScreenshotManagement` - Screenshot capture, crop, and thumbnail state
@@ -26,7 +26,6 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
-import { useToasts } from './hooks/useToasts';
 import { useTerminalManagement } from './hooks/useTerminalManagement';
 import { usePlugins } from './hooks/usePlugins';
 import { useIntegrationStatus } from './hooks/useIntegrationStatus';
@@ -56,7 +55,7 @@ import { MonorepoPickerModal } from './components/dashboard/MonorepoPickerModal'
 import { ModalFrame } from './components/primitives/ModalFrame';
 import { Button } from './components/primitives/Button';
 import { Spinner } from './components/primitives/Spinner';
-import { ToastContext } from './contexts/ToastContext';
+import { ToastProvider, useToast } from './contexts/ToastContext';
 import { ModalProvider, useModal } from './contexts/ModalContext';
 import { AgentBridgeProvider } from './contexts/AgentBridgeContext';
 import { CommandPaletteHost } from './components/CommandPalette/CommandPaletteHost';
@@ -95,15 +94,17 @@ interface AppProps {
  */
 function App({ initialProjectPath }: AppProps) {
   return (
-    <ModalProvider>
-      <PaletteContextProvider>
-        <AgentBridgeProvider>
-          <AppContents initialProjectPath={initialProjectPath} />
-          <CommandPaletteHost />
-          <AppGlobalModals />
-        </AgentBridgeProvider>
-      </PaletteContextProvider>
-    </ModalProvider>
+    <ToastProvider>
+      <ModalProvider>
+        <PaletteContextProvider>
+          <AgentBridgeProvider>
+            <AppContents initialProjectPath={initialProjectPath} />
+            <CommandPaletteHost />
+            <AppGlobalModals />
+          </AgentBridgeProvider>
+        </PaletteContextProvider>
+      </ModalProvider>
+    </ToastProvider>
   );
 }
 
@@ -339,8 +340,12 @@ function AppContents({ initialProjectPath }: AppProps) {
   // even on non-workspace views (loading / onboarding / projects).
   const helpModal = useModal('help');
 
-  // Toast notifications
-  const { toasts, showToast, dismissToast } = useToasts();
+  // Toast notifications — state lives in the app-root <ToastProvider>, so
+  // `useOptionalToast()` consumers anywhere in the tree share this stack.
+  // `toastsProps` is the memoized context value, still prop-drilled into
+  // WorkspaceView during the transition off `onToast` prop chains.
+  const toastsProps = useToast();
+  const { toasts, showToast, dismissToast } = toastsProps;
 
   // Branch management (state, polling, conflict handlers)
   const {
@@ -882,15 +887,6 @@ function AppContents({ initialProjectPath }: AppProps) {
     [isEducationMode, setIsEducationMode, closeEducation]
   );
 
-  const toastsProps = useMemo(
-    () => ({
-      toasts,
-      showToast,
-      dismissToast,
-    }),
-    [toasts, showToast, dismissToast]
-  );
-
   const branchMgmtProps = useMemo(
     () => ({
       currentBranch,
@@ -1084,7 +1080,7 @@ function AppContents({ initialProjectPath }: AppProps) {
 
   if (view === 'account-select') {
     return (
-      <ToastContext.Provider value={toastsProps}>
+      <>
         <div className="app">
           <AccountSelectScreen onContinue={() => setView('projects')} />
         </div>
@@ -1104,13 +1100,13 @@ function AppContents({ initialProjectPath }: AppProps) {
           </div>
         )}
         {quitConfirmModal}
-      </ToastContext.Provider>
+      </>
     );
   }
 
   if (view === 'projects') {
     return (
-      <ToastContext.Provider value={toastsProps}>
+      <>
         <div className={`projects-with-rail${isCompact ? ' is-compact' : ''}`} key="view-projects">
           {!isCompact && (
             <WorkspaceSidebar
@@ -1198,7 +1194,7 @@ function AppContents({ initialProjectPath }: AppProps) {
           </div>
         )}
         {quitConfirmModal}
-      </ToastContext.Provider>
+      </>
     );
   }
 
@@ -1251,7 +1247,7 @@ function AppContents({ initialProjectPath }: AppProps) {
     );
   }
   return (
-    <ToastContext.Provider value={toastsProps}>
+    <>
       <WorkspaceView
         currentProject={currentProject}
         previewRef={previewRef}
@@ -1280,7 +1276,7 @@ function AppContents({ initialProjectPath }: AppProps) {
         isProjectDevServerRunning={isServerRunning}
       />
       {quitConfirmModal}
-    </ToastContext.Provider>
+    </>
   );
 }
 

--- a/src/components/dashboard/AgentsPanel.tsx
+++ b/src/components/dashboard/AgentsPanel.tsx
@@ -279,29 +279,21 @@ export function AgentsPanel() {
 
   const isWorkspaceActive = !!activeAccount && !activeAccount.isDefault;
 
-  // Keep showToast in a ref so refresh() has a stable identity — otherwise
-  // the mount effect re-fires on every render (useOptionalToast returns a
-  // fresh object each render when there's no ToastProvider), causing a
-  // storm of refetches that makes the default pill flicker.
-  const showToastRef = useRef(showToast);
-  useEffect(() => {
-    showToastRef.current = showToast;
-  }, [showToast]);
-
+  // `showToast` is referentially stable: the app-root <ToastProvider> keeps
+  // it in a useCallback, and outside a provider `useOptionalToast` returns a
+  // module-level no-op singleton. So it's safe in dep arrays and refresh()
+  // keeps a stable identity (no refetch storms on re-render).
   const refresh = useCallback(async () => {
     try {
       const data = await getAgentsStatus();
       setAgents(data);
     } catch (err) {
       logger.warn('Failed to load agent status');
-      showToastRef.current(
-        `Failed to load agents: ${formatCommandError(asCommandError(err))}`,
-        'error'
-      );
+      showToast(`Failed to load agents: ${formatCommandError(asCommandError(err))}`, 'error');
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [showToast]);
 
   useEffect(() => {
     void refresh();

--- a/src/contexts/ToastContext.test.tsx
+++ b/src/contexts/ToastContext.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Tests for ToastContext (issue #48).
+ *
+ * The app mounts <ToastProvider> at the root, so `useOptionalToast()` must
+ * return the real context (not the no-op fallback) and its `showToast` must
+ * be referentially stable across re-renders — components put it in
+ * useCallback/useEffect dep arrays.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, renderHook, act } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { ToastProvider, useToast, useOptionalToast } from './ToastContext';
+
+/** Fires a toast through the optional hook — the path that used to no-op. */
+function OptionalToastTrigger() {
+  const { showToast } = useOptionalToast();
+  return (
+    <button onClick={() => showToast('Saved via optional hook', 'success')}>Trigger toast</button>
+  );
+}
+
+/** Renders the shared toast stack the way App.tsx does (from `useToast().toasts`). */
+function ToastStack() {
+  const { toasts } = useToast();
+  return (
+    <div className="toast-container">
+      {toasts.map((t) => (
+        <div key={t.id} className={`toast toast-${t.type}`}>
+          {t.message}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <ToastProvider>{children}</ToastProvider>
+);
+
+describe('ToastContext', () => {
+  it('useOptionalToast inside the provider shows a toast in the shared stack', () => {
+    render(
+      <ToastProvider>
+        <OptionalToastTrigger />
+        <ToastStack />
+      </ToastProvider>
+    );
+
+    expect(screen.queryByText('Saved via optional hook')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger toast' }));
+
+    expect(screen.getByText('Saved via optional hook')).toBeInTheDocument();
+  });
+
+  it('useOptionalToast returns a stable showToast identity across re-renders', () => {
+    const { result, rerender } = renderHook(() => useOptionalToast(), { wrapper });
+    const first = result.current.showToast;
+
+    rerender();
+    rerender();
+
+    expect(result.current.showToast).toBe(first);
+  });
+
+  it('showToast identity survives toast state changes', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    const first = result.current.showToast;
+
+    // Adding a toast re-renders the provider — showToast must not change.
+    act(() => {
+      result.current.showToast('A toast', 'info');
+    });
+
+    expect(result.current.showToast).toBe(first);
+    expect(result.current.toasts).toHaveLength(1);
+  });
+
+  it('useOptionalToast outside a provider returns the stable no-op singleton', () => {
+    const { result, rerender } = renderHook(() => useOptionalToast());
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(first);
+    expect(() => result.current.showToast('dropped')).not.toThrow();
+  });
+});

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, type ReactNode } from 'react';
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
 import { useToasts, type UseToastsReturn, type ToastType } from '../hooks/useToasts';
 
 export const ToastContext = createContext<UseToastsReturn | null>(null);
@@ -8,7 +8,15 @@ interface ProviderProps {
 }
 
 export function ToastProvider({ children }: ProviderProps) {
-  const value = useToasts();
+  const { toasts, showToast, dismissToast } = useToasts();
+  // Memoize the context value so consumers only re-render when toast state
+  // actually changes (not when an ancestor re-renders the provider). The
+  // `showToast` / `dismissToast` functions are useCallback-stable inside
+  // `useToasts`, so effects and callbacks may safely list them as deps.
+  const value = useMemo(
+    () => ({ toasts, showToast, dismissToast }),
+    [toasts, showToast, dismissToast]
+  );
   return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>;
 }
 


### PR DESCRIPTION
## Why

`ToastContext` existed, but no `<ToastProvider>` was mounted at the app root — only three view branches inside `AppContents` wrapped themselves in a raw `ToastContext.Provider`. Everything outside those branches (command palette host, global modals, loading/onboarding/project-loading views) hit `useOptionalToast()`'s NOOP fallback, so errors surfaced through it **silently vanished app-wide** (this bit us in #164/#165, and caused the `AgentsPanel` refetch storm in #46). Mounting the provider also unlocks the incremental removal of `onToast` prop chains as follow-up work.

## What changed

- **`src/App.tsx`** — `App()` now wraps the whole tree in `<ToastProvider>` (per window: each window has its own React root via `main.tsx`, so toast state stays per-window). `AppContents` consumes the context with `useToast()` instead of owning state via `useToasts()`; the three inline `ToastContext.Provider` wrappers and the redundant `toastsProps` memo are removed. The prop-drilled path (`WorkspaceView`'s `toasts` prop) keeps working unchanged — both it and `useOptionalToast()` consumers now feed the same toast stack.
- **`src/contexts/ToastContext.tsx`** — the provider memoizes its context value with `useMemo`; `showToast`/`dismissToast` were already `useCallback`-stable, so they're now safe in `useCallback`/`useEffect` dep arrays everywhere. Public API unchanged.
- **`src/components/dashboard/AgentsPanel.tsx`** — drops the `showToastRef` workaround (issue acceptance criterion); `refresh` now lists the stable `showToast` as a dep directly.

## Tests

New `src/contexts/ToastContext.test.tsx` (4 tests):
- `useOptionalToast` inside the provider triggers a visible toast render in the shared stack
- `showToast` identity is stable across re-renders
- `showToast` identity survives toast state changes
- outside a provider, the no-op fallback is a stable singleton and doesn't throw

Full suite: 66 files, 954 tests — all green. `typecheck`, `lint:strict`, `format:check`, `check:patterns`, `check:loc` all pass.

Fixes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)