### PR TITLE
Agent Connect uses dedicated auth flows; verify Windows cmd.exe quoting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,16 @@ jobs:
       - name: Build frontend
         run: pnpm build
 
+      # ConPTY spawn-shape canaries (direct vs. cmd.exe-wrapped PowerShell,
+      # see pty_session.rs tests). Run first and with --nocapture so the
+      # captured PTY output of BOTH variants is in the log as evidence even
+      # when they pass — these tests exist to answer a quoting question, not
+      # just to gate.
+      - name: PTY spawn-shape canaries (verbose)
+        env:
+          CSTAR_IDENTITY_SECRET: ${{ secrets.CSTAR_IDENTITY_SECRET }}
+        run: cargo test --manifest-path src-tauri/Cargo.toml preserves_pipe_and_spaces_through_pty -- --nocapture
+
       - name: Backend tests
         env:
           CSTAR_IDENTITY_SECRET: ${{ secrets.CSTAR_IDENTITY_SECRET }}

--- a/src-tauri/src/commands/pty_session.rs
+++ b/src-tauri/src/commands/pty_session.rs
@@ -642,25 +642,43 @@ mod tests {
         assert!(!env_has_key(&env, "COMSPEC"));
     }
 
-    /// Spawn `argv` through a real ConPTY and read its output with a hard
-    /// deadline. Never hangs: the PTY read runs on a separate thread; if the
-    /// deadline passes, the child is killed and whatever output WAS captured
-    /// is returned as diagnostic evidence (`timed_out = true`).
+    /// Spawn `argv` through a real ConPTY, read its output with a hard
+    /// deadline, and emulate the one piece of terminal behavior ConPTY
+    /// requires: answering its Device Status Report query.
     ///
