### PR TITLE
Fix drag-drop on Retina Macs: stop halving already-logical macOS drop coordinates

### DIFF
--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -49,7 +49,7 @@ import { isWindows } from '../../lib/setup';
 import { isPasteChord, readClipboardText, stageClipboardImage } from '../../lib/clipboard';
 import { logger } from '../../lib/logger';
 import { asCommandError, formatCommandError } from '../../lib/errors';
-import { isPointInRect, physicalToLogical } from '../../lib/dropTarget';
+import { isPointInRect, dropPointToLogical } from '../../lib/dropTarget';
 import { getTerminalGpuEnabled } from '../../lib/settings';
 import { decideStartupTimeoutAction } from './startupWatchdog';
 import type { AgentConfig } from '../../lib/agent';
@@ -330,10 +330,16 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           // `visibility: hidden`, so their rects still overlap the visible
           // pane — computed visibility is the discriminator.
           if (getComputedStyle(container).visibility !== 'visible') return;
-          // The payload position is in physical (device) pixels; DOM rects
-          // are logical CSS pixels — convert before hit-testing. In a split,
-          // this naturally routes the drop to the pane under the cursor.
-          const point = physicalToLogical(event.payload.position, window.devicePixelRatio);
+          // Normalize the payload position to logical CSS pixels before
+          // hit-testing. Only Windows sends device pixels — macOS sends
+          // logical AppKit points despite the PhysicalPosition typing, and
+          // dividing them by DPR broke every Retina drop (see dropTarget.ts).
+          // In a split, this routes the drop to the pane under the cursor.
+          const point = dropPointToLogical(
+            event.payload.position,
+            isWindows(),
+            window.devicePixelRatio
+          );
           if (!isPointInRect(point, container.getBoundingClientRect())) return;
 
           // Debounce - ignore duplicate events within 500ms

--- a/src/lib/dropTarget.test.ts
+++ b/src/lib/dropTarget.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { physicalToLogical, isPointInRect } from './dropTarget';
+import { physicalToLogical, dropPointToLogical, isPointInRect } from './dropTarget';
 
 describe('physicalToLogical', () => {
   it('divides physical coordinates by the device pixel ratio', () => {
@@ -53,5 +53,27 @@ describe('isPointInRect', () => {
     const dropInRight = physicalToLogical({ x: 1200, y: 400 }, 2); // -> (600, 200)
     expect(isPointInRect(dropInRight, leftPane)).toBe(false);
     expect(isPointInRect(dropInRight, rightPane)).toBe(true);
+  });
+});
+
+describe('dropPointToLogical', () => {
+  it('divides by DPR on Windows (wry sends true device pixels there)', () => {
+    expect(dropPointToLogical({ x: 1200, y: 400 }, true, 2)).toEqual({ x: 600, y: 200 });
+  });
+
+  it('passes macOS coordinates through untouched — they are already logical AppKit points', () => {
+    // Regression: v0.13.2 divided these by DPR, so on a Retina display every
+    // drop landed at half-coordinates, missed the terminal rect, and was
+    // silently ignored ("can't drag screenshots into the terminal anymore").
+    expect(dropPointToLogical({ x: 600, y: 200 }, false, 2)).toEqual({ x: 600, y: 200 });
+  });
+
+  it('a Retina-Mac drop over the terminal hit-tests true end to end', () => {
+    const terminalPane = { left: 400, top: 40, right: 800, bottom: 600 };
+    // Cursor visually at (600, 200) on a DPR-2 Mac: wry reports logical
+    // (600, 200). The old code halved it to (300, 100) -> miss.
+    const point = dropPointToLogical({ x: 600, y: 200 }, false, 2);
+    expect(isPointInRect(point, terminalPane)).toBe(true);
+    expect(isPointInRect(physicalToLogical({ x: 600, y: 200 }, 2), terminalPane)).toBe(false);
   });
 });

--- a/src/lib/dropTarget.ts
+++ b/src/lib/dropTarget.ts
@@ -9,8 +9,16 @@
  * whether the drop belongs to it, or a single drop fans out to every
  * agent's PTY (issue #167).
  *
- * The payload's `position` is a Tauri `PhysicalPosition` (device pixels);
- * DOM rects are in logical CSS pixels — convert before hit-testing.
+ * The payload's `position` is *typed* as a Tauri `PhysicalPosition`, but
+ * what wry actually delivers is platform-dependent:
+ *   - Windows: true device pixels (`ScreenToClient` on the raw screen point)
+ *   - macOS: AppKit points — ALREADY logical CSS pixels, passed through
+ *     unscaled (wry `wkwebview/drag_drop.rs` uses `draggingLocation()` with
+ *     no scale-factor conversion; tauri-runtime-wry wraps the tuple verbatim)
+ *   - GTK/Linux: logical, like macOS
+ * Dividing by devicePixelRatio on macOS therefore lands every Retina drop at
+ * half-coordinates, the hit-test misses, and drops are silently ignored —
+ * use {@link dropPointToLogical}, which only converts where conversion is due.
  */
 
 /** An x/y point. Physical or logical depending on context. */
@@ -35,6 +43,20 @@ export interface DropRect {
 export function physicalToLogical(position: DropPoint, devicePixelRatio: number): DropPoint {
   const scale = Number.isFinite(devicePixelRatio) && devicePixelRatio > 0 ? devicePixelRatio : 1;
   return { x: position.x / scale, y: position.y / scale };
+}
+
+/**
+ * Normalize a Tauri drag-drop position to logical CSS pixels for rect
+ * hit-testing. Only Windows delivers true device pixels; macOS (and GTK)
+ * deliver logical coordinates despite the `PhysicalPosition` typing — see
+ * the module docs. Scaling those breaks every drop on a Retina display.
+ */
+export function dropPointToLogical(
+  position: DropPoint,
+  isWindowsPlatform: boolean,
+  devicePixelRatio: number
+): DropPoint {
+  return isWindowsPlatform ? physicalToLogical(position, devicePixelRatio) : position;
 }
 
 /**


### PR DESCRIPTION
**Regression shipped in v0.13.2 (#188), reported by Julian**: dragging files/screenshots into terminals is dead on Retina Macs.

## Root cause
#188's fan-out fix hit-tests the window-global drop position against the pane rect, converting "physical" coordinates to logical by dividing by devicePixelRatio. But wry's coordinate space is platform-dependent despite Tauri's `PhysicalPosition` typing (verified in vendored wry 0.55.1 source):
- **Windows** (`webview2/drag_drop.rs`): `ScreenToClient` → true device pixels → division correct
- **macOS** (`wkwebview/drag_drop.rs`): `draggingLocation()` AppKit points, no scale conversion → **already logical** → dividing by 2 on Retina lands every drop at half-coordinates → hit-test miss → drop silently ignored

## Fix
`dropPointToLogical(position, isWindows, dpr)` — converts only on Windows; macOS/GTK pass through. Terminal.tsx uses it with the existing `isWindows()` helper. Module docs rewritten so the platform asymmetry is impossible to miss.

## Verification
- 3 new regression tests incl. the end-to-end Retina case (old behavior asserted as a miss)
- typecheck / lint:strict clean, all dropTarget tests pass
- Live drag test on Julian's Retina Mac pending on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)