### PR TITLE
Templates: remove Nuxt starter from the picker

### DIFF
--- a/src/hooks/useProjectCreation.ts
+++ b/src/hooks/useProjectCreation.ts
@@ -118,13 +118,6 @@ export const TEMPLATES: Template[] = [
     category: 'web',
   },
   {
-    id: 'nuxt-basic',
-    name: 'Nuxt',
-    description: 'Best for Vue teams building full-stack apps with server rendering.',
-    repo: 'https://github.com/ship-studio/nuxt-static-marketing-site-starter',
-    category: 'web',
-  },
-  {
     id: 'html-basic',
     name: 'HTML/CSS/JS',
     description: 'A plain site with no framework or build step — just HTML, CSS, and JS.',


### PR DESCRIPTION
## What

Removes the **Nuxt** template from the New Project picker.

## Why

Low demand. If it turns out people ask for it, restoring is a 7-line revert.

## Notes

- Framework detection for imported/existing Nuxt projects is untouched — this only removes the scaffolding option.
- A user with `nuxt-basic` saved as their default template falls back to the first template (`getDefaultTemplate` already handles missing ids).
- The starter repo itself stays up on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the Nuxt template from the project template picker, so it no longer appears as an available option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->