-    /// This boundedness is not optional hygiene — the first version of the
-    /// quoting canary below read the PTY to EOF on the test thread, wedged on
-    /// the very bug it was probing, and had to be killed by the CI job's
-    /// 40-minute timeout:
-    /// https://github.com/ship-studio/ship-studio/actions/runs/28903431927/job/85745268821
+    /// On session start (and possibly again later) ConPTY writes `ESC[6n`
+    /// (cursor position query) to the terminal side and BLOCKS pumping child
+    /// output until a cursor position report comes back. In the app, xterm.js
+    /// answers this automatically; a raw harness that never replies stalls
+    /// EVERY spawn shape on the handshake, regardless of quoting. Both
+    /// earlier versions of the canaries below hit exactly that:
+    ///  - unbounded first version: wedged a CI runner until the job's
+    ///    40-minute kill —
+    ///    https://github.com/ship-studio/ship-studio/actions/runs/28903431927/job/85745268821
+    ///  - bounded second version: the DIRECT (unwrapped) spawn also timed
+    ///    out, with `ESC[6n` as the only captured output —
+    ///    https://github.com/ship-studio/ship-studio/actions/runs/28905743965/job/85752341507
+    /// So this harness scans the accumulated output for `ESC[6n` (it can
+    /// arrive split across reads, and ConPTY may re-query) and writes
+    /// `ESC[1;1R` back to the PTY for each query seen.
+    ///
+    /// Boundedness: the PTY read runs on a separate thread; if the deadline
+    /// passes, the child is killed and whatever output WAS captured is
+    /// returned as diagnostic evidence (`timed_out = true`).
     #[cfg(windows)]
     fn run_through_pty_bounded(
         argv: &[&str],
         deadline: std::time::Duration,
     ) -> (String, Option<portable_pty::ExitStatus>, bool) {
         use portable_pty::{native_pty_system, CommandBuilder, PtySize};
-        use std::io::Read;
+        use std::io::{Read, Write};
         use std::sync::mpsc;
         use std::time::{Duration, Instant};
+
+        /// ConPTY's cursor-position query (DSR 6).
+        const DSR_QUERY: &[u8] = b"\x1b[6n";
+        /// Cursor position report: "cursor at row 1, col 1".
+        const DSR_REPLY: &[u8] = b"\x1b[1;1R";
 
         let pty_system = native_pty_system();
         let pair = pty_system
@@ -677,6 +695,10 @@ mod tests {
 
         let mut child = pair.slave.spawn_command(cmd).expect("spawn failed");
         drop(pair.slave);
+
+        // Writer for the terminal->child direction: used solely to answer
+        // ConPTY's DSR queries. Kept alive for the whole session.
+        let mut writer = pair.master.take_writer().expect("take PTY writer failed");
 
         // Reader thread: forwards each chunk over a channel; dropping the
         // sender signals EOF. The test thread never blocks on the PTY itself.
@@ -704,13 +726,29 @@ mod tests {
         let start = Instant::now();
         let mut raw = Vec::new();
         let mut timed_out = false;
+        let mut dsr_replies_sent = 0usize;
         loop {
             let Some(remaining) = deadline.checked_sub(start.elapsed()) else {
                 timed_out = true;
                 break;
             };
             match rx.recv_timeout(remaining) {
-                Ok(chunk) => raw.extend_from_slice(&chunk),
+                Ok(chunk) => {
+                    raw.extend_from_slice(&chunk);
+                    // Answer every DSR query seen so far. Scan the WHOLE
+                    // accumulated buffer (a query can arrive split across
+                    // reads) and track how many we've already answered
+                    // (ConPTY may re-query).
+                    let queries_seen = raw
+                        .windows(DSR_QUERY.len())
+                        .filter(|w| *w == DSR_QUERY)
+                        .count();
+                    while dsr_replies_sent < queries_seen {
+                        writer.write_all(DSR_REPLY).expect("DSR reply failed");
+                        writer.flush().expect("DSR reply flush failed");
+                        dsr_replies_sent += 1;
+                    }
+                }
                 Err(mpsc::RecvTimeoutError::Timeout) => {
                     timed_out = true;
                     break;
@@ -736,17 +774,15 @@ mod tests {
         )
     }
 
-    /// Windows quoting verification (onboarding audit finding #13) — proves
-    /// the FIX: spawning PowerShell *directly* through portable_pty (no
-    /// cmd.exe wrapper) preserves a piped, space-laden `-Command` argument.
-    ///
-    /// This mirrors how OnboardingTerminal (src/components/setup/
-    /// OnboardingTerminal.tsx) now spawns real executables on Windows after
-    /// the cmd.exe wrapper was scoped down to `.cmd`/`.bat` shims only (see
-    /// `needsCmdExeWrapper` in src/lib/setup.ts). portable_pty quotes each
-    /// argv entry with CRT-compatible ArgvQuote rules, and PowerShell's own
-    /// argv parsing reverses exactly those rules — no shell re-parse in
-    /// between.
+    /// Windows spawn-shape canary (onboarding audit finding #13), variant 1:
+    /// PowerShell spawned DIRECTLY through portable_pty (no cmd.exe wrapper)
+    /// with a piped, space-laden `-Command` argument. This mirrors how
+    /// OnboardingTerminal (src/components/setup/OnboardingTerminal.tsx) now
+    /// spawns real executables on Windows after the cmd.exe wrapper was
+    /// scoped down to `.cmd`/`.bat` shims (see `needsCmdExeWrapper` in
+    /// src/lib/setup.ts). portable_pty quotes each argv entry with
+    /// CRT-compatible ArgvQuote rules, and PowerShell's own argv parsing
+    /// reverses exactly those rules — no shell re-parse in between.
     ///
     /// The pipe stage uppercases the string, so the expected output
     /// ("HELLO WORLD") can only appear if the *whole* expression — spaces,
@@ -763,6 +799,12 @@ mod tests {
             std::time::Duration::from_secs(60),
         );
 
+        // Always print the evidence — CI runs this step with --nocapture so
+        // the captured PTY output is on record even when the test passes.
+        println!(
+            "[canary:direct] timed_out={timed_out} status={status:?} output:\n{}",
+            output.escape_debug()
+        );
         assert!(
             output.contains("HELLO WORLD"),
             "PowerShell pipe/spaces did not survive a direct portable_pty spawn.\n\
@@ -775,32 +817,28 @@ mod tests {
         );
     }
 
-    /// Regression record for the BUG behind audit finding #13 — kept
-    /// `#[ignore]`d so the failure mode stays on file without spending ~30s
-    /// of CI on every run.
+    /// Windows spawn-shape canary, variant 2: the same piped PowerShell
+    /// expression routed through `cmd.exe /C` — the shape OnboardingTerminal
+    /// used for EVERY Windows command before `needsCmdExeWrapper` scoped the
+    /// wrapper down to `.cmd`/`.bat` shims.
     ///
-    /// OnboardingTerminal used to wrap EVERY Windows command as
-    /// `cmd.exe /C <command> <args...>`. portable_pty rebuilds a single
-    /// command-line string from the argv, and `cmd.exe /C` then RE-PARSES
-    /// that string with its own rules: when the quoted section contains a
-    /// special character (`|` here), cmd strips the outer quotes (see the
-    /// quote-processing rules in `cmd /?`), exposing the pipe to cmd itself.
-    /// The pipeline is split at `|`, PowerShell runs with a mangled
-    /// `-Command`, and the PTY blocks forever — observed live as this exact
-    /// test's first (unbounded) version hanging a CI runner until the job's
-    /// 40-minute kill:
-    /// https://github.com/ship-studio/ship-studio/actions/runs/28903431927/job/85745268821
-    /// That is the same failure users hit as "the Windows Claude/Cursor
-    /// installer hangs".
+    /// This test answers audit finding #13's actual question: does cmd.exe's
+    /// re-parse of the portable_pty-composed command line mangle a quoted
+    /// argument containing `|` and spaces? (cmd's quote-processing rules —
+    /// see `cmd /?` — strip quotes in some special-character cases, which
+    /// would split the pipeline at the `|` and leave PowerShell interactive.)
     ///
-    /// The assertion is inverted — it PASSES while the wrapper stays broken.
-    /// If a run of `cargo test -- --ignored` ever fails here, cmd.exe/
-    /// portable_pty composition has changed and the cmd.exe path in
-    /// `needsCmdExeWrapper` (src/lib/setup.ts) deserves a fresh look.
+    /// History, for honesty: two earlier CI hangs were attributed to this
+    /// quote-stripping, but both were actually the harness failing to answer
+    /// ConPTY's DSR handshake (see `run_through_pty_bounded`) — the direct
+    /// (unwrapped) variant stalled identically. With the handshake answered,
+    /// this test measures quoting and nothing else. Whichever way it
+    /// resolves, the direct spawn in OnboardingTerminal stays preferable
+    /// (one fewer re-parse layer), but the outcome decides how loudly
+    /// `needsCmdExeWrapper` must warn about the wrapped path.
     #[cfg(windows)]
     #[test]
-    #[ignore = "documents the broken cmd.exe /C wrapper shape; run with -- --ignored"]
-    fn cmd_exe_slash_c_wrapper_breaks_piped_powershell_expression() {
+    fn cmd_exe_wrapped_powershell_spawn_preserves_pipe_and_spaces_through_pty() {
         let expression = "'hello world' | ForEach-Object { $_.ToUpper() }";
         let (output, status, timed_out) = run_through_pty_bounded(
             &[
@@ -811,14 +849,20 @@ mod tests {
                 "-Command",
                 expression,
             ],
-            std::time::Duration::from_secs(30),
+            std::time::Duration::from_secs(60),
         );
 
+        println!(
+            "[canary:cmd-wrapped] timed_out={timed_out} status={status:?} output:\n{}",
+            output.escape_debug()
+        );
         assert!(
-            timed_out || !output.contains("HELLO WORLD"),
-            "cmd.exe /C wrapping unexpectedly preserved the piped expression — \
-             the wrapper decision in needsCmdExeWrapper may be revisitable.\n\
-             Exit status: {status:?}\nCaptured PTY output:\n{output}"
+            output.contains("HELLO WORLD") && !timed_out,
+            "cmd.exe /C re-parse mangled the piped PowerShell expression — \
+             audit finding #13's quote-stripping hazard is real for the wrapped \
+             shape. Keep needsCmdExeWrapper routing real executables to direct \
+             spawn, and document this captured evidence.\n\
+             timed_out: {timed_out}\nExit status: {status:?}\nCaptured PTY output:\n{output}"
         );
     }
 }

--- a/src-tauri/src/commands/pty_session.rs
+++ b/src-tauri/src/commands/pty_session.rs
@@ -805,15 +805,15 @@ mod tests {
             "[canary:direct] timed_out={timed_out} status={status:?} output:\n{}",
             output.escape_debug()
         );
+        // Success = the marker made it through intact. `timed_out` is
+        // deliberately NOT asserted: ConPTY sessions linger after the child
+        // exits (observed on the runner — expected output present, child
+        // status Some(code 0), session still open at the deadline), so
+        // "didn't EOF by the deadline" says nothing about quoting.
         assert!(
             output.contains("HELLO WORLD"),
             "PowerShell pipe/spaces did not survive a direct portable_pty spawn.\n\
              timed_out: {timed_out}\nExit status: {status:?}\nCaptured PTY output:\n{output}"
-        );
-        assert!(
-            !timed_out,
-            "pipeline produced the expected output but never exited; status: {status:?}\n\
-             Captured PTY output:\n{output}"
         );
     }
 
@@ -832,10 +832,15 @@ mod tests {
     /// quote-stripping, but both were actually the harness failing to answer
     /// ConPTY's DSR handshake (see `run_through_pty_bounded`) — the direct
     /// (unwrapped) variant stalled identically. With the handshake answered,
-    /// this test measures quoting and nothing else. Whichever way it
-    /// resolves, the direct spawn in OnboardingTerminal stays preferable
-    /// (one fewer re-parse layer), but the outcome decides how loudly
-    /// `needsCmdExeWrapper` must warn about the wrapped path.
+    /// this test measures quoting and nothing else.
+    ///
+    /// VERDICT (verified on the Windows runner, job 85754711506): the piped
+    /// expression survives cmd.exe's re-parse INTACT — "HELLO WORLD" was
+    /// produced by both this wrapped shape and the direct one. Audit finding
+    /// #13's quote-stripping hazard is a false alarm. The direct spawn in
+    /// OnboardingTerminal is kept anyway as a defensive simplification (one
+    /// fewer re-parse layer, deterministic absolute-path spawn) — not as a
+    /// bug fix.
     #[cfg(windows)]
     #[test]
     fn cmd_exe_wrapped_powershell_spawn_preserves_pipe_and_spaces_through_pty() {
@@ -856,12 +861,14 @@ mod tests {
             "[canary:cmd-wrapped] timed_out={timed_out} status={status:?} output:\n{}",
             output.escape_debug()
         );
+        // Same success criterion as the direct variant: the marker arriving
+        // intact IS the answer to the quoting question. Session-lingering
+        // past the deadline is a ConPTY teardown quirk, not evidence of
+        // mangling (see the direct variant's comment).
         assert!(
-            output.contains("HELLO WORLD") && !timed_out,
+            output.contains("HELLO WORLD"),
             "cmd.exe /C re-parse mangled the piped PowerShell expression — \
-             audit finding #13's quote-stripping hazard is real for the wrapped \
-             shape. Keep needsCmdExeWrapper routing real executables to direct \
-             spawn, and document this captured evidence.\n\
+             the quoted argument did not reach PowerShell intact.\n\
              timed_out: {timed_out}\nExit status: {status:?}\nCaptured PTY output:\n{output}"
         );
     }

--- a/src-tauri/src/commands/pty_session.rs
+++ b/src-tauri/src/commands/pty_session.rs
@@ -642,39 +642,25 @@ mod tests {
         assert!(!env_has_key(&env, "COMSPEC"));
     }
 
-    /// Windows-only quoting verification (onboarding audit finding #13).
+    /// Spawn `argv` through a real ConPTY and read its output with a hard
+    /// deadline. Never hangs: the PTY read runs on a separate thread; if the
+    /// deadline passes, the child is killed and whatever output WAS captured
+    /// is returned as diagnostic evidence (`timed_out = true`).
     ///
-    /// OnboardingTerminal wraps every Windows command as
-    /// `cmd.exe /C <command> <args...>` and spawns it through portable_pty
-    /// (see src/components/setup/OnboardingTerminal.tsx and the vendored
-    /// plugin at plugins/tauri-plugin-pty — this crate is where CI actually
-    /// runs tests, the plugin package's own test module is not a workspace
-    /// member). portable_pty rebuilds a single command-line string from the
-    /// argv on Windows, and cmd.exe then RE-PARSES that string. For the
-    /// PowerShell one-liner installers in TERMINAL_COMMANDS (src/lib/setup.ts),
-    /// e.g. `powershell -Command "irm https://claude.ai/install.ps1 | iex"`,
-    /// the pipe + spaces argument was a suspected quoting-breakage vector:
-    /// if the argv-to-string composition drops the quotes, cmd.exe splits the
-    /// pipeline at `|` itself and the PowerShell expression never runs intact.
-    ///
-    /// The pipe stage uppercases the string, so the expected output
-    /// ("HELLO WORLD") can only appear if the *whole* expression — spaces,
-    /// quotes, and pipe — reached PowerShell as one argument. If quoting
-    /// broke, cmd.exe would pipe PowerShell's lowercase output into a
-    /// nonexistent `ForEach-Object` executable instead ("'ForEach-Object' is
-    /// not recognized…"), and the assertion fails with the captured output.
+    /// This boundedness is not optional hygiene — the first version of the
+    /// quoting canary below read the PTY to EOF on the test thread, wedged on
+    /// the very bug it was probing, and had to be killed by the CI job's
+    /// 40-minute timeout:
+    /// https://github.com/ship-studio/ship-studio/actions/runs/28903431927/job/85745268821
     #[cfg(windows)]
-    #[test]
-    fn cmd_exe_slash_c_preserves_powershell_pipe_and_spaces_through_pty() {
+    fn run_through_pty_bounded(
+        argv: &[&str],
+        deadline: std::time::Duration,
+    ) -> (String, Option<portable_pty::ExitStatus>, bool) {
         use portable_pty::{native_pty_system, CommandBuilder, PtySize};
         use std::io::Read;
-
-        // Mirror OnboardingTerminal's composition exactly: cmd.exe, /C, then
-        // the command and its args as SEPARATE argv entries.
-        //   spawnCmd  = 'cmd.exe'
-        //   spawnArgs = ['/C', command, ...args]
-        // with command='powershell', args=['-Command', <expr with spaces + pipe>].
-        let expression = "'hello world' | ForEach-Object { $_.ToUpper() }";
+        use std::sync::mpsc;
+        use std::time::{Duration, Instant};
 
         let pty_system = native_pty_system();
         let pair = pty_system
@@ -686,45 +672,153 @@ mod tests {
             })
             .expect("openpty failed");
 
-        let mut cmd = CommandBuilder::new("cmd.exe");
-        cmd.args(["/C", "powershell", "-Command", expression]);
+        let mut cmd = CommandBuilder::new(argv[0]);
+        cmd.args(&argv[1..]);
 
-        let mut child = pair.slave.spawn_command(cmd).expect("spawn cmd.exe failed");
+        let mut child = pair.slave.spawn_command(cmd).expect("spawn failed");
         drop(pair.slave);
 
-        // Watchdog: if the pipeline wedges (e.g. PowerShell waiting on stdin
-        // because the expression was mangled into a bare `powershell` REPL),
-        // kill it so the test fails with output instead of hanging CI.
-        let mut killer = child.clone_killer();
-        std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_secs(60));
-            let _ = killer.kill();
-        });
-
+        // Reader thread: forwards each chunk over a channel; dropping the
+        // sender signals EOF. The test thread never blocks on the PTY itself.
         let mut reader = pair
             .master
             .try_clone_reader()
             .expect("clone PTY reader failed");
+        let (tx, rx) = mpsc::channel::<Vec<u8>>();
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => break, // EOF: child exited, ConPTY closed
+                    Ok(n) => {
+                        if tx.send(buf[..n].to_vec()).is_err() {
+                            break;
+                        }
+                    }
+                    // ConPTY reports the close as an error on some builds.
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let start = Instant::now();
         let mut raw = Vec::new();
-        let mut buf = [0u8; 4096];
+        let mut timed_out = false;
         loop {
-            match reader.read(&mut buf) {
-                Ok(0) => break, // EOF: child exited, ConPTY closed
-                Ok(n) => raw.extend_from_slice(&buf[..n]),
-                Err(_) => break, // ConPTY reports the close as an error on some builds
+            let Some(remaining) = deadline.checked_sub(start.elapsed()) else {
+                timed_out = true;
+                break;
+            };
+            match rx.recv_timeout(remaining) {
+                Ok(chunk) => raw.extend_from_slice(&chunk),
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    timed_out = true;
+                    break;
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => break, // EOF
             }
         }
-        let status = child.wait().expect("wait on child failed");
-        let output = String::from_utf8_lossy(&raw);
+
+        if timed_out {
+            // Kill the wedged child so `wait()` below returns promptly, then
+            // drain any teardown output (the reader hits EOF after the kill
+            // and drops the sender, ending this loop via Disconnected).
+            let _ = child.kill();
+            while let Ok(chunk) = rx.recv_timeout(Duration::from_secs(5)) {
+                raw.extend_from_slice(&chunk);
+            }
+        }
+        let status = child.wait().ok();
+        (
+            String::from_utf8_lossy(&raw).into_owned(),
+            status,
+            timed_out,
+        )
+    }
+
+    /// Windows quoting verification (onboarding audit finding #13) — proves
+    /// the FIX: spawning PowerShell *directly* through portable_pty (no
+    /// cmd.exe wrapper) preserves a piped, space-laden `-Command` argument.
+    ///
+    /// This mirrors how OnboardingTerminal (src/components/setup/
+    /// OnboardingTerminal.tsx) now spawns real executables on Windows after
+    /// the cmd.exe wrapper was scoped down to `.cmd`/`.bat` shims only (see
+    /// `needsCmdExeWrapper` in src/lib/setup.ts). portable_pty quotes each
+    /// argv entry with CRT-compatible ArgvQuote rules, and PowerShell's own
+    /// argv parsing reverses exactly those rules — no shell re-parse in
+    /// between.
+    ///
+    /// The pipe stage uppercases the string, so the expected output
+    /// ("HELLO WORLD") can only appear if the *whole* expression — spaces,
+    /// quotes, and pipe — reached PowerShell as one argument. The test lives
+    /// in this crate (not the vendored plugin at plugins/tauri-plugin-pty)
+    /// because the plugin package is not a workspace member and CI never runs
+    /// its test module.
+    #[cfg(windows)]
+    #[test]
+    fn direct_powershell_spawn_preserves_pipe_and_spaces_through_pty() {
+        let expression = "'hello world' | ForEach-Object { $_.ToUpper() }";
+        let (output, status, timed_out) = run_through_pty_bounded(
+            &["powershell", "-NoProfile", "-Command", expression],
+            std::time::Duration::from_secs(60),
+        );
 
         assert!(
             output.contains("HELLO WORLD"),
-            "PowerShell pipe/spaces did not survive `cmd.exe /C` re-parsing.\n\
-             Exit status: {status:?}\nCaptured PTY output:\n{output}"
+            "PowerShell pipe/spaces did not survive a direct portable_pty spawn.\n\
+             timed_out: {timed_out}\nExit status: {status:?}\nCaptured PTY output:\n{output}"
         );
         assert!(
-            status.success(),
-            "pipeline exited non-zero ({status:?}); captured PTY output:\n{output}"
+            !timed_out,
+            "pipeline produced the expected output but never exited; status: {status:?}\n\
+             Captured PTY output:\n{output}"
+        );
+    }
+
+    /// Regression record for the BUG behind audit finding #13 — kept
+    /// `#[ignore]`d so the failure mode stays on file without spending ~30s
+    /// of CI on every run.
+    ///
+    /// OnboardingTerminal used to wrap EVERY Windows command as
+    /// `cmd.exe /C <command> <args...>`. portable_pty rebuilds a single
+    /// command-line string from the argv, and `cmd.exe /C` then RE-PARSES
+    /// that string with its own rules: when the quoted section contains a
+    /// special character (`|` here), cmd strips the outer quotes (see the
+    /// quote-processing rules in `cmd /?`), exposing the pipe to cmd itself.
+    /// The pipeline is split at `|`, PowerShell runs with a mangled
+    /// `-Command`, and the PTY blocks forever — observed live as this exact
+    /// test's first (unbounded) version hanging a CI runner until the job's
+    /// 40-minute kill:
+    /// https://github.com/ship-studio/ship-studio/actions/runs/28903431927/job/85745268821
+    /// That is the same failure users hit as "the Windows Claude/Cursor
+    /// installer hangs".
+    ///
+    /// The assertion is inverted — it PASSES while the wrapper stays broken.
+    /// If a run of `cargo test -- --ignored` ever fails here, cmd.exe/
+    /// portable_pty composition has changed and the cmd.exe path in
+    /// `needsCmdExeWrapper` (src/lib/setup.ts) deserves a fresh look.
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "documents the broken cmd.exe /C wrapper shape; run with -- --ignored"]
+    fn cmd_exe_slash_c_wrapper_breaks_piped_powershell_expression() {
+        let expression = "'hello world' | ForEach-Object { $_.ToUpper() }";
+        let (output, status, timed_out) = run_through_pty_bounded(
+            &[
+                "cmd.exe",
+                "/C",
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                expression,
+            ],
+            std::time::Duration::from_secs(30),
+        );
+
+        assert!(
+            timed_out || !output.contains("HELLO WORLD"),
+            "cmd.exe /C wrapping unexpectedly preserved the piped expression — \
+             the wrapper decision in needsCmdExeWrapper may be revisitable.\n\
+             Exit status: {status:?}\nCaptured PTY output:\n{output}"
         );
     }
 }

--- a/src-tauri/src/commands/pty_session.rs
+++ b/src-tauri/src/commands/pty_session.rs
@@ -641,4 +641,90 @@ mod tests {
         assert!(env_has_key(&env, "systemroot"));
         assert!(!env_has_key(&env, "COMSPEC"));
     }
+
+    /// Windows-only quoting verification (onboarding audit finding #13).
+    ///
+    /// OnboardingTerminal wraps every Windows command as
+    /// `cmd.exe /C <command> <args...>` and spawns it through portable_pty
+    /// (see src/components/setup/OnboardingTerminal.tsx and the vendored
+    /// plugin at plugins/tauri-plugin-pty — this crate is where CI actually
+    /// runs tests, the plugin package's own test module is not a workspace
+    /// member). portable_pty rebuilds a single command-line string from the
+    /// argv on Windows, and cmd.exe then RE-PARSES that string. For the
+    /// PowerShell one-liner installers in TERMINAL_COMMANDS (src/lib/setup.ts),
+    /// e.g. `powershell -Command "irm https://claude.ai/install.ps1 | iex"`,
+    /// the pipe + spaces argument was a suspected quoting-breakage vector:
+    /// if the argv-to-string composition drops the quotes, cmd.exe splits the
+    /// pipeline at `|` itself and the PowerShell expression never runs intact.
+    ///
+    /// The pipe stage uppercases the string, so the expected output
+    /// ("HELLO WORLD") can only appear if the *whole* expression — spaces,
+    /// quotes, and pipe — reached PowerShell as one argument. If quoting
+    /// broke, cmd.exe would pipe PowerShell's lowercase output into a
+    /// nonexistent `ForEach-Object` executable instead ("'ForEach-Object' is
+    /// not recognized…"), and the assertion fails with the captured output.
+    #[cfg(windows)]
+    #[test]
+    fn cmd_exe_slash_c_preserves_powershell_pipe_and_spaces_through_pty() {
+        use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+        use std::io::Read;
+
+        // Mirror OnboardingTerminal's composition exactly: cmd.exe, /C, then
+        // the command and its args as SEPARATE argv entries.
+        //   spawnCmd  = 'cmd.exe'
+        //   spawnArgs = ['/C', command, ...args]
+        // with command='powershell', args=['-Command', <expr with spaces + pipe>].
+        let expression = "'hello world' | ForEach-Object { $_.ToUpper() }";
+
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows: 24,
+                cols: 120,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("openpty failed");
+
+        let mut cmd = CommandBuilder::new("cmd.exe");
+        cmd.args(["/C", "powershell", "-Command", expression]);
+
+        let mut child = pair.slave.spawn_command(cmd).expect("spawn cmd.exe failed");
+        drop(pair.slave);
+
+        // Watchdog: if the pipeline wedges (e.g. PowerShell waiting on stdin
+        // because the expression was mangled into a bare `powershell` REPL),
+        // kill it so the test fails with output instead of hanging CI.
+        let mut killer = child.clone_killer();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_secs(60));
+            let _ = killer.kill();
+        });
+
+        let mut reader = pair
+            .master
+            .try_clone_reader()
+            .expect("clone PTY reader failed");
+        let mut raw = Vec::new();
+        let mut buf = [0u8; 4096];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break, // EOF: child exited, ConPTY closed
+                Ok(n) => raw.extend_from_slice(&buf[..n]),
+                Err(_) => break, // ConPTY reports the close as an error on some builds
+            }
+        }
+        let status = child.wait().expect("wait on child failed");
+        let output = String::from_utf8_lossy(&raw);
+
+        assert!(
+            output.contains("HELLO WORLD"),
+            "PowerShell pipe/spaces did not survive `cmd.exe /C` re-parsing.\n\
+             Exit status: {status:?}\nCaptured PTY output:\n{output}"
+        );
+        assert!(
+            status.success(),
+            "pipeline exited non-zero ({status:?}); captured PTY output:\n{output}"
+        );
+    }
 }

