### PR TITLE
Onboarding terminals: fail fast and loud instead of hanging silently

### DIFF
--- a/src-tauri/plugins/tauri-plugin-pty/src/lib.rs
+++ b/src-tauri/plugins/tauri-plugin-pty/src/lib.rs
@@ -77,7 +77,7 @@ async fn spawn<R: Runtime>(
     let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
     let reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
 
-    let mut cmd = CommandBuilder::new(file);
+    let mut cmd = CommandBuilder::new(&file);
     cmd.args(args);
     if let Some(cwd) = cwd {
         cmd.cwd(OsString::from(cwd));
@@ -85,7 +85,12 @@ async fn spawn<R: Runtime>(
     for (k, v) in env.iter() {
         cmd.env(OsString::from(k), OsString::from(v));
     }
-    let child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
+    // Name the binary in the error — this string is what the frontend shows
+    // when a spawn fails (e.g. binary missing from the PTY's PATH).
+    let child = pair
+        .slave
+        .spawn_command(cmd)
+        .map_err(|e| format!("Failed to start `{file}`: {e}"))?;
     let child_killer = child.clone_killer();
     let handler = state.session_id.fetch_add(1, Ordering::Relaxed);
 
@@ -138,11 +143,20 @@ async fn read(pid: PtyHandler, state: tauri::State<'_, PluginState>) -> Result<V
         .clone();
     tokio::task::spawn_blocking(move || {
         let mut buf = vec![0u8; 4096];
-        let n = session
-            .reader
-            .blocking_lock()
-            .read(&mut buf)
-            .map_err(|e| e.to_string())?;
+        let mut reader = session.reader.blocking_lock();
+        let n = loop {
+            match reader.read(&mut buf) {
+                Ok(n) => break n,
+                // A signal delivered to the process (e.g. SIGCHLD from any
+                // other exiting subprocess) can interrupt the blocking read.
+                // The frontend's read loop treats ANY error as fatal and
+                // stops reading forever, so a transient EINTR must be
+                // retried here — otherwise one stray signal permanently
+                // freezes the terminal mid-session.
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e.to_string()),
+            }
+        };
         if n == 0 {
             // n == 0 on a blocking read means the PTY master side saw
             // the slave close (child process exited). Signal EOF so the

--- a/src-tauri/src/commands/setup/status.rs
+++ b/src-tauri/src/commands/setup/status.rs
@@ -10,6 +10,7 @@ use crate::commands::accounts::{
 };
 use crate::commands::claude::find_binary_by_name;
 use crate::commands::github::get_gh_command;
+use crate::errors::CommandError;
 use crate::types::{FullSetupStatus, OptionalAuths, SetupItemInfo, SetupItemStatus};
 use crate::utils::{create_command, find_executable};
 
@@ -602,5 +603,89 @@ pub async fn quick_setup_check() -> crate::types::QuickSetupCheck {
     crate::types::QuickSetupCheck {
         all_present,
         setup_complete_cached: true,
+    }
+}
+
+/// A CLI binary resolved on the backend's extended PATH.
+///
+/// Returned by [`resolve_cli_path`] so the frontend can (a) fail fast with a
+/// clear message when a binary is missing instead of spawning a PTY that
+/// silently produces nothing, and (b) add the binary's directory to the PTY's
+/// PATH so the spawn sees the same binary the status checks saw. The install
+/// status checks (`find_executable`) search the user's login-shell PATH plus
+/// common install locations — the frontend's hand-built PTY PATH is a subset,
+/// so "installed ✓ but Connect hangs" was possible whenever a tool lived in a
+/// nonstandard prefix (MacPorts, custom Homebrew, portable installs).
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedCli {
+    /// Absolute path to the resolved binary.
+    pub path: String,
+    /// Directory containing the binary — for appending to a PTY PATH.
+    pub dir: String,
+}
+
+/// Resolve a CLI binary name to an absolute path using the same discovery the
+/// setup status checks use. Returns `Ok(None)` when the binary genuinely
+/// isn't installed anywhere we know how to look.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn resolve_cli_path(name: String) -> Result<Option<ResolvedCli>, CommandError> {
+    // Bare command names only — reject separators/metacharacters so this can
+    // never be used to probe arbitrary filesystem paths from the frontend.
+    let valid = !name.is_empty()
+        && name.len() <= 64
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'));
+    if !valid {
+        return Err(CommandError::Validation {
+            field: "name".to_string(),
+            reason: "must be a bare command name".to_string(),
+        });
+    }
+
+    Ok(find_executable(&name).map(|path| {
+        let dir = path
+            .parent()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default();
+        ResolvedCli {
+            path: path.to_string_lossy().to_string(),
+            dir,
+        }
+    }))
+}
+
+#[cfg(test)]
+mod resolve_cli_tests {
+    use super::resolve_cli_path;
+
+    #[tokio::test]
+    async fn resolves_a_ubiquitous_binary() {
+        // `ls` exists on every Unix; `cmd` on every Windows.
+        let name = if cfg!(windows) { "cmd" } else { "ls" };
+        let resolved = resolve_cli_path(name.to_string()).await.unwrap();
+        let resolved = resolved.expect("binary should resolve");
+        assert!(!resolved.path.is_empty());
+        assert!(!resolved.dir.is_empty());
+    }
+
+    #[tokio::test]
+    async fn returns_none_for_missing_binary() {
+        let resolved = resolve_cli_path("definitely-not-a-real-cli-98765".to_string())
+            .await
+            .unwrap();
+        assert!(resolved.is_none());
+    }
+
+    #[tokio::test]
+    async fn rejects_paths_and_metacharacters() {
+        for bad in ["/bin/ls", "..\\cmd", "a b", "x;y", "", "ls\n"] {
+            assert!(
+                resolve_cli_path(bad.to_string()).await.is_err(),
+                "should reject {bad:?}"
+            );
+        }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -619,6 +619,7 @@ pub fn run() {
             commands::templates::download_template_zip,
             // Setup/Onboarding
             commands::setup::get_full_setup_status,
+            commands::setup::resolve_cli_path,
             commands::setup::install_homebrew,
             commands::setup::install_node_via_brew,
             commands::setup::install_git_via_brew,

--- a/src/components/setup/OnboardingTerminal.tsx
+++ b/src/components/setup/OnboardingTerminal.tsx
@@ -11,12 +11,12 @@ import { Terminal as XTerm } from '@xterm/xterm';
 import { createWebLinksAddon } from '../../lib/terminalLinks';
 import { FitAddon } from '@xterm/addon-fit';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
-import { spawn, IPty } from 'tauri-pty';
+import { spawnOnboardingPty, OnboardingPty } from '../../lib/onboardingPty';
 import { homeDir } from '@tauri-apps/api/path';
-import { getSystemEnv } from '../../lib/project';
+import { getSystemEnv, getShellPath } from '../../lib/project';
 import { readDir, exists } from '@tauri-apps/plugin-fs';
 import { loadNerdFonts } from '../../lib/fonts';
-import { isWindows } from '../../lib/setup';
+import { isWindows, resolveCliPath, ResolvedCli } from '../../lib/setup';
 import { isPasteChord, readClipboardText } from '../../lib/clipboard';
 import { createPtyChunkDecoder, toPtyBytes, type PtyChunk } from '../../lib/terminalDiagnostics';
 import { logger } from '../../lib/logger';
@@ -50,7 +50,7 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
-  const ptyRef = useRef<IPty | null>(null);
+  const ptyRef = useRef<OnboardingPty | null>(null);
   // Bounded tail of raw PTY output, handed to onExit for failure diagnostics.
   const outputTailRef = useRef('');
   const [isReady, setIsReady] = useState(false);
@@ -181,6 +181,20 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
         let spawnCmd: string;
         let spawnArgs: string[];
 
+        // The backend's extended PATH is the authority: it queries the user's
+        // login shell and knows version-manager layouts (asdf/volta/fnm/nvm,
+        // incl. the Windows fnm_multishells + nvm-windows symlink dirs). The
+        // hand-built lists below stay as a fallback/supplement, but without
+        // this the install/auth status checks (which use the backend PATH)
+        // could say "installed ✓" for a binary this PTY then can't see.
+        const backendPath = await getShellPath().catch((err: unknown) => {
+          logger.warn('[OnboardingTerminal] getShellPath failed — using fallback PATH', {
+            error: String(err),
+          });
+          return '';
+        });
+        if (!mounted) return;
+
         if (isWin) {
           // Windows: get system env vars from backend and build Windows-compatible env
           const systemEnv = await getSystemEnv();
@@ -208,7 +222,9 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
           ];
 
           const systemPath = systemEnv['PATH'] || '';
-          const fullPath = `${extraPaths.join(';')};${systemPath}`;
+          const fullPath = [extraPaths.join(';'), systemPath, backendPath]
+            .filter((part) => part.length > 0)
+            .join(';');
 
           env = {
             ...systemEnv,
@@ -249,7 +265,9 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
           }
 
           const systemPaths = '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin';
-          const fullPath = `${userPaths.join(':')}:${systemPaths}`;
+          const fullPath = [userPaths.join(':'), systemPaths, backendPath]
+            .filter((part) => part.length > 0)
+            .join(':');
 
           // Onboarding always runs in the Default workspace, which maps to the
           // global config dirs the CLIs use by default (~/.claude, ~/.config/gh,
@@ -274,10 +292,55 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
         env.INIT_CWD = homePath;
         env.PNPM_SCRIPT_SRC_DIR = homePath;
 
-        // Spawn PTY using tauri-pty
-        // Must pass all essential env vars since env replaces (not merges with) parent environment
-        // eslint-disable-next-line @typescript-eslint/await-thenable
-        const pty = await spawn(spawnCmd, spawnArgs, {
+        // Fail fast on a missing binary. Bare command names are resolved on
+        // the backend (same discovery the status checks use); a definitive
+        // "not installed" gets an instant, plain-English message instead of a
+        // PTY that spawns nothing and hangs. Resolution errors fail OPEN —
+        // the spawn proceeds and the watchdog below stays the backstop.
+        const isBareName = !command.includes('/') && !command.includes('\\');
+        if (isBareName) {
+          let resolved: ResolvedCli | null | undefined;
+          try {
+            resolved = await resolveCliPath(command);
+          } catch (err) {
+            logger.warn('[OnboardingTerminal] resolveCliPath failed — spawning anyway', {
+              command,
+              error: String(err),
+            });
+            resolved = undefined;
+          }
+          if (!mounted) return;
+          if (resolved === null) {
+            const message = `${command}: not found — it doesn't appear to be installed on this computer.`;
+            logger.warn('[OnboardingTerminal] Binary not found — skipping spawn', { command });
+            terminalRef.current?.write(
+              `\r\n\x1b[31m${message}\x1b[0m\r\n` +
+                `\x1b[33mClose this window and install ${command} first — the setup checklist can do that for you.\x1b[0m\r\n`
+            );
+            setTimeout(() => onExitRef.current(1, message), 1000);
+            return;
+          }
+          if (resolved) {
+            // Make the PTY see the exact binary the status checks found,
+            // even when it lives in a prefix the PATH above doesn't cover.
+            const pathSep = isWin ? ';' : ':';
+            if (!env.PATH.split(pathSep).includes(resolved.dir)) {
+              env.PATH = `${env.PATH}${pathSep}${resolved.dir}`;
+            }
+            if (!isWin) {
+              // Spawn the resolved absolute path — deterministic, no PATH
+              // shadowing. (Windows keeps the cmd.exe /C wrapper: .cmd shims
+              // need it, and quoting paths with spaces through cmd is riskier
+              // than the PATH append above.)
+              spawnCmd = resolved.path;
+            }
+          }
+        }
+
+        // Spawn the PTY. This rejects with the backend's real error (e.g.
+        // "Failed to start `gh`: No such file or directory") — caught below.
+        // The env replaces (not merges with) the parent environment.
+        const pty = await spawnOnboardingPty(spawnCmd, spawnArgs, {
           cwd: homePath,
           cols: term.cols,
           rows: term.rows,
@@ -301,12 +364,11 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
         const decodeChunk = createPtyChunkDecoder();
 
         // Handle PTY output -> terminal, keeping a bounded tail for
-        // diagnostics. CRITICAL: a throw in this listener propagates into
-        // tauri-pty's internal read loop and permanently kills it — the
-        // terminal freezes after the first chunk (the v0.13.2 frozen
-        // connect/install terminal bug). Chunks arrive as plain number
-        // arrays over IPC despite the `string` typing, so everything below
-        // must normalize and must not throw.
+        // diagnostics. Chunks arrive as plain number arrays over IPC, so
+        // everything below must normalize. The client tolerates listener
+        // throws (unlike tauri-pty, where one throw froze the terminal — the
+        // v0.13.2 bug), but stay defensive: diagnostics must never cost
+        // output.
         const dataDisposable = pty.onData((data: PtyChunk) => {
           if (!receivedOutput) {
             receivedOutput = true;
@@ -338,6 +400,15 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
             startupTimer = null;
           }
           onExitRef.current(exitCode, outputTailRef.current);
+        });
+
+        // Output stream died mid-session (rare, post-retries). Say so
+        // instead of freezing silently — the process may still be running.
+        pty.onStreamError(() => {
+          terminalRef.current?.write(
+            '\r\n\x1b[33mOutput stream interrupted — the command may still be running. ' +
+              'If nothing else appears, close this window and try again.\x1b[0m\r\n'
+          );
         });
 
         // Startup watchdog: a first PTY spawn can wedge and emit nothing

--- a/src/lib/onboardingPty.test.ts
+++ b/src/lib/onboardingPty.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for the onboarding PTY client's failure-mode guarantees — each one
+ * inverts a silent-failure behavior of the npm tauri-pty client it replaced:
+ * spawn rejects loudly, listener throws can't kill the stream, transient read
+ * errors retry, and an exit event always fires (unless the caller killed).
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mockIPC, clearMocks } from '@tauri-apps/api/mocks';
+import { spawnOnboardingPty } from './onboardingPty';
+
+const utf8 = (s: string): number[] => Array.from(new TextEncoder().encode(s));
+
+const OPTS = { cwd: '/home/user', cols: 80, rows: 24, env: { PATH: '/usr/bin' } };
+
+/** Let the client's async loops drain. */
+async function flush(rounds = 30) {
+  for (let i = 0; i < rounds; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+interface PtyIpcScript {
+  /** Values (or thrown errors) the read command yields, in order. */
+  reads: Array<number[] | Error>;
+  /** What exitstatus resolves to; an Error rejects. Default: never settles. */
+  exit?: number | Error;
+}
+
+function mockPtyIpc(script: PtyIpcScript) {
+  let next = 0;
+  mockIPC((cmd) => {
+    switch (cmd) {
+      case 'plugin:pty|spawn':
+        return 7;
+      case 'plugin:pty|read': {
+        if (next < script.reads.length) {
+          const step = script.reads[next++];
+          if (step instanceof Error) throw step;
+          return step;
+        }
+        return new Promise<never>(() => {});
+      }
+      case 'plugin:pty|exitstatus':
+        if (script.exit === undefined) return new Promise<never>(() => {});
+        if (script.exit instanceof Error) throw script.exit;
+        return script.exit;
+      default:
+        return undefined;
+    }
+  });
+}
+
+afterEach(() => {
+  clearMocks();
+  vi.restoreAllMocks();
+});
+
+describe('spawnOnboardingPty', () => {
+  it('rejects when the backend spawn fails (tauri-pty swallowed this)', async () => {
+    mockIPC((cmd) => {
+      if (cmd === 'plugin:pty|spawn') throw new Error('Failed to start `gh`: No such file');
+      return undefined;
+    });
+    await expect(spawnOnboardingPty('gh', [], OPTS)).rejects.toThrow('Failed to start `gh`');
+  });
+
+  it('keeps streaming when an onData listener throws', async () => {
+    mockPtyIpc({ reads: [utf8('one'), utf8('two'), utf8('three')] });
+    const pty = await spawnOnboardingPty('gh', [], OPTS);
+    const seen: unknown[] = [];
+    pty.onData((data) => {
+      seen.push(data);
+      throw new Error('listener bug');
+    });
+    await flush();
+    expect(seen).toHaveLength(3);
+  });
+
+  it('retries transient read errors instead of dying', async () => {
+    mockPtyIpc({ reads: [utf8('a'), new Error('transient glitch'), utf8('b')] });
+    const pty = await spawnOnboardingPty('gh', [], OPTS);
+    const seen: unknown[] = [];
+    pty.onData((data) => seen.push(data));
+    await flush(60);
+    expect(seen).toHaveLength(2);
+  });
+
+  it('stops on EOF without reporting a stream error', async () => {
+    mockPtyIpc({ reads: [utf8('bye'), new Error('EOF')] });
+    const pty = await spawnOnboardingPty('gh', [], OPTS);
+    const streamErrors: string[] = [];
+    pty.onStreamError((message) => streamErrors.push(message));
+    await flush();
+    expect(streamErrors).toHaveLength(0);
+  });
+
+  it('reports a stream error after persistent read failures', async () => {
+    mockPtyIpc({
+      reads: [new Error('boom'), new Error('boom'), new Error('boom'), new Error('boom')],
+    });
+    const pty = await spawnOnboardingPty('gh', [], OPTS);
+    const streamErrors: string[] = [];
+    pty.onStreamError((message) => streamErrors.push(message));
+    // Retry backoff totals ~600ms before the error is declared persistent.
+    await flush(200);
+    expect(streamErrors).toHaveLength(1);
+  });
+
+  it('fires onExit with the real exit code', async () => {
+    mockPtyIpc({ reads: [new Error('EOF')], exit: 3 });
+    const pty = await spawnOnboardingPty('gh', [], OPTS);
+    const exits: Array<number | null> = [];
+    pty.onExit(({ exitCode }) => exits.push(exitCode));
+    await flush();
+    expect(exits).toEqual([3]);
+  });
+
+  it('still fires onExit (as failure) when exitstatus rejects — tauri-pty hung forever here', async () => {
+    mockPtyIpc({ reads: [new Error('EOF')], exit: new Error('Unavaliable pid') });
+    const pty = await spawnOnboardingPty('gh', [], OPTS);
+    const exits: Array<number | null> = [];
+    pty.onExit(({ exitCode }) => exits.push(exitCode));
+    await flush();
+    expect(exits).toEqual([1]);
+  });
+
+  it('does not fire onExit after the caller killed the session', async () => {
+    mockPtyIpc({ reads: [], exit: new Error('Unavaliable pid') });
+    const pty = await spawnOnboardingPty('gh', [], OPTS);
+    const exits: Array<number | null> = [];
+    pty.onExit(({ exitCode }) => exits.push(exitCode));
+    pty.kill();
+    await flush();
+    expect(exits).toHaveLength(0);
+  });
+
+  it('treats a null chunk (broken bridge / bare mock) as end-of-stream instead of spinning', async () => {
+    let readCalls = 0;
+    mockIPC((cmd) => {
+      if (cmd === 'plugin:pty|spawn') return 7;
+      if (cmd === 'plugin:pty|read') {
+        readCalls += 1;
+        return undefined;
+      }
+      return undefined;
+    });
+    const pty = await spawnOnboardingPty('gh', [], OPTS);
+    pty.onData(() => {});
+    await flush();
+    expect(readCalls).toBe(1);
+  });
+});

--- a/src/lib/onboardingPty.ts
+++ b/src/lib/onboardingPty.ts
@@ -1,0 +1,200 @@
+/**
+ * Minimal PTY client for onboarding/connect/install terminals.
+ *
+ * Replaces the npm `tauri-pty` client for OnboardingTerminal because that
+ * client structurally swallows failures (the root of the "Starting..."
+ * forever bug class):
+ *   - `spawn()` returns synchronously; a backend spawn error (binary missing,
+ *     PTY open failure) rejects an internal promise nobody can observe.
+ *   - its read loop treats ANY listener throw or read error as fatal and
+ *     exits silently — output freezes with no signal to the UI.
+ *   - if the `exitstatus` invoke rejects, `onExit` never fires — the modal
+ *     hangs open with no way to auto-advance.
+ *
+ * This client talks to the same vendored Rust plugin (`plugin:pty|*`) with
+ * inverted guarantees: spawn REJECTS on failure, listener throws can never
+ * kill the read loop, transient read errors are retried, and exactly one
+ * exit event always fires unless the caller itself killed the session.
+ *
+ * @module lib/onboardingPty
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+import { logger } from './logger';
+import type { PtyChunk } from './terminalDiagnostics';
+
+/** Options for {@link spawnOnboardingPty}. */
+export interface OnboardingPtyOptions {
+  cwd: string;
+  cols: number;
+  rows: number;
+  /** Full replacement environment (the plugin does not merge with the app's). */
+  env: Record<string, string>;
+}
+
+/** A disposable event subscription (parity with tauri-pty/xterm). */
+export interface Disposable {
+  dispose(): void;
+}
+
+/** Handle to a live onboarding PTY session. */
+export interface OnboardingPty {
+  /** Raw output chunks. Listener errors are logged, never fatal. */
+  onData(listener: (data: PtyChunk) => void): Disposable;
+  /**
+   * Process exit. Fires exactly once — with the real exit code when the
+   * backend reports one, or `1` if the session died in a way the backend
+   * couldn't report (so callers can never hang waiting). Does not fire when
+   * the caller itself called {@link kill}.
+   */
+  onExit(listener: (event: { exitCode: number | null }) => void): Disposable;
+  /**
+   * Output-stream failure after retries (rare). The process may still be
+   * running; callers should tell the user instead of freezing silently.
+   */
+  onStreamError(listener: (message: string) => void): Disposable;
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  kill(): void;
+}
+
+/** Consecutive read failures tolerated (with backoff) before giving up. */
+const MAX_READ_RETRIES = 3;
+/** Delay between read retries. */
+const READ_RETRY_DELAY_MS = 100;
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function addListener<T>(listeners: Set<T>, listener: T): Disposable {
+  listeners.add(listener);
+  return { dispose: () => listeners.delete(listener) };
+}
+
+/**
+ * Spawn a command in a backend PTY. Rejects with the backend's error when the
+ * spawn fails (e.g. "Failed to start `gh`: No such file or directory") — the
+ * caller can show a real message instead of a terminal that never speaks.
+ */
+export async function spawnOnboardingPty(
+  file: string,
+  args: string[],
+  options: OnboardingPtyOptions
+): Promise<OnboardingPty> {
+  // Throws on backend failure — this await is the entire point.
+  const pid = await invoke<number>('plugin:pty|spawn', {
+    file,
+    args,
+    termName: 'Terminal',
+    cols: options.cols,
+    rows: options.rows,
+    cwd: options.cwd,
+    env: options.env,
+    encoding: null,
+    handleFlowControl: null,
+    flowControlPause: null,
+    flowControlResume: null,
+  });
+
+  const dataListeners = new Set<(data: PtyChunk) => void>();
+  const exitListeners = new Set<(event: { exitCode: number | null }) => void>();
+  const streamErrorListeners = new Set<(message: string) => void>();
+  let killed = false;
+  let exitFired = false;
+
+  const fireExit = (exitCode: number | null) => {
+    if (exitFired || killed) return;
+    exitFired = true;
+    for (const listener of exitListeners) {
+      try {
+        listener({ exitCode });
+      } catch (err) {
+        logger.warn('[onboardingPty] onExit listener threw', { error: String(err) });
+      }
+    }
+  };
+
+  const readLoop = async () => {
+    let consecutiveErrors = 0;
+    for (;;) {
+      if (killed || exitFired) return;
+      let data: PtyChunk | null | undefined;
+      try {
+        data = await invoke<PtyChunk>('plugin:pty|read', { pid });
+      } catch (err) {
+        const message = String(err);
+        // Backend signals EOF when the child exits or the session is gone.
+        if (message.includes('EOF')) return;
+        consecutiveErrors += 1;
+        if (consecutiveErrors <= MAX_READ_RETRIES) {
+          await delay(READ_RETRY_DELAY_MS * consecutiveErrors);
+          continue;
+        }
+        logger.error('[onboardingPty] read loop failed after retries', { pid, error: message });
+        for (const listener of streamErrorListeners) {
+          try {
+            listener(message);
+          } catch {
+            // Listener errors must never propagate.
+          }
+        }
+        return;
+      }
+      consecutiveErrors = 0;
+      // A null/undefined chunk means a broken bridge (or a test mock) — treat
+      // as end-of-stream rather than spinning on empty reads.
+      if (data == null) return;
+      for (const listener of dataListeners) {
+        try {
+          listener(data);
+        } catch (err) {
+          // A listener throw must NEVER kill the read loop (the v0.13.2
+          // frozen-terminal bug was exactly this, inside tauri-pty).
+          logger.warn('[onboardingPty] onData listener threw', { error: String(err) });
+        }
+      }
+    }
+  };
+
+  const waitLoop = async () => {
+    try {
+      const exitCode = await invoke<number>('plugin:pty|exitstatus', { pid });
+      fireExit(exitCode);
+    } catch (err) {
+      // The backend couldn't report an exit status (session torn down in a
+      // race, IPC failure). Callers must still get an exit event — a hung
+      // "Cancel"-only modal is worse than a generic failure code.
+      if (!killed) {
+        logger.warn('[onboardingPty] exitstatus failed — reporting generic failure', {
+          pid,
+          error: String(err),
+        });
+      }
+      fireExit(1);
+    }
+  };
+
+  void readLoop();
+  void waitLoop();
+
+  return {
+    onData: (listener) => addListener(dataListeners, listener),
+    onExit: (listener) => addListener(exitListeners, listener),
+    onStreamError: (listener) => addListener(streamErrorListeners, listener),
+    write: (data: string) => {
+      invoke('plugin:pty|write', { pid, data }).catch((err: unknown) => {
+        logger.warn('[onboardingPty] write failed', { pid, error: String(err) });
+      });
+    },
+    resize: (cols: number, rows: number) => {
+      invoke('plugin:pty|resize', { pid, cols, rows }).catch((err: unknown) => {
+        logger.warn('[onboardingPty] resize failed', { pid, error: String(err) });
+      });
+    },
+    kill: () => {
+      killed = true;
+      invoke('plugin:pty|kill', { pid }).catch(() => {
+        // Session already gone — that's the goal.
+      });
+    },
+  };
+}

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -476,6 +476,26 @@ export async function getFullSetupStatus(): Promise<FullSetupStatus> {
   return invoke<FullSetupStatus>('get_full_setup_status');
 }
 
+/** A CLI binary resolved on the backend's extended PATH. */
+export interface ResolvedCli {
+  /** Absolute path to the binary. */
+  path: string;
+  /** Directory containing the binary — for appending to a PTY PATH. */
+  dir: string;
+}
+
+/**
+ * Resolve a bare CLI name (e.g. "gh", "vercel") to an absolute path using the
+ * same discovery the setup status checks use (login-shell PATH + common
+ * install locations). Returns `null` when the binary isn't installed.
+ * Terminal spawns use this to fail fast with a clear message instead of
+ * launching a PTY that silently produces nothing, and to make the PTY see the
+ * exact binary the status checks saw.
+ */
+export async function resolveCliPath(name: string): Promise<ResolvedCli | null> {
+  return invoke<ResolvedCli | null>('resolve_cli_path', { name });
+}
+
 /**
  * Start GitHub authentication flow (opens browser).
  * Returns a message to display to the user.


### PR DESCRIPTION
Part 1 of the installation-robustness pass (audit-driven). Kills the structural causes of the "Starting..." silent-hang class:

## Changes

1. **New `src/lib/onboardingPty.ts`** — replaces the npm `tauri-pty` client for OnboardingTerminal, with inverted failure guarantees:
   - `spawn()` **rejects** with the backend's real error (was: swallowed → silent hang until watchdog)
   - a throwing `onData` listener can never kill the read loop (the v0.13.2 freeze mechanism)
   - transient read errors retry with backoff, persistent ones surface a visible warning instead of freezing
   - exactly one exit event always fires, even when `exitstatus` fails (was: modal hung open forever with no way to advance — audit finding #2)
2. **`resolve_cli_path` backend command** + pre-spawn resolution: a missing binary gets an instant plain-English message; a found binary's dir joins the PTY PATH and (macOS) is spawned by absolute path — the PTY always sees the exact binary the checklist verified.
3. **PATH unification (audit finding #1, the top setup-blocker)**: the PTY env now includes the backend's extended login-shell PATH via `get_shell_path` on both platforms. Version-manager users (asdf/volta/fnm/nvm, incl. Windows `fnm_multishells` and nvm-windows) no longer pass the Node check and then fail agent installs with `npm: command not found`.
4. **Plugin hardening**: `read` retries EINTR (one stray SIGCHLD could permanently freeze a stream); spawn errors name the binary.

## Verification
- 9 new tests for the client's guarantees (spawn rejection, throw-tolerant streaming, retry, EOF vs stream-error, exit-always-fires, kill suppression, null-chunk guard)
- 3 new Rust tests for `resolve_cli_path` (resolves, returns None, rejects path/metacharacter probing)
- Full suite: 1071 passed; typecheck, lint:strict clean; cargo fmt/clippy clean
- Fail-open design: if `resolve_cli_path` or `get_shell_path` errors, the spawn proceeds exactly as before and the existing watchdog remains the backstop

Part 2 (wizard-flow robustness: post-install verification, staggered auth re-check, npm --force parity on mac, guards) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)