### PR TITLE
Templates: add Next.js (Vanilla) starter, rename Next.js → Next.js (Tailwind)

### DIFF
--- a/src/hooks/useProjectCreation.ts
+++ b/src/hooks/useProjectCreation.ts
@@ -77,16 +77,23 @@ function getDefaultTemplate(): Template {
     const found = TEMPLATES.find((t) => t.id === stored);
     if (found) return found;
   }
-  return TEMPLATES[0]; // Next.js
+  return TEMPLATES[0]; // Next.js (Tailwind)
 }
 
 /** Available project templates */
 export const TEMPLATES: Template[] = [
   {
     id: 'nextjs-basic',
-    name: 'Next.js',
+    name: 'Next.js (Tailwind)',
     description: 'The most flexible, especially for web apps. A great default if unsure.',
     repo: 'https://github.com/ship-studio/static-marketing-site-starter',
+    category: 'web',
+  },
+  {
+    id: 'nextjs-plain-css',
+    name: 'Next.js (Vanilla)',
+    description: 'Styled with vanilla CSS — best for people who write their own styles.',
+    repo: 'https://github.com/ship-studio/nextjs-plain-css-starter',
     category: 'web',
   },
   {


### PR DESCRIPTION
## What

- Adds a new **Next.js (Vanilla)** starter to the template picker, cloning [ship-studio/nextjs-plain-css-starter](https://github.com/ship-studio/nextjs-plain-css-starter) — a plain-CSS Next.js template (no Tailwind), built for the visual editor. Description: *"Styled with vanilla CSS — best for people who write their own styles."*
- Renames the existing **Next.js** template to **Next.js (Tailwind)** so the two are unambiguous side by side.

## Why

With the CSS visual editor now working on vanilla-CSS Next.js projects (#203), users need a Next.js starting point that isn't Tailwind-locked. Mirrors the existing Astro (Tailwind) / Astro (Vanilla) split.

## Notes

- IDs: existing template keeps `nextjs-basic` (preserves stored default-template preferences); new one is `nextjs-plain-css`.
- Verified the starter repo exists and is public (default branch `main`).
- Picker renders generically from `TEMPLATES` — no other code keys off template names or IDs.
- Typecheck + full frontend suite pass (1184 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Next.js starter option for users who want a vanilla CSS setup.
  * Updated the existing Next.js starter label to more clearly indicate it uses Tailwind.

* **Bug Fixes**
  * Improved the default template fallback wording so the selected starter is clearer at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->