--- a/src/components/setup/OnboardingScreen.tsx
+++ b/src/components/setup/OnboardingScreen.tsx
@@ -402,9 +402,10 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
       // Refresh status immediately
       void fetchStatus();
       // For auth items, do a delayed re-check in case the auth process
-      // was still completing when the user cancelled (e.g., gh/vercel
-      // writing the token after receiving the OAuth callback)
-      if (itemId === 'gh_auth' || itemId === 'vercel_auth' || itemId === 'claude_auth') {
+      // was still completing when the user cancelled (e.g., gh/vercel/codex
+      // writing the token after receiving the OAuth callback). Derived from
+      // the `*_auth` convention so new auth flows get this for free.
+      if (itemId.endsWith('_auth')) {
         setTimeout(() => void fetchStatus(), 2000);
       }
     }

--- a/src/components/setup/OnboardingTerminal.tsx
+++ b/src/components/setup/OnboardingTerminal.tsx
@@ -343,14 +343,15 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
           // Windows spawn shape. Only .cmd/.bat shims (npm, vercel, npx)
           // go through `cmd.exe /C` — they are batch scripts and need it.
           // Real executables (powershell, gh, claude, codex, git) are
-          // spawned DIRECTLY: routing them through cmd.exe means cmd
-          // re-parses the portable_pty-composed command line, and its quote
-          // rules strip the quotes around any argument containing a special
-          // char — a piped PowerShell one-liner installer gets split at the
-          // `|` by cmd itself and PowerShell blocks forever in interactive
-          // mode. Observed live as a CI Windows runner hang (the exact
-          // installer-hang users reported):
-          // https://github.com/ship-studio/ship-studio/actions/runs/28903431927/job/85745268821
+          // spawned DIRECTLY: routing them through cmd.exe adds a second
+          // parse layer (cmd re-parses the portable_pty-composed command
+          // line with its own quote rules) between us and the target;
+          // direct spawn removes it, so arguments like a piped PowerShell
+          // installer one-liner reach the target exactly as composed. Both
+          // spawn shapes are exercised under a real ConPTY by the canary
+          // tests in src-tauri/src/commands/pty_session.rs (windows-check
+          // CI job, "PTY spawn-shape canaries" step) — see
+          // needsCmdExeWrapper's doc comment for the evidence history.
           if (needsCmdExeWrapper(command, resolved?.path)) {
             spawnCmd = 'cmd.exe';
             spawnArgs = ['/C', command, ...args];

--- a/src/components/setup/OnboardingTerminal.tsx
+++ b/src/components/setup/OnboardingTerminal.tsx
@@ -16,7 +16,7 @@ import { homeDir } from '@tauri-apps/api/path';
 import { getSystemEnv, getShellPath } from '../../lib/project';
 import { readDir, exists } from '@tauri-apps/plugin-fs';
 import { loadNerdFonts } from '../../lib/fonts';
-import { isWindows, resolveCliPath, ResolvedCli } from '../../lib/setup';
+import { isWindows, needsCmdExeWrapper, resolveCliPath, ResolvedCli } from '../../lib/setup';
 import { isPasteChord, readClipboardText } from '../../lib/clipboard';
 import { createPtyChunkDecoder, toPtyBytes, type PtyChunk } from '../../lib/terminalDiagnostics';
 import { logger } from '../../lib/logger';
@@ -232,9 +232,12 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
             TERM: 'xterm-256color',
           };
 
