### PR TITLE
Fix v0.13.2 regression: onboarding/connect/install terminals freeze after first output chunk

### DIFF
--- a/src/components/setup/OnboardingTerminal.tsx
+++ b/src/components/setup/OnboardingTerminal.tsx
@@ -18,6 +18,7 @@ import { readDir, exists } from '@tauri-apps/plugin-fs';
 import { loadNerdFonts } from '../../lib/fonts';
 import { isWindows } from '../../lib/setup';
 import { isPasteChord, readClipboardText } from '../../lib/clipboard';
+import { createPtyChunkDecoder, toPtyBytes, type PtyChunk } from '../../lib/terminalDiagnostics';
 import { logger } from '../../lib/logger';
 import { asCommandError, formatCommandError } from '../../lib/errors';
 import '@xterm/xterm/css/xterm.css';
@@ -28,9 +29,6 @@ import '@xterm/xterm/css/xterm.css';
  * unboundedly during long-running commands.
  */
 const OUTPUT_TAIL_MAX_CHARS = 8192;
-
-/** Decodes PTY byte chunks for the diagnostics tail (output may be binary). */
-const OUTPUT_DECODER = new TextDecoder();
 
 /** Props for the OnboardingTerminal component */
 interface OnboardingTerminalProps {
@@ -298,8 +296,18 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
         // First byte from this PTY cancels the startup watchdog below.
         let receivedOutput = false;
 
-        // Handle PTY output -> terminal, keeping a bounded tail for diagnostics
-        const dataDisposable = pty.onData((data) => {
+        // Streaming decoder for the diagnostics tail — one per PTY so
+        // multi-byte characters split across chunks decode correctly.
+        const decodeChunk = createPtyChunkDecoder();
+
+        // Handle PTY output -> terminal, keeping a bounded tail for
+        // diagnostics. CRITICAL: a throw in this listener propagates into
+        // tauri-pty's internal read loop and permanently kills it — the
+        // terminal freezes after the first chunk (the v0.13.2 frozen
+        // connect/install terminal bug). Chunks arrive as plain number
+        // arrays over IPC despite the `string` typing, so everything below
+        // must normalize and must not throw.
+        const dataDisposable = pty.onData((data: PtyChunk) => {
           if (!receivedOutput) {
             receivedOutput = true;
             if (startupTimer) {
@@ -307,13 +315,20 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
               startupTimer = null;
             }
           }
-          terminalRef.current?.write(data);
-          const text = typeof data === 'string' ? data : OUTPUT_DECODER.decode(data);
-          const combined = outputTailRef.current + text;
-          outputTailRef.current =
-            combined.length > OUTPUT_TAIL_MAX_CHARS
-              ? combined.slice(-OUTPUT_TAIL_MAX_CHARS)
-              : combined;
+          try {
+            const chunk = typeof data === 'string' ? data : toPtyBytes(data);
+            terminalRef.current?.write(chunk);
+            const combined = outputTailRef.current + decodeChunk(data);
+            outputTailRef.current =
+              combined.length > OUTPUT_TAIL_MAX_CHARS
+                ? combined.slice(-OUTPUT_TAIL_MAX_CHARS)
+                : combined;
+          } catch (err) {
+            // Never let rendering/diagnostics break the read loop.
+            logger.warn('[OnboardingTerminal] Failed to process PTY chunk', {
+              error: String(err),
+            });
+          }
         });
 
         // Handle PTY exit

--- a/src/lib/tauriPtyReadLoop.test.ts
+++ b/src/lib/tauriPtyReadLoop.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression test for the v0.13.2 frozen connect/install terminal bug.
+ *
+ * tauri-pty's internal read loop (`for(;;) { data = await invoke('read');
+ * onData.fire(data) }`) fires listeners synchronously and treats ANY listener
+ * throw as a fatal read error — the loop exits and the terminal never renders
+ * another byte. Because Tauri's JSON IPC delivers the plugin's `Vec<u8>` as a
+ * plain number array (NOT a Uint8Array, despite tauri-pty's `string` typing),
+ * calling `TextDecoder.decode(data)` directly in a listener throws a
+ * TypeError on the first chunk. That's exactly what OnboardingTerminal's
+ * diagnostics tail did in v0.13.2: every onboarding/connect/install terminal
+ * froze after the first output chunk ("Starting..." forever).
+ *
+ * These tests drive the REAL tauri-pty client over mocked IPC with
+ * production-shaped payloads to pin both the failure mechanism and the fix.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mockIPC, clearMocks } from '@tauri-apps/api/mocks';
+// The global test setup replaces 'tauri-pty' with a stub (vitest alias +
+// vi.mock). This test exists precisely to exercise the REAL client's read
+// loop, so import the actual distributed module by path and re-type it with
+// the package's own declarations.
+// @ts-expect-error — untyped direct dist import; typed via the cast below
+import { spawn as spawnUntyped } from '../../node_modules/tauri-pty/dist/index.es.js';
+import { createPtyChunkDecoder, toPtyBytes, type PtyChunk } from './terminalDiagnostics';
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const spawn: typeof import('tauri-pty').spawn = spawnUntyped;
+
+const utf8 = (s: string): number[] => Array.from(new TextEncoder().encode(s));
+
+/** Queue chunks the mocked `read` command hands out one per invoke. */
+function mockPtyIpc(chunks: number[][]) {
+  let next = 0;
+  mockIPC((cmd) => {
+    switch (cmd) {
+      case 'plugin:pty|spawn':
+        return 1;
+      case 'plugin:pty|read':
+        if (next < chunks.length) return chunks[next++];
+        // No more scripted output — block like a real PTY with no data.
+        return new Promise<never>(() => {});
+      case 'plugin:pty|exitstatus':
+        // Child still running.
+        return new Promise<never>(() => {});
+      default:
+        return undefined;
+    }
+  });
+}
+
+/** Let the client's async read loop drain the scripted chunks. */
+async function flushReadLoop() {
+  for (let i = 0; i < 20; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+const CHUNKS = [utf8('\x1b[?25l\x1b[2K'), utf8('? Press Enter to open '), utf8('github.com…')];
+
+afterEach(() => {
+  clearMocks();
+  vi.restoreAllMocks();
+});
+
+describe('tauri-pty read loop vs onData listeners', () => {
+  it('DOCUMENTS THE BUG: a listener that TextDecoder.decode()s the raw chunk kills the loop after chunk 1', async () => {
+    // tauri-pty logs the listener throw as 'Reading error:' — silence it.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockPtyIpc(CHUNKS);
+
+    const received: string[] = [];
+    const decoder = new TextDecoder();
+    const pty = spawn('gh', ['auth', 'login'], {});
+    pty.onData((data) => {
+      // The exact v0.13.2 pattern: decode(plain array) throws a TypeError.
+      received.push(typeof data === 'string' ? data : decoder.decode(data));
+    });
+
+    await flushReadLoop();
+
+    // The first chunk's throw killed the read loop: chunks 2 and 3 are
+    // never delivered even though the mocked PTY has them ready.
+    expect(received).toHaveLength(0);
+    expect(consoleError).toHaveBeenCalledWith('Reading error: ', expect.any(TypeError));
+  });
+
+  it('FIXED: normalizing chunks via toPtyBytes/createPtyChunkDecoder streams every chunk', async () => {
+    mockPtyIpc(CHUNKS);
+
+    const written: Array<string | Uint8Array> = [];
+    let tail = '';
+    const decodeChunk = createPtyChunkDecoder();
+    const pty = spawn('gh', ['auth', 'login'], {});
+    pty.onData((data: PtyChunk) => {
+      // The fixed OnboardingTerminal pattern.
+      const chunk = typeof data === 'string' ? data : toPtyBytes(data);
+      written.push(chunk);
+      tail += decodeChunk(data);
+    });
+
+    await flushReadLoop();
+
+    expect(written).toHaveLength(CHUNKS.length);
+    expect(tail).toBe('\x1b[?25l\x1b[2K? Press Enter to open github.com…');
+  });
+});

--- a/src/lib/terminalDiagnostics.test.ts
+++ b/src/lib/terminalDiagnostics.test.ts
@@ -1,9 +1,58 @@
 import { describe, it, expect } from 'vitest';
 import {
+  createPtyChunkDecoder,
   detectAlreadyLoggedIn,
   extractTerminalError,
   isNodeMissingError,
+  toPtyBytes,
 } from './terminalDiagnostics';
+
+const utf8 = (s: string): number[] => Array.from(new TextEncoder().encode(s));
+
+describe('toPtyBytes', () => {
+  it('passes Uint8Array through unchanged', () => {
+    const input = new Uint8Array([104, 105]);
+    expect(toPtyBytes(input)).toBe(input);
+  });
+
+  it('wraps a plain number array (the real Tauri IPC shape for Vec<u8>)', () => {
+    const result = toPtyBytes([104, 105]);
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(Array.from(result)).toEqual([104, 105]);
+  });
+
+  it('wraps an ArrayBuffer', () => {
+    const result = toPtyBytes(new Uint8Array([104, 105]).buffer);
+    expect(Array.from(result)).toEqual([104, 105]);
+  });
+});
+
+describe('createPtyChunkDecoder', () => {
+  it('decodes plain number arrays without throwing (v0.13.2 frozen-terminal regression)', () => {
+    const decode = createPtyChunkDecoder();
+    // TextDecoder.decode() throws a TypeError on plain arrays — the old code
+    // did exactly that inside onData, killing tauri-pty's read loop.
+    expect(decode(utf8('Checking for `sudo` access...'))).toBe('Checking for `sudo` access...');
+  });
+
+  it('passes strings through', () => {
+    const decode = createPtyChunkDecoder();
+    expect(decode('hello')).toBe('hello');
+  });
+
+  it('preserves multi-byte characters split across chunk boundaries', () => {
+    const decode = createPtyChunkDecoder();
+    const encoded = utf8('✓ done');
+    // '✓' is 3 bytes — split it mid-character across two chunks.
+    expect(decode(encoded.slice(0, 2)) + decode(encoded.slice(2))).toBe('✓ done');
+  });
+
+  it('never throws, even on garbage input', () => {
+    const decode = createPtyChunkDecoder();
+    expect(() => decode({} as never)).not.toThrow();
+    expect(decode({} as never)).toBe('');
+  });
+});
 
 describe('extractTerminalError', () => {
   it('returns null for an empty tail', () => {

--- a/src/lib/terminalDiagnostics.ts
+++ b/src/lib/terminalDiagnostics.ts
@@ -12,6 +12,42 @@
 
 import { stripAnsi } from './ansi';
 
+/**
+ * Raw PTY chunk shapes seen at runtime. tauri-pty's types claim `string`, but
+ * the plugin's `read` command returns `Vec<u8>`, which Tauri's JSON IPC
+ * delivers as a **plain number array** — not a Uint8Array. Passing that
+ * array straight to `TextDecoder.decode()` throws a TypeError, and a throw
+ * inside an onData listener propagates into tauri-pty's internal read loop
+ * and kills it — the terminal freezes after the first chunk (the v0.13.2
+ * frozen connect/install terminal regression).
+ */
+export type PtyChunk = string | Uint8Array | ArrayBuffer | number[];
+
+/** Normalize any raw PTY chunk shape to Uint8Array (strings pass through). */
+export function toPtyBytes(data: Exclude<PtyChunk, string>): Uint8Array {
+  if (data instanceof Uint8Array) return data;
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  return new Uint8Array(data);
+}
+
+/**
+ * Create a streaming PTY chunk decoder. Returns a function that converts any
+ * chunk shape to text, preserving multi-byte characters split across chunk
+ * boundaries, and never throws — diagnostics must never be able to break the
+ * output stream (a throw here is exactly what froze terminals in v0.13.2).
+ */
+export function createPtyChunkDecoder(): (data: PtyChunk) => string {
+  const decoder = new TextDecoder();
+  return (data: PtyChunk): string => {
+    if (typeof data === 'string') return data;
+    try {
+      return decoder.decode(toPtyBytes(data), { stream: true });
+    } catch {
+      return '';
+    }
+  };
+}
+
 /** Lines that look like they describe the failure. */
 const ERROR_LINE_PATTERN = /error|not recognized|not found|EACCES|EPERM|EEXIST|ENOENT|npm ERR!/i;
 


### PR DESCRIPTION
## The bug (v0.13.2 regression — live user reports today)

Yotam, Lukas, Magnus, Ryan (#users, GitHub/Vercel/Cursor connect stuck at "Starting...") and Gabriel (Homebrew install frozen before the sudo password prompt) are all the same defect.

The v0.13.2 diagnostics tail (from the #180/#186 merge) does `OUTPUT_DECODER.decode(data)` inside `pty.onData`. `tauri-pty` delivers chunks as **plain number arrays** over Tauri's JSON IPC (its `Uint8Array` typing is a lie — `src/lib/project.ts` even documents this and converts correctly), and `TextDecoder.decode()` throws a `TypeError` on plain arrays. `tauri-pty` fires listeners synchronously inside its internal `for(;;)` read loop and treats any listener throw as a fatal read error — **the loop exits permanently**. Net effect: every onboarding/connect/install terminal renders at most its first chunk (often invisible ANSI init codes) and then freezes forever. Keystrokes still reach the process — the user just can't see anything, which is why Gabriel "typed his password but nothing happened."

The startup watchdog doesn't fire because output *was* technically received.

## The fix

- `terminalDiagnostics.ts`: `toPtyBytes()` + `createPtyChunkDecoder()` — normalize any chunk shape (string / number[] / Uint8Array / ArrayBuffer), streaming decode that preserves multi-byte chars split across chunks, and **never throws**.
- `OnboardingTerminal.tsx`: use the helpers, normalize bytes before `term.write()`, and wrap the whole listener body in try/catch — diagnostics can never kill the output stream again.

## Verification

- New regression test (`src/lib/tauriPtyReadLoop.test.ts`) drives the **real** `tauri-pty` client over mocked IPC with production-shaped payloads: proves the old listener pattern kills the read loop after chunk 1 (`Reading error: TypeError`), and the fixed pattern streams every chunk.
- 6 new unit tests for the helpers (number[], Uint8Array, ArrayBuffer, split multi-byte, garbage input).
- Full suite: 1062 passed. Typecheck, lint:strict, check:patterns clean.

Fixes the frozen-terminal reports in #users today; ship as v0.13.3 hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal output handling so PTY data continues streaming reliably instead of freezing after the first chunk.
  * Better support for terminal content that arrives in different raw formats, including byte arrays and mixed encoded chunks.
  * Terminal diagnostics now handle decoding errors safely, preventing unexpected interruptions and preserving more of the output tail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->