### PR TITLE
Preview HMR reliability: stop the stale-preview-until-reenter bug (#181)

### DIFF
--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -28,6 +28,23 @@ use tokio::task::JoinHandle;
 /// Maximum response body size to buffer for HTML injection (50 MB).
 const MAX_BODY_SIZE: usize = 50 * 1024 * 1024;
 
+/// Timeout for establishing the upstream TCP connection. Localhost either
+/// accepts immediately or refuses outright; a hang here means a firewalled or
+/// wedged port and should fail fast instead of holding the request forever.
+const UPSTREAM_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Timeout for the upstream response headers. Must be generous: dev servers
+/// compile routes on demand and hold the request open until the compile
+/// finishes — tens of seconds on a real dependency tree (the frontend's
+/// readiness probe rides the same wait). This is a backstop against a truly
+/// hung upstream, not a UX timeout.
+const UPSTREAM_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Timeout for buffering an HTML body once response headers have arrived.
+/// Headers-then-stall is not a compile wait — after headers the body should
+/// flow immediately on localhost.
+const HTML_BODY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 /// Script injected into HTML responses to report navigation events to the parent window.
 /// Monkey-patches history.pushState/replaceState and listens for popstate to catch all
 /// client-side navigation in frameworks like Next.js, React Router, etc.
@@ -68,19 +85,30 @@ const SCROLLBAR_STYLE: &str = r#"<style id="ss-hide-scrollbars">::-webkit-scroll
 /// (`visibility:hidden`) until the saved position is restored — then reveal. The
 /// net effect: a save reloads but the preview stays put, with no visible jump.
 /// Keyed by pathname, so a real navigation still starts at the top.
-const SCROLL_RESTORE: &str = r#"<script id="ss-scroll-restore">(function(){try{if(window.__ssScroll)return;window.__ssScroll=1;if('scrollRestoration' in history)history.scrollRestoration='manual';var K='ssScroll:'+location.pathname;var de=document.documentElement;var save=function(){try{sessionStorage.setItem(K,String(window.scrollY||window.pageYOffset||0));}catch(e){}};window.addEventListener('scroll',save,{passive:true});window.addEventListener('pagehide',save);window.addEventListener('beforeunload',save);var y=sessionStorage.getItem(K);if(y==null)return;var n=parseFloat(y)||0;if(n<=0)return;de.style.visibility='hidden';var done=false;var reveal=function(){if(done)return;done=true;window.scrollTo(0,n);de.style.visibility='';};document.addEventListener('DOMContentLoaded',function(){window.scrollTo(0,n);requestAnimationFrame(reveal);});window.addEventListener('load',function(){window.scrollTo(0,n);reveal();});setTimeout(reveal,1200);}catch(e){try{document.documentElement.style.visibility='';}catch(_){}}})();</script>"#;
+///
+/// The hold is released as soon as the document is tall enough to reach the
+/// saved position (rAF poll), with DOMContentLoaded/load and a 400ms hard cap
+/// as fallbacks — an over-long hold reads as a blank flash unique to the
+/// preview. The script body lives in `scroll_restore.html` so it stays readable
+/// and can be exercised by jsdom tests like the selection script.
+const SCROLL_RESTORE: &str = include_str!("scroll_restore.html");
 
 /// Makes the editor's OWN save feel like Next's in-place Fast Refresh. Astro
 /// full-reloads the whole document on a `.astro` save (which is what makes the
 /// preview jerk), but the edit is ALREADY shown live and Tailwind pushes its new
 /// CSS over a SEPARATE css-update HMR message. So we wrap Vite's HMR WebSocket and
 /// swallow just the `full-reload` message — but ONLY in the brief window right after
-/// the editor commits a save (`window.__ssSuppressUntil`, set on `ss:commit`).
-/// Outside that window full-reloads pass through normally, so an agent editing files
-/// still reloads the preview. CSS updates always pass, so the real compiled CSS
-/// applies. Gated to Vite's `vite-hmr` subprotocol so it never touches a site's own
-/// sockets. Injected at head start so it wraps WebSocket before `@vite/client` connects.
-const RELOAD_SUPPRESS: &str = r#"<script id="ss-reload-suppress">(function(){try{var O=window.WebSocket;if(!O)return;function drop(d){if(!(window.__ssSuppressUntil&&Date.now()<window.__ssSuppressUntil))return false;try{var m=JSON.parse(d);return !!(m&&m.type==='full-reload');}catch(e){return false;}}function W(url,protocols){var ws=arguments.length>1?new O(url,protocols):new O(url);var isVite=protocols==='vite-hmr'||(protocols&&(''+protocols).indexOf('vite-hmr')>=0);if(!isVite)return ws;var add=ws.addEventListener.bind(ws);function flt(h){return function(ev){if(ev&&typeof ev.data==='string'&&drop(ev.data))return;return h.call(ws,ev);};}ws.addEventListener=function(t,h,o){return (t==='message'&&typeof h==='function')?add(t,flt(h),o):add(t,h,o);};var _om=null;try{Object.defineProperty(ws,'onmessage',{configurable:true,get:function(){return _om;},set:function(h){_om=h;if(typeof h==='function')add('message',flt(h));}});}catch(e){}return ws;}W.prototype=O.prototype;try{W.CONNECTING=O.CONNECTING;W.OPEN=O.OPEN;W.CLOSING=O.CLOSING;W.CLOSED=O.CLOSED;}catch(e){}window.WebSocket=W;}catch(e){}})();</script>"#;
+/// the editor commits a save (`window.__ssSuppressUntil`, set on `ss:commit`),
+/// and at most ONE per window: dropping a reload closes the window, so a racing
+/// reload from an unrelated change (an agent editing files) still lands instead
+/// of leaving the preview permanently stale. CSS updates always pass, so the real
+/// compiled CSS applies. Gated to Vite's `vite-hmr` subprotocol so it never touches
+/// a site's own sockets. Injected at head start so it wraps WebSocket before
+/// `@vite/client` connects.
+///
+/// The script body lives in `reload_suppress.html` so the same source is shared
+/// with the jsdom behavior test (`src/components/preview/reloadSuppress.test.ts`).
+const RELOAD_SUPPRESS: &str = include_str!("reload_suppress.html");
 
 /// Boxed body type that can be either a full buffered body or a streamed body.
 type ProxyBody = BoxBody<Bytes, hyper::Error>;
@@ -236,6 +264,25 @@ fn redact_handshake_values(input: &str) -> String {
     }
     out.push_str(rest);
     out
+}
+
+/// Rewrite a `localhost`/`127.0.0.1` Origin header to the dev server's port.
+///
+/// Requests reaching the proxy come from pages served *by* the proxy, so their
+/// Origin names the proxy's ephemeral port. Dev servers that host/origin-check
+/// requests (Vite's HMR WebSocket upgrade, CSRF-guarded endpoints) must instead
+/// see the origin they expect — their own. Non-localhost origins pass through
+/// untouched.
+fn rewrite_localhost_origin(
+    value: &hyper::header::HeaderValue,
+    target_port: u16,
+) -> Option<hyper::header::HeaderValue> {
+    let s = value.to_str().ok()?;
+    let host = s.strip_prefix("http://")?.split(':').next()?;
+    if host != "localhost" && host != "127.0.0.1" {
+        return None;
+    }
+    hyper::header::HeaderValue::from_str(&format!("http://{host}:{target_port}")).ok()
 }
 
 /// A running proxy instance.
@@ -396,7 +443,11 @@ async fn proxy_http_request(
     // Connect to target via hostname so both IPv4 and IPv6 are tried.
     // Vite-based dev servers (Astro, SvelteKit, Nuxt) bind to `localhost` which
     // resolves to `::1` (IPv6) on macOS -- hardcoding 127.0.0.1 fails for those.
-    let stream = TcpStream::connect(format!("localhost:{target_port}")).await?;
+    let stream = tokio::time::timeout(
+        UPSTREAM_CONNECT_TIMEOUT,
+        TcpStream::connect(format!("localhost:{target_port}")),
+    )
+    .await??;
     let io = TokioIo::new(stream);
 
     let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
@@ -441,13 +492,25 @@ async fn proxy_http_request(
             builder = builder.header(key, format!("localhost:{target_port}"));
             continue;
         }
+        // Rewrite Origin for the same reason — a CSRF/origin-checking dev
+        // server must not see the proxy's ephemeral port.
+        if key == hyper::header::ORIGIN {
+            if let Some(v) = rewrite_localhost_origin(value, target_port) {
+                builder = builder.header(key, v);
+                continue;
+            }
+        }
         builder = builder.header(key, value);
     }
 
     let forwarded_req = builder.body(body)?;
 
     // Send request and get response
-    let resp = sender.send_request(forwarded_req).await?;
+    let resp = tokio::time::timeout(
+        UPSTREAM_RESPONSE_TIMEOUT,
+        sender.send_request(forwarded_req),
+    )
+    .await??;
 
     // Intercept auth-handshake redirect loops before they leave the proxy.
     // Forwarding the redirect would bounce the iframe through a third-party
