### PR TITLE
Sitewide error messages: always show the real error, and make it readable/copyable

### DIFF
--- a/src-tauri/src/commands/assets.rs
+++ b/src-tauri/src/commands/assets.rs
@@ -62,7 +62,7 @@ fn validate_asset_path(root_dir: &Path, asset_path: &str) -> Result<PathBuf, Str
         // For non-existent paths, verify parent exists and is within the root
         let parent = full_path
             .parent()
-            .ok_or("Invalid path: no parent directory")?;
+            .ok_or_else(|| format!("Invalid path {}: no parent directory", full_path.display()))?;
         if !parent.exists() {
             return Err("Parent directory does not exist".to_string());
         }
@@ -98,7 +98,13 @@ fn path_to_asset(path: &PathBuf, root_dir: &PathBuf) -> Result<Asset, String> {
     let relative_path = normalize_separators(
         &path
             .strip_prefix(root_dir)
-            .map_err(|_| "Failed to get relative path")?
+            .map_err(|e| {
+                format!(
+                    "Failed to get path of {} relative to assets root {}: {e}",
+                    path.display(),
+                    root_dir.display()
+                )
+            })?
             .to_string_lossy(),
     );
 

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -874,7 +874,9 @@ pub async fn delete_project(path: String) -> Result<(), CommandError> {
     // below can't be defeated by a lexical path like `~/ShipStudio/../../.ssh`.
     // `Path::starts_with` is purely lexical and would otherwise pass such a path
     // straight through to `remove_dir_all`.
-    let canonical = dunce::canonicalize(&path).map_err(|_| "Project not found".to_string())?;
+    let canonical = dunce::canonicalize(&path).map_err(|e| CommandError::Io {
+        message: format!("Couldn't resolve project path {path}: {e}"),
+    })?;
 
     // Check if this is an external project
     if crate::commands::external_projects::is_registered_external_path(&canonical)? {
@@ -1014,8 +1016,9 @@ pub async fn rename_project(
     // lexical, so checking the raw `old_path` would let `~/ShipStudio/../../foo`
     // escape the sandbox and rename arbitrary directories. State stores are
     // still keyed by the original `old_path` string the frontend passed.
-    let project_path =
-        dunce::canonicalize(&old_path).map_err(|_| "Project not found".to_string())?;
+    let project_path = dunce::canonicalize(&old_path).map_err(|e| CommandError::Io {
+        message: format!("Couldn't resolve project path {old_path}: {e}"),
+    })?;
     let project_path = project_path.as_path();
 
     // Reject external projects (their folders live outside ~/ShipStudio).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,8 +68,9 @@ import {
 } from './components/CommandPalette/paletteContext';
 import { useAppCommands } from './commands/useAppCommands';
 import { useProjectNumberShortcuts } from './hooks/useProjectNumberShortcuts';
-import { SuccessIcon, InfoIcon, CloseIcon } from './components/icons';
+import { ToastList } from './components/primitives/ToastList';
 import { logger } from './lib/logger';
+import { asCommandError, formatCommandError } from './lib/errors';
 import { trackEvent, setActiveProject, trackPageview } from './lib/analytics';
 import { endProjectSession } from './lib/session';
 import { installAppLifecycleTracking, quitAppWithTracking } from './lib/appLifecycle';
@@ -467,8 +468,11 @@ function AppContents({ initialProjectPath }: AppProps) {
         // when its save handler returns successfully.
         await restartDevServer(currentProject.path, newPort);
         showToast('Port updated and server restarted', 'success');
-      } catch {
-        showToast('Failed to save port setting', 'error');
+      } catch (err) {
+        showToast(
+          `Couldn't set dev server to port ${newPort}: ${formatCommandError(asCommandError(err))}`,
+          'error'
+        );
       }
     },
     [currentProject, restartDevServer, showToast, setDevServerPort]
@@ -526,14 +530,16 @@ function AppContents({ initialProjectPath }: AppProps) {
         try {
           await stopServer(projectPath);
         } catch (err) {
-          logger.warn('[CloseProject] stopServer threw', { error: String(err) });
+          logger.warn('[CloseProject] stopServer threw', {
+            error: formatCommandError(asCommandError(err)),
+          });
         }
         closeAllTerminalsForProject(projectPath);
         try {
           await unregisterProjectSession(projectPath);
         } catch (err) {
           logger.warn('[CloseProject] unregisterProjectSession failed', {
-            error: String(err),
+            error: formatCommandError(asCommandError(err)),
           });
         }
         sessionRegistry.destroy(projectPath);
@@ -580,7 +586,7 @@ function AppContents({ initialProjectPath }: AppProps) {
             });
           } catch (err) {
             logger.warn('[SelectProjectTab] Failed to persist active tab', {
-              error: String(err),
+              error: formatCommandError(asCommandError(err)),
             });
           }
         }
