### PR TITLE
Explain the macOS screen-recording prompt and stop re-prompting after denial (#160)

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -83,6 +83,7 @@ Fired from `useIntegrationStatus` once GitHub auth resolves with a username.
 | Event | Properties |
 |---|---|
 | `screenshot_captured` | `mode` (`viewport`/`fullpage`), `success`, `fell_back`, `fallback_success` (fullpage only, present when `fell_back` — whether the viewport fallback produced a file) |
+| `thumbnail_consent_answered` | `allowed` — the user's answer to the first-run "Preview thumbnails" explainer shown before the first automatic thumbnail capture (#160) |
 | `preview_refreshed` | `trigger: 'user'` |
 | `preview_page_selected` | `route_pattern` (id segments → `:id`, capped 200), `depth` |
 | `preview_fix_with_agent` | `has_logs`, `is_static`, `reason` (`server-down`/`blank-iframe`) |
@@ -160,6 +161,7 @@ To get an aggregate "any modal opened" count in PostHog, use a regex match on ev
 |---|---|
 | `calendar_visibility_toggled` | `visible` |
 | `terminal_gpu_toggled` | `enabled` |
+| `thumbnails_toggled` | `enabled` (the "Project thumbnails" auto-capture toggle) |
 | `projects_root_changed` | `is_custom` (false when reset to the default `~/ShipStudio`) |
 | `projects_moved` | `moved_count`, `skipped_count` (after moving projects into a newly-chosen folder) |
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -60,6 +60,27 @@ pub fn set_terminal_gpu_enabled(enabled: bool) -> Result<(), CommandError> {
     write_app_state(&state).map_err(CommandError::from)
 }
 
+/// Get the project-thumbnail auto-capture consent.
+///
+/// `None` = the user has never been asked (the frontend shows an in-app
+/// explainer before the first auto-capture), `Some(true)` = allowed,
+/// `Some(false)` = opted out or a capture failed because macOS Screen
+/// Recording permission was denied.
+#[tauri::command]
+#[tracing::instrument]
+pub fn get_thumbnails_enabled() -> Result<Option<bool>, CommandError> {
+    Ok(read_app_state().thumbnails_enabled)
+}
+
+/// Set the project-thumbnail auto-capture consent (persisted to app state).
+#[tauri::command]
+#[tracing::instrument]
+pub fn set_thumbnails_enabled(enabled: bool) -> Result<(), CommandError> {
+    let mut state = read_app_state();
+    state.thumbnails_enabled = Some(enabled);
+    write_app_state(&state).map_err(CommandError::from)
+}
+
 /// Get the projects root directory (absolute path). Falls back to the default
 /// `~/ShipStudio` when no custom root is configured.
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -482,6 +482,8 @@ pub fn run() {
             commands::settings::set_slack_cta_hidden,
             commands::settings::get_terminal_gpu_enabled,
             commands::settings::set_terminal_gpu_enabled,
+            commands::settings::get_thumbnails_enabled,
+            commands::settings::set_thumbnails_enabled,
             // Accounts (Workspaces)
             commands::accounts::list_accounts,
             commands::accounts::create_account,

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -764,6 +764,12 @@ pub struct AppState {
     /// macOS beta / GPU-driver combinations).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub terminal_gpu_enabled: Option<bool>,
+    /// Consent for automatic project-thumbnail capture. `None` = the user has
+    /// never been asked (the in-app explainer is shown before the first
+    /// auto-capture), `Some(true)` = allowed, `Some(false)` = opted out or a
+    /// capture failed because macOS Screen Recording permission was denied.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thumbnails_enabled: Option<bool>,
     /// Workspaces (org/client accounts) with isolated Claude/GitHub config and credentials
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub accounts: Vec<Account>,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,7 @@ import { sessionRegistry } from './lib/sessionRegistry';
 import { unregisterProjectSession } from './lib/projectSessions';
 import { UpdateBanner } from './components/UpdateBanner';
 import { MonorepoPickerModal } from './components/dashboard/MonorepoPickerModal';
+import { ThumbnailConsentModal } from './components/preview/ThumbnailConsentModal';
 import { ModalFrame } from './components/primitives/ModalFrame';
 import { Button } from './components/primitives/Button';
 import { Spinner } from './components/primitives/Spinner';
@@ -301,6 +302,9 @@ function AppContents({ initialProjectPath }: AppProps) {
     handleCropComplete,
     handleCropCancel,
     handlePreviewReady: onPreviewReady,
+    showThumbnailConsent,
+    resolveThumbnailConsent,
+    dismissThumbnailConsent,
     startScreenshotInterval,
     clearScreenshotInterval,
   } = useScreenshotManagement({
@@ -1258,6 +1262,12 @@ function AppContents({ initialProjectPath }: AppProps) {
         onOpenProjectPicker={openProjectPicker}
         onSwitchAccount={() => setView('account-select')}
         isProjectDevServerRunning={isServerRunning}
+      />
+      <ThumbnailConsentModal
+        isOpen={showThumbnailConsent}
+        onAllow={() => void resolveThumbnailConsent(true)}
+        onDeny={() => void resolveThumbnailConsent(false)}
+        onDismiss={dismissThumbnailConsent}
       />
       {quitConfirmModal}
     </>

--- a/src/components/dashboard/SettingsModal.tsx
+++ b/src/components/dashboard/SettingsModal.tsx
@@ -21,6 +21,8 @@ import {
   setSlackCtaHidden,
   getTerminalGpuEnabled,
   setTerminalGpuEnabled,
+  getThumbnailsEnabled,
+  setThumbnailsEnabled,
   getProjectsRoot,
   isCustomProjectsRoot,
   pickProjectsRoot,
@@ -68,6 +70,7 @@ export function SettingsModal({
   const [calendarVisible, setLocalCalendarVisible] = useState(true);
   const [slackCtaVisible, setLocalSlackCtaVisible] = useState(true);
   const [terminalGpuEnabled, setLocalTerminalGpuEnabled] = useState(true);
+  const [thumbnailsOn, setLocalThumbnailsOn] = useState(true);
   const [loading, setLoading] = useState(true);
 
   const [projectsRoot, setLocalProjectsRoot] = useState('');
@@ -80,19 +83,24 @@ export function SettingsModal({
     if (!isOpen) return;
     let cancelled = false;
     void (async () => {
-      const [enabled, calHidden, slackHidden, gpuEnabled, root, custom] = await Promise.all([
-        getAnalyticsEnabled(),
-        getCalendarHidden(),
-        getSlackCtaHidden(),
-        getTerminalGpuEnabled(),
-        getProjectsRoot().catch(() => ''),
-        isCustomProjectsRoot(),
-      ]);
+      const [enabled, calHidden, slackHidden, gpuEnabled, thumbnails, root, custom] =
+        await Promise.all([
+          getAnalyticsEnabled(),
+          getCalendarHidden(),
+          getSlackCtaHidden(),
+          getTerminalGpuEnabled(),
+          getThumbnailsEnabled(),
+          getProjectsRoot().catch(() => ''),
+          isCustomProjectsRoot(),
+        ]);
       if (!cancelled) {
         setLocalAnalyticsEnabled(enabled);
         setLocalCalendarVisible(!calHidden);
         setLocalSlackCtaVisible(!slackHidden);
         setLocalTerminalGpuEnabled(gpuEnabled);
+        // `null` = not asked yet; the toggle reflects the default-on behavior
+        // (the first auto-capture will show the in-app explainer).
+        setLocalThumbnailsOn(thumbnails !== false);
         setLocalProjectsRoot(root);
         setCustomRoot(custom);
         setLoading(false);
@@ -140,6 +148,16 @@ export function SettingsModal({
       $screen_name: 'Settings',
     });
   }, [terminalGpuEnabled]);
+
+  const handleThumbnailsToggle = useCallback(() => {
+    const newEnabled = !thumbnailsOn;
+    setLocalThumbnailsOn(newEnabled);
+    void setThumbnailsEnabled(newEnabled);
+    void trackEvent('thumbnails_toggled', {
+      enabled: newEnabled,
+      $screen_name: 'Settings',
+    });
+  }, [thumbnailsOn]);
 
   // Persist a new projects root, then offer to move existing projects over.
   const applyNewRoot = useCallback(
@@ -322,6 +340,28 @@ export function SettingsModal({
                 disabled={loading}
                 role="switch"
                 aria-checked={terminalGpuEnabled}
+              >
+                <span className="settings-toggle-track">
+                  <span className="settings-toggle-thumb" />
+                </span>
+              </button>
+            </div>
+            <div className="settings-row">
+              <div className="settings-row-info">
+                <span className="settings-row-label">Project thumbnails</span>
+                <span className="settings-row-description">
+                  Automatically screenshot the preview to show project thumbnails on the dashboard.
+                  On macOS this may require Screen Recording permission — allow Ship Studio under
+                  System Settings → Privacy &amp; Security → Screen Recording, then turn this back
+                  on.
+                </span>
+              </div>
+              <button
+                className={`settings-toggle ${thumbnailsOn ? 'on' : 'off'}`}
+                onClick={handleThumbnailsToggle}
+                disabled={loading}
+                role="switch"
+                aria-checked={thumbnailsOn}
               >
                 <span className="settings-toggle-track">
                   <span className="settings-toggle-thumb" />

--- a/src/components/preview/ThumbnailConsentModal.tsx
+++ b/src/components/preview/ThumbnailConsentModal.tsx
@@ -1,0 +1,61 @@
+/**
+ * ThumbnailConsentModal - first-run explainer shown before the first automatic
+ * project-thumbnail capture (#160).
+ *
+ * macOS surfaces window screenshots as a "record audio and screen content"
+ * permission prompt, which is alarming with zero context. This modal explains
+ * what the capture is (a single local image of Ship Studio's own window) and
+ * lets the user opt in or out BEFORE the OS prompt can appear. Manual
+ * screenshot-button captures are intentionally not gated by this modal.
+ *
+ * @module components/preview/ThumbnailConsentModal
+ */
+
+import { ModalFrame } from '../primitives/ModalFrame';
+import { Button } from '../primitives/Button';
+
+interface ThumbnailConsentModalProps {
+  isOpen: boolean;
+  /** "Allow thumbnails" — persists opt-in and runs the deferred capture. */
+  onAllow: () => void;
+  /** "No thumbnails" — persists opt-out; auto-capture never runs. */
+  onDeny: () => void;
+  /** ESC / overlay click — no persisted answer, ask again next launch. */
+  onDismiss: () => void;
+}
+
+export function ThumbnailConsentModal({
+  isOpen,
+  onAllow,
+  onDeny,
+  onDismiss,
+}: ThumbnailConsentModalProps) {
+  return (
+    <ModalFrame
+      isOpen={isOpen}
+      onClose={onDismiss}
+      title="Preview thumbnails"
+      className="thumbnail-consent-modal"
+    >
+      <div className="thumbnail-consent-body">
+        <p>
+          Ship Studio takes a screenshot of its own preview window to show a thumbnail for each
+          project on your dashboard.
+        </p>
+        <p>
+          macOS calls this &ldquo;recording screen content&rdquo;, so it may ask for permission.
+          Nothing is recorded or sent anywhere &mdash; it&rsquo;s a single image of Ship
+          Studio&rsquo;s own window, saved locally inside your project.
+        </p>
+        <div className="thumbnail-consent-actions">
+          <Button variant="ghost" onClick={onDeny}>
+            No thumbnails
+          </Button>
+          <Button variant="primary" onClick={onAllow}>
+            Allow thumbnails
+          </Button>
+        </div>
+      </div>
+    </ModalFrame>
+  );
+}

--- a/src/hooks/usePreviewCapture.ts
+++ b/src/hooks/usePreviewCapture.ts
@@ -14,6 +14,23 @@ import { logger } from '../lib/logger';
 import { trackEvent } from '../lib/analytics';
 import { useOptionalToast } from '../contexts/ToastContext';
 import { isMac } from '../lib/setup';
+import { setThumbnailsEnabled } from '../lib/settings';
+import { isPermissionDenialError } from '../lib/thumbnailGate';
+import { asCommandError, formatCommandError } from '../lib/errors';
+
+/** Real underlying message for a capture failure (never "[object Object]"). */
+const captureErrorMessage = (error: unknown): string => formatCommandError(asCommandError(error));
+
+/**
+ * A capture failure that looks like a macOS Screen Recording denial also
+ * turns off background thumbnail capture, so the scary OS prompt is never
+ * re-triggered on a timer. Re-enable via Settings → Project thumbnails.
+ */
+const stopAutoCaptureIfDenied = (error: unknown): void => {
+  if (isPermissionDenialError(error)) {
+    void setThumbnailsEnabled(false);
+  }
+};
 
 interface UsePreviewCaptureParams {
   /** Absolute path to the project directory */
@@ -53,7 +70,7 @@ export function usePreviewCapture({
   const cropOverlayRef = useRef<HTMLDivElement>(null);
 
   // Shared helper: capture the current window and return the temp file path
-  const captureWindowScreenshot = useCallback(async (): Promise<string | null> => {
+  const captureWindowScreenshot = useCallback(async (): Promise<string> => {
     const { getScreenshotableWindows, getWindowScreenshot } =
       await import('tauri-plugin-screenshots-api');
 
@@ -64,7 +81,17 @@ export function usePreviewCapture({
     );
 
     if (!ourWindow) {
-      return null;
+      // macOS omits window titles from the capturable-windows list when Screen
+      // Recording permission is denied, so "our window is missing" is the
+      // denial signature there. Throw the real reason instead of silently
+      // returning null (the message doubles as the denial-detection signal).
+      throw new Error(
+        isMac()
+          ? "Ship Studio's window isn't visible to macOS screen capture — Screen Recording " +
+              'permission was likely denied. Allow Ship Studio in System Settings → ' +
+              'Privacy & Security → Screen Recording, then try again.'
+          : "Ship Studio's window wasn't found in the list of capturable windows."
+      );
     }
 
     return await getWindowScreenshot(ourWindow.id);
@@ -86,7 +113,6 @@ export function usePreviewCapture({
         if (!iframeWrapperRef.current) return null;
 
         const tempPath = await captureWindowScreenshot();
-        if (!tempPath) return null;
 
         const rect = iframeWrapperRef.current.getBoundingClientRect();
         const dpr = window.devicePixelRatio || 1;
@@ -113,10 +139,13 @@ export function usePreviewCapture({
         }
         return finalPath;
       } catch (error) {
-        logger.error('[Preview] Viewport capture failed', {
-          error: error instanceof Error ? error.message : String(error),
-        });
+        const message = captureErrorMessage(error);
+        logger.error('[Preview] Viewport capture failed', { error: message });
+        stopAutoCaptureIfDenied(error);
         if (!opts?.silent) {
+          // Surface the real underlying error — "couldn't capture" alone is
+          // undebuggable (and hides a denied Screen Recording permission).
+          showToast(`Couldn't capture the preview: ${message}`, 'error');
           void trackEvent('screenshot_captured', {
             mode: 'viewport',
             success: false,
@@ -128,7 +157,7 @@ export function usePreviewCapture({
         setIsCapturing(false);
       }
     },
-    [projectPath, captureWindowScreenshot, isCapturing]
+    [projectPath, captureWindowScreenshot, isCapturing, showToast]
   );
 
   // Full-page capture using Playwright (scrolls page to trigger lazy content, then captures)
@@ -187,7 +216,6 @@ export function usePreviewCapture({
 
       try {
         const tempPath = await captureWindowScreenshot();
-        if (!tempPath) return null;
 
         // Get the iframe's position relative to the window
         const iframeRect = iframeWrapperRef.current.getBoundingClientRect();
@@ -216,13 +244,14 @@ export function usePreviewCapture({
 
         return finalPath;
       } catch (error) {
-        logger.error('[Preview] Region capture failed', {
-          error: error instanceof Error ? error.message : String(error),
-        });
+        const message = captureErrorMessage(error);
+        logger.error('[Preview] Region capture failed', { error: message });
+        stopAutoCaptureIfDenied(error);
+        showToast(`Couldn't capture the selection: ${message}`, 'error');
         return null;
       }
     },
-    [projectPath, captureWindowScreenshot]
+    [projectPath, captureWindowScreenshot, showToast]
   );
 
   // Handle crop selection mouse events

--- a/src/hooks/useScreenshotManagement.test.ts
+++ b/src/hooks/useScreenshotManagement.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for the auto-capture consent gate (#160).
+ *
+ * The background thumbnail capture must never trigger the macOS
+ * "record screen content" prompt without context:
+ * - first run (never asked) → defer the capture and show the explainer
+ * - opted out → never capture
+ * - allowed → capture proceeds
+ * - permission-denial failure → persist the opt-out, stop retrying
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { RefObject } from 'react';
+import { useScreenshotManagement } from './useScreenshotManagement';
+import type { PreviewHandle } from '../components/preview/Preview';
+import { getThumbnailsEnabled, setThumbnailsEnabled } from '../lib/settings';
+
+const invokeMock = vi.fn<(cmd: string, args?: Record<string, unknown>) => Promise<unknown>>();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (cmd: string, args?: Record<string, unknown>) => invokeMock(cmd, args),
+}));
+
+vi.mock('../lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../lib/analytics', () => ({
+  trackEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../lib/settings', () => ({
+  getThumbnailsEnabled: vi.fn(),
+  setThumbnailsEnabled: vi.fn().mockResolvedValue(undefined),
+}));
+
+const PROJECT = '/Users/test/ShipStudio/demo';
+
+function makeParams() {
+  return {
+    previewRef: {
+      current: { isServerReady: () => true },
+    } as unknown as RefObject<PreviewHandle | null>,
+    devServerPort: 3000,
+    pasteToActiveTerminal: vi.fn(),
+    currentProjectPathRef: { current: PROJECT } as unknown as RefObject<string | null>,
+  };
+}
+
+/** Fire the preview-ready signal and run past the 8s capture delay. */
+async function triggerAutoCapture(result: { current: ReturnType<typeof useScreenshotManagement> }) {
+  act(() => {
+    result.current.handlePreviewReady(PROJECT);
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(8_000);
+  });
+}
+
+describe('useScreenshotManagement auto-capture consent gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    invokeMock.mockResolvedValue('/thumb.png');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('first run: defers the capture and shows the explainer instead', async () => {
+    vi.mocked(getThumbnailsEnabled).mockResolvedValue(null);
+    const { result } = renderHook(() => useScreenshotManagement(makeParams()));
+
+    await triggerAutoCapture(result);
+
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(result.current.showThumbnailConsent).toBe(true);
+  });
+
+  it('opted out: never captures and never asks again', async () => {
+    vi.mocked(getThumbnailsEnabled).mockResolvedValue(false);
+    const { result } = renderHook(() => useScreenshotManagement(makeParams()));
+
+    await triggerAutoCapture(result);
+
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(result.current.showThumbnailConsent).toBe(false);
+  });
+
+  it('allowed: capture proceeds without asking', async () => {
+    vi.mocked(getThumbnailsEnabled).mockResolvedValue(true);
+    const { result } = renderHook(() => useScreenshotManagement(makeParams()));
+
+    await triggerAutoCapture(result);
+
+    expect(result.current.showThumbnailConsent).toBe(false);
+    expect(invokeMock).toHaveBeenCalledWith('capture_project_thumbnail', {
+      projectPath: PROJECT,
+      url: 'http://localhost:3000',
+    });
+  });
+
+  it('"Allow thumbnails": persists opt-in and runs the deferred capture', async () => {
+    vi.mocked(getThumbnailsEnabled).mockResolvedValueOnce(null);
+    const { result } = renderHook(() => useScreenshotManagement(makeParams()));
+
+    await triggerAutoCapture(result);
+    expect(result.current.showThumbnailConsent).toBe(true);
+
+    vi.mocked(getThumbnailsEnabled).mockResolvedValue(true);
+    await act(async () => {
+      await result.current.resolveThumbnailConsent(true);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(setThumbnailsEnabled).toHaveBeenCalledWith(true);
+    expect(result.current.showThumbnailConsent).toBe(false);
+    expect(invokeMock).toHaveBeenCalledWith('capture_project_thumbnail', {
+      projectPath: PROJECT,
+      url: 'http://localhost:3000',
+    });
+  });
+
+  it('"No thumbnails": persists opt-out and does not capture', async () => {
+    vi.mocked(getThumbnailsEnabled).mockResolvedValueOnce(null);
+    const { result } = renderHook(() => useScreenshotManagement(makeParams()));
+
+    await triggerAutoCapture(result);
+
+    vi.mocked(getThumbnailsEnabled).mockResolvedValue(false);
+    await act(async () => {
+      await result.current.resolveThumbnailConsent(false);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(setThumbnailsEnabled).toHaveBeenCalledWith(false);
+    expect(result.current.showThumbnailConsent).toBe(false);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('dismissing the explainer defers for the session instead of nagging', async () => {
+    vi.mocked(getThumbnailsEnabled).mockResolvedValue(null);
+    const { result } = renderHook(() => useScreenshotManagement(makeParams()));
+
+    await triggerAutoCapture(result);
+    expect(result.current.showThumbnailConsent).toBe(true);
+
+    act(() => {
+      result.current.dismissThumbnailConsent();
+    });
+
+    // Next scheduled capture (e.g. the 5-minute interval) stays silent.
+    await triggerAutoCapture(result);
+    expect(result.current.showThumbnailConsent).toBe(false);
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(setThumbnailsEnabled).not.toHaveBeenCalled();
+  });
+
+  it('permission-denial failure: persists opt-out and stops retrying', async () => {
+    vi.mocked(getThumbnailsEnabled).mockResolvedValue(true);
+    invokeMock.mockRejectedValue('Screen recording permission denied by TCC');
+    const { result } = renderHook(() => useScreenshotManagement(makeParams()));
+
+    await triggerAutoCapture(result);
+
+    expect(setThumbnailsEnabled).toHaveBeenCalledWith(false);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+
+    // Past the retry delay: no second attempt was scheduled.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('non-denial failure keeps the retry behavior', async () => {
+    vi.mocked(getThumbnailsEnabled).mockResolvedValue(true);
+    invokeMock.mockRejectedValue('Dev server not responding, skipping thumbnail capture');
+    const { result } = renderHook(() => useScreenshotManagement(makeParams()));
+
+    await triggerAutoCapture(result);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+
+    // Retry fires after the 3s delay and thumbnails stay enabled.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+    expect(invokeMock).toHaveBeenCalledTimes(2);
+    expect(setThumbnailsEnabled).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useScreenshotManagement.ts
+++ b/src/hooks/useScreenshotManagement.ts
@@ -9,6 +9,9 @@ import { useState, useRef, useCallback, useEffect, type RefObject } from 'react'
 import type { PreviewHandle } from '../components/preview/Preview';
 import { invoke } from '@tauri-apps/api/core';
 import { logger } from '../lib/logger';
+import { trackEvent } from '../lib/analytics';
+import { getThumbnailsEnabled, setThumbnailsEnabled } from '../lib/settings';
+import { decideAutoCapture, isPermissionDenialError } from '../lib/thumbnailGate';
 
 /** Delay after page load before capturing screenshot (8 seconds to allow Next.js/Vite to fully compile) */
 const SCREENSHOT_DELAY_MS = 8000;
@@ -45,6 +48,17 @@ export function useScreenshotManagement({
   // Refs for periodic capture and session tracking
   const screenshotIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const captureSessionIdRef = useRef<number>(0);
+
+  // First-run consent for auto-capture (#160). The macOS "record screen
+  // content" prompt must never appear without context, so the first automatic
+  // capture is deferred behind an in-app explainer. Manual captures (camera
+  // button, crop) are intentionally NOT gated — a user clicking the camera has
+  // clear intent, and that click is an obvious cause for the OS prompt.
+  const [showThumbnailConsent, setShowThumbnailConsent] = useState(false);
+  const pendingConsentCaptureRef = useRef<{ projectPath: string; sessionId: number } | null>(null);
+  // Dismissing the explainer without answering (ESC / overlay click) defers
+  // the question for this session instead of nagging every 5 minutes.
+  const consentDeferredThisSessionRef = useRef(false);
 
   // Capture viewport screenshot and paste path into terminal
   const handleCaptureScreenshot = useCallback(async () => {
@@ -124,6 +138,19 @@ export function useScreenshotManagement({
         });
         return;
       }
+      const decision = decideAutoCapture(await getThumbnailsEnabled());
+      if (decision === 'skip') {
+        logger.info('[Thumbnail] Skipping - thumbnails disabled in Settings');
+        return;
+      }
+      if (decision === 'ask') {
+        if (!consentDeferredThisSessionRef.current) {
+          logger.info('[Thumbnail] Deferring - asking for thumbnail consent first');
+          pendingConsentCaptureRef.current = { projectPath, sessionId };
+          setShowThumbnailConsent(true);
+        }
+        return;
+      }
       try {
         logger.info('[Thumbnail] Capturing now', {
           projectPath,
@@ -137,6 +164,15 @@ export function useScreenshotManagement({
         });
         logger.info('Thumbnail captured successfully', { projectPath, attempt });
       } catch (error) {
+        if (isPermissionDenialError(error)) {
+          // Denied at the OS level. Persist the opt-out so background capture
+          // never re-triggers the macOS prompt; re-enable via Settings →
+          // Project thumbnails (after allowing Ship Studio in System Settings
+          // → Privacy & Security → Screen Recording).
+          logger.error('[Thumbnail] Permission denied - disabling auto-capture', { error });
+          void setThumbnailsEnabled(false);
+          return;
+        }
         if (captureSessionIdRef.current !== sessionId) {
           logger.info('[Thumbnail] Skipping retry - session cancelled');
           return;
@@ -177,6 +213,31 @@ export function useScreenshotManagement({
     },
     [captureScreenshot]
   );
+
+  // User answered the thumbnail explainer. Persist the choice, then run the
+  // deferred capture on "Allow" (its session guards handle project changes).
+  const resolveThumbnailConsent = useCallback(
+    async (allowed: boolean) => {
+      setShowThumbnailConsent(false);
+      const pending = pendingConsentCaptureRef.current;
+      pendingConsentCaptureRef.current = null;
+      // Persist before capturing — captureScreenshot re-reads the consent.
+      await setThumbnailsEnabled(allowed);
+      void trackEvent('thumbnail_consent_answered', { allowed });
+      if (allowed && pending) {
+        void captureScreenshot(pending.projectPath, pending.sessionId);
+      }
+    },
+    [captureScreenshot]
+  );
+
+  // Explainer dismissed without an answer: don't persist anything, just stop
+  // asking until the next launch (auto-capture stays deferred meanwhile).
+  const dismissThumbnailConsent = useCallback(() => {
+    setShowThumbnailConsent(false);
+    pendingConsentCaptureRef.current = null;
+    consentDeferredThisSessionRef.current = true;
+  }, []);
 
   // Start periodic screenshot interval for a project
   const startScreenshotInterval = useCallback(
@@ -252,6 +313,11 @@ export function useScreenshotManagement({
     handleCropComplete,
     handleCropCancel,
     handlePreviewReady,
+
+    // First-run consent for auto-capture (#160)
+    showThumbnailConsent,
+    resolveThumbnailConsent,
+    dismissThumbnailConsent,
 
     // Interval management (for handleSelectProject / handleBackToProjects)
     startScreenshotInterval,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -77,6 +77,38 @@ export async function setTerminalGpuEnabled(enabled: boolean): Promise<void> {
   }
 }
 
+// ============ Project thumbnails (auto-capture consent) ============
+
+/**
+ * Consent state for automatic project-thumbnail capture.
+ * `null` = the user has never been asked (the in-app explainer is shown before
+ * the first auto-capture), `true` = allowed, `false` = opted out or a capture
+ * failed because macOS Screen Recording permission was denied.
+ */
+export type ThumbnailConsent = boolean | null;
+
+/**
+ * Get the project-thumbnail auto-capture consent. Falls back to `null`
+ * (undecided) on error so auto-capture stays deferred rather than triggering
+ * the macOS screen-recording prompt without context.
+ */
+export async function getThumbnailsEnabled(): Promise<ThumbnailConsent> {
+  try {
+    return await invoke<boolean | null>('get_thumbnails_enabled');
+  } catch {
+    return null;
+  }
+}
+
+/** Set the project-thumbnail auto-capture consent (persisted across sessions). */
+export async function setThumbnailsEnabled(enabled: boolean): Promise<void> {
+  try {
+    await invoke('set_thumbnails_enabled', { enabled });
+  } catch {
+    // Silently fail
+  }
+}
+
 // ============ Projects root directory ============
 
 /**

--- a/src/lib/thumbnailGate.test.ts
+++ b/src/lib/thumbnailGate.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { decideAutoCapture, isPermissionDenialError } from './thumbnailGate';
+
+describe('decideAutoCapture', () => {
+  it('defers and asks on first run (consent never given)', () => {
+    expect(decideAutoCapture(null)).toBe('ask');
+  });
+
+  it('never captures when the user opted out', () => {
+    expect(decideAutoCapture(false)).toBe('skip');
+  });
+
+  it('proceeds when the user allowed thumbnails', () => {
+    expect(decideAutoCapture(true)).toBe('proceed');
+  });
+});
+
+describe('isPermissionDenialError', () => {
+  it('detects the explicit macOS screen-recording denial message', () => {
+    expect(
+      isPermissionDenialError(
+        new Error(
+          "Ship Studio's window isn't visible to macOS screen capture — Screen Recording permission is likely denied."
+        )
+      )
+    ).toBe(true);
+  });
+
+  it('detects plugin errors mentioning ScreenCaptureKit authorization', () => {
+    expect(isPermissionDenialError('SCStream error: not authorized to capture')).toBe(true);
+    expect(isPermissionDenialError(new Error('TCC denied screen recording for Ship Studio'))).toBe(
+      true
+    );
+  });
+
+  it('detects CommandError objects, not just Error instances', () => {
+    expect(
+      isPermissionDenialError({
+        type: 'Other',
+        message: 'Screen recording permission denied by the user',
+      })
+    ).toBe(true);
+  });
+
+  it('does not flag unrelated capture failures', () => {
+    expect(isPermissionDenialError('Dev server not responding, skipping thumbnail capture')).toBe(
+      false
+    );
+    expect(isPermissionDenialError(new Error('playwright is not installed'))).toBe(false);
+    expect(
+      isPermissionDenialError(
+        'No supported browser found for screenshots (Chrome, Chromium, or Edge required)'
+      )
+    ).toBe(false);
+  });
+
+  it('does not flag generic filesystem permission errors', () => {
+    expect(
+      isPermissionDenialError(new Error("EACCES: permission denied, open '/tmp/thumbnail.png'"))
+    ).toBe(false);
+  });
+
+  it('handles null/undefined without throwing', () => {
+    expect(isPermissionDenialError(null)).toBe(false);
+    expect(isPermissionDenialError(undefined)).toBe(false);
+  });
+});

--- a/src/lib/thumbnailGate.ts
+++ b/src/lib/thumbnailGate.ts
@@ -1,0 +1,46 @@
+/**
+ * Decision logic for automatic project-thumbnail capture.
+ *
+ * macOS surfaces window screenshots as a scary "record audio and screen
+ * content" permission prompt (#160). These helpers make sure the prompt never
+ * appears without context: auto-capture is gated on explicit in-app consent,
+ * and a capture failure that looks like a permission denial permanently stops
+ * auto-capture instead of re-triggering the prompt every 5 minutes.
+ *
+ * Kept pure (no Tauri, no React) so the gate is unit-testable.
+ *
+ * @module lib/thumbnailGate
+ */
+
+import type { ThumbnailConsent } from './settings';
+import { asCommandError, formatCommandError } from './errors';
+
+/**
+ * What the auto-capture path should do given the persisted consent state.
+ * - `proceed` — user allowed thumbnails; capture normally.
+ * - `ask`     — never asked; defer the capture and show the in-app explainer.
+ * - `skip`    — user opted out (or a capture hit a permission denial); never
+ *               capture automatically until re-enabled in Settings.
+ */
+export type AutoCaptureDecision = 'proceed' | 'ask' | 'skip';
+
+/** Gate for the background thumbnail capture. Manual captures are never gated. */
+export function decideAutoCapture(consent: ThumbnailConsent): AutoCaptureDecision {
+  if (consent === true) return 'proceed';
+  if (consent === false) return 'skip';
+  return 'ask';
+}
+
+/**
+ * Heuristic: does a capture error look like a macOS screen-recording
+ * permission denial (as opposed to a dead dev server, missing Playwright,
+ * etc.)? Requires both a denial word and a screen/capture word so generic
+ * failures ("EACCES: permission denied, open …") don't disable thumbnails.
+ */
+export function isPermissionDenialError(error: unknown): boolean {
+  const message = formatCommandError(asCommandError(error)).toLowerCase();
+  const denial = /permission|denied|not authorized|declined/.test(message);
+  const screen =
+    /screen recording|screen capture|screencapturekit|scstream|tcc|cgdisplay|record/.test(message);
+  return denial && screen;
+}

--- a/src/styles/features/thumbnail-consent.css
+++ b/src/styles/features/thumbnail-consent.css
@@ -1,0 +1,28 @@
+/* Thumbnail consent explainer (#160) — shown before the first automatic
+   project-thumbnail capture so the macOS screen-recording prompt never
+   appears without context. */
+
+.thumbnail-consent-modal {
+  max-width: 440px;
+}
+
+.thumbnail-consent-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  padding: var(--spacing-lg);
+}
+
+.thumbnail-consent-body p {
+  margin: 0;
+  font-size: var(--font-size-base);
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.thumbnail-consent-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -24,6 +24,7 @@
 @import './features/workspace/compact-workspace.css';
 @import './features/toolbar.css';
 @import './features/preview.css';
+@import './features/thumbnail-consent.css';
 @import './features/visual-editor.css';
 @import './features/visual-editor-image.css';
 @import './features/visual-editor-classes.css';


### PR DESCRIPTION
Fixes #160.

macOS shows **"Ship Studio wants to record audio and screen content"** with zero context, users are alarmed (two Slack reports), and after a denial the background thumbnail machinery kept re-attempting capture on a timer.

## What changed

### 1. The OS prompt never appears without context
Before the **first** automatic thumbnail capture ever, an in-app "Preview thumbnails" explainer (built on `ModalFrame`) opens instead of capturing:

- Explains that Ship Studio screenshots its own preview window for dashboard thumbnails, that macOS calls this "recording screen content", and that nothing is recorded or sent anywhere — it's a single local image.
- **Allow thumbnails** → persists opt-in and runs the deferred capture (so if the OS prompt appears, it appears right after an informed choice).
- **No thumbnails** → persists opt-out; auto-capture never runs.
- ESC / overlay dismiss → no persisted answer; auto-capture stays deferred and the question waits until the next launch instead of nagging every 5 minutes.

**The manual capture path is intentionally not gated.** A user clicking the camera/crop button has clear intent — that click is an obvious cause for the OS prompt, so it proceeds directly.

### 2. Denial is respected — no more re-prompting
- Consent is persisted as `thumbnails_enabled: Option<bool>` in app state (`None` = never asked), following the existing `settings.rs` pattern (`get_thumbnails_enabled` / `set_thumbnails_enabled`).
- A capture failure that looks like a Screen Recording denial permanently disables auto-capture instead of retrying. Denial detection (`src/lib/thumbnailGate.ts`) requires both a denial word and a screen/capture word, so generic failures (dead dev server, missing Playwright, file EACCES) don't disable thumbnails.
- On macOS, the concrete denial signature is that the capturable-windows list omits window titles when permission is off — `captureWindowScreenshot` now throws a descriptive error for that case (pointing at System Settings → Privacy & Security → Screen Recording) instead of silently returning null.
- **Settings → "Project thumbnails" toggle** to re-enable, with the System Settings hint. Deliberately *not* a Cmd+K command (deep one-shot setting, out of palette scope per CLAUDE.md).

### 3. Real errors are surfaced
Manual viewport/region capture failures now toast the actual underlying error (formatted via `asCommandError`/`formatCommandError`), not a generic "couldn't capture".

## Note on the two capture paths
While verifying, I found the automatic thumbnail path (`capture_project_thumbnail`) currently renders via headless Playwright/Chromium — the ScreenCaptureKit (`getWindowScreenshot`) calls live in the manual camera/crop path and the full-page fallback. The consent gate + denial persistence still cover both trust concerns: the explainer runs before any background capture, and any denial-shaped failure (from whichever path hits ScreenCaptureKit) stops the background machinery from running into it again.

## Tests
- `src/lib/thumbnailGate.test.ts` — pure decision gate (first-run → ask/defer, opted-out → skip, allowed → proceed) and denial-detection heuristics (positive + negative cases).
- `src/hooks/useScreenshotManagement.test.ts` — hook-level: defer + explainer on first run, never capture when opted out, capture when allowed, both consent answers (incl. deferred capture resuming after "Allow"), session-deferral on dismiss, denial → persist opt-out + no retry, non-denial → retry preserved.
- `pnpm typecheck`, `lint:strict`, `test:run` (1152 passed), `check:patterns`, `check:loc`, `cargo test` (651 passed), `cargo fmt`, `clippy` all green.

## Needs manual macOS verification
- Fresh machine / reset TCC (`tccutil reset ScreenCapture com.shipstudio.app`): explainer appears ~8s after the preview loads, before any OS prompt.
- Denying the OS prompt after "Allow thumbnails": next manual capture surfaces the Screen Recording message and Settings shows the toggle off.
- Re-enabling the toggle after granting permission in System Settings (grant may require an app relaunch to take effect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)