-          // Wrap command through cmd.exe /C for .cmd scripts (vercel, npx, etc.)
-          spawnCmd = 'cmd.exe';
-          spawnArgs = ['/C', command, ...args];
+          // Placeholder — the real Windows spawn shape (direct vs. wrapped in
+          // cmd.exe /C) is decided AFTER binary resolution below, because the
+          // decision depends on what the command resolves to (.cmd shim vs.
+          // real executable). See needsCmdExeWrapper in lib/setup.ts.
+          spawnCmd = command;
+          spawnArgs = args;
         } else {
           // macOS/Linux: existing Unix path and env logic
           const userPaths = [
@@ -298,8 +301,8 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
         // PTY that spawns nothing and hangs. Resolution errors fail OPEN —
         // the spawn proceeds and the watchdog below stays the backstop.
         const isBareName = !command.includes('/') && !command.includes('\\');
+        let resolved: ResolvedCli | null | undefined;
         if (isBareName) {
-          let resolved: ResolvedCli | null | undefined;
           try {
             resolved = await resolveCliPath(command);
           } catch (err) {
@@ -329,11 +332,35 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
             }
             if (!isWin) {
               // Spawn the resolved absolute path — deterministic, no PATH
-              // shadowing. (Windows keeps the cmd.exe /C wrapper: .cmd shims
-              // need it, and quoting paths with spaces through cmd is riskier
-              // than the PATH append above.)
+              // shadowing. (The Windows equivalent happens in the spawn-shape
+              // block below, where wrapper-vs-direct is decided.)
               spawnCmd = resolved.path;
             }
+          }
+        }
+
+        if (isWin) {
+          // Windows spawn shape. Only .cmd/.bat shims (npm, vercel, npx)
+          // go through `cmd.exe /C` — they are batch scripts and need it.
+          // Real executables (powershell, gh, claude, codex, git) are
+          // spawned DIRECTLY: routing them through cmd.exe means cmd
+          // re-parses the portable_pty-composed command line, and its quote
+          // rules strip the quotes around any argument containing a special
+          // char — a piped PowerShell one-liner installer gets split at the
+          // `|` by cmd itself and PowerShell blocks forever in interactive
+          // mode. Observed live as a CI Windows runner hang (the exact
+          // installer-hang users reported):
+          // https://github.com/ship-studio/ship-studio/actions/runs/28903431927/job/85745268821
+          if (needsCmdExeWrapper(command, resolved?.path)) {
+            spawnCmd = 'cmd.exe';
+            spawnArgs = ['/C', command, ...args];
+          } else {
+            // Prefer the resolved absolute path (deterministic, no PATH
+            // shadowing — quoting paths with spaces is safe without cmd.exe
+            // in the middle); fall back to the bare name on the extended
+            // PATH when resolution failed open (powershell reaches here).
+            spawnCmd = resolved?.path ?? command;
+            spawnArgs = args;
           }
         }
 

--- a/src/lib/setup.test.ts
+++ b/src/lib/setup.test.ts
@@ -27,6 +27,7 @@ import {
   isWizardStepComplete,
   getStepItems,
   findFirstIncompleteStep,
+  needsCmdExeWrapper,
 } from './setup';
 import {
   FRESH_INSTALL_ITEMS,
@@ -484,6 +485,58 @@ describe('TERMINAL_COMMANDS', () => {
     expect(script).toContain('exit 1');
     expect(script).toContain('[ -n "$script" ]');
     expect(script).toContain('exec /bin/bash -c "$script"');
+  });
+});
+
+// ============ needsCmdExeWrapper (Windows spawn shape) ============
+
+describe('needsCmdExeWrapper', () => {
+  // Wrapping a real executable in `cmd.exe /C` makes cmd re-parse the
+  // portable_pty-composed command line; its quote rules strip the quotes
+  // around args containing special chars, so a piped PowerShell one-liner
+  // installer gets split at the `|` and hangs (audit #13; observed as a CI
+  // Windows runner hang — see needsCmdExeWrapper's doc comment for the link).
+
+  it('wraps .cmd shims (npm-style) — batch scripts need cmd.exe', () => {
+    expect(needsCmdExeWrapper('npm', 'C:\\Program Files\\nodejs\\npm.cmd')).toBe(true);
+    expect(needsCmdExeWrapper('vercel', 'C:\\Users\\x\\AppData\\Roaming\\npm\\vercel.cmd')).toBe(
+      true
+    );
+    expect(needsCmdExeWrapper('legacy', 'C:\\tools\\legacy.BAT')).toBe(true);
+  });
+
+  it('never wraps PowerShell, even unresolved — real exe on every Windows', () => {
+    expect(needsCmdExeWrapper('powershell')).toBe(false);
+    expect(needsCmdExeWrapper('powershell', null)).toBe(false);
+    expect(needsCmdExeWrapper('pwsh', undefined)).toBe(false);
+    expect(needsCmdExeWrapper('POWERSHELL.EXE')).toBe(false);
+  });
+
+  it('spawns resolved real executables directly', () => {
+    expect(needsCmdExeWrapper('gh', 'C:\\Program Files\\GitHub CLI\\gh.exe')).toBe(false);
+    expect(needsCmdExeWrapper('claude', 'C:\\Users\\x\\.local\\bin\\claude.exe')).toBe(false);
+    expect(needsCmdExeWrapper('codex', 'C:\\Users\\x\\AppData\\Local\\codex\\codex.exe')).toBe(
+      false
+    );
+  });
+
+  it('keeps the conservative cmd.exe wrapper for unresolved unknown commands', () => {
+    // Resolution failed open — the command may be an npm-style .cmd shim
+    // that only PATH search inside cmd.exe would find.
+    expect(needsCmdExeWrapper('some-tool', undefined)).toBe(true);
+    expect(needsCmdExeWrapper('npm', null)).toBe(true);
+  });
+
+  it('wraps when the resolved path has no recognized executable extension', () => {
+    // npm ships an extensionless `npm` sh script NEXT TO npm.cmd; the
+    // backend's extended-PATH probe can return it. Direct-spawning a shell
+    // script via CreateProcess would fail — let cmd.exe re-search PATHEXT.
+    expect(needsCmdExeWrapper('npm', 'C:\\Users\\x\\AppData\\Roaming\\npm\\npm')).toBe(true);
+  });
+
+  it('judges a pathful command by its own extension when unresolved', () => {
+    expect(needsCmdExeWrapper('C:\\x\\tool.cmd')).toBe(true);
+    expect(needsCmdExeWrapper('C:\\x\\pwsh.exe')).toBe(false);
   });
 });
 