@@ -1090,21 +1096,7 @@ function AppContents({ initialProjectPath }: AppProps) {
         <div className="app">
           <AccountSelectScreen onContinue={() => setView('projects')} />
         </div>
-        {toasts.length > 0 && (
-          <div className="toast-container">
-            {toasts.map((t) => (
-              <div key={t.id} className={`toast toast-${t.type}`}>
-                <span className="toast-icon">
-                  {t.type === 'success' ? <SuccessIcon size={16} /> : <InfoIcon size={16} />}
-                </span>
-                <span className="toast-message">{t.message}</span>
-                <button className="toast-close" onClick={() => dismissToast(t.id)}>
-                  <CloseIcon size={14} />
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
+        <ToastList toasts={toasts} onDismiss={dismissToast} />
         {quitConfirmModal}
       </>
     );
@@ -1184,21 +1176,7 @@ function AppContents({ initialProjectPath }: AppProps) {
             onCancel={() => void handleCancelMonorepoPick()}
           />
         )}
-        {toasts.length > 0 && (
-          <div className="toast-container">
-            {toasts.map((t) => (
-              <div key={t.id} className={`toast toast-${t.type}`}>
-                <span className="toast-icon">
-                  {t.type === 'success' ? <SuccessIcon size={16} /> : <InfoIcon size={16} />}
-                </span>
-                <span className="toast-message">{t.message}</span>
-                <button className="toast-close" onClick={() => dismissToast(t.id)}>
-                  <CloseIcon size={14} />
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
+        <ToastList toasts={toasts} onDismiss={dismissToast} />
         {quitConfirmModal}
       </>
     );

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -6,6 +6,8 @@ import { useRankedCommands, type RankedCommand } from '../../commands/useRankedC
 import { recordRun } from '../../commands/frecency';
 import type { CommandCategory } from '../../commands/types';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
+import { useOptionalToast } from '../../contexts/ToastContext';
 import { trackEvent, trackSearch, cancelTrackedSearch } from '../../lib/analytics';
 
 type DismissReason = 'command_run' | 'manual';
@@ -66,6 +68,7 @@ export function CommandPalette({
   context,
   currentProjectName,
 }: CommandPaletteProps) {
+  const { showToast } = useOptionalToast();
   const [query, setQuery] = useState('');
   const [activeTab, setActiveTabRaw] = useState<TabId>('all');
   const [selectedIdx, setSelectedIdx] = useState(0);
@@ -183,15 +186,20 @@ export function CommandPalette({
     // Close first so the UI doesn't block on long-running handlers.
     onClose();
     recordRun(cmd.id);
+    // Surface failures — a silently-failing palette command kills trust in
+    // the palette. The toast carries the command title plus the real error.
+    const reportFailure = (kind: 'failed' | 'threw', err: unknown) => {
+      const detail = formatCommandError(asCommandError(err));
+      logger.error(`[CommandPalette] command ${kind}`, { id: cmd.id, error: detail });
+      showToast(`"${cmd.title}" failed: ${detail}`, 'error');
+    };
     try {
       const result = cmd.run();
       if (result && typeof (result as Promise<unknown>).then === 'function') {
-        (result as Promise<unknown>).catch((err) =>
-          logger.error('[CommandPalette] command failed', { id: cmd.id, error: String(err) })
-        );
+        (result as Promise<unknown>).catch((err) => reportFailure('failed', err));
       }
     } catch (err) {
-      logger.error('[CommandPalette] command threw', { id: cmd.id, error: String(err) });
+      reportFailure('threw', err);
     }
   };
 

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -19,6 +19,7 @@ import { Update } from '@tauri-apps/plugin-updater';
 import { checkForUpdate, downloadAndInstall, restartApp, UpdateInfo } from '../lib/updater';
 import { trackEvent, trackError } from '../lib/analytics';
 import { logger } from '../lib/logger';
+import { asCommandError, formatCommandError } from '../lib/errors';
 import { Button } from './primitives/Button';
 import '../styles/features/update-banner.css';
 
@@ -119,9 +120,12 @@ export function UpdateBanner() {
     try {
       await restartApp();
     } catch (err) {
-      logger.warn('[UpdateBanner] Restart failed');
+      // Keep the underlying detail (mirrors the download-failure handler
+      // above, which extracts message + cause) and tell the user what to do.
+      const detail = formatCommandError(asCommandError(err));
+      logger.warn('[UpdateBanner] Restart failed', { error: detail });
       trackError('app_restart', err, 'Dashboard');
-      setError('Failed to restart. Please restart manually.');
+      setError(`Couldn't restart the app: ${detail}. Please quit and reopen Ship Studio manually.`);
     }
   }, []);
 

--- a/src/components/branches/CreateBranchConflictModal.tsx
+++ b/src/components/branches/CreateBranchConflictModal.tsx
@@ -69,7 +69,10 @@ export function CreateBranchConflictModal({
       onToast(`Created and switched to ${targetBranch}${extra ? ` — ${extra}` : ''}`, 'success');
       onClose();
     } else {
-      onToast(result.error || 'Failed to switch to the new branch', 'error');
+      // Keep whatever detail git gave us; only explain when it gave none.
+      const detail =
+        result.error || '(git reported failure with no detail — check for uncommitted changes)';
+      onToast(`Created "${targetBranch}", but couldn't switch to it: ${detail}`, 'error');
     }
   };
 

--- a/src/components/branches/PublishBranchDropdown.tsx
+++ b/src/components/branches/PublishBranchDropdown.tsx
@@ -144,9 +144,12 @@ export function PublishBranchDropdown({
     try {
       const result = await publishBranch(projectPath);
 
-      // Check for specific error types
+      // Check for specific error types — carry the deployment state (and URL,
+      // when Vercel returned one) instead of a canned "failed" string.
       if (result.state === 'ERROR') {
-        throw new Error('Failed to publish branch');
+        throw new Error(
+          `Deployment reported state "${result.state}"${result.url ? ` — ${result.url}` : ''}`
+        );
       }
 
       logger.info('Publish succeeded', { branch: currentBranch });
@@ -179,7 +182,7 @@ export function PublishBranchDropdown({
       logger.error('Publish failed', { branch: currentBranch, errorType, message });
       trackError('git_push', e, 'Workspace');
       setPublishState({ status: 'error', message, errorType });
-      onToast?.(isMainBranch ? 'Publish failed' : 'Sync failed', 'error');
+      onToast?.(`${isMainBranch ? 'Publish' : 'Sync'} failed: ${message}`, 'error');
 
       // Notify parent about the error for GitErrorHandler
       if (onPublishError) {

--- a/src/components/code/CodeViewer.tsx
+++ b/src/components/code/CodeViewer.tsx
@@ -22,6 +22,7 @@ import { ChevronIcon, CodeIcon, FileIcon, VSCodeIcon, CursorIcon, CopyIcon } fro
 import { trackEvent } from '../../lib/analytics';
 import { fileExtensionForAnalytics } from '../../lib/code';
 import { CodeFileEditor } from './CodeFileEditor';
+import { basename } from '../../lib/paths';
 import type { SaveResult } from '../../hooks/useFileTree';
 
 interface CodeViewerProps {
@@ -201,11 +202,16 @@ export function CodeViewer({
       const result = await onSave();
       // 'noop' (read mode / clean buffer) is silent — only a real save toasts.
       if (result === 'saved') showToast('Saved', 'success');
-      else if (result === 'error') showToast('Failed to save file', 'error');
+      else if (result !== 'noop') {
+        // Failure carries the real error from the write — show it, not a
+        // canned string (it's also mirrored in the saveError banner below).
+        const name = filePath ? basename(filePath) : 'file';
+        showToast(`Couldn't save ${name}: ${result.error}`, 'error');
+      }
     } finally {
       saveInFlightRef.current = false;
     }
-  }, [onSave, showToast]);
+  }, [onSave, showToast, filePath]);
 
   // No file selected
   if (!filePath) {

--- a/src/components/dashboard/CreateProject.tsx
+++ b/src/components/dashboard/CreateProject.tsx
@@ -15,6 +15,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { trackEvent } from '../../lib/analytics';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import { UploadIcon } from '../icons';
 import { Button } from '../primitives/Button';
 import { Spinner } from '../primitives/Spinner';
@@ -146,8 +147,15 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
       } catch (err) {
         // Surface the failure (don't block the modal) — a silent catch left the
         // button snapping back to "Continue" with no explanation.
-        logger.error('Failed to download community template', { error: err });
-        setError("Couldn't download that template. Check your connection and try again.");
+        const detail = formatCommandError(asCommandError(err));
+        logger.error('Failed to download community template', {
+          template: selectedCommunityTemplate.name,
+          error: detail,
+        });
+        setError(
+          `Couldn't download "${selectedCommunityTemplate.name}": ${detail}. ` +
+            'Check your connection and try again.'
+        );
       } finally {
         setDownloading(false);
       }

--- a/src/components/dashboard/ImportProject.tsx
+++ b/src/components/dashboard/ImportProject.tsx
@@ -90,7 +90,10 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       setSelectedOwner(user);
     } catch (err) {
       trackError('github_accounts_load', err, 'Dashboard');
-      setError('Failed to load GitHub accounts. Please check your authentication.');
+      setError(
+        `Couldn't load your GitHub accounts: ${formatCommandError(asCommandError(err))}. ` +
+          'Try signing out and back into GitHub.'
+      );
     } finally {
       setLoadingAccounts(false);
     }

--- a/src/components/preview/DeviceMirror.tsx
+++ b/src/components/preview/DeviceMirror.tsx
@@ -156,6 +156,9 @@ export function DeviceMirror({ projectName, projectPath, onSendToAgent }: Device
   // because the connect effect's stable-timer closes over it; a forward reference
   // would also trip the react-hooks immutability rule.
   const healAttemptsRef = useRef(0);
+  // Last connect-flow failure (formatted) — cited by the heal loop's give-up
+  // message so the user sees the concrete cause, not just "lost connection".
+  const lastConnectErrorRef = useRef<string | null>(null);
 
   // Accumulated build-log tail + a mirror of launchStatus, both read inside the
   // output handler (which must stay identity-stable so BuildTerminal's setup
@@ -284,10 +287,12 @@ export function DeviceMirror({ projectName, projectPath, onSendToAgent }: Device
         void resolveBuild(platform, info.udid, info.launch_status);
       } catch (err) {
         if (cancelled) return;
-        logger.error('[DeviceMirror] failed', {
-          error: err instanceof Error ? err.message : String(err),
-        });
-        setErrorMsg(formatCommandError(asCommandError(err)));
+        const detail = formatCommandError(asCommandError(err));
+        logger.error('[DeviceMirror] failed', { error: detail });
+        // Remembered so the heal-loop's give-up message can cite the last
+        // concrete failure instead of a bare "lost connection".
+        lastConnectErrorRef.current = detail;
+        setErrorMsg(detail);
         setStatus('error');
       }
     };
@@ -339,7 +344,12 @@ export function DeviceMirror({ projectName, projectPath, onSendToAgent }: Device
     if (healTimerRef.current !== null) return; // a heal is already pending
     if (healAttemptsRef.current >= MAX_HEAL_ATTEMPTS) {
       // Mirror won't come back on its own — stop looping and let the user act.
-      setErrorMsg('Lost the connection to the device mirror.');
+      const lastError = lastConnectErrorRef.current;
+      setErrorMsg(
+        `Lost the connection to the device mirror after ${MAX_HEAL_ATTEMPTS} reconnect attempts` +
+          `${lastError ? ` (last error: ${lastError})` : ' (the mirror stream kept dropping)'}. ` +
+          'Try restarting the preview.'
+      );
       setStatus('error');
       return;
     }

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -35,6 +35,7 @@ import { useOptionalToast } from '../../contexts/ToastContext';
 import { DevServerLogs } from '../terminal/DevServerLogs';
 import { DevServerStatus } from '../terminal/DevServerStatus';
 import { stripAnsi } from '../../lib/ansi';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import { trackEvent } from '../../lib/analytics';
 import { BrowserTools } from './BrowserTools';
 import { HealthTabPanel, type HealthTabPanelRef } from '../code/HealthTabPanel';
@@ -642,8 +643,9 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
         setCssScope(scope);
         if (!cssEditorOn) cssToggleEditMode();
       } catch (err) {
-        onToast('Could not open the CSS editor', 'error');
-        logger.error('[Preview] openCssEditor failed', { error: String(err) });
+        const detail = formatCommandError(asCommandError(err));
+        onToast(`Could not open the CSS editor: ${detail}`, 'error');
+        logger.error('[Preview] openCssEditor failed', { error: detail });
       }
     },
     [cssEditorOn, cssToggleEditMode, onToast]
@@ -663,8 +665,9 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
                   if (cssEditorOn) cssToggleEditMode();
                   else openCssEditor('element');
                 } catch (err) {
-                  onToast('Could not toggle the CSS editor', 'error');
-                  logger.error('[Preview] toggle CSS editor failed', { error: String(err) });
+                  const detail = formatCommandError(asCommandError(err));
+                  onToast(`Could not toggle the CSS editor: ${detail}`, 'error');
+                  logger.error('[Preview] toggle CSS editor failed', { error: detail });
                 }
               },
             },

--- a/src/components/primitives/ToastList.tsx
+++ b/src/components/primitives/ToastList.tsx
@@ -1,0 +1,55 @@
+/**
+ * Shared toast list — the single rendering of the app's toast notifications.
+ *
+ * Previously duplicated inline in App.tsx (twice) and WorkspaceModals.tsx.
+ * Error toasts persist until dismissed (see useToasts) and carry a Copy
+ * button so the full error text can be pasted into Slack/a bug report
+ * instead of screenshotted.
+ */
+
+import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
+import { SuccessIcon, InfoIcon, CloseIcon, CopyIcon } from '../icons';
+import type { Toast } from '../../hooks/useToasts';
+
+interface ToastListProps {
+  toasts: Toast[];
+  onDismiss: (id: number) => void;
+}
+
+function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: (id: number) => void }) {
+  // Per-toast hook so each error toast gets its own "Copied" flag.
+  const { copy, isCopied } = useCopyToClipboard();
+
+  return (
+    <div className={`toast toast-${toast.type}`}>
+      <span className="toast-icon">
+        {toast.type === 'success' ? <SuccessIcon size={16} /> : <InfoIcon size={16} />}
+      </span>
+      <span className="toast-message">{toast.message}</span>
+      {toast.type === 'error' && (
+        <button
+          className="toast-copy"
+          onClick={() => void copy(toast.message)}
+          title="Copy the full error text"
+        >
+          <CopyIcon size={12} />
+          {isCopied ? 'Copied' : 'Copy'}
+        </button>
+      )}
+      <button className="toast-close" onClick={() => onDismiss(toast.id)} aria-label="Dismiss">
+        <CloseIcon size={14} />
+      </button>
+    </div>
+  );
+}
+
+export function ToastList({ toasts, onDismiss }: ToastListProps) {
+  if (toasts.length === 0) return null;
+  return (
+    <div className="toast-container">
+      {toasts.map((t) => (
+        <ToastItem key={t.id} toast={t} onDismiss={onDismiss} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/support/ArticleView.tsx
+++ b/src/components/support/ArticleView.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from 'react';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import { getArticle, recordArticleView } from '../../lib/support';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import type { LibraryArticle } from '../../lib/support';
 import type { SupportView } from './SupportPanel';
 
@@ -32,8 +33,10 @@ export function ArticleView({ slug, onNavigate }: ArticleViewProps) {
           setArticle(result);
           void recordArticleView(slug);
         }
-      } catch {
-        if (!cancelled) setError('Failed to load article.');
+      } catch (err) {
+        if (!cancelled) {
+          setError(`Couldn't load this article: ${formatCommandError(asCommandError(err))}`);
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/src/components/terminal/DevServerStatus.test.tsx
+++ b/src/components/terminal/DevServerStatus.test.tsx
@@ -65,15 +65,28 @@ describe('DevServerStatus', () => {
     const output = `${esc}[32mready${esc}[0m\nError: listen EADDRINUSE 3001`;
     renderStatus({ phase: 'error', devServerOutput: output });
 
-    const body = screen.getByText(/EADDRINUSE 3001/);
-    expect(body).toBeInTheDocument();
-    expect(body.textContent).toContain('ready');
-    expect(body.textContent).not.toContain(esc);
-    expect(body.textContent).not.toContain('[32m');
+    // The last log line is echoed into the error hint too, so target the
+    // log body by class rather than by text.
+    const body = document.querySelector('.preview-status__logs-body');
+    expect(body).not.toBeNull();
+    expect(body!.textContent).toContain('EADDRINUSE 3001');
+    expect(body!.textContent).toContain('ready');
+    expect(body!.textContent).not.toContain(esc);
+    expect(body!.textContent).not.toContain('[32m');
 
     // Collapsing hides the body.
     fireEvent.click(screen.getByText(/Logs/));
-    expect(screen.queryByText(/EADDRINUSE 3001/)).not.toBeInTheDocument();
+    expect(document.querySelector('.preview-status__logs-body')).toBeNull();
+  });
+
+  it('echoes the last log line into the error hint', () => {
+    renderStatus({ phase: 'error', devServerOutput: 'compiling…\nError: boom\n' });
+    expect(screen.getByText(/last output: “Error: boom”/)).toBeInTheDocument();
+  });
+
+  it('says the server produced no output when the log is empty in the error state', () => {
+    renderStatus({ phase: 'error', devServerOutput: '' });
+    expect(screen.getByText(/produced no output/)).toBeInTheDocument();
   });
 
   it('does not render a logs section when there is no output', () => {

--- a/src/components/terminal/DevServerStatus.tsx
+++ b/src/components/terminal/DevServerStatus.tsx
@@ -97,6 +97,14 @@ export function DevServerStatus({
     return stripAnsi(devServerOutput).split('\n').slice(-LOG_TAIL_LINES).join('\n').trim();
   }, [devServerOutput]);
 
+  // Last non-empty output line — echoed into the error card so the likely
+  // cause (compile error, EADDRINUSE, crash message) is visible without
+  // expanding the logs.
+  const lastLogLine = useMemo(() => {
+    const lines = logTail.split('\n').filter((l) => l.trim().length > 0);
+    return lines.length > 0 ? lines[lines.length - 1].trim() : null;
+  }, [logTail]);
+
   // Follow the tail as new lines arrive (unless the user scrolled up).
   useEffect(() => {
     const el = logBodyRef.current;
@@ -147,7 +155,9 @@ export function DevServerStatus({
 
       <p className="hint">
         {phase === 'error' && !isStaticProject
-          ? 'It never responded — check the logs below or hand it to the agent.'
+          ? lastLogLine
+            ? `It never responded — last output: “${lastLogLine}”. Check the full logs below or hand it to the agent.`
+            : 'It never responded and produced no output — check the logs below or hand it to the agent.'
           : phase === 'error' && isStaticProject
             ? 'Make sure the project contains an index.html file.'
             : `Waiting for localhost:${port}`}

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -268,7 +268,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           .catch((err) => {
             logger.error('[Terminal] Font loading failed, proceeding anyway', {
               agent: agent.id,
-              error: String(err),
+              error: formatCommandError(asCommandError(err)),
             });
             if (!cancelled) setIsReady(true);
           });
@@ -1021,7 +1021,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
             if (selection) {
               navigator.clipboard.writeText(selection).catch((err: unknown) => {
                 logger.warn('[Terminal] Failed to copy selection to clipboard', {
-                  error: String(err),
+                  error: formatCommandError(asCommandError(err)),
                 });
               });
               term.clearSelection();
@@ -1071,7 +1071,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
                 }
               } catch (err) {
                 logger.warn('[Terminal] Native clipboard paste failed', {
-                  error: String(err),
+                  error: formatCommandError(asCommandError(err)),
                 });
                 // Best-effort fallback to the browser clipboard (may be slow
                 // on WebView2, but better than dropping the paste entirely).
@@ -1094,7 +1094,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         logger.error('[Terminal] Failed to spawn PTY', {
           agent: agent.id,
           binary: agent.binaryName,
-          error: String(err),
+          error: formatCommandError(asCommandError(err)),
           retry: retryCount,
         });
 

--- a/src/components/workspace/WorkspaceModals.tsx
+++ b/src/components/workspace/WorkspaceModals.tsx
@@ -27,7 +27,8 @@ import { GitErrorHandler } from '../branches/GitErrorHandler';
 import { SubmitReviewModal } from '../branches/SubmitReviewModal';
 import { ConflictResolutionModal } from '../branches/ConflictResolutionModal';
 import { OnboardingTerminal } from '../setup';
-import { SuccessIcon, InfoIcon, CloseIcon, DownloadIcon, ZapIcon } from '../icons';
+import { DownloadIcon, ZapIcon } from '../icons';
+import { ToastList } from '../primitives/ToastList';
 import type { Toast } from '../../hooks/useToasts';
 import type { NotificationSettings } from '../../lib/sounds';
 import type { AgentConfig } from '../../lib/agent';
@@ -236,21 +237,7 @@ export function WorkspaceModals({
       {isEducationMode && <EducationOverlay onClose={onCloseEducation} />}
 
       {/* Toast notifications */}
-      {toasts.length > 0 && (
-        <div className="toast-container">
-          {toasts.map((toast) => (
-            <div key={toast.id} className={`toast toast-${toast.type}`}>
-              <span className="toast-icon">
-                {toast.type === 'success' ? <SuccessIcon size={16} /> : <InfoIcon size={16} />}
-              </span>
-              <span className="toast-message">{toast.message}</span>
-              <button className="toast-close" onClick={() => dismissToast(toast.id)}>
-                <CloseIcon size={14} />
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
+      <ToastList toasts={toasts} onDismiss={dismissToast} />
 
       {/* Screenshot Preview Toast */}
       {screenshotPreviewPath && !showScreenshotModal && (

--- a/src/hooks/useBranchManagement.test.ts
+++ b/src/hooks/useBranchManagement.test.ts
@@ -356,6 +356,48 @@ describe('useBranchManagement', () => {
       expect(result.current.gitError).toBeNull();
     });
 
+    it('toasts the branch name and git detail when the switch fails', async () => {
+      vi.mocked(branches.switchBranch).mockResolvedValue({
+        success: false,
+        stashedChanges: false,
+        pendingStashFrom: null,
+        stashApplied: false,
+        error: 'your local changes would be overwritten',
+      });
+      const params = createParams();
+      const { result } = renderHook(() => useBranchManagement(params));
+
+      await act(async () => {
+        await result.current.handleResolveConflicts('feature/x', 'main');
+      });
+
+      expect(params.showToast).toHaveBeenCalledWith(
+        'Couldn\'t switch to "feature/x": your local changes would be overwritten',
+        'error'
+      );
+    });
+
+    it('explains when git reported a switch failure with no detail', async () => {
+      vi.mocked(branches.switchBranch).mockResolvedValue({
+        success: false,
+        stashedChanges: false,
+        pendingStashFrom: null,
+        stashApplied: false,
+        error: null,
+      });
+      const params = createParams();
+      const { result } = renderHook(() => useBranchManagement(params));
+
+      await act(async () => {
+        await result.current.handleResolveConflicts('feature/x', 'main');
+      });
+
+      expect(params.showToast).toHaveBeenCalledWith(
+        'Couldn\'t switch to "feature/x": (git reported failure with no detail — check for uncommitted changes)',
+        'error'
+      );
+    });
+
     it('handleConflictsResolved closes modal and refreshes', () => {
       const params = createParams();
       const { result } = renderHook(() => useBranchManagement(params));

--- a/src/hooks/useBranchManagement.ts
+++ b/src/hooks/useBranchManagement.ts
@@ -235,7 +235,11 @@ export function useBranchManagement({
           // Switch to the PR's head branch
           const switchResult = await switchBranch(currentProject.path, headBranch, true);
           if (!switchResult.success) {
-            showToast(switchResult.error || 'Failed to switch branch', 'error');
+            // Keep whatever detail git gave us; only explain when it gave none.
+            const detail =
+              switchResult.error ||
+              '(git reported failure with no detail — check for uncommitted changes)';
+            showToast(`Couldn't switch to "${headBranch}": ${detail}`, 'error');
             return;
           }
 

--- a/src/hooks/useFileTree.test.ts
+++ b/src/hooks/useFileTree.test.ts
@@ -134,7 +134,7 @@ describe('useFileTree — saveFile', () => {
       result.current.updateDraft('abcX');
       await flush();
     });
-    let ret: string | undefined;
+    let ret: Awaited<ReturnType<typeof result.current.saveFile>> | undefined;
     await act(async () => {
       ret = await result.current.saveFile();
     });
@@ -146,7 +146,7 @@ describe('useFileTree — saveFile', () => {
     const { result } = await setup(true);
     await open(result, 'a.ts', file({ content: 'abc' }));
     // draft === content → unchanged
-    let ret: string | undefined;
+    let ret: Awaited<ReturnType<typeof result.current.saveFile>> | undefined;
     await act(async () => {
       ret = await result.current.saveFile();
     });
@@ -154,7 +154,7 @@ describe('useFileTree — saveFile', () => {
     expect(ret).toBe('noop');
   });
 
-  it('surfaces a save failure and returns false', async () => {
+  it('surfaces a save failure with the real error message', async () => {
     (saveProjectFile as Fn).mockRejectedValueOnce(new Error('disk full'));
     const { result } = await setup(true);
     await open(result, 'a.ts', file({ content: 'abc' }));
@@ -162,11 +162,11 @@ describe('useFileTree — saveFile', () => {
       result.current.updateDraft('abcX');
       await flush();
     });
-    let ret: string | undefined;
+    let ret: Awaited<ReturnType<typeof result.current.saveFile>> | undefined;
     await act(async () => {
       ret = await result.current.saveFile();
     });
-    expect(ret).toBe('error');
+    expect(ret).toEqual({ error: 'disk full' });
     expect(result.current.saveError).toBe('disk full');
   });
 });

--- a/src/hooks/useFileTree.ts
+++ b/src/hooks/useFileTree.ts
@@ -38,7 +38,9 @@ const CODE_EDIT_MODE_KEY = 'shipstudio:code-edit-mode';
 export type PendingFileAction = { kind: 'switch'; path: string } | { kind: 'disable-edit' } | null;
 
 /** Outcome of a save attempt: written, nothing-to-write, or failed. */
-export type SaveResult = 'saved' | 'noop' | 'error';
+/** Result of a save attempt. Failures carry the real error message so the
+ *  caller can put it in front of the user (never a canned "failed" string). */
+export type SaveResult = 'saved' | 'noop' | { error: string };
 
 interface UseFileTreeResult {
   tree: FileTreeNode[];
@@ -330,7 +332,7 @@ export function useFileTree(projectPath: string): UseFileTreeResult {
       const msg = formatCommandError(asCommandError(err));
       logger.error('Failed to save file', { path, error: msg });
       setSaveError(msg);
-      return 'error';
+      return { error: msg };
     } finally {
       setIsSaving(false);
     }

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -796,9 +796,9 @@ export function useProjectLifecycle({
     try {
       await restartDevServer(cfg.projectPath);
     } catch (err) {
-      logger.error('[Install] Post-install dev server restart failed', {
-        error: err instanceof Error ? err.message : String(err),
-      });
+      const detail = formatCommandError(asCommandError(err));
+      logger.error('[Install] Post-install dev server restart failed', { error: detail });
+      showToast(`Installed, but the dev server didn't restart: ${detail}`, 'error');
     }
   };
 

--- a/src/hooks/useProjectRail.ts
+++ b/src/hooks/useProjectRail.ts
@@ -15,6 +15,7 @@ import { useCallback } from 'react';
 import type { Project } from '../lib/project';
 import { usePinnedProjects, type UsePinnedProjectsReturn } from './usePinnedProjects';
 import { logger } from '../lib/logger';
+import { asCommandError, formatCommandError } from '../lib/errors';
 import { basename } from '../lib/paths';
 
 export interface UseProjectRailParams {
@@ -55,9 +56,11 @@ export function useProjectRail({
           await pinnedProjects.unpin(projectPath);
         }
       } catch (e) {
-        showToast(shouldPin ? 'Failed to pin project' : 'Failed to unpin project', 'error');
+        const detail = formatCommandError(asCommandError(e));
+        const name = basename(projectPath) || 'project';
+        showToast(`Couldn't ${shouldPin ? 'pin' : 'unpin'} ${name}: ${detail}`, 'error');
         logger.error('[useProjectRail] Pin toggle failed', {
-          error: String(e),
+          error: detail,
           projectPath,
           shouldPin,
         });

--- a/src/hooks/useToasts.test.ts
+++ b/src/hooks/useToasts.test.ts
@@ -88,6 +88,64 @@ describe('useToasts', () => {
     expect(result.current.toasts).toHaveLength(0);
   });
 
+  it('auto-dismisses info toasts after 4000ms', () => {
+    const { result } = renderHook(() => useToasts());
+
+    act(() => {
+      result.current.showToast('FYI', 'info');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it('never auto-dismisses error toasts', () => {
+    const { result } = renderHook(() => useToasts());
+
+    act(() => {
+      result.current.showToast('Something broke: detail here', 'error');
+    });
+    expect(result.current.toasts).toHaveLength(1);
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0].type).toBe('error');
+  });
+
+  it('error toasts can still be dismissed manually', () => {
+    const { result } = renderHook(() => useToasts());
+
+    act(() => {
+      result.current.showToast('Something broke', 'error');
+    });
+    const id = result.current.toasts[0].id;
+
+    act(() => {
+      result.current.dismissToast(id);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it('success toasts auto-dismiss while an error toast persists', () => {
+    const { result } = renderHook(() => useToasts());
+
+    act(() => {
+      result.current.showToast('Something broke', 'error');
+      result.current.showToast('All good');
+    });
+    expect(result.current.toasts).toHaveLength(2);
+
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0].type).toBe('error');
+  });
+
   it('keeps max 5 toasts, removing oldest first', () => {
     const { result } = renderHook(() => useToasts());
 

--- a/src/hooks/useToasts.ts
+++ b/src/hooks/useToasts.ts
@@ -35,7 +35,9 @@ export interface UseToastsReturn {
 
 /** Maximum number of toasts to display at once */
 const MAX_TOASTS = 5;
-/** Time in ms before a toast auto-dismisses */
+/** Time in ms before a success/info toast auto-dismisses. Error toasts never
+ *  auto-dismiss — the user needs time to read (and copy) the full detail, so
+ *  they persist until manually dismissed via the ✕ button. */
 const TOAST_DURATION_MS = 4000;
 
 /**
@@ -78,12 +80,15 @@ export function useToasts(): UseToastsReturn {
       const updated = [...prev, { id, message, type }];
       return updated.slice(-MAX_TOASTS);
     });
-    // Auto-dismiss after timeout
-    const timer = setTimeout(() => {
-      timerMap.current.delete(id);
-      setToasts((prev) => prev.filter((t) => t.id !== id));
-    }, TOAST_DURATION_MS);
-    timerMap.current.set(id, timer);
+    // Auto-dismiss after timeout — except errors, which persist until the
+    // user dismisses them (they carry detail worth reading/copying).
+    if (type !== 'error') {
+      const timer = setTimeout(() => {
+        timerMap.current.delete(id);
+        setToasts((prev) => prev.filter((t) => t.id !== id));
+      }, TOAST_DURATION_MS);
+      timerMap.current.set(id, timer);
+    }
   }, []);
 
   const dismissToast = useCallback((id: number) => {

--- a/src/styles/features/publish/toasts.css
+++ b/src/styles/features/publish/toasts.css
@@ -45,6 +45,32 @@
 
 .toast-message {
   flex: 1;
+  /* Long error payloads (multi-line stderr) scroll instead of clipping. */
+  max-height: 40vh;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* Copy-to-clipboard affordance on error toasts — lets the user paste the
+   full error into Slack/a bug report instead of screenshotting it. */
+.toast-copy {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.toast-copy:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
 }
 
 .toast-close {


### PR DESCRIPTION
Implements the error-message audit under the standing rule: **no arbitrary error messages** — every user-facing error carries what was attempted, the underlying detail (via `formatCommandError(asCommandError(err))`, never `String(err)` on Tauri rejections), and a next step when known. Detail is appended, never replaced.

Setup wizard files (`src/components/setup/**`, `src/lib/setup.ts`, `src/lib/terminalDiagnostics.ts`) were left untouched per the parallel PR in flight.

## Part 1 — Infrastructure

| Finding | Change |
|---|---|
| A. Error toasts vanished in 4s | `src/hooks/useToasts.ts`: `error`-type toasts persist until manually dismissed (✕ button); success/info keep the 4s auto-dismiss |
| B. No copy affordance | Duplicated toast markup (App.tsx ×2, WorkspaceModals.tsx) factored into `src/components/primitives/ToastList.tsx`; error toasts get a Copy button via `useCopyToClipboard` so the full error can be pasted into Slack instead of screenshotted |
| C. Long errors clipped at 420px | `toasts.css`: `.toast-message` gets `max-height: 40vh` + `overflow-y: auto` + `pre-wrap`, so multi-line stderr scrolls; styled with design tokens only |

## Part 2 — HIGH findings

| # | Site | Change |
|---|---|---|
| 1 | `CommandPalette.tsx` | Command failures were logger-only. Now toast `"<cmd.title>" failed: <detail>` via `useOptionalToast` for both the sync catch and async `.catch`; logger calls use formatted errors |
| 2 | `App.tsx` port save | Bound the dropped error: `Couldn't set dev server to port <port>: <detail>` |
| 3 | `CodeViewer.tsx` + `useFileTree.ts` | `SaveResult` failure variant now carries the real message (`{ error: string }`); toast reads `Couldn't save <basename>: <detail>` instead of "Failed to save file" |
| 4 | `useBranchManagement.ts` | Null-blind `switchResult.error \|\| 'Failed to switch branch'` → `Couldn't switch to "<branch>": <detail>` with an explicit `(git reported failure with no detail — check for uncommitted changes)` fallback |
| 5 | `ImportProject.tsx` | GitHub accounts load appends formatted detail + "Try signing out and back into GitHub." |
| 6 | `CreateProject.tsx` | Template download: `Couldn't download "<template>": <detail>. Check your connection and try again.` |
| 7 | `useProjectRail.ts` | Pin/unpin toast includes project name + detail; `String(e)` logging fixed |
| 8 | `PublishBranchDropdown.tsx` | `throw new Error('Failed to publish branch')` discarded state/url → `Deployment reported state "<state>" — <url>`; failure toast now carries the message |
| 9 | `DevServerStatus.tsx` | Error card echoes the last non-empty log line (`last output: "…"`) from the output the component already receives — no new plumbing needed; explicit "produced no output" case |

## Part 3 — MEDIUM/LOW findings

| # | Site | Change |
|---|---|---|
| 10 | `useProjectLifecycle.ts` | Failed post-install restart now toasts `Installed, but the dev server didn't restart: <detail>` |
| 11 | `Preview.tsx` | CSS editor open/toggle appends detail; `String(err)` logs fixed |
| 12 | `DeviceMirror.tsx` | Heal-cap message includes attempt count, cites the last connect error when one exists, suggests restarting the preview |
| 13 | `UpdateBanner.tsx` | Restart failure: `Couldn't restart the app: <detail>. Please quit and reopen Ship Studio manually.` |
| 14 | `CreateBranchConflictModal.tsx` | Null-blind fallback → branch name + detail-or-explanation (mirrors #4) |
| 15 | `ArticleView.tsx` | Error bound: `Couldn't load this article: <detail>` |
| 16 | Rust: `projects/mod.rs` (delete/rename), `assets.rs` | `map_err(\|_\| "Project not found")` → `CommandError::Io` with `Couldn't resolve project path <path>: <os error>`; assets helpers include the path (and root) in strip-prefix/parent failures |
| 17 | `App.tsx`, `useProjectRail.ts`, `Terminal.tsx` (×4) | Remaining `String(err)` logger sites routed through `formatCommandError(asCommandError(err))` |

## Tests

- `useToasts.test.ts`: error toasts persist past 4s / 60s, stay manually dismissible, success auto-dismisses alongside a persisting error (+2 more)
- `useFileTree.test.ts`: save failure asserts the carried `{ error }` payload
- `useBranchManagement.test.ts`: two new tests for the switch-failure toast (detail present / git gave none)
- `DevServerStatus.test.tsx`: last-log-line hint, no-output case; log-body assertions retargeted

`pnpm typecheck`, `pnpm lint:strict`, `pnpm test:run` (1079 passed), `pnpm check:patterns`, `pnpm check:loc` all pass; `cargo test` (650 passed), `cargo fmt`, `cargo clippy` (no new warnings — remaining warnings pre-exist on main in untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)