### PR TITLE
Claude auth: stale tokens no longer shadow re-login; unified status checks; honest auth errors

### DIFF
--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -276,6 +276,33 @@ fn unix_now() -> u64 {
         .unwrap_or(0)
 }
 
+/// Decide whether a workspace's stored Claude token should be injected as
+/// `CLAUDE_CODE_OAUTH_TOKEN` into a spawned process, from stored state only
+/// (this runs on every PTY spawn — never make a network call here).
+///
+/// `CLAUDE_CODE_OAUTH_TOKEN` takes precedence over any interactive `/login`
+/// the user performs inside the terminal, so injecting a token past its
+/// recorded expiry would permanently shadow a fresh re-login with a dead
+/// credential (issue #159 — "cannot sign back into Claude"). Expired → don't
+/// inject; the terminal is then free to authenticate interactively.
+///
+/// Tokens the API rejected at connect time are never persisted in the first
+/// place (see `claude_token_is_rejected` in `connect_claude_account`), so
+/// "no token stored" is the stored rejection state and this helper only needs
+/// the expiry. No expiry recorded (older connect) → inject, mirroring
+/// `resolve_claude_identity`'s benefit-of-the-doubt for pre-expiry connects.
+fn should_inject_claude_token(expires_at: Option<u64>, now: u64) -> bool {
+    match expires_at {
+        Some(expires_at) => now < expires_at,
+        None => true,
+    }
+}
+
+/// Read a workspace's stored Claude token expiry (unix seconds), if any.
+fn read_claude_token_expiry(account_id: &str) -> Option<u64> {
+    read_from_keychain(account_id, CLAUDE_EXPIRES_KEY).and_then(|s| s.trim().parse::<u64>().ok())
+}
+
 /// Connection state of a workspace's Claude login, for the agent card.
 #[derive(serde::Serialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -315,17 +342,14 @@ pub async fn resolve_claude_identity(account_id: &str) -> ClaudeIdentity {
         };
     };
     let email = read_from_keychain(account_id, CLAUDE_EMAIL_KEY);