@@ -494,7 +557,9 @@ async fn proxy_http_request(
 
     if is_html {
         // Buffer HTML response body and inject nav script (and error overlay for 5xx)
-        let body_bytes = resp.collect().await?.to_bytes();
+        let body_bytes = tokio::time::timeout(HTML_BODY_TIMEOUT, resp.collect())
+            .await??
+            .to_bytes();
         let is_server_error = status.is_server_error();
 
         let response_body = if body_bytes.len() < MAX_BODY_SIZE {
@@ -528,6 +593,16 @@ async fn proxy_http_request(
             if key == hyper::header::CONTENT_LENGTH || key == hyper::header::CONTENT_ENCODING {
                 continue;
             }
+            // The injected body no longer matches upstream's cache validators,
+            // and the iframe URL carries no cache-busting param — the webview
+            // must never reuse a cached copy of injected HTML (replaced with a
+            // hard no-store below).
+            if key == hyper::header::CACHE_CONTROL
+                || key == hyper::header::ETAG
+                || key == hyper::header::LAST_MODIFIED
+            {
+                continue;
+            }
             // The page renders inside the preview iframe — drop anti-framing
             // headers (Shopify storefronts send X-Frame-Options: DENY).
             if key == hyper::header::X_FRAME_OPTIONS {
@@ -541,6 +616,7 @@ async fn proxy_http_request(
             }
             response = response.header(key, value);
         }
+        response = response.header(hyper::header::CACHE_CONTROL, "no-store");
 
         Ok(response.body(response_body)?)
     } else {
@@ -573,7 +649,14 @@ async fn handle_websocket_upgrade(
     target_port: u16,
 ) -> Result<Response<ProxyBody>, hyper::Error> {
     // Connect via hostname for IPv4/IPv6 compatibility (see proxy_http_request)
-    let target_stream = match TcpStream::connect(format!("localhost:{target_port}")).await {
+    let target_stream = match tokio::time::timeout(
+        UPSTREAM_CONNECT_TIMEOUT,
+        TcpStream::connect(format!("localhost:{target_port}")),
+    )
+    .await
+    .map_err(std::io::Error::from)
+    .and_then(|r| r)
+    {
         Ok(s) => s,
         Err(e) => {
             tracing::error!("[Proxy] WebSocket target connection failed: {}", e);
@@ -623,6 +706,21 @@ async fn handle_websocket_upgrade(
         .version(parts.version);
 
     for (key, value) in &parts.headers {
+        // Rewrite Host/Origin to the dev server's own port, exactly like the
+        // HTTP path. Vite host/origin-checks its HMR WebSocket upgrade; leaking
+        // the proxy's ephemeral port here gets the HMR socket rejected on
+        // stricter setups — the preview then silently stops receiving updates
+        // until the dev server is restarted.
+        if key == hyper::header::HOST {
+            builder = builder.header(key, format!("localhost:{target_port}"));
+            continue;
+        }
+        if key == hyper::header::ORIGIN {
+            if let Some(v) = rewrite_localhost_origin(value, target_port) {
+                builder = builder.header(key, v);
+                continue;
+            }
+        }
         builder = builder.header(key, value);
     }
 
@@ -717,10 +815,45 @@ async fn handle_websocket_upgrade(
 mod tests {
     use super::{
         is_auth_redirect_loop, is_document_navigation, redact_handshake_values,
-        sanitize_csp_for_preview,
+        rewrite_localhost_origin, sanitize_csp_for_preview,
     };
     use hyper::header::HeaderValue;
     use hyper::StatusCode;
+
+    #[test]
+    fn localhost_origin_is_rewritten_to_target_port() {
+        let v = HeaderValue::from_static("http://localhost:61234");
+        assert_eq!(
+            rewrite_localhost_origin(&v, 3000).unwrap(),
+            HeaderValue::from_static("http://localhost:3000")
+        );
+    }
+
+    #[test]
+    fn loopback_ip_origin_keeps_its_host_form() {
+        let v = HeaderValue::from_static("http://127.0.0.1:61234");
+        assert_eq!(
+            rewrite_localhost_origin(&v, 3000).unwrap(),
+            HeaderValue::from_static("http://127.0.0.1:3000")
+        );
+    }
+
+    #[test]
+    fn portless_localhost_origin_gains_target_port() {
+        let v = HeaderValue::from_static("http://localhost");
+        assert_eq!(
+            rewrite_localhost_origin(&v, 4321).unwrap(),
+            HeaderValue::from_static("http://localhost:4321")
+        );
+    }
+
+    #[test]
+    fn non_localhost_origins_pass_through_untouched() {
+        for origin in ["https://localhost:1234", "http://example.com:80", "null"] {
+            let v = HeaderValue::from_str(origin).unwrap();
+            assert!(rewrite_localhost_origin(&v, 3000).is_none());
+        }
+    }
 
     #[test]
     fn csp_without_stripped_directives_passes_through() {
@@ -931,5 +1064,154 @@ mod tests {
     fn redaction_leaves_strings_without_the_param_unchanged() {
         let s = "HTTP 307 redirect to https://my-app.clerk.accounts.dev/v1/client/handshake?redirect_url=x (requested /)";
         assert_eq!(redact_handshake_values(s), s);
+    }
+}
+
+/// End-to-end tests over real sockets: a canned upstream records exactly what
+/// the proxy forwards, and the raw response bytes show what a webview would see.
+#[cfg(test)]
+mod e2e_tests {
+    use super::{start_preview_proxy, stop_preview_proxy};
+    use std::sync::Arc;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio::sync::Mutex;
+
+    /// Spawn a fake dev server that captures each request's head (through the
+    /// blank line) and answers with `response`. Returns its port.
+    async fn spawn_upstream(response: &'static str, captured: Arc<Mutex<Vec<String>>>) -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                let captured = captured.clone();
+                tokio::spawn(async move {
+                    let mut head = Vec::new();
+                    let mut buf = [0u8; 1024];
+                    while !head.windows(4).any(|w| w == b"\r\n\r\n") {
+                        match stream.read(&mut buf).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => head.extend_from_slice(&buf[..n]),
+                        }
+                    }
+                    captured
+                        .lock()
+                        .await
+                        .push(String::from_utf8_lossy(&head).to_string());
+                    let _ = stream.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+        port
+    }
+
+    /// Send raw bytes to the proxy and collect the full response.
+    async fn roundtrip(proxy_port: u16, request: String) -> String {
+        let mut client = TcpStream::connect(("127.0.0.1", proxy_port)).await.unwrap();
+        client.write_all(request.as_bytes()).await.unwrap();
+        let mut resp = Vec::new();
+        // WS upgrades keep the socket open — read until headers, then stop.
+        let mut buf = [0u8; 1024];
+        while !resp.windows(4).any(|w| w == b"\r\n\r\n") || resp.starts_with(b"HTTP/1.1 200") {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), client.read(&mut buf))
+                .await
+            {
+                Ok(Ok(0)) | Err(_) => break,
+                Ok(Ok(n)) => resp.extend_from_slice(&buf[..n]),
+                Ok(Err(_)) => break,
+            }
+        }
+        String::from_utf8_lossy(&resp).to_string()
+    }
+
+    #[tokio::test]
+    async fn http_path_rewrites_headers_hardens_caching_and_injects() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let body = "<html><head><title>t</title></head><body>hi</body></html>";
+        let upstream = spawn_upstream(
+            // Cacheable upstream response — the proxy must strip the validators
+            // since the injected body no longer matches them.
+            Box::leak(
+                format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nCache-Control: max-age=3600\r\nETag: \"abc\"\r\n\r\n{body}",
+                    body.len()
+                )
+                .into_boxed_str(),
+            ),
+            captured.clone(),
+        )
+        .await;
+        let proxy_port = start_preview_proxy("e2e-http".into(), upstream)
+            .await
+            .unwrap();
+
+        let resp = roundtrip(
+            proxy_port,
+            format!(
+                "GET / HTTP/1.1\r\nHost: localhost:{proxy_port}\r\nOrigin: http://localhost:{proxy_port}\r\nAccept-Encoding: gzip, br\r\nConnection: close\r\n\r\n"
+            ),
+        )
+        .await;
+        stop_preview_proxy("e2e-http");
+
+        // What the dev server saw: its own port in Host/Origin, no Accept-Encoding.
+        let seen = captured.lock().await.join("").to_lowercase();
+        assert!(
+            seen.contains(&format!("host: localhost:{upstream}")),
+            "{seen}"
+        );
+        assert!(
+            seen.contains(&format!("origin: http://localhost:{upstream}")),
+            "{seen}"
+        );
+        assert!(!seen.contains("accept-encoding"), "{seen}");
+
+        // What the webview gets: injected scripts, hard no-store, no validators.
+        assert!(resp.contains("ss-reload-suppress"), "{resp}");
+        assert!(resp.contains("ss-scroll-restore"), "{resp}");
+        assert!(resp.contains("shipstudio:navigate"), "{resp}");
+        let lower = resp.to_lowercase();
+        assert!(lower.contains("cache-control: no-store"), "{resp}");
+        assert!(!lower.contains("etag"), "{resp}");
+        assert!(!lower.contains("max-age"), "{resp}");
+    }
+
+    #[tokio::test]
+    async fn ws_upgrade_rewrites_host_and_origin_for_hmr() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let upstream = spawn_upstream(
+            "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\nSec-WebSocket-Protocol: vite-hmr\r\n\r\n",
+            captured.clone(),
+        )
+        .await;
+        let proxy_port = start_preview_proxy("e2e-ws".into(), upstream)
+            .await
+            .unwrap();
+
+        let resp = roundtrip(
+            proxy_port,
+            format!(
+                "GET / HTTP/1.1\r\nHost: localhost:{proxy_port}\r\nOrigin: http://localhost:{proxy_port}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Protocol: vite-hmr\r\n\r\n"
+            ),
+        )
+        .await;
+        stop_preview_proxy("e2e-ws");
+
+        // The upgrade reached the dev server with ITS port in Host/Origin —
+        // Vite origin-checks the HMR socket; the proxy port would get it
+        // rejected and silently kill hot updates.
+        let seen = captured.lock().await.join("").to_lowercase();
+        assert!(
+            seen.contains(&format!("host: localhost:{upstream}")),
+            "{seen}"
+        );
+        assert!(
+            seen.contains(&format!("origin: http://localhost:{upstream}")),
+            "{seen}"
+        );
+        assert!(seen.contains("sec-websocket-protocol: vite-hmr"), "{seen}");
+
+        // And the upgrade completed through the proxy.
+        assert!(resp.starts_with("HTTP/1.1 101"), "{resp}");
     }
 }

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -40,10 +40,17 @@ const UPSTREAM_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_
 /// hung upstream, not a UX timeout.
 const UPSTREAM_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
-/// Timeout for buffering an HTML body once response headers have arrived.
-/// Headers-then-stall is not a compile wait — after headers the body should
-/// flow immediately on localhost.
+/// Timeout for buffering an HTML *error* body once response headers have
+/// arrived (5xx pages are buffered whole to extract the framework's error
+/// message; ordinary HTML streams through `HeadInjector` untimed, like any
+/// other streamed response). Headers-then-stall is not a compile wait — after
+/// headers the body should flow immediately on localhost.
 const HTML_BODY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Cap on how much of an HTML document is held back while scanning for
+/// `</head>`. Real heads are a few KB; if the marker hasn't shown up by now
+/// the document is degenerate — inject at the head-start position and stream on.
+const HEAD_SCAN_CAP: usize = 256 * 1024;
 
 /// Script injected into HTML responses to report navigation events to the parent window.
 /// Monkey-patches history.pushState/replaceState and listens for popstate to catch all
@@ -106,12 +113,153 @@ const SCROLL_RESTORE: &str = include_str!("scroll_restore.html");
 /// a site's own sockets. Injected at head start so it wraps WebSocket before
 /// `@vite/client` connects.
 ///
+/// The same script also runs the HMR watchdog: it tracks HMR sockets (Vite's
+/// `vite-hmr` subprotocol, Next.js's `_next/webpack-hmr` path) and posts
+/// `shipstudio:hmr-down` to the parent when they all close and none reopens
+/// within 5s — the parent then health-checks the dev server and auto-reloads
+/// the preview instead of leaving it silently stale.
+///
 /// The script body lives in `reload_suppress.html` so the same source is shared
 /// with the jsdom behavior test (`src/components/preview/reloadSuppress.test.ts`).
 const RELOAD_SUPPRESS: &str = include_str!("reload_suppress.html");
 
 /// Boxed body type that can be either a full buffered body or a streamed body.
 type ProxyBody = BoxBody<Bytes, hyper::Error>;
+
+/// Incremental HTML injector: buffers the stream only until `</head>` is seen,
+/// injects there, then passes every later chunk straight through.
+///
+/// Both injection points — right after `<head …>` (styles/early scripts) and
+/// right before `</head>` (nav + selection scripts) — live in the document
+/// prefix, so once the prefix is cut the standard whole-document pipeline
+/// (`inject_nav_script`) applies to it verbatim and the remainder needs no
+/// inspection. This is what lets streaming-SSR frameworks (Next.js App Router,
+/// Astro) paint progressively in the preview: they flush the head early and
+/// stream the body, and buffering the whole document — as the proxy used to —
+/// held the first paint until the last byte.
+struct HeadInjector {
+    /// Buffered prefix; `None` once injection happened (pass-through mode).
+    pending: Option<Vec<u8>>,
+    /// How far `pending` has been scanned, so each chunk is scanned once
+    /// (with marker-length overlap for markers split across chunks).
+    scanned: usize,
+}
+
+const HEAD_CLOSE: &[u8] = b"</head>";
+
+impl HeadInjector {
+    fn new() -> Self {
+        Self {
+            pending: Some(Vec::new()),
+            scanned: 0,
+        }
+    }
+
+    /// Feed one chunk; returns bytes ready to emit downstream (empty while the
+    /// injection point is still being scanned for).
+    fn push(&mut self, chunk: &[u8]) -> Vec<u8> {
+        let Some(mut buf) = self.pending.take() else {
+            // Pass-through mode: injection already happened.
+            return chunk.to_vec();
+        };
+        buf.extend_from_slice(chunk);
+        let start = self.scanned.saturating_sub(HEAD_CLOSE.len() - 1);
+
+        if let Some(rel) = find_subslice(&buf[start..], HEAD_CLOSE) {
+            let cut = start + rel + HEAD_CLOSE.len();
+            let (prefix, rest) = buf.split_at(cut);
+            let mut out = inject_nav_script(prefix);
+            out.extend_from_slice(rest);
+            out
+        } else if buf.len() > HEAD_SCAN_CAP {
+            // Degenerate document: no `</head>` in the first 256 KB. Drop
+            // every snippet at the head-start position (after `<head …>`,
+            // `<html …>`, or the document start) and go pass-through.
+            inject_at_head_start(
+                &buf,
+                &format!(
+                    "{SCROLLBAR_STYLE}{RELOAD_SUPPRESS}{SCROLL_RESTORE}{NAV_SCRIPT}{SELECT_SCRIPT}"
+                ),
+            )
+        } else {
+            // Marker not seen yet — keep buffering.
+            self.scanned = buf.len();
+            self.pending = Some(buf);
+            Vec::new()
+        }
+    }
+
+    /// Body ended. A document that never reached `</head>` under the cap gets
+    /// the standard whole-document fallback injection (before `</body>`, else
+    /// appended) — identical to the old buffered behavior.
+    fn finish(mut self) -> Vec<u8> {
+        match self.pending.take() {
+            Some(buf) => inject_nav_script(&buf),
+            None => Vec::new(),
+        }
+    }
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Body implementation fed by a channel — lets a spawned task transform the
+/// upstream stream (head injection) while hyper streams frames to the webview.
+struct ChannelBody {
+    rx: tokio::sync::mpsc::Receiver<Result<hyper::body::Frame<Bytes>, hyper::Error>>,
+}
+
+impl hyper::body::Body for ChannelBody {
+    type Data = Bytes;
+    type Error = hyper::Error;
+
+    fn poll_frame(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<hyper::body::Frame<Bytes>, hyper::Error>>> {
+        self.rx.poll_recv(cx)
+    }
+}
+
+/// Stream an HTML body through [`HeadInjector`]: the (injected) prefix is
+/// emitted as soon as `</head>` arrives, everything after it is piped through.
+fn streaming_injected_body(mut body: Incoming) -> ProxyBody {
+    let (tx, rx) = tokio::sync::mpsc::channel(16);
+    tokio::spawn(async move {
+        let mut injector = HeadInjector::new();
+        loop {
+            match body.frame().await {
+                Some(Ok(frame)) => {
+                    // Trailers are irrelevant for dev-server HTML — dropped.
+                    if let Ok(data) = frame.into_data() {
+                        let out = injector.push(&data);
+                        if !out.is_empty()
+                            && tx
+                                .send(Ok(hyper::body::Frame::data(Bytes::from(out))))
+                                .await
+                                .is_err()
+                        {
+                            return; // client went away
+                        }
+                    }
+                }
+                Some(Err(e)) => {
+                    let _ = tx.send(Err(e)).await;
+                    return;
+                }
+                None => break,
+            }
+        }
+        let tail = injector.finish();
+        if !tail.is_empty() {
+            let _ = tx
+                .send(Ok(hyper::body::Frame::data(Bytes::from(tail))))
+                .await;
+        }
+    });
+    ChannelBody { rx }.boxed()
+}
 
 /// Convert full bytes into a ProxyBody.
 fn full_body(data: Bytes) -> ProxyBody {
@@ -556,26 +704,30 @@ async fn proxy_http_request(
     let headers = resp.headers().clone();
 
     if is_html {
-        // Buffer HTML response body and inject nav script (and error overlay for 5xx)
-        let body_bytes = tokio::time::timeout(HTML_BODY_TIMEOUT, resp.collect())
-            .await??
-            .to_bytes();
         let is_server_error = status.is_server_error();
 
-        let response_body = if body_bytes.len() < MAX_BODY_SIZE {
-            let modified = if is_server_error {
-                tracing::warn!(
-                    "[Proxy] Dev server returned {} for HTML response, injecting error overlay",
-                    status.as_u16()
-                );
-                inject_error_into_html(&body_bytes, status.as_u16())
+        let response_body = if is_server_error {
+            // Error pages are buffered whole: extracting the framework's error
+            // message for the overlay needs the full document, and they're small.
+            tracing::warn!(
+                "[Proxy] Dev server returned {} for HTML response, injecting error overlay",
+                status.as_u16()
+            );
+            let body_bytes = tokio::time::timeout(HTML_BODY_TIMEOUT, resp.collect())
+                .await??
+                .to_bytes();
+            if body_bytes.len() < MAX_BODY_SIZE {
+                full_body(Bytes::from(inject_error_into_html(
+                    &body_bytes,
+                    status.as_u16(),
+                )))
             } else {
-                inject_nav_script(&body_bytes)
-            };
-            full_body(Bytes::from(modified))
+                // Too large to inject, pass through as-is
+                full_body(body_bytes)
+            }
         } else {
-            // Too large to inject, pass through as-is
-            full_body(body_bytes)
+            // Ordinary HTML streams through the head injector — see HeadInjector.
+            streaming_injected_body(resp.into_body())
         };
 
         // For error responses, return 200 so the iframe actually renders our overlay.
@@ -809,6 +961,70 @@ async fn handle_websocket_upgrade(
     }
 
     Ok(client_response)
+}
+
+#[cfg(test)]
+mod injector_tests {
+    use super::{inject_nav_script, HeadInjector, HEAD_SCAN_CAP};
+
+    /// Run the injector over `chunks` and return the concatenated output.
+    fn run(chunks: &[&[u8]]) -> Vec<u8> {
+        let mut injector = HeadInjector::new();
+        let mut out = Vec::new();
+        for chunk in chunks {
+            out.extend(injector.push(chunk));
+        }
+        out.extend(injector.finish());
+        out
+    }
+
+    #[test]
+    fn single_chunk_matches_buffered_pipeline() {
+        let html = b"<html><head><title>t</title></head><body>hi</body></html>";
+        assert_eq!(run(&[html]), inject_nav_script(html));
+    }
+
+    #[test]
+    fn marker_split_across_chunks_matches_buffered_pipeline() {
+        let html = b"<html><head><title>t</title></head><body>hi</body></html>";
+        // Split inside `</head>` itself — the nastiest boundary.
+        for split in 20..40 {
+            let (a, b) = html.split_at(split);
+            assert_eq!(run(&[a, b]), inject_nav_script(html), "split at {split}");
+        }
+    }
+
+    #[test]
+    fn body_streams_through_untouched_after_head() {
+        let mut injector = HeadInjector::new();
+        let first = injector.push(b"<html><head></head><body>");
+        assert!(!first.is_empty(), "prefix must flush once </head> is seen");
+        // Later chunks pass through verbatim — even ones containing head-like
+        // markers — because injection already happened.
+        assert_eq!(injector.push(b"<p></head></p>"), b"<p></head></p>");
+        assert!(injector.finish().is_empty());
+    }
+
+    #[test]
+    fn no_head_document_falls_back_like_buffered_pipeline() {
+        let html = b"<html><body>plain</body></html>";
+        assert_eq!(run(&[html]), inject_nav_script(html));
+    }
+
+    #[test]
+    fn cap_overflow_injects_at_head_start_and_streams_on() {
+        // A document whose </head> never arrives within the cap.
+        let mut big = b"<html><head>".to_vec();
+        big.resize(HEAD_SCAN_CAP + 1024, b'x');
+        let mut injector = HeadInjector::new();
+        let out = injector.push(&big);
+        assert!(!out.is_empty(), "cap overflow must flush");
+        let s = String::from_utf8_lossy(&out);
+        assert!(s.contains("ss-hide-scrollbars"));
+        assert!(s.contains("shipstudio:navigate"));
+        // And we're in pass-through mode now.
+        assert_eq!(injector.push(b"tail"), b"tail");
+    }
 }
 
 #[cfg(test)]
@@ -1213,5 +1429,77 @@ mod e2e_tests {
 
         // And the upgrade completed through the proxy.
         assert!(resp.starts_with("HTTP/1.1 101"), "{resp}");
+    }
+
+    #[tokio::test]
+    async fn html_streams_progressively_through_the_proxy() {
+        // Upstream sends the head, then HOLDS the rest until we've verified the
+        // injected head already reached the client — proving the proxy streams
+        // instead of buffering the whole document (progressive SSR paint).
+        let head = "<html><head><title>t</title></head><body><p>first</p>";
+        let tail = "<p>second</p></body></html>";
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let upstream = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 2048];
+            let _ = stream.read(&mut buf).await;
+            let headers = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\n\r\n",
+                head.len() + tail.len()
+            );
+            stream.write_all(headers.as_bytes()).await.unwrap();
+            stream.write_all(head.as_bytes()).await.unwrap();
+            stream.flush().await.unwrap();
+            let _ = release_rx.await;
+            stream.write_all(tail.as_bytes()).await.unwrap();
+        });
+
+        let proxy_port = start_preview_proxy("e2e-stream".into(), upstream)
+            .await
+            .unwrap();
+        let mut client = TcpStream::connect(("127.0.0.1", proxy_port)).await.unwrap();
+        client
+            .write_all(
+                format!(
+                    "GET / HTTP/1.1\r\nHost: localhost:{proxy_port}\r\nConnection: close\r\n\r\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+
+        // Read until the first body part arrives — the tail hasn't been sent yet.
+        let mut received = Vec::new();
+        let mut buf = [0u8; 4096];
+        while !String::from_utf8_lossy(&received).contains("<p>first</p>") {
+            let n = tokio::time::timeout(std::time::Duration::from_secs(5), client.read(&mut buf))
+                .await
+                .expect("head must stream before the body completes")
+                .unwrap();
+            assert!(n > 0, "connection closed before head arrived");
+            received.extend_from_slice(&buf[..n]);
+        }
+        let so_far = String::from_utf8_lossy(&received).to_string();
+        assert!(so_far.contains("ss-reload-suppress"), "{so_far}");
+        assert!(so_far.contains("shipstudio:navigate"), "{so_far}");
+        assert!(!so_far.contains("<p>second</p>"), "{so_far}");
+
+        // Release the tail and confirm it flows through untouched.
+        release_tx.send(()).unwrap();
+        loop {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), client.read(&mut buf))
+                .await
+            {
+                Ok(Ok(0)) | Err(_) => break,
+                Ok(Ok(n)) => received.extend_from_slice(&buf[..n]),
+                Ok(Err(_)) => break,
+            }
+        }
+        stop_preview_proxy("e2e-stream");
+        let full = String::from_utf8_lossy(&received).to_string();
+        assert!(full.contains("<p>second</p></body></html>"), "{full}");
     }
 }

--- a/src-tauri/src/proxy/reload_suppress.html
+++ b/src-tauri/src/proxy/reload_suppress.html
@@ -1,0 +1,103 @@
+<script id="ss-reload-suppress">
+(function () {
+  try {
+    if (window.__ssReloadSuppress) return;
+    window.__ssReloadSuppress = 1;
+    var Native = window.WebSocket;
+    if (!Native) return;
+
+    // Decide once per event whether it is a Vite `full-reload` that falls inside
+    // the editor's suppress window (`window.__ssSuppressUntil`, set on ss:commit).
+    // The verdict is memoized ON the event so every listener on the socket sees
+    // the same answer — without this, the first listener would consume the
+    // suppress window and later listeners would let the same reload through.
+    // Swallow-once: dropping a reload closes the window immediately, so a
+    // full-reload from an unrelated change (an agent editing files) still lands
+    // even when it races the editor's commit.
+    function shouldDrop(ev) {
+      if (ev.__ssDrop !== undefined) return ev.__ssDrop;
+      var drop = false;
+      if (
+        window.__ssSuppressUntil &&
+        Date.now() < window.__ssSuppressUntil &&
+        typeof ev.data === 'string'
+      ) {
+        try {
+          var msg = JSON.parse(ev.data);
+          drop = !!(msg && msg.type === 'full-reload');
+        } catch (e) {}
+      }
+      if (drop) window.__ssSuppressUntil = 0;
+      try {
+        Object.defineProperty(ev, '__ssDrop', { value: drop });
+      } catch (e) {
+        ev.__ssDrop = drop;
+      }
+      return drop;
+    }
+
+    function Wrapped(url, protocols) {
+      var ws = arguments.length > 1 ? new Native(url, protocols) : new Native(url);
+      var isVite =
+        protocols === 'vite-hmr' || (protocols && ('' + protocols).indexOf('vite-hmr') >= 0);
+      if (!isVite) return ws;
+
+      var nativeAdd = ws.addEventListener.bind(ws);
+      var nativeRemove = ws.removeEventListener.bind(ws);
+
+      // Original handler -> filtered wrapper, so removeEventListener can hand
+      // the native API the exact function that was registered.
+      var filters = new Map();
+      function filterFor(handler) {
+        var existing = filters.get(handler);
+        if (existing) return existing;
+        var filtered = function (ev) {
+          if (shouldDrop(ev)) return;
+          return typeof handler === 'function' ? handler.call(ws, ev) : handler.handleEvent(ev);
+        };
+        filters.set(handler, filtered);
+        return filtered;
+      }
+      ws.addEventListener = function (type, handler, opts) {
+        if (type !== 'message' || !handler) return nativeAdd(type, handler, opts);
+        return nativeAdd(type, filterFor(handler), opts);
+      };
+      ws.removeEventListener = function (type, handler, opts) {
+        if (type !== 'message' || !handler) return nativeRemove(type, handler, opts);
+        var filtered = filters.get(handler);
+        if (filtered) filters.delete(handler);
+        return nativeRemove(type, filtered || handler, opts);
+      };
+
+      // `onmessage` routes through ONE persistent dispatcher; the setter only
+      // swaps the stored handler. (Re-registering per assignment stacks stale
+      // handlers — every reassignment used to add another listener.)
+      var onmsg = null;
+      nativeAdd('message', function (ev) {
+        if (!onmsg || shouldDrop(ev)) return;
+        return onmsg.call(ws, ev);
+      });
+      try {
+        Object.defineProperty(ws, 'onmessage', {
+          configurable: true,
+          get: function () {
+            return onmsg;
+          },
+          set: function (h) {
+            onmsg = typeof h === 'function' ? h : null;
+          },
+        });
+      } catch (e) {}
+      return ws;
+    }
+    Wrapped.prototype = Native.prototype;
+    try {
+      Wrapped.CONNECTING = Native.CONNECTING;
+      Wrapped.OPEN = Native.OPEN;
+      Wrapped.CLOSING = Native.CLOSING;
+      Wrapped.CLOSED = Native.CLOSED;
+    } catch (e) {}
+    window.WebSocket = Wrapped;
+  } catch (e) {}
+})();
+</script>

--- a/src-tauri/src/proxy/reload_suppress.html
+++ b/src-tauri/src/proxy/reload_suppress.html
@@ -36,10 +36,44 @@
       return drop;
     }
 
+    // ---- HMR watchdog -------------------------------------------------
+    // A dead HMR socket is the silent killer: the page keeps rendering but
+    // stops receiving updates, and the user "fixes" it by restarting the dev
+    // server. Track HMR sockets (Vite's `vite-hmr` subprotocol, Next.js's
+    // `_next/webpack-hmr` path); if every one closes and no replacement is
+    // OPEN within 5s, tell the parent so it can health-check the server and
+    // reload the preview. Navigations tear this timer down with the document,
+    // so ordinary page loads never fire it.
+    var hmrLive = 0;
+    var hmrDownTimer = null;
+    function trackHmr(ws) {
+      ws.addEventListener('open', function () {
+        hmrLive++;
+        if (hmrDownTimer) {
+          clearTimeout(hmrDownTimer);
+          hmrDownTimer = null;
+        }
+      });
+      ws.addEventListener('close', function () {
+        hmrLive = Math.max(0, hmrLive - 1);
+        if (hmrLive > 0) return;
+        if (hmrDownTimer) clearTimeout(hmrDownTimer);
+        hmrDownTimer = setTimeout(function () {
+          hmrDownTimer = null;
+          if (hmrLive === 0) {
+            try {
+              window.parent.postMessage({ type: 'shipstudio:hmr-down' }, '*');
+            } catch (e) {}
+          }
+        }, 5000);
+      });
+    }
+
     function Wrapped(url, protocols) {
       var ws = arguments.length > 1 ? new Native(url, protocols) : new Native(url);
       var isVite =
         protocols === 'vite-hmr' || (protocols && ('' + protocols).indexOf('vite-hmr') >= 0);
+      if (isVite || ('' + url).indexOf('_next/webpack-hmr') >= 0) trackHmr(ws);
       if (!isVite) return ws;
 
       var nativeAdd = ws.addEventListener.bind(ws);

--- a/src-tauri/src/proxy/scroll_restore.html
+++ b/src-tauri/src/proxy/scroll_restore.html
@@ -1,0 +1,58 @@
+<script id="ss-scroll-restore">
+(function () {
+  try {
+    if (window.__ssScroll) return;
+    window.__ssScroll = 1;
+    if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
+    var KEY = 'ssScroll:' + location.pathname;
+    var de = document.documentElement;
+    var save = function () {
+      try {
+        sessionStorage.setItem(KEY, String(window.scrollY || window.pageYOffset || 0));
+      } catch (e) {}
+    };
+    window.addEventListener('scroll', save, { passive: true });
+    window.addEventListener('pagehide', save);
+    window.addEventListener('beforeunload', save);
+
+    var saved = sessionStorage.getItem(KEY);
+    if (saved == null) return;
+    var target = parseFloat(saved) || 0;
+    if (target <= 0) return;
+
+    // Hold the first paint until the saved position is restored — restoring
+    // *after* paint makes the page visibly jump top -> back. But hold it as
+    // briefly as possible: reveal the moment the document is tall enough to
+    // scroll to the target (usually a few frames into parsing) instead of
+    // waiting for DOMContentLoaded, which module-loading dev servers can delay
+    // by seconds. A hard cap bounds the blank hold no matter what.
+    de.style.visibility = 'hidden';
+    var done = false;
+    var reveal = function () {
+      if (done) return;
+      done = true;
+      window.scrollTo(0, target);
+      de.style.visibility = '';
+    };
+    var poll = function () {
+      if (done) return;
+      if (de.scrollHeight - window.innerHeight >= target) {
+        reveal();
+        return;
+      }
+      requestAnimationFrame(poll);
+    };
+    requestAnimationFrame(poll);
+    document.addEventListener('DOMContentLoaded', function () {
+      window.scrollTo(0, target);
+      requestAnimationFrame(reveal);
+    });
+    window.addEventListener('load', reveal);
+    setTimeout(reveal, 400);
+  } catch (e) {
+    try {
+      document.documentElement.style.visibility = '';
+    } catch (_) {}
+  }
+})();
+</script>

--- a/src-tauri/src/webview_scripts.rs
+++ b/src-tauri/src/webview_scripts.rs
@@ -240,42 +240,71 @@ pub const INSPECTOR_SHIM: &str = r#"
       }
     };
 
-    // Debounced auto-refresh on mutations.
+    // Debounced auto-refresh on mutations — only while the host is subscribed
+    // (i.e. the Elements view is actually visible). Re-serializing up to 1500
+    // nodes every 300ms on mutation-heavy pages (animations flip attributes
+    // constantly) is real main-thread work the previewed page must not pay
+    // invisibly; it made the preview measurably jankier than Chrome.
     var domTimer = null;
+    var domSubscribed = false;
+    var domObserver = null;
     var scheduleDomSend = function () {
-      if (domTimer) return;
+      if (!domSubscribed || domTimer) return;
       domTimer = setTimeout(function () {
         domTimer = null;
-        sendDomTree();
+        if (domSubscribed) sendDomTree();
       }, 300);
     };
 
-    var startDomObserver = function () {
-      if (!document.documentElement || !window.MutationObserver) return;
-      try {
-        var mo = new MutationObserver(scheduleDomSend);
-        mo.observe(document.documentElement, {
-          childList: true,
-          subtree: true,
-          attributes: true,
-          characterData: true,
-        });
-      } catch (_) {}
-      sendDomTree();
+    var setDomSubscribed = function (on) {
+      domSubscribed = !!on;
+      if (!domSubscribed) {
+        if (domTimer) {
+          clearTimeout(domTimer);
+          domTimer = null;
+        }
+        if (domObserver) {
+          try {
+            domObserver.disconnect();
+          } catch (_) {}
+          domObserver = null;
+        }
+        return;
+      }
+      var arm = function () {
+        if (!domSubscribed || !document.documentElement || !window.MutationObserver) return;
+        if (!domObserver) {
+          try {
+            domObserver = new MutationObserver(scheduleDomSend);
+            domObserver.observe(document.documentElement, {
+              childList: true,
+              subtree: true,
+              attributes: true,
+              characterData: true,
+            });
+          } catch (_) {}
+        }
+        sendDomTree();
+      };
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', arm, { once: true });
+      } else {
+        arm();
+      }
     };
 
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', startDomObserver, { once: true });
-    } else {
-      startDomObserver();
-    }
-
-    // Host can request a fresh tree on demand (e.g., when Elements tab opens).
+    // Host commands: one-shot tree refresh, and subscribe/unsubscribe from the
+    // Elements view (drives the mutation observer above). A fresh document
+    // always starts unsubscribed; the host re-arms on our 'ready' beacon.
     window.addEventListener('message', function (e) {
       var d = e.data;
-      if (!d || typeof d !== 'object') return;
-      if (d.source === 'shipstudio-inspect-host' && d.type === 'request-dom-tree') {
+      if (!d || typeof d !== 'object' || d.source !== 'shipstudio-inspect-host') return;
+      if (d.type === 'request-dom-tree') {
         sendDomTree();
+      } else if (d.type === 'subscribe-dom-tree') {
+        setDomSubscribed(true);
+      } else if (d.type === 'unsubscribe-dom-tree') {
+        setDomSubscribed(false);
       }
     });
 

--- a/src/components/preview/BrowserTools.tsx
+++ b/src/components/preview/BrowserTools.tsx
@@ -23,9 +23,13 @@ type InnerTab = 'console' | 'network' | 'elements';
 interface BrowserToolsProps {
   /** Pipe the currently active tab's serialized content into the agent terminal. */
   onSendToAgent?: (text: string) => void;
+  /** Whether this panel is actually visible (panel open AND Browser tab
+   *  selected). BrowserTools stays mounted in a hidden slot, so visibility
+   *  must come from the parent — it gates the live DOM subscription. */
+  active?: boolean;
 }
 
-export function BrowserTools({ onSendToAgent }: BrowserToolsProps) {
+export function BrowserTools({ onSendToAgent, active = true }: BrowserToolsProps) {
   const [tab, setTabRaw] = useState<InnerTab>('console');
   const setTab = (next: InnerTab) => {
     if (next !== tab) {
@@ -44,11 +48,15 @@ export function BrowserTools({ onSendToAgent }: BrowserToolsProps) {
   );
   const domSnapshot = useSyncExternalStore(inspectStore.subscribe, inspectStore.getDomSnapshot);
 
-  // Refresh DOM whenever the Elements tab activates so the user always sees
-  // current state (auto-refresh from the shim is debounced at 300ms).
+  // Live DOM snapshots only while the Elements view is actually visible —
+  // the shim's mutation observer re-serializes the page's DOM on changes,
+  // which is too expensive to leave running invisibly (see inspectStore).
+  // Subscribing also triggers an immediate fresh tree.
   useEffect(() => {
-    if (tab === 'elements') inspectStore.refreshDom();
-  }, [tab]);
+    if (!active || tab !== 'elements') return;
+    inspectStore.setDomSubscription(true);
+    return () => inspectStore.setDomSubscription(false);
+  }, [active, tab]);
 
   const handleClear = () => {
     if (tab === 'console') {

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -558,13 +558,14 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
   const activeBreakpoint =
     (pinnedBreakpoint && breakpoints.find((b) => b.name === pinnedBreakpoint.name)) ||
     derivedBreakpoint;
-  // The selected breakpoint can exceed what the pane can show (the frame caps its
-  // visible width at the viewport). When so, edits still apply at that breakpoint
-  // but won't be visible here — the panel shows a note.
+  // The selected edit breakpoint can exceed the width the canvas actually
+  // renders at (e.g. a pinned wide layer while the canvas is narrower); edits
+  // then apply but aren't visible, so the panel shows a note. A preset wider
+  // than the pane does NOT trigger this: it renders at its true CSS width and
+  // is only scaled down visually (previewScale), so its media queries hold.
+  const renderedWidth = resize.customWidth ?? resize.viewportWidth;
   const breakpointTooWide =
-    activeBreakpoint.minPx > 0 &&
-    resize.viewportWidth > 0 &&
-    resize.viewportWidth < activeBreakpoint.minPx;
+    activeBreakpoint.minPx > 0 && renderedWidth > 0 && renderedWidth < activeBreakpoint.minPx;
 
   // Visual editor (Next.js, Vite/React, Astro). Inert until the user toggles edit mode.
   const editor = useVisualEditor({
@@ -1135,36 +1136,44 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
 
         {previewPlugins}
 
-        {iframeSize && iframeSize.w > 0 && iframeSize.h > 0 && (
-          <button
-            type="button"
-            className="preview-dimensions"
-            title={onSendToClaude ? 'Click to send to agent' : undefined}
-            disabled={!onSendToClaude}
-            aria-label={`Preview dimensions ${iframeSize.w} by ${iframeSize.h}${
-              onSendToClaude ? ', click to send to agent' : ''
-            }`}
-            onClick={() => {
-              if (!onSendToClaude) return;
-              onSendToClaude(
-                `The preview viewport is currently ${iframeSize.w} × ${iframeSize.h} (width × height in CSS pixels).`
-              );
-            }}
-          >
-            {iframeSize.w} × {iframeSize.h}
-          </button>
-        )}
+        {iframeSize &&
+          iframeSize.w > 0 &&
+          iframeSize.h > 0 &&
+          (() => {
+            // The wrapper reports its VISUAL box; when the frame is scaled to
+            // fit, the page actually lays out at the true (unscaled) size —
+            // that's the honest number to show and to tell the agent.
+            const w = Math.round(iframeSize.w / resize.previewScale);
+            const h = Math.round(iframeSize.h / resize.previewScale);
+            const scaleNote =
+              resize.previewScale < 1
+                ? ` (scaled to ${Math.round(resize.previewScale * 100)}%)`
+                : '';
+            return (
+              <button
+                type="button"
+                className="preview-dimensions"
+                title={onSendToClaude ? 'Click to send to agent' : undefined}
+                disabled={!onSendToClaude}
+                aria-label={`Preview dimensions ${w} by ${h}${scaleNote}${
+                  onSendToClaude ? ', click to send to agent' : ''
+                }`}
+                onClick={() => {
+                  if (!onSendToClaude) return;
+                  onSendToClaude(
+                    `The preview viewport is currently ${w} × ${h} (width × height in CSS pixels)${scaleNote}.`
+                  );
+                }}
+              >
+                {w} × {h}
+              </button>
+            );
+          })()}
 
         <div className="preview-breakpoints" data-education-id="breakpoints">
           {(Object.keys(BREAKPOINTS) as Breakpoint[]).map((bp) => {
-            // Always show 'full' - it adapts to any size
-            // Hide other breakpoints if they won't fit in the viewport
-            if (bp !== 'full') {
-              const bpWidth = parseInt(BREAKPOINTS[bp].width, 10);
-              if (resize.viewportWidth > 0 && bpWidth > resize.viewportWidth) {
-                return null;
-              }
-            }
+            // Every preset is always available — one wider than the pane
+            // renders at true size and scales down to fit (previewScale).
             return (
               <button
                 key={bp}
@@ -1200,10 +1209,15 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
               : ''
           }`}
           style={{
+            // A width wider than the pane keeps its true size in the iframe
+            // and shrinks visually via previewScale — the grid (and with it
+            // the wrapper, handles, crop overlay and drag math) stays at the
+            // VISUAL size so every parent-side measurement remains in screen
+            // space.
             width:
               resize.customWidth === null
                 ? 'calc(100% - 4px)'
-                : `${resize.customWidth + RESIZE_HANDLE_PX}px`,
+                : `${Math.round(resize.customWidth * resize.previewScale) + RESIZE_HANDLE_PX}px`,
             maxWidth: 'calc(100% - 4px)',
             // While Inspect is open the bottom resize handle is hidden, so
             // we ignore (but preserve) the user's customHeight to avoid an
@@ -1224,6 +1238,21 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
               className="preview-iframe"
               title="Preview"
               onLoad={conn.handleIframeLoad}
+              // Scale-to-fit (Chrome-DevTools style): lay the page out at the
+              // true breakpoint width and shrink the rendering to the wrapper.
+              // Height is inflated by 1/scale so the scaled result fills the
+              // wrapper exactly. In-iframe overlays (visual editor) live in
+              // the scaled coordinate space and need no mapping.
+              style={
+                resize.previewScale < 1 && resize.customWidth !== null
+                  ? {
+                      width: `${resize.customWidth}px`,
+                      height: `${100 / resize.previewScale}%`,
+                      transform: `scale(${resize.previewScale})`,
+                      transformOrigin: 'top left',
+                    }
+                  : undefined
+              }
             />
             {/* Blank-iframe watchdog overlay: the server is healthy top-level but
                 the page never proved it rendered inside the embedded iframe —
@@ -1579,7 +1608,7 @@ const InspectPanel = forwardRef<HTMLDivElement, InspectPanelProps>(function Insp
           />
         </div>
         <div className={`preview-logs-slot ${activeTab === 'browser' ? 'is-active' : ''}`}>
-          <BrowserTools onSendToAgent={onSendToAgent} />
+          <BrowserTools onSendToAgent={onSendToAgent} active={!hidden && activeTab === 'browser'} />
         </div>
         <div className={`preview-logs-slot ${activeTab === 'health' ? 'is-active' : ''}`}>
           <HealthTabPanel

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -750,13 +750,15 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     };
   }, []);
 
-  // Force refresh the preview iframe with cache busting
+  // Force refresh the preview iframe via an about:blank round-trip (the URL
+  // carries no cache-buster, so re-setting the same src wouldn't be a reliable
+  // reload; the proxy serves HTML with no-store, so the round-trip refetches).
   // Uses currentPage (tracked via proxy) so it refreshes the actual visible page,
   // not the stale iframe src attribute (which doesn't update on client-side navigation).
   const refresh = useCallback(() => {
     if (iframeRef.current && conn.serverReady) {
       conn.setIframePath(conn.currentPage);
-      const refreshUrl = `${conn.baseUrl}${conn.currentPage === '/' ? '' : conn.currentPage}?_cb=${Date.now()}&shipstudio=1`;
+      const refreshUrl = `${conn.baseUrl}${conn.currentPage === '/' ? '' : conn.currentPage}`;
       iframeRef.current.src = 'about:blank';
       setTimeout(() => {
         if (iframeRef.current) {
@@ -766,6 +768,16 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- specific conn properties are listed; conn object changes on every render
   }, [conn.serverReady, conn.baseUrl, conn.currentPage, conn.setIframePath]);
+
+  // Imperative reload requests from the connection hook (toolbar refresh on the
+  // current page, static-project file changes). Token 0 is the "no reload
+  // requested" reset on project/port switches — never fire on it.
+  const prevReloadTokenRef = useRef(0);
+  useEffect(() => {
+    if (conn.reloadToken === prevReloadTokenRef.current) return;
+    prevReloadTokenRef.current = conn.reloadToken;
+    if (conn.reloadToken !== 0) refresh();
+  }, [conn.reloadToken, refresh]);
 
   // Expose methods to parent
   useImperativeHandle(

--- a/src/components/preview/reloadSuppress.test.ts
+++ b/src/components/preview/reloadSuppress.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Behavior test for the HMR reload-suppress script (`RELOAD_SUPPRESS`).
+ *
+ * The script's canonical source lives in `src-tauri/src/proxy/reload_suppress.html`
+ * (Rust injects it via `include_str!`). It wraps `window.WebSocket` and swallows
+ * at most one Vite `full-reload` inside the editor's suppress window
+ * (`window.__ssSuppressUntil`), while leaving every other socket and message
+ * untouched. Here we evaluate that exact source against a fake WebSocket and
+ * exercise the contracts the preview depends on: swallow-once, css-updates pass,
+ * working removeEventListener, non-stacking onmessage, non-Vite sockets ignored.
+ */
+
+import { beforeAll, beforeEach, expect, it } from 'vitest';
+// Import the exact script Rust injects (via `include_str!`) as a raw string so
+// both consumers share one source of truth.
+import scriptHtml from '../../../src-tauri/src/proxy/reload_suppress.html?raw';
+
+const scriptJs = scriptHtml.replace(/^<script[^>]*>/, '').replace(/<\/script>\s*$/, '');
+
+type Listener = (ev: unknown) => void;
+
+/** Minimal stand-in for the native WebSocket the script wraps. */
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  /** The most recently constructed underlying socket, for dispatching events. */
+  static last: FakeWebSocket | null = null;
+
+  url: string;
+  protocols?: string | string[];
+  private listeners = new Map<string, Set<Listener>>();
+
+  constructor(url: string, protocols?: string | string[]) {
+    this.url = url;
+    this.protocols = protocols;
+    FakeWebSocket.last = this;
+  }
+
+  addEventListener(type: string, handler: Listener) {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(handler);
+  }
+
+  removeEventListener(type: string, handler: Listener) {
+    this.listeners.get(type)?.delete(handler);
+  }
+
+  /** Simulate a server->client message reaching this socket. */
+  dispatch(type: string, ev: Record<string, unknown>) {
+    for (const handler of [...(this.listeners.get(type) ?? [])]) handler(ev);
+  }
+}
+
+const FULL_RELOAD = JSON.stringify({ type: 'full-reload' });
+const CSS_UPDATE = JSON.stringify({ type: 'update', updates: [] });
+
+type TestWindow = Window & { __ssSuppressUntil?: number; WebSocket: unknown };
+const win = window as unknown as TestWindow;
+
+/** Construct a socket through the (possibly wrapped) global WebSocket. */
+function connect(protocols?: string) {
+  const Ctor = win.WebSocket as new (
+    url: string,
+    protocols?: string
+  ) => {
+    addEventListener: (type: string, handler: Listener) => void;
+    removeEventListener: (type: string, handler: Listener) => void;
+    onmessage: Listener | null;
+  };
+  const ws =
+    protocols !== undefined
+      ? new Ctor('ws://localhost:5173', protocols)
+      : new Ctor('ws://localhost:5173');
+  return { ws, native: FakeWebSocket.last! };
+}
+
+beforeAll(() => {
+  win.WebSocket = FakeWebSocket;
+  window.eval(scriptJs);
+});
+
+beforeEach(() => {
+  win.__ssSuppressUntil = 0;
+  FakeWebSocket.last = null;
+});
+
+it('wraps the global WebSocket', () => {
+  expect(win.WebSocket).not.toBe(FakeWebSocket);
+});
+
+it('passes full-reload through outside the suppress window', () => {
+  const { ws, native } = connect('vite-hmr');
+  const seen: unknown[] = [];
+  ws.addEventListener('message', (ev) => seen.push((ev as { data: string }).data));
+  native.dispatch('message', { data: FULL_RELOAD });
+  expect(seen).toEqual([FULL_RELOAD]);
+});
+
+it('drops exactly one full-reload inside the suppress window', () => {
+  const { ws, native } = connect('vite-hmr');
+  const seen: unknown[] = [];
+  ws.addEventListener('message', (ev) => seen.push((ev as { data: string }).data));
+
+  win.__ssSuppressUntil = Date.now() + 5000;
+  native.dispatch('message', { data: FULL_RELOAD });
+  expect(seen).toEqual([]);
+  // Swallowing closed the window — a second reload (e.g. an agent editing
+  // files right after an editor commit) must land, not leave the preview stale.
+  expect(win.__ssSuppressUntil).toBe(0);
+  native.dispatch('message', { data: FULL_RELOAD });
+  expect(seen).toEqual([FULL_RELOAD]);
+});
+
+it('lets css updates through during the suppress window without consuming it', () => {
+  const { ws, native } = connect('vite-hmr');
+  const seen: unknown[] = [];
+  ws.addEventListener('message', (ev) => seen.push((ev as { data: string }).data));
+
+  win.__ssSuppressUntil = Date.now() + 5000;
+  native.dispatch('message', { data: CSS_UPDATE });
+  expect(seen).toEqual([CSS_UPDATE]);
+  expect(win.__ssSuppressUntil).toBeGreaterThan(0);
+});
+
+it('gives every listener the same verdict on a dropped event', () => {
+  const { ws, native } = connect('vite-hmr');
+  const a: unknown[] = [];
+  const b: unknown[] = [];
+  ws.addEventListener('message', (ev) => a.push((ev as { data: string }).data));
+  ws.addEventListener('message', (ev) => b.push((ev as { data: string }).data));
+
+  win.__ssSuppressUntil = Date.now() + 5000;
+  // The first listener's drop consumes the window; the second must not see the
+  // same event slip through because the window is now closed.
+  native.dispatch('message', { data: FULL_RELOAD });
+  expect(a).toEqual([]);
+  expect(b).toEqual([]);
+});
+
+it('removeEventListener detaches a filtered handler', () => {
+  const { ws, native } = connect('vite-hmr');
+  const seen: unknown[] = [];
+  const handler = (ev: unknown) => seen.push((ev as { data: string }).data);
+  ws.addEventListener('message', handler);
+  ws.removeEventListener('message', handler);
+  native.dispatch('message', { data: CSS_UPDATE });
+  expect(seen).toEqual([]);
+});
+
+it('onmessage reassignment replaces the handler instead of stacking', () => {
+  const { ws, native } = connect('vite-hmr');
+  const first: unknown[] = [];
+  const second: unknown[] = [];
+  ws.onmessage = (ev) => first.push((ev as { data: string }).data);
+  ws.onmessage = (ev) => second.push((ev as { data: string }).data);
+  native.dispatch('message', { data: CSS_UPDATE });
+  expect(first).toEqual([]);
+  expect(second).toEqual([CSS_UPDATE]);
+});
+
+it('leaves non-Vite sockets completely alone', () => {
+  const { ws, native } = connect();
+  const seen: unknown[] = [];
+  ws.addEventListener('message', (ev) => seen.push((ev as { data: string }).data));
+
+  win.__ssSuppressUntil = Date.now() + 5000;
+  native.dispatch('message', { data: FULL_RELOAD });
+  expect(seen).toEqual([FULL_RELOAD]);
+});

--- a/src/components/preview/reloadSuppress.test.ts
+++ b/src/components/preview/reloadSuppress.test.ts
@@ -10,7 +10,7 @@
  * working removeEventListener, non-stacking onmessage, non-Vite sockets ignored.
  */
 
-import { beforeAll, beforeEach, expect, it } from 'vitest';
+import { afterEach, beforeAll, beforeEach, expect, it, vi } from 'vitest';
 // Import the exact script Rust injects (via `include_str!`) as a raw string so
 // both consumers share one source of truth.
 import scriptHtml from '../../../src-tauri/src/proxy/reload_suppress.html?raw';
@@ -64,7 +64,7 @@ type TestWindow = Window & { __ssSuppressUntil?: number; WebSocket: unknown };
 const win = window as unknown as TestWindow;
 
 /** Construct a socket through the (possibly wrapped) global WebSocket. */
-function connect(protocols?: string) {
+function connect(protocols?: string, url = 'ws://localhost:5173') {
   const Ctor = win.WebSocket as new (
     url: string,
     protocols?: string
@@ -73,10 +73,7 @@ function connect(protocols?: string) {
     removeEventListener: (type: string, handler: Listener) => void;
     onmessage: Listener | null;
   };
-  const ws =
-    protocols !== undefined
-      ? new Ctor('ws://localhost:5173', protocols)
-      : new Ctor('ws://localhost:5173');
+  const ws = protocols !== undefined ? new Ctor(url, protocols) : new Ctor(url);
   return { ws, native: FakeWebSocket.last! };
 }
 
@@ -172,4 +169,67 @@ it('leaves non-Vite sockets completely alone', () => {
   win.__ssSuppressUntil = Date.now() + 5000;
   native.dispatch('message', { data: FULL_RELOAD });
   expect(seen).toEqual([FULL_RELOAD]);
+});
+
+// ---- HMR watchdog ----------------------------------------------------------
+
+/** Capture messages the script posts to the parent (window.parent === window in jsdom). */
+function capturePosts() {
+  const posted: unknown[] = [];
+  const spy = vi.spyOn(window, 'postMessage').mockImplementation(((msg: unknown) => {
+    posted.push(msg);
+  }) as typeof window.postMessage);
+  return { posted, spy };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+it('posts hmr-down when the HMR socket closes and stays closed', () => {
+  vi.useFakeTimers();
+  const { posted } = capturePosts();
+  const { native } = connect('vite-hmr');
+  native.dispatch('open', {});
+  native.dispatch('close', {});
+  vi.advanceTimersByTime(4999);
+  expect(posted).toEqual([]);
+  vi.advanceTimersByTime(1);
+  expect(posted).toContainEqual({ type: 'shipstudio:hmr-down' });
+});
+
+it('stays quiet when a replacement HMR socket reconnects in time', () => {
+  vi.useFakeTimers();
+  const { posted } = capturePosts();
+  const { native } = connect('vite-hmr');
+  native.dispatch('open', {});
+  native.dispatch('close', {});
+  vi.advanceTimersByTime(2000);
+  const { native: reconnected } = connect('vite-hmr');
+  reconnected.dispatch('open', {});
+  vi.advanceTimersByTime(10000);
+  expect(posted).toEqual([]);
+  // Keep watchdog state clean for later tests.
+  reconnected.dispatch('close', {});
+  vi.advanceTimersByTime(10000);
+});
+
+it('watches Next.js webpack-hmr sockets without filtering their messages', () => {
+  vi.useFakeTimers();
+  const { posted } = capturePosts();
+  const { ws, native } = connect(undefined, 'ws://localhost:3000/_next/webpack-hmr');
+
+  // No message filtering on non-Vite sockets, even during a suppress window.
+  const seen: unknown[] = [];
+  ws.addEventListener('message', (ev) => seen.push((ev as { data: string }).data));
+  win.__ssSuppressUntil = Date.now() + 5000;
+  native.dispatch('message', { data: FULL_RELOAD });
+  expect(seen).toEqual([FULL_RELOAD]);
+
+  // But the watchdog still covers them.
+  native.dispatch('open', {});
+  native.dispatch('close', {});
+  vi.advanceTimersByTime(5000);
+  expect(posted).toContainEqual({ type: 'shipstudio:hmr-down' });
 });

--- a/src/hooks/usePreviewCapture.ts
+++ b/src/hooks/usePreviewCapture.ts
@@ -168,7 +168,7 @@ export function usePreviewCapture({
 
     setIsCapturing(true);
     try {
-      const captureUrl = `${baseUrl}${currentPage === '/' ? '' : currentPage}?_cb=${Date.now()}&shipstudio=1`;
+      const captureUrl = `${baseUrl}${currentPage === '/' ? '' : currentPage}`;
       const filePath = await invoke<string>('capture_fullpage_playwright', {
         projectPath,
         url: captureUrl,

--- a/src/hooks/usePreviewConnection.ts
+++ b/src/hooks/usePreviewConnection.ts
@@ -106,6 +106,9 @@ export function usePreviewConnection({
 
   const wasRestartingRef = useRef(false);
   const healthCheckFailuresRef = useRef(0);
+  // Last time the HMR watchdog auto-reloaded the preview — throttles recovery
+  // so a flapping HMR socket can't put the iframe in a reload loop.
+  const lastHmrRecoveryRef = useRef(0);
   const isStoppedRef = useRef(false);
   isStoppedRef.current = isStopped;
   const retryCountRef = useRef(0);
@@ -390,10 +393,42 @@ export function usePreviewConnection({
         const prompt = `My dev server is returning an error:\n\n${data.message}\n\nPlease help me fix this.`;
         onSendToClaude?.(prompt);
       }
+      if (data && data.type === 'shipstudio:hmr-down') {
+        // The page's HMR socket died and never came back (watchdog in the
+        // injected reload-suppress script). The page still renders but no
+        // longer receives updates — the classic "stale preview until you
+        // restart the dev server". If the server itself is healthy, one
+        // reload reconnects everything; if it's down, the health-check flow
+        // owns recovery, so do nothing here.
+        if (!serverReady) return;
+        if (Date.now() - lastHmrRecoveryRef.current < 15000) return;
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 3000);
+        fetch(devServerUrl, { mode: 'no-cors', signal: controller.signal })
+          .then(() => {
+            lastHmrRecoveryRef.current = Date.now();
+            logger.warn(
+              '[Preview] HMR connection lost while dev server is healthy — auto-reloading preview'
+            );
+            setReloadToken((t) => t + 1);
+          })
+          .catch(() => {
+            // Server unreachable — the periodic health check will surface it.
+          })
+          .finally(() => clearTimeout(timeoutId));
+      }
     };
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [onSendToClaude, onToast, port, proxyPort, clearIframeWatchdogTimer]);
+  }, [
+    onSendToClaude,
+    onToast,
+    port,
+    proxyPort,
+    serverReady,
+    devServerUrl,
+    clearIframeWatchdogTimer,
+  ]);
 
   // Auto-reload for static HTML projects when files change on disk
   useEffect(() => {

--- a/src/hooks/usePreviewConnection.ts
+++ b/src/hooks/usePreviewConnection.ts
@@ -84,7 +84,12 @@ export function usePreviewConnection({
   const [showPageDropdown, setShowPageDropdown] = useState(false);
   const [pageSearch, setPageSearch] = useState('');
   const [proxyPort, setProxyPort] = useState<number | null>(null);
-  const [cacheBuster, setCacheBuster] = useState(() => Date.now());
+  // Bumped to request an imperative iframe reload (Preview watches it). The
+  // iframe URL used to carry a `?_cb=<ts>&shipstudio=1` cache-buster instead,
+  // but those params leaked into the previewed app — its router, SSR search
+  // params, and analytics all saw junk Chrome never sends. Freshness is now the
+  // proxy's job (it serves injected HTML with Cache-Control: no-store).
+  const [reloadToken, setReloadToken] = useState(0);
   // The iframe never proved it rendered a document (issue #179): the server is
   // healthy top-level, but the subframe load aborted — e.g. an auth-middleware
   // redirect loop — and WebKit renders an empty frame with no error anywhere.
@@ -92,11 +97,11 @@ export function usePreviewConnection({
 
   const devServerUrl = `http://localhost:${port}`;
   const baseUrl = proxyPort ? `http://localhost:${proxyPort}` : devServerUrl;
-  const currentUrl = `${baseUrl}${iframePath === '/' ? '' : iframePath}?_cb=${cacheBuster}&shipstudio=1`;
-  // URL safe to hand to the user's default browser: real dev server,
-  // current iframe path, no proxy and no Ship Studio query params. The
-  // iframe needs the proxy URL (for navigation tracking + cache busting)
-  // but external browsers should land on the dev server directly.
+  const currentUrl = `${baseUrl}${iframePath === '/' ? '' : iframePath}`;
+  // URL safe to hand to the user's default browser: real dev server and
+  // current iframe path, no proxy. The iframe needs the proxy URL (for
+  // navigation tracking and script injection) but external browsers should
+  // land on the dev server directly.
   const externalUrl = `${devServerUrl}${iframePath === '/' ? '' : iframePath}`;
 
   const wasRestartingRef = useRef(false);
@@ -156,7 +161,7 @@ export function usePreviewConnection({
     setPages([]);
     setShowPageDropdown(false);
     setPageSearch('');
-    setCacheBuster(Date.now());
+    setReloadToken(0);
     setIframeBlank(false);
     iframeAliveRef.current = false;
 
@@ -285,10 +290,11 @@ export function usePreviewConnection({
   }, [serverReady, port]);
 
   // Arm the blank-iframe watchdog on every explicit navigation: initial proxy
-  // URL, refresh, and page select all change `currentUrl` (cache buster), which
-  // replaces the iframe's document — so the previous proof-of-life no longer
-  // stands. Skipped (and cleared) while the server isn't ready or the URL
-  // bypasses the injecting proxy, where no page could ever prove life.
+  // URL and page select change `currentUrl`, and refresh / same-page select bump
+  // `reloadToken` (imperative reload) — each replaces the iframe's document, so
+  // the previous proof-of-life no longer stands. Skipped (and cleared) while the
+  // server isn't ready or the URL bypasses the injecting proxy, where no page
+  // could ever prove life.
   useEffect(() => {
     const action = decideIframeWatchdogArm('navigation', {
       serverReady,
@@ -304,7 +310,14 @@ export function usePreviewConnection({
     setIframeBlank(false);
     startIframeWatchdogTimer();
     return clearIframeWatchdogTimer;
-  }, [currentUrl, serverReady, proxyPort, startIframeWatchdogTimer, clearIframeWatchdogTimer]);
+  }, [
+    currentUrl,
+    reloadToken,
+    serverReady,
+    proxyPort,
+    startIframeWatchdogTimer,
+    clearIframeWatchdogTimer,
+  ]);
 
   // Give each document hop a fresh window: the iframe's `load` event fires per
   // document (redirect chains, about:blank bounces during refresh). Injected
@@ -390,7 +403,7 @@ export function usePreviewConnection({
 
     void listen<{ windowLabel: string }>('static-file-changed', () => {
       logger.debug('[Preview] File change detected, reloading preview');
-      setCacheBuster(Date.now());
+      setReloadToken((t) => t + 1);
     }).then((fn) => {
       unlisten = fn;
     });
@@ -542,23 +555,35 @@ export function usePreviewConnection({
   // Handlers
   const handleRefresh = useCallback(() => {
     void trackEvent('preview_refreshed', { trigger: 'user' });
-    setIframePath(currentPage);
-    setCacheBuster(Date.now());
-  }, [currentPage]);
+    if (iframePath === currentPage) {
+      // Same URL — a src diff won't reload; request an imperative reload.
+      setReloadToken((t) => t + 1);
+    } else {
+      // Path changed — the src change itself performs a fresh load.
+      setIframePath(currentPage);
+    }
+  }, [currentPage, iframePath]);
 
-  const handlePageSelect = useCallback((route: string) => {
-    void trackEvent('preview_page_selected', {
-      // Strip dynamic-looking segments (numeric ids, uuids) so the cardinality
-      // doesn't explode while still keeping the route shape useful.
-      route_pattern: route.replace(/\/(\d+|[0-9a-f-]{8,})/g, '/:id').slice(0, 200),
-      depth: route.split('/').filter(Boolean).length,
-    });
-    setCurrentPage(route);
-    setIframePath(route);
-    setShowPageDropdown(false);
-    setPageSearch('');
-    setCacheBuster(Date.now());
-  }, []);
+  const handlePageSelect = useCallback(
+    (route: string) => {
+      void trackEvent('preview_page_selected', {
+        // Strip dynamic-looking segments (numeric ids, uuids) so the cardinality
+        // doesn't explode while still keeping the route shape useful.
+        route_pattern: route.replace(/\/(\d+|[0-9a-f-]{8,})/g, '/:id').slice(0, 200),
+        depth: route.split('/').filter(Boolean).length,
+      });
+      setCurrentPage(route);
+      setShowPageDropdown(false);
+      setPageSearch('');
+      if (iframePath === route) {
+        // Re-selecting the visible page acts as a refresh.
+        setReloadToken((t) => t + 1);
+      } else {
+        setIframePath(route);
+      }
+    },
+    [iframePath]
+  );
 
   const handleRetry = useCallback(() => {
     setHasError(false);
@@ -607,6 +632,7 @@ export function usePreviewConnection({
     baseUrl,
     currentUrl,
     externalUrl,
+    reloadToken,
 
     // Page navigation
     currentPage,

--- a/src/hooks/usePreviewResize.ts
+++ b/src/hooks/usePreviewResize.ts
@@ -22,9 +22,6 @@ export const BREAKPOINTS: Record<Breakpoint, { width: string; label: string }> =
   mobile: { width: '375px', label: 'Mobile' },
 };
 
-/** Pixel widths for fixed breakpoints (excludes 'full' which is 100%) */
-const BREAKPOINT_WIDTHS: number[] = [1440, 1024, 768, 375];
-
 /** Space reserved for the resize handle on the right side of the viewport */
 const VIEWPORT_PADDING_PX = 12;
 
@@ -94,18 +91,14 @@ export function usePreviewResize({ iframeWrapperRef, onUserResize }: UsePreviewR
       // Set initial width (subtract padding for resize handle)
       setViewportWidth(node.offsetWidth - VIEWPORT_PADDING_PX);
 
-      // Observe future size changes — also auto-switch breakpoint if current no longer fits
+      // Observe future size changes. A selected width WIDER than the pane is
+      // kept (not auto-shrunk): the frame renders at the true width and is
+      // visually scaled down to fit (`previewScale`), so media queries keep
+      // firing at the labeled breakpoint — matching what a real browser at
+      // that width shows.
       observerRef.current = new ResizeObserver((entries) => {
         for (const entry of entries) {
-          const newWidth = entry.contentRect.width - VIEWPORT_PADDING_PX;
-          setViewportWidth(newWidth);
-
-          const currentCustom = customWidthRef.current;
-          if (currentCustom !== null && currentCustom > newWidth) {
-            const fittingWidth = BREAKPOINT_WIDTHS.find((w) => w <= newWidth);
-            setCustomWidth(fittingWidth ?? null);
-            onUserResizeRef.current?.(); // pane shrank past the width — follow it
-          }
+          setViewportWidth(entry.contentRect.width - VIEWPORT_PADDING_PX);
         }
       });
       observerRef.current.observe(node);
@@ -215,13 +208,21 @@ export function usePreviewResize({ iframeWrapperRef, onUserResize }: UsePreviewR
 
   // Resize the canvas to an exact pixel width. Used by the editor's Tailwind
   // breakpoint selector so picking a breakpoint sets the preview to that width
-  // (and the editor's derived active breakpoint follows). Deliberately NOT clamped
-  // to the viewport — like the device presets, the frame caps its visible width at
-  // the pane (CSS maxWidth), so a too-wide breakpoint stays the edit target even
-  // when it can't be shown; the panel surfaces a "preview too narrow" note instead.
+  // (and the editor's derived active breakpoint follows). Deliberately NOT
+  // clamped to the viewport — a width wider than the pane renders at true size
+  // and is scaled down to fit (`previewScale`).
   const previewAtWidth = useCallback((px: number) => {
     setCustomWidth(px);
   }, []);
+
+  // How much the frame must shrink visually so the selected width fits the
+  // pane (1 = no scaling). The iframe always renders at the true CSS width —
+  // Chrome-DevTools-style — so a "Desktop 1440" preview really lays out at
+  // 1440px instead of silently reflowing at whatever the pane allows.
+  const previewScale =
+    customWidth !== null && viewportWidth > 0 && customWidth > viewportWidth
+      ? viewportWidth / customWidth
+      : 1;
 
   // Handle breakpoint button click
   const handleBreakpointClick = useCallback((bp: Breakpoint) => {
@@ -247,6 +248,7 @@ export function usePreviewResize({ iframeWrapperRef, onUserResize }: UsePreviewR
     isResizing,
     isVerticalResizing,
     viewportWidth,
+    previewScale,
     getActiveBreakpoint,
     setViewportRefs,
     handleResizeStart,

--- a/src/lib/inspectStore.ts
+++ b/src/lib/inspectStore.ts
@@ -68,6 +68,11 @@ let consoleEntries: ConsoleEntry[] = [];
 let networkEntries: NetworkEntry[] = [];
 let domSnapshot: DomSnapshot | null = null;
 let consoleId = 0;
+// Whether the Elements view wants live DOM snapshots. The shim's mutation
+// observer only runs while subscribed (serializing the tree on every mutation
+// burst is too expensive to leave on invisibly); a freshly loaded document
+// starts unsubscribed, so we re-arm it on the shim's 'ready' beacon.
+let domSubscriptionActive = false;
 
 const listeners = new Set<() => void>();
 const notify = () => {
@@ -93,6 +98,9 @@ const handleMessage = (event: MessageEvent) => {
       networkEntries = [];
       domSnapshot = null;
       consoleId = 0;
+      // A new document just installed the shim (reload/navigation); it starts
+      // unsubscribed, so re-arm live DOM snapshots if Elements is watching.
+      if (domSubscriptionActive) broadcastToPreviews('subscribe-dom-tree');
       notify();
       return;
     }
@@ -157,21 +165,24 @@ if (typeof window !== 'undefined') {
   window.addEventListener('message', handleMessage);
 }
 
-/**
- * Ask any preview iframes to re-serialize and post their DOM tree.
- * Called when the Elements tab activates so the user always sees fresh state.
- */
-const requestDomTree = () => {
+/** Broadcast a host command to any preview iframes. */
+const broadcastToPreviews = (type: string) => {
   if (typeof document === 'undefined') return;
   const iframes = document.querySelectorAll('iframe');
   iframes.forEach((iframe) => {
     try {
-      iframe.contentWindow?.postMessage({ source: HOST_CHANNEL, type: 'request-dom-tree' }, '*');
+      iframe.contentWindow?.postMessage({ source: HOST_CHANNEL, type }, '*');
     } catch {
       // ignore — cross-origin frames may not allow postMessage in some setups
     }
   });
 };
+
+/**
+ * Ask any preview iframes to re-serialize and post their DOM tree.
+ * Called when the Elements tab activates so the user always sees fresh state.
+ */
+const requestDomTree = () => broadcastToPreviews('request-dom-tree');
 
 /* All store methods are arrow properties (not method shorthand) so
    that references like `inspectStore.subscribe` passed into
@@ -198,4 +209,10 @@ export const inspectStore = {
     notify();
   },
   refreshDom: requestDomTree,
+  /** Turn live DOM snapshots on/off (Elements view visible/hidden). */
+  setDomSubscription: (active: boolean) => {
+    if (domSubscriptionActive === active) return;
+    domSubscriptionActive = active;
+    broadcastToPreviews(active ? 'subscribe-dom-tree' : 'unsubscribe-dom-tree');
+  },
 };


### PR DESCRIPTION
Fixes #181 — Tom's report: the Next.js preview stops refreshing until you leave and re-enter the project.

This extracts **only** the two approved HMR-reliability commits from `preview-improvements`. The unreleased Chrome preview engine on that branch (5cb0b6c, 9b3cae4, 046fffe) is intentionally **not** included.

## What each commit fixes

### 1. `Preview reliability: HMR through the proxy, cache hardening, clean URLs` (d9890ef)
The root cause of the stale-preview bug class:
- **HMR WebSocket upgrades now get Host/Origin rewritten to the dev server's own port** (matching the HTTP path). Origin-checking dev servers (Vite) were rejecting the HMR socket when it leaked the proxy's ephemeral port — silently killing hot updates until a dev-server restart. Covered by new real-socket e2e tests.
- **RELOAD_SUPPRESS rewritten** (`proxy/reload_suppress.html` + jsdom tests): `removeEventListener` works, `onmessage` no longer stacks listeners, drop verdicts are memoized per event, and at most one full-reload is swallowed per suppress window — a racing legitimate reload can no longer leave the preview stale.
- **SCROLL_RESTORE rewritten** (`proxy/scroll_restore.html`): reveals as soon as the document can scroll to the saved position; blank hold capped at 400ms.
- **Cache hardening**: injected HTML is served `Cache-Control: no-store` with upstream validators stripped; upstream connect/response/body timeouts bound previously-unbounded proxy requests.
- **Clean URLs**: preview URLs no longer carry `?_cb=<ts>&shipstudio=1`; reloads are imperative (`reloadToken` → about:blank round-trip).

### 2. `Preview: streaming SSR paint, HMR self-healing, cheaper inspector, true-width breakpoints` (b4c3eba)
- **HMR self-healing watchdog**: the injected script tracks HMR sockets (vite-hmr subprotocol + `_next/webpack-hmr`) and posts `shipstudio:hmr-down` when they all close with no replacement within 5s. The connection hook health-checks the dev server and auto-reloads the iframe (throttled to once per 15s) — this is the direct self-heal for #181's "stale until re-enter" ritual.
- **Streaming HTML injection**: `HeadInjector` holds back only the prefix through `</head>` and pipes the rest through — streaming-SSR frameworks (Next.js App Router, Astro) paint progressively. 5xx pages keep the buffered error-overlay path. Injector output asserted byte-identical to the buffered pipeline + a real-socket e2e test.
- **Inspector DOM serialization is subscription-gated** (only while Elements view is visible).
- **True-width breakpoints**: presets wider than the pane render at true CSS width and shrink via `transform: scale()`.

## Conflict-resolution decisions (vs #194 / #203 / #205 on main)

Main moved since these commits; conflicts were resolved by **keeping both feature sets**:

- **`src-tauri/src/proxy/mod.rs`**: kept #194's auth-redirect interstitial machinery (`is_auth_redirect_loop`, `is_document_navigation`, `redact_handshake_values`, `shipstudio:alive` in NAV_SCRIPT, Sec-Fetch-Dest gating) alongside the cherry-picks' `rewrite_localhost_origin`, timeouts, cache hardening, and streaming `HeadInjector`. Request flow: interstitial check runs first (on redirects), ordinary HTML then streams through the injector, 5xx stays buffered. Test modules merged into one `tests` module (interstitial + CSP + origin-rewrite unit tests) plus the new `e2e_tests` live-socket module.
- **`src/hooks/usePreviewConnection.ts`**: main's `cacheBuster` state is superseded by `reloadToken` (that removal is the point of the commit), but #194's iframe watchdog (`iframeBlank`, `previewIframeWatchdog.ts`, `handleIframeLoad`) is fully kept. One deliberate addition: the watchdog's navigation-arm effect now also keys on `reloadToken` — on main, refresh re-armed the watchdog because `currentUrl` changed (cache buster); with imperative reloads the URL is stable, so without this the watchdog would not re-arm on refresh. The message-listener effect merges both sides' dependency lists (watchdog's `clearIframeWatchdogTimer` + HMR watchdog's `serverReady`/`devServerUrl`).
- **`src/components/preview/Preview.tsx`**: the iframe keeps both #194's `onLoad={conn.handleIframeLoad}` and the new scale-to-fit `style`; #194's blank-pane overlay and #203's editor gating are untouched.
- Rebased onto `0b296bd` (#205, thumbnail consent) — auto-merged cleanly.

## Verification

- `pnpm typecheck`, `pnpm lint:strict`, `pnpm check:patterns`, `pnpm check:loc` — clean
- `pnpm test:run` — 85 files, 1163 passed / 4 skipped (incl. `reloadSuppress.test.ts` 11, `usePreviewConnection.test.ts` 8, `previewIframeWatchdog.test.ts` 10)
- `cargo test` — 663 passed, incl. the 3 live-socket proxy e2e tests (`ws_upgrade_rewrites_host_and_origin_for_hmr`, `http_path_rewrites_headers_hardens_caching_and_injects`, `html_streams_progressively_through_the_proxy`) and all interstitial/CSP/injector unit tests
- `cargo fmt --check` — clean; `cargo clippy` (CI flags) — no new warnings (non-test unwrap count in proxy unchanged vs main)
- Grepped the full diff for Chrome-engine leakage — none (only pre-existing "like Chrome" prose in comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