--- a/src/lib/setup.test.ts
+++ b/src/lib/setup.test.ts
@@ -492,10 +492,11 @@ describe('TERMINAL_COMMANDS', () => {
 
 describe('needsCmdExeWrapper', () => {
   // Wrapping a real executable in `cmd.exe /C` makes cmd re-parse the
-  // portable_pty-composed command line; its quote rules strip the quotes
-  // around args containing special chars, so a piped PowerShell one-liner
-  // installer gets split at the `|` and hangs (audit #13; observed as a CI
-  // Windows runner hang — see needsCmdExeWrapper's doc comment for the link).
+  // portable_pty-composed command line with its own quote rules — a second
+  // parse layer between us and the target (audit #13). Direct spawn removes
+  // that layer; both shapes are measured under a real ConPTY by the canary
+  // tests in src-tauri/src/commands/pty_session.rs — see needsCmdExeWrapper's
+  // doc comment for the evidence history.
 
   it('wraps .cmd shims (npm-style) — batch scripts need cmd.exe', () => {
     expect(needsCmdExeWrapper('npm', 'C:\\Program Files\\nodejs\\npm.cmd')).toBe(true);

--- a/src/lib/setup.test.ts
+++ b/src/lib/setup.test.ts
@@ -446,6 +446,19 @@ describe('TERMINAL_COMMANDS', () => {
     expect(TERMINAL_COMMANDS.claude_auth.command).toBe('claude');
   });
 
+  it('agent Connect buttons run dedicated auth flows, never the bare agent CLI (audit #7)', () => {
+    // A bare `claude`/`codex` invocation relies on the CLI auto-prompting for
+    // login; when it doesn't, non-technical users land in a full agent chat
+    // REPL with no idea what to do. Every agent auth entry must use the CLI's
+    // documented sign-in invocation, which exits when auth completes.
+    expect(TERMINAL_COMMANDS.claude_auth.args).toEqual(['auth', 'login']);
+    expect(TERMINAL_COMMANDS.codex_auth.args).toEqual(['login']);
+    expect(TERMINAL_COMMANDS.opencode_auth.command).toBe('opencode');
+    expect(TERMINAL_COMMANDS.opencode_auth.args).toEqual(['auth', 'login']);
+    expect(TERMINAL_COMMANDS.cursor_auth.command).toBe('cursor-agent');
+    expect(TERMINAL_COMMANDS.cursor_auth.args).toEqual(['login']);
+  });
+
   it('has vercel entry', () => {
     expect(TERMINAL_COMMANDS.vercel).toBeDefined();
   });

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -548,12 +548,12 @@ export async function resolveCliPath(name: string): Promise<ResolvedCli | null> 
  *
  * Whether cmd's re-parse actually mangles a piped `-Command` argument is
  * measured (not assumed) by the canary pair in
- * src-tauri/src/commands/pty_session.rs — see the "PTY spawn-shape canaries"
- * step of the windows-check CI job for the recorded verdict on both shapes.
- * (Two earlier CI hangs initially blamed on quote-stripping turned out to be
- * the test harness not answering ConPTY's DSR handshake; direct spawn is
- * kept because it is strictly more deterministic, not because breakage of
- * the wrapped shape was proven.)
+ * src-tauri/src/commands/pty_session.rs. RECORDED VERDICT (Windows runner,
+ * job 85754711506): the piped expression survives BOTH shapes intact — the
+ * quote-stripping hazard was a false alarm. (Two earlier CI hangs initially
+ * blamed on quote-stripping were the test harness not answering ConPTY's
+ * DSR handshake.) Direct spawn is kept as a defensive simplification —
+ * strictly more deterministic — not as a bug fix.
  *
  * @param command the command as configured (e.g. "npm", "powershell", "gh")
  * @param resolvedPath absolute path from {@link resolveCliPath}, when

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -691,8 +691,14 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
         args: ['-Command', 'irm https://claude.ai/install.ps1 | iex'],
       },
       claude_auth: {
+        // Dedicated sign-in flow (`claude auth login` — "Sign in to your
+        // Anthropic account"). The bare CLI used to be spawned here, which
+        // stranded non-technical users in the chat REPL when the CLI didn't
+        // auto-prompt for login (audit #7). The `claude auth` command family
+        // is the same one the backend already relies on for status checks
+        // (`claude auth status`, src-tauri/src/commands/accounts.rs).
         command: 'claude',
-        args: [],
+        args: ['auth', 'login'],
       },
       codex: {
         // --force clears EEXIST failures from stale/partial global installs,
@@ -701,8 +707,11 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
         args: ['install', '-g', '@openai/codex', '--force'],
       },
       codex_auth: {
+        // Dedicated login subcommand (`codex login` — "Manage login") instead
+        // of the bare CLI, which dropped users into the agent chat UI when it
+        // didn't auto-prompt for sign-in (audit #7). Exits when auth completes.
         command: 'codex',
-        args: [],
+        args: ['login'],
       },
       opencode: {
         // No clean PowerShell one-liner installer exists for Windows; install
@@ -785,8 +794,10 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
         args: ['-c', 'curl -fsSL https://claude.ai/install.sh | bash'],
       },
       claude_auth: {
+        // Dedicated sign-in flow (`claude auth login`) — see the Windows entry
+        // above for why the bare CLI is not spawned here (audit #7).
         command: 'claude',
-        args: [],
+        args: ['auth', 'login'],
       },
       codex: {
         // --force clears EEXIST failures from stale/partial global installs,
@@ -795,8 +806,10 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
         args: ['-c', 'npm install -g @openai/codex --force'],
       },
       codex_auth: {
+        // Dedicated login subcommand (`codex login`) — see the Windows entry
+        // above for why the bare CLI is not spawned here (audit #7).
         command: 'codex',
-        args: [],
+        args: ['login'],
       },
       opencode: {
         command: '/bin/bash',

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -535,6 +535,57 @@ export async function resolveCliPath(name: string): Promise<ResolvedCli | null> 
 }
 
 /**
+ * Windows spawn decision: should this command be wrapped as
+ * `cmd.exe /C <command> <args...>`, or spawned directly through the PTY?
+ *
+ * Only `.cmd`/`.bat` shims (npm, vercel, npx, …) NEED the cmd.exe wrapper —
+ * they are batch scripts, not executables. For real executables the wrapper
+ * is not just unnecessary, it is actively harmful: portable_pty rebuilds a
+ * single command-line string from the argv, and `cmd.exe /C` RE-PARSES that
+ * string with its own quote rules. When a quoted argument contains a special
+ * character, cmd strips the outer quotes (see `cmd /?`), so a PowerShell
+ * one-liner like `powershell -Command "irm … | iex"` gets split at the `|`
+ * by cmd itself and PowerShell blocks forever in interactive mode. This was
+ * observed live: the CI canary test for this exact shape hung a Windows
+ * runner until the job's 40-minute kill —
+ * https://github.com/ship-studio/ship-studio/actions/runs/28903431927/job/85745268821
+ * — the same hang users reported for the Windows Claude/Cursor installers.
+ *
+ * @param command the command as configured (e.g. "npm", "powershell", "gh")
+ * @param resolvedPath absolute path from {@link resolveCliPath}, when
+ *   resolution succeeded; `undefined`/`null` when it failed or was skipped
+ *   (fail-open), in which case the conservative default is to wrap — except
+ *   for PowerShell, which is a real executable on every Windows install.
+ */
+export function needsCmdExeWrapper(command: string, resolvedPath?: string | null): boolean {
+  const base = command.toLowerCase().split(/[\\/]/).pop() ?? '';
+  if (
+    base === 'powershell' ||
+    base === 'powershell.exe' ||
+    base === 'pwsh' ||
+    base === 'pwsh.exe'
+  ) {
+    // Always safe to spawn directly — and required for piped -Command args.
+    return false;
+  }
+  // Judge by the binary the spawn will actually hit; fall back to the
+  // command string itself if it already names a script.
+  const probe = (resolvedPath ?? command).toLowerCase();
+  if (probe.endsWith('.cmd') || probe.endsWith('.bat')) {
+    return true; // batch shim — only cmd.exe can run it
+  }
+  if (probe.endsWith('.exe') || probe.endsWith('.com')) {
+    return false; // real executable — spawn directly
+  }
+  // Unresolved, or resolved to something without a recognized executable
+  // extension (npm ships an extensionless `npm` sh script NEXT TO npm.cmd,
+  // and the backend's extended-PATH probe can return it): keep the historical
+  // cmd.exe wrapper as the conservative default — cmd re-searches PATH with
+  // PATHEXT and finds the proper .cmd/.exe.
+  return true;
+}
+
+/**
  * Start GitHub authentication flow (opens browser).
  * Returns a message to display to the user.
  */

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -540,16 +540,20 @@ export async function resolveCliPath(name: string): Promise<ResolvedCli | null> 
  *
  * Only `.cmd`/`.bat` shims (npm, vercel, npx, …) NEED the cmd.exe wrapper —
  * they are batch scripts, not executables. For real executables the wrapper
- * is not just unnecessary, it is actively harmful: portable_pty rebuilds a
- * single command-line string from the argv, and `cmd.exe /C` RE-PARSES that
- * string with its own quote rules. When a quoted argument contains a special
- * character, cmd strips the outer quotes (see `cmd /?`), so a PowerShell
- * one-liner like `powershell -Command "irm … | iex"` gets split at the `|`
- * by cmd itself and PowerShell blocks forever in interactive mode. This was
- * observed live: the CI canary test for this exact shape hung a Windows
- * runner until the job's 40-minute kill —
- * https://github.com/ship-studio/ship-studio/actions/runs/28903431927/job/85745268821
- * — the same hang users reported for the Windows Claude/Cursor installers.
+ * adds a second parse layer with its own quote rules: portable_pty rebuilds
+ * a single command-line string from the argv, and `cmd.exe /C` RE-PARSES
+ * that string (see the quote-processing rules in `cmd /?`) before the target
+ * ever sees it. Spawning the resolved executable directly removes that layer
+ * entirely — the target's CRT parses exactly what portable_pty composed.
+ *
+ * Whether cmd's re-parse actually mangles a piped `-Command` argument is
+ * measured (not assumed) by the canary pair in
+ * src-tauri/src/commands/pty_session.rs — see the "PTY spawn-shape canaries"
+ * step of the windows-check CI job for the recorded verdict on both shapes.
+ * (Two earlier CI hangs initially blamed on quote-stripping turned out to be
+ * the test harness not answering ConPTY's DSR handshake; direct spawn is
+ * kept because it is strictly more deterministic, not because breakage of
+ * the wrapped shape was proven.)
  *
  * @param command the command as configured (e.g. "npm", "powershell", "gh")
  * @param resolvedPath absolute path from {@link resolveCliPath}, when


### PR DESCRIPTION
## Two items from the onboarding robustness audit

### 1. Agent Connect buttons use dedicated sign-in flows (audit #7)

Clicking Connect for Claude/Codex ran the BARE CLI, stranding non-technical users in the agent chat REPL when it didn't auto-prompt for login. Now (verified against the installed CLIs):

| Agent | Before | After |
|---|---|---|
| Claude | `claude` | `claude auth login` ("Sign in to your Anthropic account") |
| Codex | `codex` | `codex login` ("Manage login", exits when auth completes) |

Both platforms. The post-cancel delayed re-check now derives from the `*_auth` convention so new auth flows get it for free.

### 2. Windows spawn shape + the quoting question — SETTLED WITH EVIDENCE (audit #13)

**Verdict (Windows runner, job 85754711506): the suspected cmd.exe quote-stripping hazard is a FALSE ALARM.** A piped, space-laden `powershell -Command "… | …"` expression survives intact through BOTH the historical `cmd.exe /C` wrapper AND direct spawn — the canary printed `HELLO WORLD` both ways.

What the investigation ACTUALLY found (all evidence recorded in the test docs):
- **ConPTY blocks ALL child output until the terminal answers its `ESC[6n` cursor query.** Both earlier CI hangs (one ate a runner for 40 minutes) were this handshake, not quoting — the same mechanism as community PR #182. Any raw PTY consumer that doesn't reply (or render output to xterm, which replies automatically) stalls every spawn. The canary harness now answers the handshake.
- ConPTY sessions linger after the child exits — assertions must key on output, not on prompt EOF.

**Changes kept:** `needsCmdExeWrapper` routes real executables (powershell, gh, claude, codex — by resolved extension) to DIRECT spawn as a defensive simplification (one fewer re-parse layer, deterministic absolute-path spawn) — explicitly *not* a bug fix; `.cmd`/`.bat` shims and unresolved commands keep the cmd.exe wrapper. Both spawn shapes stay permanently exercised under a real ConPTY by the bounded canary pair in `pty_session.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)