-    let expired = read_from_keychain(account_id, CLAUDE_EXPIRES_KEY)
-        .and_then(|s| s.trim().parse::<u64>().ok())
-        .map(|exp| unix_now() >= exp)
-        // No expiry recorded (older connect): treat as still valid rather than
-        // nagging the user with a false red.
-        .unwrap_or(false);
+    // No expiry recorded (older connect): treat as still valid rather than
+    // nagging the user with a false red (see should_inject_claude_token).
+    let valid = should_inject_claude_token(read_claude_token_expiry(account_id), unix_now());
     ClaudeIdentity {
-        state: if expired {
-            ClaudeConnState::NeedsReconnect
-        } else {
+        state: if valid {
             ClaudeConnState::Connected
+        } else {
+            ClaudeConnState::NeedsReconnect
         },
         email,
     }
@@ -333,50 +357,58 @@ pub async fn resolve_claude_identity(account_id: &str) -> ClaudeIdentity {
 
 /// Identity for the Default workspace via `claude auth status` (native login).
 async fn resolve_default_claude_identity() -> ClaudeIdentity {
-    let Some(binary) = find_binary_by_name("claude") else {
-        return ClaudeIdentity {
+    match claude_cli_auth_status().await {
+        Some((true, email)) => ClaudeIdentity {
+            state: ClaudeConnState::Connected,
+            email,
+        },
+        // Logged out, or the CLI couldn't answer — either way there's no
+        // usable native login to report.
+        _ => ClaudeIdentity {
             state: ClaudeConnState::NotConnected,
             email: None,
-        };
-    };
-    let mut cmd = create_command(binary);
-    cmd.args(["auth", "status"]);
-    cmd.env("PATH", get_extended_path());
-    // Default = native locations; do NOT pin CLAUDE_CONFIG_DIR or inject a token.
-    let tokio_cmd = tokio::process::Command::from(cmd);
-    let stdout = match run_with_timeout(tokio_cmd, "claude auth status", 10).await {
-        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).to_string(),
-        _ => {
-            return ClaudeIdentity {
-                state: ClaudeConnState::NotConnected,
-                email: None,
-            }
-        }
-    };
-    let (logged_in, email) = parse_claude_auth_status(&stdout);
-    ClaudeIdentity {
-        state: if logged_in {
-            ClaudeConnState::Connected
-        } else {
-            ClaudeConnState::NotConnected
         },
-        email,
     }
 }
 
-/// Parse `claude auth status` JSON → (logged_in, email). Tolerant of unknown
-/// fields and non-JSON output (returns `(false, None)`).
-fn parse_claude_auth_status(stdout: &str) -> (bool, Option<String>) {
-    let Ok(v) = serde_json::from_str::<serde_json::Value>(stdout.trim()) else {
-        return (false, None);
-    };
-    let logged_in = v.get("loggedIn").and_then(|b| b.as_bool()).unwrap_or(false);
+/// Ask the Claude CLI for its *native* (keychain/`~/.claude`) login state via
+/// `claude auth status`. This is the single source of truth shared by the
+/// dashboard's Agents panel and onboarding's `check_claude_auth_status` — file
+/// indicators like `~/.claude/settings.json` survive a sign-out and would make
+/// the two disagree (issue #159).
+///
+/// Returns `Some((logged_in, email))` when the CLI gave a definitive answer.
+/// Returns `None` when it *couldn't* answer — binary missing, spawn
+/// failure/timeout, or output that isn't the expected status JSON (e.g. an
+/// older CLI without the `auth` subcommand) — so callers may fall back to
+/// weaker signals.
+pub async fn claude_cli_auth_status() -> Option<(bool, Option<String>)> {
+    let binary = find_binary_by_name("claude")?;
+    let mut cmd = create_command(binary);
+    cmd.args(["auth", "status"]);
+    cmd.env("PATH", get_extended_path());
+    // Native locations; do NOT pin CLAUDE_CONFIG_DIR or inject a token.
+    let tokio_cmd = tokio::process::Command::from(cmd);
+    let out = run_with_timeout(tokio_cmd, "claude auth status", 10)
+        .await
+        .ok()?;
+    // Parse stdout regardless of exit code: a logged-out CLI may exit non-zero
+    // while still printing the status JSON. Unparseable output → None.
+    parse_claude_auth_status(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Parse `claude auth status` JSON → `Some((logged_in, email))`. Tolerant of
+/// unknown fields; returns `None` for non-JSON output or JSON without a
+/// `loggedIn` bool (not a definitive answer).
+fn parse_claude_auth_status(stdout: &str) -> Option<(bool, Option<String>)> {
+    let v = serde_json::from_str::<serde_json::Value>(stdout.trim()).ok()?;
+    let logged_in = v.get("loggedIn").and_then(|b| b.as_bool())?;
     let email = v
         .get("email")
         .and_then(|e| e.as_str())
         .map(str::to_string)
         .filter(|e| !e.is_empty());
-    (logged_in, email)
+    Some((logged_in, email))
 }
 
 // ============ Config dir isolation ============
@@ -614,8 +646,22 @@ pub fn get_env_vars_for_account(account_id: &str) -> HashMap<String, String> {
         // ever reading or writing the shared keychain entry. Only injected when
         // the workspace has actually connected Claude; otherwise its terminals
         // stay logged out (the correct "not connected" state).
+        //
+        // A token past its stored expiry is NOT injected (only the stored
+        // expiry is consulted — no network on this hot path): the env token
+        // overrides any interactive `/login` inside the terminal, so a dead
+        // token would make re-login impossible (issue #159). Skipping it keeps
+        // the isolated CLAUDE_CONFIG_DIR (set above) but lets the terminal
+        // authenticate interactively until the workspace is reconnected.
         if let Some(token) = read_from_keychain(account_id, CLAUDE_TOKEN_KEY) {
-            vars.insert("CLAUDE_CODE_OAUTH_TOKEN".to_string(), token);
+            if should_inject_claude_token(read_claude_token_expiry(account_id), unix_now()) {
+                vars.insert("CLAUDE_CODE_OAUTH_TOKEN".to_string(), token);
+            } else {
+                tracing::warn!(
+                    account_id = %account_id,
+                    "stored Claude token for workspace has expired; not injecting CLAUDE_CODE_OAUTH_TOKEN so an interactive login can work — reconnect the workspace to refresh it"
+                );
+            }
         }
     }
 
@@ -2009,16 +2055,47 @@ mod tests {
         let json = r#"{"loggedIn":true,"authMethod":"claude.ai","email":"a@b.com"}"#;
         assert_eq!(
             parse_claude_auth_status(json),
-            (true, Some("a@b.com".into()))
+            Some((true, Some("a@b.com".into())))
         );
 
         // Token-auth shape has no email — must not invent one.
         let token_shape = r#"{"loggedIn":true,"authMethod":"oauth_token"}"#;
-        assert_eq!(parse_claude_auth_status(token_shape), (true, None));
+        assert_eq!(parse_claude_auth_status(token_shape), Some((true, None)));
 
-        // Non-JSON / empty → not logged in, no email (never panics).
-        assert_eq!(parse_claude_auth_status("not json"), (false, None));
-        assert_eq!(parse_claude_auth_status(""), (false, None));
+        // A definitive logged-out answer is still an answer.
+        let logged_out = r#"{"loggedIn":false}"#;
+        assert_eq!(parse_claude_auth_status(logged_out), Some((false, None)));
+    }
+
+    #[test]
+    fn parse_claude_auth_status_returns_none_when_cli_cannot_answer() {
+        // Non-JSON (e.g. an older CLI without `auth status`) / empty output is
+        // NOT a definitive "logged out" — callers fall back to weaker signals.
+        assert_eq!(parse_claude_auth_status("not json"), None);
+        assert_eq!(parse_claude_auth_status(""), None);
+        assert_eq!(parse_claude_auth_status(r#"Unknown command "auth""#), None);
+        // JSON without a loggedIn bool is equally non-definitive.
+        assert_eq!(parse_claude_auth_status(r#"{"email":"a@b.com"}"#), None);
+        assert_eq!(parse_claude_auth_status(r#"{"loggedIn":"yes"}"#), None);
+    }
+
+    #[test]
+    fn should_inject_claude_token_skips_expired_tokens() {
+        let now = 1_750_000_000_u64;
+        // Valid (expiry in the future) → inject.
+        assert!(should_inject_claude_token(Some(now + 1), now));
+        // Expired → never inject: CLAUDE_CODE_OAUTH_TOKEN would override an
+        // interactive /login inside the terminal with a dead token (#159).
+        assert!(!should_inject_claude_token(Some(now - 1), now));
+        // Exactly at expiry counts as expired (mirrors the old `now >= exp`).
+        assert!(!should_inject_claude_token(Some(now), now));
+    }
+
+    #[test]
+    fn should_inject_claude_token_gives_benefit_of_the_doubt_without_expiry() {
+        // Older connects recorded no expiry — inject rather than silently
+        // logging every terminal out (matches resolve_claude_identity).
+        assert!(should_inject_claude_token(None, 1_750_000_000));
     }
 
     #[test]

--- a/src-tauri/src/commands/setup/auth.rs
+++ b/src-tauri/src/commands/setup/auth.rs
@@ -6,7 +6,8 @@
 use super::{is_mock_installed, is_mock_mode, mock_install, AUTH_PIDS};
 use crate::agent::{get_active_agent, get_agent_by_id};
 use crate::commands::accounts::{
-    agent_auth_dir, get_active_account_id, get_env_vars_for_active_account,
+    agent_auth_dir, claude_cli_auth_status, get_active_account_id, get_env_vars_for_active_account,
+    resolve_claude_identity, ClaudeConnState, DEFAULT_ACCOUNT_ID,
 };
 use crate::commands::claude::find_binary_by_name;
 use crate::errors::CommandError;
@@ -142,6 +143,29 @@ pub async fn check_claude_auth_status(agent_id: Option<String>) -> bool {
     }
 
     let active_account_id = get_active_account_id().unwrap_or_else(|_| "default".to_string());
+
+    // Claude: use the same source of truth as the dashboard's Agents panel
+    // (`resolve_claude_identity`) instead of file indicators. Files like
+    // `~/.claude/settings.json` survive a sign-out, so the old existence check
+    // reported "authenticated" while the dashboard's `claude auth status`
+    // check said "not connected" — a disagreement that left users stuck
+    // (issue #159). File indicators remain only as the fallback for when the
+    // CLI can't answer (e.g. an older binary without `auth status`).
+    if agent.id == "claude-code" {
+        if active_account_id != DEFAULT_ACCOUNT_ID {
+            // Isolated workspaces are vault-driven, exactly like the dashboard.
+            // NeedsReconnect (expired token) counts as not authenticated so the
+            // wizard prompts a reconnect instead of green-lighting a dead token.
+            let identity = resolve_claude_identity(&active_account_id).await;
+            return identity.state == ClaudeConnState::Connected;
+        }
+        // Default workspace: the CLI's native keychain login is the truth.
+        if let Some((logged_in, _email)) = claude_cli_auth_status().await {
+            return logged_in;
+        }
+        // CLI couldn't answer — fall through to the file-indicator fallback.
+    }
+
     let agent_dir = agent_auth_dir(&active_account_id, agent);
     agent.auth_indicators.iter().any(|indicator| {
         let path = agent_dir.join(indicator);

--- a/src/components/setup/OnboardingScreen.test.tsx
+++ b/src/components/setup/OnboardingScreen.test.tsx
@@ -87,6 +87,24 @@ vi.mock('./OnboardingTerminal', () => ({
       >
         Exit 1 (npm missing)
       </button>
+      <button
+        data-testid="terminal-exit-0-already-logged-in"
+        onClick={() => onExit(0, 'Already logged in as julian@example.com\n')}
+      >
+        Exit 0 (already logged in)
+      </button>
+      <button
+        data-testid="terminal-exit-0-auth-error"
+        onClick={() => onExit(0, 'Error: OAuth token exchange failed\n')}
+      >
+        Exit 0 (auth error in tail)
+      </button>
+      <button
+        data-testid="terminal-exit-1-gh-already-logged-in"
+        onClick={() => onExit(1, '✓ Logged in to github.com account juliangalluzzo (keyring)\n')}
+      >
+        Exit 1 (gh already logged in)
+      </button>
     </div>
   ),
 }));
@@ -1345,6 +1363,135 @@ describe('OnboardingScreen', () => {
       await waitFor(() => {
         expect(
           screen.getByText('Authentication not completed. Click to try again.')
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('claude_auth failure surfaces the extracted error from the output tail', async () => {
+      // Verification fails AND the tail names the real cause — show the cause,
+      // not the generic "Authentication not completed" (issue #159).
+      const items = HAS_BASE_NO_AGENTS_ITEMS.map((i) => {
+        if (i.id === 'claude') return { ...i, status: 'ready' as const, version: '1.0.0' };
+        return i;
+      });
+      const status = makeSetupStatus({
+        items,
+        optionalAuths: { githubAuthenticated: true },
+        detectedAgents: [],
+      });
+      mockInvoke('get_full_setup_status', status);
+      mockInvoke('check_claude_auth_status', false);
+
+      render(<OnboardingScreen onComplete={onComplete} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Install at least one AI coding assistant')).toBeInTheDocument();
+      });
+
+      act(() => {
+        fireEvent.click(screen.getAllByText('Connect')[0]);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('mock-terminal')).toBeInTheDocument();
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('terminal-exit-0-auth-error'));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Error: OAuth token exchange failed')).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByText('Authentication not completed. Click to try again.')
+      ).not.toBeInTheDocument();
+    });
+
+    it('claude_auth failure when the CLI says already-logged-in names the identity', async () => {
+      // The #159 desync: the CLI insists it has a login, but the status check
+      // disagrees. Tell the user what the CLI reported and where to fix it.
+      const items = HAS_BASE_NO_AGENTS_ITEMS.map((i) => {
+        if (i.id === 'claude') return { ...i, status: 'ready' as const, version: '1.0.0' };
+        return i;
+      });
+      const status = makeSetupStatus({
+        items,
+        optionalAuths: { githubAuthenticated: true },
+        detectedAgents: [],
+      });
+      mockInvoke('get_full_setup_status', status);
+      mockInvoke('check_claude_auth_status', false);
+
+      render(<OnboardingScreen onComplete={onComplete} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Install at least one AI coding assistant')).toBeInTheDocument();
+      });
+
+      act(() => {
+        fireEvent.click(screen.getAllByText('Connect')[0]);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('mock-terminal')).toBeInTheDocument();
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByTestId('terminal-exit-0-already-logged-in'));
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Claude reports you're already signed in as julian@example.com — if this looks wrong, sign out from the Agents panel first."
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('gh_auth nonzero exit with already-logged-in tail names the gh identity', async () => {
+      const items = STEP1_COMPLETE_ITEMS.map((i) => {
+        if (i.id === 'git') return { ...i, status: 'ready' as const, version: '2.43.0' };
+        if (i.id === 'gh') return { ...i, status: 'ready' as const, version: '2.40.0' };
+        return i;
+      });
+      const status = makeSetupStatus({ items, detectedAgents: [] });
+      mockInvoke('get_full_setup_status', status);
+
+      render(<OnboardingScreen onComplete={onComplete} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Save your work safely and publish it online. Required.')
+        ).toBeInTheDocument();
+      });
+
+      // Pre-check: not authenticated → terminal opens
+      mockCheckGitHubCliStatus.mockResolvedValueOnce({ installed: true, authenticated: false });
+
+      act(() => {
+        fireEvent.click(screen.getAllByText('Connect')[0]);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('mock-terminal')).toBeInTheDocument();
+      });
+
+      // gh exits nonzero while insisting a login already exists
+      act(() => {
+        fireEvent.click(screen.getByTestId('terminal-exit-1-gh-already-logged-in'));
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByText('Close'));
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "GitHub reports you're already signed in as juliangalluzzo — if this looks wrong, sign out by running `gh auth logout` in a terminal first."
+          )
         ).toBeInTheDocument();
       });
     });

--- a/src/components/setup/OnboardingScreen.tsx
+++ b/src/components/setup/OnboardingScreen.tsx
@@ -44,7 +44,11 @@ import {
 import { initDefaultAgent } from '../../lib/agent';
 import { checkGitHubCliStatus } from '../../lib/github';
 import { asCommandError, formatCommandError } from '../../lib/errors';
-import { extractTerminalError, isNodeMissingError } from '../../lib/terminalDiagnostics';
+import {
+  detectAlreadyLoggedIn,
+  extractTerminalError,
+  isNodeMissingError,
+} from '../../lib/terminalDiagnostics';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { SlackIcon } from '../icons';
 
@@ -65,6 +69,42 @@ interface TerminalConfig {
   itemId: string;
   command: string;
   args: string[];
+}
+
+/** Friendly tool names for auth items, used in already-signed-in messages. */
+const AUTH_TOOL_LABELS: Record<string, string> = {
+  claude_auth: 'Claude',
+  codex_auth: 'Codex',
+  opencode_auth: 'Opencode',
+  gh_auth: 'GitHub',
+};
+
+/**
+ * Message for the "CLI insists it's already signed in, but our status check
+ * disagrees" case — e.g. a partial sign-out desynced `claude auth status`
+ * from the checklist (issue #159). A generic "authentication not completed"
+ * would be dishonest here; name the identity the CLI reported and point at
+ * the real fix instead.
+ */
+function alreadySignedInMessage(itemId: string, identity: string | null): string {
+  const tool = AUTH_TOOL_LABELS[itemId] ?? 'The CLI';
+  const who = identity ? ` as ${identity}` : '';
+  const fix =
+    itemId === 'gh_auth'
+      ? 'sign out by running `gh auth logout` in a terminal first'
+      : 'sign out from the Agents panel first';
+  return `${tool} reports you're already signed in${who} — if this looks wrong, ${fix}.`;
+}
+
+/**
+ * Honest error for an auth item whose post-terminal verification failed:
+ * prefer the already-signed-in special case, then whatever the terminal
+ * actually said, over the generic message.
+ */
+function authFailureMessage(itemId: string, outputTail: string): string {
+  const already = detectAlreadyLoggedIn(outputTail);
+  if (already) return alreadySignedInMessage(itemId, already.identity);
+  return extractTerminalError(outputTail) ?? 'Authentication not completed. Click to try again.';
 }
 
 interface OnboardingScreenProps {
@@ -217,7 +257,7 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
           if (!status.authenticated) {
             updateItemStatus(itemId, {
               status: 'error',
-              errorMessage: 'Authentication not completed. Click to try again.',
+              errorMessage: authFailureMessage(itemId, outputTail),
             });
             setActiveItemId(null);
             return;
@@ -227,7 +267,7 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
           if (!isAuthed) {
             updateItemStatus(itemId, {
               status: 'error',
-              errorMessage: 'Authentication not completed. Click to try again.',
+              errorMessage: authFailureMessage(itemId, outputTail),
             });
             setActiveItemId(null);
             return;
@@ -242,6 +282,7 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
         // Surface the actual failure from the terminal output instead of a
         // generic message (issue #164 — installs failed with zero diagnostics).
         const extractedError = extractTerminalError(outputTail);
+        const alreadySignedIn = itemId.endsWith('_auth') ? detectAlreadyLoggedIn(outputTail) : null;
         let errorMessage = extractedError ?? 'Command failed. Click to try again.';
         if (itemId === 'homebrew') {
           errorMessage =
@@ -249,6 +290,10 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
         } else if (isNodeMissingError(outputTail)) {
           errorMessage =
             "Node.js/npm wasn't found. Complete the Node.js step first, or restart Ship Studio if you just installed it.";
+        } else if (alreadySignedIn) {
+          // Auth flow failed while the CLI insists it already has a login —
+          // surface the disagreement instead of a misleading command error.
+          errorMessage = alreadySignedInMessage(itemId, alreadySignedIn.identity);
         }
         void trackEvent('setup_action_failed', {
           item_id: itemId,

--- a/src/lib/terminalDiagnostics.test.ts
+++ b/src/lib/terminalDiagnostics.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { extractTerminalError, isNodeMissingError } from './terminalDiagnostics';
+import {
+  detectAlreadyLoggedIn,
+  extractTerminalError,
+  isNodeMissingError,
+} from './terminalDiagnostics';
 
 describe('extractTerminalError', () => {
   it('returns null for an empty tail', () => {
@@ -90,5 +94,47 @@ describe('isNodeMissingError', () => {
     expect(isNodeMissingError('npm ERR! code EACCES')).toBe(false);
     expect(isNodeMissingError("gh: command 'foo' not found")).toBe(false);
     expect(isNodeMissingError('')).toBe(false);
+  });
+});
+
+describe('detectAlreadyLoggedIn', () => {
+  it('captures the identity from "Logged in as <email>" (claude/codex style)', () => {
+    expect(detectAlreadyLoggedIn('Logged in as julian@example.com\n')).toEqual({
+      identity: 'julian@example.com',
+    });
+  });
+
+  it('captures the identity from the gh "account" phrasing', () => {
+    expect(
+      detectAlreadyLoggedIn('✓ Logged in to github.com account juliangalluzzo (keyring)\n')
+    ).toEqual({ identity: 'juliangalluzzo' });
+  });
+
+  it('captures the identity from the older gh "as" phrasing', () => {
+    expect(detectAlreadyLoggedIn('Logged in to github.com as juliangalluzzo\n')).toEqual({
+      identity: 'juliangalluzzo',
+    });
+  });
+
+  it('detects "already logged in" without a named identity', () => {
+    expect(detectAlreadyLoggedIn('You are already logged in.\n')).toEqual({ identity: null });
+  });
+
+  it('prefers the named identity when both signatures appear', () => {
+    expect(detectAlreadyLoggedIn('Already logged in as a@b.com. Nothing to do.\n')).toEqual({
+      identity: 'a@b.com',
+    });
+  });
+
+  it('sees through ANSI-colored output', () => {
+    expect(detectAlreadyLoggedIn('\x1b[32mLogged in as\x1b[0m a@b.com\n')).toEqual({
+      identity: 'a@b.com',
+    });
+  });
+
+  it('does not fire on "not logged in" or unrelated output', () => {
+    expect(detectAlreadyLoggedIn('You are not logged in. Run /login to sign in.\n')).toBeNull();
+    expect(detectAlreadyLoggedIn('error: OAuth token exchange failed\n')).toBeNull();
+    expect(detectAlreadyLoggedIn('')).toBeNull();
   });
 });

--- a/src/lib/terminalDiagnostics.ts
+++ b/src/lib/terminalDiagnostics.ts
@@ -74,3 +74,41 @@ export function extractTerminalError(tail: string): string | null {
 export function isNodeMissingError(tail: string): boolean {
   return NODE_MISSING_PATTERN.test(stripAnsi(tail));
 }
+
+/**
+ * Identity-capturing shapes of "the CLI believes it's signed in":
+ * - "Logged in as julian@example.com" (claude / codex)
+ * - "✓ Logged in to github.com account juliangalluzzo (keyring)" and
+ *   "Logged in to github.com as juliangalluzzo" (gh, old and new phrasing)
+ */
+const LOGGED_IN_AS_PATTERNS = [
+  /\blogged in as\s+['"]?([^\s'"]+)/i,
+  /\blogged in to \S+ (?:account |as )['"]?([^\s()'"]+)/i,
+];
+
+/** "You are already logged in" and friends — no identity attached. */
+const ALREADY_LOGGED_IN_PATTERN = /\balready logged in\b/i;
+
+/**
+ * Detect the "CLI says it's already signed in" signature in an auth command's
+ * output tail. When an auth flow fails *while* the CLI insists it has a login
+ * (e.g. a partial sign-out desynced the CLI from Ship Studio's status check —
+ * issue #159), a generic "authentication not completed" message hides the real
+ * situation; callers use this to name the identity the CLI reported instead.
+ *
+ * Returns `null` when nothing matches; otherwise `{ identity }` where
+ * `identity` is the captured user/email if the output named one.
+ */
+export function detectAlreadyLoggedIn(tail: string): { identity: string | null } | null {
+  const text = toVisibleLines(tail).join('\n');
+  for (const pattern of LOGGED_IN_AS_PATTERNS) {
+    const match = pattern.exec(text);
+    if (match) {
+      // Emails contain dots, so the capture is greedy about punctuation —
+      // trim a trailing sentence period/comma ("Logged in as a@b.com.").
+      const identity = match[1].replace(/[.,;:!]+$/, '');
+      return { identity: identity.length > 0 ? identity : null };
+    }
+  }
+  return ALREADY_LOGGED_IN_PATTERN.test(text) ? { identity: null } : null;
+}


### PR DESCRIPTION
Addresses the recoverable paths of #159 ("cannot sign back into Claude; reinstall doesn't help"). The full "reset Claude auth" action (clearing Claude's own keychain entry) is deliberately out of scope — that's a separate decision.

## Why reinstall doesn't help

The state driving all three failure modes survives an app reinstall: Claude's own login (macOS keychain `Claude Code-credentials` + `~/.claude`), Ship Studio's per-workspace token vault (app keychain entries), and the isolated workspace config dirs under `~/.ship-studio/accounts/`.

## The three failure modes → fixes

**1. A dead vault token was injected into every PTY, overriding fresh logins.**
Non-default workspaces inject `CLAUDE_CODE_OAUTH_TOKEN` (captured via `claude setup-token`) into every agent terminal, and the env token takes precedence over any interactive `/login` the user performs — so once the stored token expired, re-login inside the terminal silently did nothing. `get_env_vars_for_account` now consults the stored expiry (`claude_token_expires_at`) before injecting: expired → skip the token (with a `tracing::warn`), still inject `CLAUDE_CONFIG_DIR` so the workspace stays isolated. Stored state only — no network call on the PTY-spawn hot path. Tokens the API rejected at connect time were already never persisted, so token absence covers the rejection case. The decision is a pure, unit-tested helper (`should_inject_claude_token(expires_at, now)`), also now shared by `resolve_claude_identity`'s NeedsReconnect logic.

**2. Onboarding and the dashboard disagreed about auth after a partial sign-out.**
Onboarding's `check_claude_auth_status` checked file indicators (`~/.claude/settings.json` etc.), which survive a sign-out — so the wizard said "connected" while the dashboard's `claude auth status` CLI check said "not connected". `check_claude_auth_status` now uses the same source of truth as the Agents panel: the factored `claude_cli_auth_status()` (parse unit-tested; `None` = "CLI couldn't answer" vs `Some(false)` = definitively logged out) for the Default workspace, and the vault-driven `resolve_claude_identity` for isolated workspaces. File indicators remain only as the fallback when the CLI can't answer (e.g. an older binary without `auth status`). Signature/return shape unchanged for the frontend.

**3. A generic error hid the real cause.**
Auth failures in the setup wizard hard-coded "Authentication not completed. Click to try again." They now surface the real terminal output via `extractTerminalError` (the #186 output-tail infrastructure), and when the tail shows the CLI insisting it *is* logged in ("already logged in" / "Logged in as …" / gh's "Logged in to github.com account …"), the message names the reported identity and points at the actual fix, e.g. "Claude reports you're already signed in as julian@example.com — if this looks wrong, sign out from the Agents panel first." Homebrew and node-missing special cases preserved.

## Tests

- Rust: pure-helper tests for `should_inject_claude_token` (expired / boundary / valid / no-expiry) and `parse_claude_auth_status` (definitive answers vs can't-answer); full suite 616 passed
- Frontend: `detectAlreadyLoggedIn` unit tests (claude/codex/gh phrasings, ANSI, "not logged in" non-match) + three new OnboardingScreen integration tests following the #186 pattern (extracted-error, claude already-logged-in, gh nonzero already-logged-in); 956 passed
- `typecheck`, `lint:strict`, `format:check`, `check:patterns`, `check:loc`, `cargo clippy`, `cargo fmt --check` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)