### PR TITLE
Enable the CSS editor for Next.js projects using vanilla CSS

### DIFF
--- a/src-tauri/src/commands/edit_css.rs
+++ b/src-tauri/src/commands/edit_css.rs
@@ -1579,11 +1579,16 @@ fn discover_stylesheets(root: &Path) -> Vec<(String, String)> {
     // freshly imported starter) would otherwise descend into `dist/` and `node_modules/`
     // — making every `src/` selector also match the built bundle → "defined in multiple
     // files" → read-only. This backstop keeps discovery correct without requiring git.
+    // `SKIP_DIRS` covers `.next/` (Next.js build output — its compiled CSS bundle would
+    // double-match every global-stylesheet selector); `out/` is Next's `next export`
+    // output, pruned only here (it's too generic a name to hide from code mode).
+    const DISCOVERY_EXTRA_SKIP_DIRS: &[&str] = &["out"];
     let walker = ignore::WalkBuilder::new(root)
         .standard_filters(true)
         .filter_entry(|entry| {
             let name = entry.file_name().to_string_lossy();
             !crate::commands::code::SKIP_DIRS.contains(&name.as_ref())
+                && !DISCOVERY_EXTRA_SKIP_DIRS.contains(&name.as_ref())
         })
         .build();
     for entry in walker.flatten() {
@@ -3532,6 +3537,37 @@ mod tests {
             .map(|(r, _)| r)
             .collect();
         assert_eq!(rels, vec!["app.css".to_string()]);
+    }
+
+    #[test]
+    fn discovery_prunes_nextjs_build_output_so_source_rules_resolve_uniquely() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        // A Next.js layout: the hand-authored global stylesheet…
+        std::fs::create_dir_all(root.join("app")).unwrap();
+        std::fs::write(root.join("app/globals.css"), ".title {\n  color: red;\n}\n").unwrap();
+        // …and the SAME selector in the compiled `.next/` bundle and `next export`'s
+        // `out/`. If either were discovered, locate would see the selector in two
+        // files → Multiple → the rule turns read-only in the editor.
+        std::fs::create_dir_all(root.join(".next/static/css")).unwrap();
+        std::fs::write(root.join(".next/static/css/x.css"), ".title{color:red}\n").unwrap();
+        std::fs::create_dir_all(root.join("out/_next/static/css")).unwrap();
+        std::fs::write(
+            root.join("out/_next/static/css/x.css"),
+            ".title{color:red}\n",
+        )
+        .unwrap();
+
+        let discovered = discover_stylesheets(root);
+        let rels: Vec<_> = discovered.iter().map(|(r, _)| r.clone()).collect();
+        assert_eq!(rels, vec!["app/globals.css".to_string()]);
+
+        // End to end: the rule still resolves to the single source file, not Multiple.
+        let sheets = idx(discovered);
+        match locate_rule(&sheets, &query(".title", None, None)) {
+            RuleLocation::Resolved { file, .. } => assert_eq!(file, "app/globals.css"),
+            other => panic!("expected unique resolution to the source rule, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -66,6 +66,7 @@ import { kbd } from '../../lib/shortcuts';
 import { useCommands } from '../../commands/useCommands';
 import { logger } from '../../lib/logger';
 import type { ProjectType } from '../../lib/static-server';
+import { isEditorFramework, resolveEditorMode } from '../../lib/editorGate';
 
 // SVG icons for breakpoints
 const BreakpointIcon = ({ type }: { type: Breakpoint }) => {
@@ -497,11 +498,7 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
       cancelled = true;
     };
   }, [projectType, projectPath]);
-  const editorFramework =
-    projectType === 'nextjs' ||
-    projectType === 'astro' ||
-    projectType === 'shopifytheme' ||
-    (projectType === 'vite' && viteUsesReact);
+  const editorFramework = isEditorFramework({ projectType, viteUsesReact });
   useEffect(() => {
     if (!projectPath || !editorFramework) {
       setTailwindActive(false);
@@ -519,8 +516,11 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
   // Visual editor supports className/class string resolution for React (Next.js
   // and Vite), Astro, and Shopify Liquid templates — all resolve the same way in
   // the Rust backend. The Tailwind gate keeps plain-CSS themes from showing an
-  // edit button whose class writes would never compile.
-  const editorEnabled = conn.serverReady && editorFramework && tailwindActive;
+  // edit button whose class writes would never compile. Which editor a project
+  // qualifies for (Tailwind vs code-first CSS) is decided by the pure gate in
+  // `lib/editorGate.ts` — the two are mutually exclusive.
+  const qualifiedEditorMode = resolveEditorMode({ projectType, tailwindActive, viteUsesReact });
+  const editorEnabled = conn.serverReady && qualifiedEditorMode === 'tailwind';
 
   // Locale config reported by the locale switcher (null when the project has
   // fewer than 2 configured languages). Used to keep page selection inside
@@ -576,18 +576,20 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     onToast,
   });
 
-  // Code-first CSS editor — a SEPARATE feature for vanilla-CSS projects (Astro
-  // without Tailwind, or plain HTML/CSS). Mutually exclusive with the Tailwind
-  // editor above: Astro+Tailwind → `editor`; vanilla CSS → `cssEditor`. Same
-  // toggle and selection experience; it surfaces the clicked element's full
-  // cascade and edits the real `.css` source (not utility classes).
-  const cssEditorEnabled =
-    conn.serverReady &&
-    ((projectType === 'astro' && !tailwindActive) || projectType === 'statichtml');
+  // Code-first CSS editor — a SEPARATE feature for vanilla-CSS projects (Astro or
+  // Next.js without Tailwind, or plain HTML/CSS). Mutually exclusive with the
+  // Tailwind editor above: framework+Tailwind → `editor`; vanilla CSS →
+  // `cssEditor`. Same toggle and selection experience; it surfaces the clicked
+  // element's full cascade and edits the real `.css` source (not utility classes).
+  // For Next.js this covers global stylesheets (e.g. app/globals.css); CSS-Module
+  // rules can't be mapped back (hashed class names) and render read-only with an
+  // explanation.
+  const cssEditorEnabled = conn.serverReady && qualifiedEditorMode === 'css';
   const cssEditor = useCssCascadeEditor({
     iframeRef,
     projectPath,
     enabled: cssEditorEnabled,
+    cssModulesHint: projectType === 'nextjs',
     onToast,
   });
   // Settings tab (element tag/classes/attributes) — shares the cascade selection.

--- a/src/hooks/useCssCascadeEditor.ts
+++ b/src/hooks/useCssCascadeEditor.ts
@@ -81,10 +81,19 @@ interface Params {
   iframeRef: React.RefObject<HTMLIFrameElement | null>;
   projectPath: string;
   enabled: boolean;
+  /** The project bundles CSS Modules (Next.js) — unmapped module-hashed selectors
+   *  get a CSS-Modules explanation instead of the generic read-only reason. */
+  cssModulesHint?: boolean;
   onToast: (message: string, type?: 'success' | 'error') => void;
 }
 
-export function useCssCascadeEditor({ iframeRef, projectPath, enabled, onToast }: Params) {
+export function useCssCascadeEditor({
+  iframeRef,
+  projectPath,
+  enabled,
+  cssModulesHint = false,
+  onToast,
+}: Params) {
   const [editModeOn, setEditModeOn] = useState(false);
   const editMode = enabled && editModeOn;
 
@@ -263,7 +272,7 @@ export function useCssCascadeEditor({ iframeRef, projectPath, enabled, onToast }
             const locByIndex = new Map<number, RuleLocation>();
             toLocate.forEach((x, k) => locByIndex.set(x.index, locations[k]));
             if (selTokenRef.current !== token) return;
-            const merged = mergeCascade(matched, locByIndex);
+            const merged = mergeCascade(matched, locByIndex, { cssModulesHint });
 
             const nextBodies: Record<string, RuleBody> = {};
             const nextOverridden: Record<string, Map<string, string>> = {};
@@ -372,7 +381,7 @@ export function useCssCascadeEditor({ iframeRef, projectPath, enabled, onToast }
           } catch (err) {
             logger.error('[CssCascade] locate failed', { error: String(err) });
             if (selTokenRef.current === token) {
-              setRows(mergeCascade(matched, new Map()));
+              setRows(mergeCascade(matched, new Map(), { cssModulesHint }));
               onToast(toastText(err), 'error');
             }
           } finally {
@@ -383,7 +392,7 @@ export function useCssCascadeEditor({ iframeRef, projectPath, enabled, onToast }
     };
     window.addEventListener('message', handler);
     return () => window.removeEventListener('message', handler);
-  }, [editMode, projectPath, post, iframeRef, onToast, clearTimers]);
+  }, [editMode, projectPath, post, iframeRef, onToast, clearTimers, cssModulesHint]);
 
   /** Live-preview a rule's current body in place (in-iframe CSSOM). */
   const previewRule = useCallback(

--- a/src/lib/cssCascade.test.ts
+++ b/src/lib/cssCascade.test.ts
@@ -147,6 +147,17 @@ describe('looksLikeCssModuleSelector', () => {
     expect(looksLikeCssModuleSelector('h1')).toBe(false);
     expect(looksLikeCssModuleSelector('.snake_case_name')).toBe(false);
   });
+
+  it('rejects BEM classes from third-party package CSS — the suffix must look like a hash', () => {
+    // Real-world BEM with long, all-lowercase "elements": these live in
+    // package stylesheets (not_found in a Next.js project) and must NOT get
+    // the "edit the .module.css" explanation. A hash has a digit/uppercase.
+    expect(looksLikeCssModuleSelector('.react-datepicker__header')).toBe(false);
+    expect(looksLikeCssModuleSelector('.card__title')).toBe(false);
+    expect(looksLikeCssModuleSelector('.swiper__wrapper .swiper__slide')).toBe(false);
+    // Still recognizes genuine hashes alongside BEM-ish nesting.
+    expect(looksLikeCssModuleSelector('.card__title .Hero_title__x7f2a')).toBe(true);
+  });
 });
 
 describe('cssModuleFileHint', () => {

--- a/src/lib/cssCascade.test.ts
+++ b/src/lib/cssCascade.test.ts
@@ -4,6 +4,8 @@ import {
   mergeCascade,
   formatRuleCss,
   rowKey,
+  looksLikeCssModuleSelector,
+  cssModuleFileHint,
   type MatchedRule,
   type RuleLocation,
 } from './cssCascade';
@@ -107,6 +109,55 @@ describe('mergeCascade', () => {
   it('treats a missing location entry as read-only (locate failed)', () => {
     const [row] = mergeCascade([rule({ selector: '.x' })], new Map());
     expect(row.editable).toBe(false);
+  });
+
+  it('explains CSS-Module rules when the project hints at hashed class names', () => {
+    const matched = [rule({ selector: '.Hero_title__x7f2a' })];
+    const [row] = mergeCascade(matched, new Map([[0, { status: 'not_found' } as RuleLocation]]), {
+      cssModulesHint: true,
+    });
+    expect(row.editable).toBe(false);
+    expect(row.readonlyReason).toMatch(/CSS Module/);
+    expect(row.readonlyReason).toContain('Hero.module.css');
+  });
+
+  it('keeps the generic not-found reason without the hint, or for non-module selectors', () => {
+    const moduleRule = [rule({ selector: '.Hero_title__x7f2a' })];
+    const notFound = new Map<number, RuleLocation>([[0, { status: 'not_found' }]]);
+    // Same selector, but the project is not Next.js → generic wording.
+    expect(mergeCascade(moduleRule, notFound)[0].readonlyReason).toMatch(/stylesheet/);
+    // Next.js project, but an ordinary class → generic wording.
+    const plain = [rule({ selector: '.hero-title' })];
+    expect(mergeCascade(plain, notFound, { cssModulesHint: true })[0].readonlyReason).toMatch(
+      /stylesheet/
+    );
+  });
+});
+
+describe('looksLikeCssModuleSelector', () => {
+  it('recognizes webpack [name]_[local]__[hash] classes and __hash suffixes', () => {
+    expect(looksLikeCssModuleSelector('.Hero_title__x7f2a')).toBe(true);
+    expect(looksLikeCssModuleSelector('.card__aB3_x9')).toBe(true);
+    expect(looksLikeCssModuleSelector('main .Hero_title__x7f2a > span')).toBe(true);
+  });
+
+  it('rejects ordinary classes, BEM-ish short suffixes, and tag selectors', () => {
+    expect(looksLikeCssModuleSelector('.hero-title')).toBe(false);
+    expect(looksLikeCssModuleSelector('.btn__sm')).toBe(false); // BEM element, too short
+    expect(looksLikeCssModuleSelector('h1')).toBe(false);
+    expect(looksLikeCssModuleSelector('.snake_case_name')).toBe(false);
+  });
+});
+
+describe('cssModuleFileHint', () => {
+  it('derives <Name>.module.css from a full-shape hashed class', () => {
+    expect(cssModuleFileHint('.Hero_title__x7f2a')).toBe('Hero.module.css');
+    expect(cssModuleFileHint('main .Nav_link__Ab12Cd')).toBe('Nav.module.css');
+  });
+
+  it('returns null when the shape does not pin a module name (no guessing)', () => {
+    expect(cssModuleFileHint('.card__aB3_x9')).toBeNull();
+    expect(cssModuleFileHint('.hero-title')).toBeNull();
   });
 });
 

--- a/src/lib/cssCascade.ts
+++ b/src/lib/cssCascade.ts
@@ -305,12 +305,61 @@ export function rulesToLocate(
   return out;
 }
 
+/** A class token that looks like CSS-Module output: webpack's default
+ *  `[name]_[local]__[hash]` (Next.js — `Hero_title__x7f2a`), or any class ending in a
+ *  `__`-joined hash of 4+ chars (Vite's `_title_x7f2a_1`-style is caught by locate
+ *  failing anyway; this targets the double-underscore convention). */
+const CSS_MODULE_FULL_RE = /^\w+_\w+__[A-Za-z0-9_-]+$/;
+const CSS_MODULE_HASH_SUFFIX_RE = /__[A-Za-z0-9_-]{4,}$/;
+
+/** True when any class in `selector` looks like a build-time-hashed CSS-Module class.
+ *  Used only to pick a better read-only explanation — never to gate editing (the
+ *  locate result already decided that). */
+export function looksLikeCssModuleSelector(selector: string): boolean {
+  const classes = selector.match(/\.([A-Za-z0-9_-]+)/g) ?? [];
+  return classes.some((c) => {
+    const name = c.slice(1);
+    return CSS_MODULE_FULL_RE.test(name) || CSS_MODULE_HASH_SUFFIX_RE.test(name);
+  });
+}
+
+/** The `<name>.module.css` filename implied by a hashed class, when the class follows
+ *  webpack's `[name]_[local]__[hash]` shape (`Hero_title__x7f2a` → `Hero.module.css`).
+ *  Returns null when the shape doesn't pin a name — the caller falls back to generic
+ *  wording rather than guessing. */
+export function cssModuleFileHint(selector: string): string | null {
+  const classes = selector.match(/\.([A-Za-z0-9_-]+)/g) ?? [];
+  for (const c of classes) {
+    const m = /^([A-Za-z0-9-]+?)_\w+__[A-Za-z0-9_-]+$/.exec(c.slice(1));
+    if (m) return `${m[1]}.module.css`;
+  }
+  return null;
+}
+
+/** Read-only explanation for a rule locate couldn't map, worded for the actual cause
+ *  when we can tell (CSS Modules in a Next.js project) instead of the generic bucket. */
+function notFoundReason(selector: string | null, cssModulesHint: boolean): string {
+  if (cssModulesHint && selector && looksLikeCssModuleSelector(selector)) {
+    const file = cssModuleFileHint(selector);
+    const source = file ? `${file}` : 'the .module.css file';
+    return `styled by a CSS Module — class names are hashed at build time, so Ship Studio can't map this rule back to its source yet. Edit ${source} directly or ask the agent.`;
+  }
+  return 'not in a project stylesheet (UA / framework / scoped)';
+}
+
+export interface MergeCascadeOptions {
+  /** The project bundles CSS Modules with hashed class names (Next.js) — locate
+   *  misses on module-looking selectors get a specific explanation. */
+  cssModulesHint?: boolean;
+}
+
 /** Join the iframe's matched rules with the backend's per-rule source locations
  *  into the panel's row model. `locByIndex` maps a matched-rule index → its
  *  resolved location; rows without one (inline, or unmapped) are read-only. */
 export function mergeCascade(
   matched: MatchedRule[],
-  locByIndex: Map<number, RuleLocation>
+  locByIndex: Map<number, RuleLocation>,
+  opts: MergeCascadeOptions = {}
 ): CascadeRow[] {
   return matched.map((m, index) => {
     const base: CascadeRow = {
@@ -333,7 +382,7 @@ export function mergeCascade(
     }
     const loc = locByIndex.get(index);
     if (!loc || loc.status === 'not_found') {
-      return { ...base, readonlyReason: 'not in a project stylesheet (UA / framework / scoped)' };
+      return { ...base, readonlyReason: notFoundReason(m.selector, opts.cssModulesHint ?? false) };
     }
     if (loc.status === 'multiple') {
       return { ...base, readonlyReason: 'this selector is defined in multiple files' };

--- a/src/lib/cssCascade.ts
+++ b/src/lib/cssCascade.ts
@@ -309,8 +309,14 @@ export function rulesToLocate(
  *  `[name]_[local]__[hash]` (Next.js — `Hero_title__x7f2a`), or any class ending in a
  *  `__`-joined hash of 4+ chars (Vite's `_title_x7f2a_1`-style is caught by locate
  *  failing anyway; this targets the double-underscore convention). */
-const CSS_MODULE_FULL_RE = /^\w+_\w+__[A-Za-z0-9_-]+$/;
-const CSS_MODULE_HASH_SUFFIX_RE = /__[A-Za-z0-9_-]{4,}$/;
+// The hash segment must actually look like a hash — at least one digit or
+// uppercase letter. Without that, BEM class names from third-party package
+// CSS (`.react-datepicker__header`, `.card__title`) match the `__suffix`
+// shape and get a wrong "edit the .module.css" explanation. Webpack/Next
+// hashes are mixed-case base62 (`x7f2a`, `Ab3Kx`), so this stays reliable;
+// a rare all-lowercase-alpha hash just falls back to the generic wording.
+const CSS_MODULE_FULL_RE = /^\w+_\w+__(?=[A-Za-z0-9_-]*[0-9A-Z])[A-Za-z0-9_-]+$/;
+const CSS_MODULE_HASH_SUFFIX_RE = /__(?=[A-Za-z0-9_-]*[0-9A-Z])[A-Za-z0-9_-]{4,}$/;
 
 /** True when any class in `selector` looks like a build-time-hashed CSS-Module class.
  *  Used only to pick a better read-only explanation — never to gate editing (the
@@ -330,7 +336,7 @@ export function looksLikeCssModuleSelector(selector: string): boolean {
 export function cssModuleFileHint(selector: string): string | null {
   const classes = selector.match(/\.([A-Za-z0-9_-]+)/g) ?? [];
   for (const c of classes) {
-    const m = /^([A-Za-z0-9-]+?)_\w+__[A-Za-z0-9_-]+$/.exec(c.slice(1));
+    const m = /^([A-Za-z0-9-]+?)_\w+__(?=[A-Za-z0-9_-]*[0-9A-Z])[A-Za-z0-9_-]+$/.exec(c.slice(1));
     if (m) return `${m[1]}.module.css`;
   }
   return null;

--- a/src/lib/editorGate.test.ts
+++ b/src/lib/editorGate.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { isEditorFramework, resolveEditorMode } from './editorGate';
+import type { ProjectType } from './static-server';
+
+const gate = (
+  projectType: ProjectType | undefined,
+  tailwindActive: boolean,
+  viteUsesReact = false
+) => resolveEditorMode({ projectType, tailwindActive, viteUsesReact });
+
+describe('resolveEditorMode', () => {
+  it('gives Next.js WITH Tailwind the Tailwind editor (never the CSS editor)', () => {
+    expect(gate('nextjs', true)).toBe('tailwind');
+  });
+
+  it('gives Next.js WITHOUT Tailwind the code-first CSS editor', () => {
+    expect(gate('nextjs', false)).toBe('css');
+  });
+
+  it('keeps the existing Astro split: Tailwind → tailwind, vanilla → css', () => {
+    expect(gate('astro', true)).toBe('tailwind');
+    expect(gate('astro', false)).toBe('css');
+  });
+
+  it('always gives plain HTML projects the CSS editor', () => {
+    expect(gate('statichtml', false)).toBe('css');
+  });
+
+  it('gates Vite on React and on Tailwind, and never offers Vite the CSS editor', () => {
+    expect(gate('vite', true, true)).toBe('tailwind');
+    expect(gate('vite', true, false)).toBeNull();
+    expect(gate('vite', false, true)).toBeNull();
+  });
+
+  it('offers Shopify themes only the Tailwind editor', () => {
+    expect(gate('shopifytheme', true)).toBe('tailwind');
+    expect(gate('shopifytheme', false)).toBeNull();
+  });
+
+  it('offers nothing when the project type is unknown', () => {
+    expect(gate(undefined, false)).toBeNull();
+    expect(gate(undefined, true)).toBeNull();
+  });
+
+  it('never selects both editors for the same input (mutual exclusivity)', () => {
+    const types: (ProjectType | undefined)[] = [
+      'nextjs',
+      'astro',
+      'vite',
+      'statichtml',
+      'shopifytheme',
+      undefined,
+    ];
+    for (const projectType of types) {
+      for (const tailwindActive of [true, false]) {
+        for (const viteUsesReact of [true, false]) {
+          const mode = resolveEditorMode({ projectType, tailwindActive, viteUsesReact });
+          expect([null, 'tailwind', 'css']).toContain(mode);
+        }
+      }
+    }
+  });
+});
+
+describe('isEditorFramework', () => {
+  it('accepts the class-resolver frameworks and rejects the rest', () => {
+    expect(isEditorFramework({ projectType: 'nextjs', viteUsesReact: false })).toBe(true);
+    expect(isEditorFramework({ projectType: 'astro', viteUsesReact: false })).toBe(true);
+    expect(isEditorFramework({ projectType: 'shopifytheme', viteUsesReact: false })).toBe(true);
+    expect(isEditorFramework({ projectType: 'vite', viteUsesReact: true })).toBe(true);
+    expect(isEditorFramework({ projectType: 'vite', viteUsesReact: false })).toBe(false);
+    expect(isEditorFramework({ projectType: 'statichtml', viteUsesReact: false })).toBe(false);
+    expect(isEditorFramework({ projectType: undefined, viteUsesReact: false })).toBe(false);
+  });
+});

--- a/src/lib/editorGate.ts
+++ b/src/lib/editorGate.ts
@@ -1,0 +1,55 @@
+/**
+ * Which visual editor (if any) a project gets — the single gate both the toolbar
+ * toggle and the panels derive from. Pure so the decision table is unit-testable.
+ *
+ * The two editors are mutually exclusive:
+ * - `tailwind` — the class-based visual editor (`useVisualEditor`). Requires a
+ *   supported framework AND Tailwind actually compiling in the project; class
+ *   writes in a plain-CSS project would never compile.
+ * - `css` — the code-first cascade editor (`useCssCascadeEditor`) for vanilla-CSS
+ *   projects: Astro or Next.js without Tailwind, or plain HTML/CSS. It edits real
+ *   `.css` source, so Tailwind projects (utility classes, no hand-authored rules
+ *   to speak of) keep the Tailwind editor instead.
+ *
+ * Note on Next.js: global stylesheets (e.g. `app/globals.css`) resolve and edit
+ * fine. CSS Modules do NOT — the build hashes class names (`.title` →
+ * `Hero_title__x7f2a`), so locate can't map them back; those rules render
+ * read-only with a CSS-Modules explanation (see `cssCascade.ts`).
+ */
+import type { ProjectType } from './static-server';
+
+export type EditorMode = 'tailwind' | 'css' | null;
+
+export interface EditorGateInput {
+  projectType: ProjectType | undefined;
+  /** Backend check: Tailwind actually compiles in this project. */
+  tailwindActive: boolean;
+  /** Vite only: the className resolver indexes `.tsx`/`.jsx`, so Vite must be React. */
+  viteUsesReact: boolean;
+}
+
+/** True when the project type is one the Tailwind visual editor supports. */
+export function isEditorFramework({
+  projectType,
+  viteUsesReact,
+}: Pick<EditorGateInput, 'projectType' | 'viteUsesReact'>): boolean {
+  return (
+    projectType === 'nextjs' ||
+    projectType === 'astro' ||
+    projectType === 'shopifytheme' ||
+    (projectType === 'vite' && viteUsesReact)
+  );
+}
+
+/** The editor mode this project qualifies for (before the serverReady gate). */
+export function resolveEditorMode(input: EditorGateInput): EditorMode {
+  const { projectType, tailwindActive } = input;
+  if (isEditorFramework(input) && tailwindActive) return 'tailwind';
+  if (
+    ((projectType === 'astro' || projectType === 'nextjs') && !tailwindActive) ||
+    projectType === 'statichtml'
+  ) {
+    return 'css';
+  }
+  return null;
+}


### PR DESCRIPTION
## What

Next.js projects **without Tailwind** now get the code-first CSS cascade editor (`CssCascadePanel` / `useCssCascadeEditor`) — the same editor Astro-without-Tailwind and plain-HTML projects already use. Next.js **with** Tailwind keeps the Tailwind visual editor, exactly as before.

## Gate change

The editor-mode decision (`editorEnabled` / `cssEditorEnabled` / `editorMode` in `Preview.tsx`) is now derived from a pure helper, `resolveEditorMode` in `src/lib/editorGate.ts`, and the CSS-editor branch includes `nextjs && !tailwindActive` (mirroring the Astro pattern; the `serverReady` condition is unchanged). The two editors stay mutually exclusive:

| Project | Editor |
|---|---|
| Next.js + Tailwind | Tailwind editor (unchanged) |
| Next.js, vanilla CSS | **CSS cascade editor (new)** |
| Astro ± Tailwind, static HTML, Vite/React | unchanged |

The full decision table is unit-tested in `src/lib/editorGate.test.ts`.

## `.next/` and `out/` pruning

The backend engine matches rendered selector text against source stylesheets, so a compiled bundle on disk would double-match every selector → spurious `Multiple` → read-only rows.

- `.next/` was **already pruned** — it's in `code.rs`'s `SKIP_DIRS` (and the walker's standard filters skip hidden dirs). Verified, not changed.
- `out/` (`next export` output) was not — it's now pruned in `discover_stylesheets` only (too generic a name to hide from code mode globally).
- New Rust regression test: a fixture with `app/globals.css` plus the same selector in `.next/static/css/x.css` and `out/_next/static/css/x.css` discovers only the source file, and `locate_rule` resolves it uniquely (`Resolved`, not `Multiple`).

## CSS Modules limitation (by design, this slice)

Next.js hashes CSS-Module class names at build time (`.title` → `Hero_title__x7f2a`), and the engine matches literal selector text — those rules resolve `not_found` and stay **read-only**. Instead of the vague generic message, the read-only note now explains it when the project is Next.js and the selector looks module-hashed:

> styled by a CSS Module — class names are hashed at build time, so Ship Studio can't map this rule back to its source yet. Edit Hero.module.css directly or ask the agent.

The `<Name>.module.css` hint is only included when the class follows webpack's `[name]_[local]__[hash]` shape (never guessed); otherwise it falls back to "the .module.css file". Global stylesheets (`app/globals.css`, any imported plain `.css`) edit normally.

Also sanity-checked: next-intl / i18n locale path prefixes don't affect stylesheet discovery (it's filesystem-based; the served-href hint only uses the CSS file's basename).

## Verification

- `pnpm typecheck`, `pnpm lint:strict`, `pnpm test:run` (1131 passed), `pnpm check:patterns`, `pnpm check:loc` — all green
- `cd src-tauri && cargo test` (all green incl. new test), `cargo fmt`, `cargo clippy` (no new warnings)

### Manual test script

1. Open a Next.js project **without** Tailwind (plain CSS, e.g. styles in `app/globals.css`) → the Edit toggle appears in the preview toolbar.
2. Enter edit mode, click an element styled from `globals.css` → its cascade shows the rule as editable with file/line.
3. Change a color → the preview updates live and the change lands in `app/globals.css` on disk.
4. Click an element styled by a `*.module.css` file → its rule is read-only with the CSS-Modules explanation (names the module file).
5. Open a Next.js project **with** Tailwind → the Tailwind visual editor appears (not the CSS editor).
6. Regression: an Astro-without-Tailwind and a plain-HTML project still get the CSS editor.
7. If the project has run `next build` / `next export` (`.next/` or `out/` present), confirm globals-styled rules are still editable (not "defined in multiple files").

🤖 Generated with [Claude Code](https://claude.com/claude-code)