### PR TITLE
Visual editor: arrow keys step numeric values (Shift ×10, Alt fine)

### DIFF
--- a/src/components/edit/EditPopover.test.tsx
+++ b/src/components/edit/EditPopover.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EditPopover } from './EditPopover';
+
+function renderPopover(initial: string, options?: string[]) {
+  const anchor = document.createElement('span');
+  document.body.appendChild(anchor);
+  const onCommit = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <EditPopover
+      anchor={anchor}
+      initial={initial}
+      options={options}
+      onCommit={onCommit}
+      onClose={onClose}
+    />
+  );
+  return { input: screen.getByRole<HTMLInputElement>('combobox'), onCommit, onClose };
+}
+
+describe('EditPopover', () => {
+  it('commits the typed value on Enter', () => {
+    const { input, onCommit, onClose } = renderPopover('12px');
+    fireEvent.change(input, { target: { value: '20px' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommit).toHaveBeenCalledWith('20px');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  // ── Arrow-key stepping (ArrowUp/Down; Shift ×10, Alt ÷10) ──
+
+  it('steps a numeric value with ArrowUp/ArrowDown and live-applies it', () => {
+    const { input, onCommit, onClose } = renderPopover('12px');
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(input.value).toBe('13px');
+    expect(onCommit).toHaveBeenLastCalledWith('13px');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(input.value).toBe('11px');
+    expect(onCommit).toHaveBeenLastCalledWith('11px');
+    expect(onClose).not.toHaveBeenCalled(); // stays open, like scrubbing
+  });
+
+  it('steps ×10 with Shift and ÷10 with Alt', () => {
+    const { input, onCommit } = renderPopover('12px');
+    fireEvent.keyDown(input, { key: 'ArrowUp', shiftKey: true });
+    expect(onCommit).toHaveBeenLastCalledWith('22px');
+    fireEvent.keyDown(input, { key: 'ArrowUp', altKey: true });
+    expect(onCommit).toHaveBeenLastCalledWith('22.1px');
+  });
+
+  it('uses the magnitude-aware step and preserves the unit (< 10 → 0.1)', () => {
+    const { input, onCommit } = renderPopover('1.5rem');
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(onCommit).toHaveBeenLastCalledWith('1.6rem');
+  });
+
+  it('steps unitless hundreds (font-weight) by 10', () => {
+    const { input, onCommit } = renderPopover('700');
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(onCommit).toHaveBeenLastCalledWith('710');
+  });
+
+  it('keeps navigating the suggestion menu with arrows while it is open', () => {
+    const { input, onCommit } = renderPopover('', ['auto', 'inherit']);
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    // The arrow moved the active option — it did not step or apply a value.
+    expect(input).toHaveAttribute('aria-activedescendant', expect.stringMatching(/-opt-1$/));
+    expect(input.value).toBe('');
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('leaves keyword values untouched on arrow keys', () => {
+    const { input, onCommit } = renderPopover('auto');
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(input.value).toBe('auto');
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/edit/EditPopover.tsx
+++ b/src/components/edit/EditPopover.tsx
@@ -189,6 +189,16 @@ export function EditPopover({ anchor, initial, options, placeholder, onCommit, o
                   } else if (e.key === 'ArrowUp' && showMenu) {
                     e.preventDefault();
                     setActive((a) => Math.max(a - 1, 0));
+                  } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+                    // Menu closed: step a numeric value (same conventions as
+                    // drag-to-scrub) and live-apply. Non-numeric values keep
+                    // the default caret behavior.
+                    const next = stepNumericValue(text, e.key === 'ArrowUp' ? 1 : -1, e);
+                    if (next === null) return;
+                    e.preventDefault();
+                    setText(next);
+                    setActive(0);
+                    onCommit(next); // live-apply, like scrubbing
                   }
                 }}
               />
@@ -232,6 +242,22 @@ function magnitudeStep(v: number): number {
   if (a < 100) return 1; //  10–99  → 1 / px
   if (a < 1000) return 10; // 100–999 → 10 / px
   return 100; //              1000+   → 100 / px
+}
+
+/** One keyboard step of a numeric value: the magnitude-aware base step with
+ *  Shift ×10 / Alt ÷10 — the same conventions as drag-to-scrub. Preserves the
+ *  unit; null when the value isn't a single number (keyword, color, calc(…)). */
+function stepNumericValue(
+  value: string,
+  dir: 1 | -1,
+  mods: { shiftKey: boolean; altKey: boolean }
+): string | null {
+  const p = parseNumericValue(value);
+  if (!p) return null;
+  const base = magnitudeStep(p.num);
+  const step = mods.shiftKey ? base * 10 : mods.altKey ? base / 10 : base;
+  const stepDecimals = step >= 1 ? 0 : step >= 0.1 ? 1 : 2;
+  return formatNumericValue(p.num + dir * step, p.unit, Math.max(p.decimals, stepDecimals));
 }
 
 /** Drag-to-scrub a numeric value (devtools-style). Horizontal drag adjusts the

--- a/src/components/edit/GapControl.tsx
+++ b/src/components/edit/GapControl.tsx
@@ -21,14 +21,17 @@ import {
   type ResetSpec,
 } from '../../lib/edit';
 
-/** Editable gap value field. Click to type, Enter/blur to apply; bad input marks
- *  the field invalid. Stays in sync when +/- steppers change it (prev-value pattern). */
+/** Editable gap value field. Click to type, Enter/blur to apply; ArrowUp/Down step
+ *  the value like the −/＋ buttons (Shift ×10, Alt fine). Bad input marks the field
+ *  invalid. Stays in sync when +/- steppers change it (prev-value pattern). */
 function GapField({
   value,
   onSet,
+  onStep,
 }: {
   value: SpacingValue | null;
   onSet: (v: SpacingValue) => void;
+  onStep: (dir: 1 | -1, step?: number) => void;
 }) {
   const display = spacingDisplay(value);
   const [text, setText] = useState(display);
@@ -75,6 +78,13 @@ function GapField({
       }}
       onKeyDown={(e) => {
         if (e.key === 'Enter' && commit()) e.currentTarget.blur();
+        else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+          e.preventDefault();
+          // Same path as the −/＋ buttons; Shift ×10, Alt fine (÷10 on unit
+          // values — the Tailwind scale stays on whole steps).
+          const fine = value?.kind === 'arbitrary' ? 0.1 : 1;
+          onStep(e.key === 'ArrowUp' ? 1 : -1, e.shiftKey ? 10 : e.altKey ? fine : 1);
+        }
       }}
     />
   );
@@ -85,7 +95,7 @@ interface Props {
   layer: LayerContext;
   onApplyEnum: (token: string, style: Record<string, string>) => void;
   onReset: (spec: ResetSpec) => void;
-  onStepGap: (dir: 1 | -1) => void;
+  onStepGap: (dir: 1 | -1, step?: number) => void;
 }
 
 export function GapControl({ currentClass, layer, onApplyEnum, onReset, onStepGap }: Props) {
@@ -110,6 +120,7 @@ export function GapControl({ currentClass, layer, onApplyEnum, onReset, onStepGa
         <GapField
           value={gap.value}
           onSet={(v) => onApplyEnum(spacingTokenFor('gap', v), { gap: spacingCss(v) })}
+          onStep={onStepGap}
         />
         <Button
           size="sm"

--- a/src/components/edit/LengthControl.tsx
+++ b/src/components/edit/LengthControl.tsx
@@ -6,7 +6,7 @@
  * token, falling back to an arbitrary value only when off-scale.
  */
 
-import { useId, useState } from 'react';
+import { useId, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { ResettableLabel } from './ResettableLabel';
 import {
   lengthValue,
@@ -62,6 +62,27 @@ export function LengthControl({
     return true;
   };
 
+  /** ArrowUp/Down step a numeric value (bare scale step or number+unit, keeping
+   *  the unit) and commit each press; Shift ×10, Alt fine (÷10 on unit values —
+   *  the Tailwind scale stays on whole steps). Keywords (`full`, `auto`) and
+   *  fractions (`1/2`) aren't steppable — the caret is left alone. */
+  const onArrowStep = (e: ReactKeyboardEvent<HTMLInputElement>) => {
+    const m = /^(-?\d*\.?\d+)\s*([a-z%]*)$/i.exec(text.trim());
+    if (!m) return; // non-numeric — leave the caret alone
+    const unit = m[2];
+    const fine = unit ? 0.1 : 1;
+    const step = e.shiftKey ? 10 : e.altKey ? fine : 1;
+    const dir = e.key === 'ArrowUp' ? 1 : -1;
+    const num = Math.max(0, Math.round((parseFloat(m[1]) + dir * step) * 100) / 100);
+    const next = `${num}${unit}`;
+    const parsed = parseLengthInput(next, prefix, css);
+    if (parsed.kind === 'invalid') return;
+    e.preventDefault();
+    setText(next);
+    setInvalid(false);
+    onApplyEnum(parsed.token, { [css]: parsed.css });
+  };
+
   return (
     <div className="ss-edit-panel__control">
       <ResettableLabel
@@ -97,6 +118,7 @@ export function LengthControl({
         }}
         onKeyDown={(e) => {
           if (e.key === 'Enter' && commit()) e.currentTarget.blur();
+          else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') onArrowStep(e);
         }}
       />
       <datalist id={listId}>

--- a/src/components/edit/PropControlRenderer.tsx
+++ b/src/components/edit/PropControlRenderer.tsx
@@ -23,7 +23,7 @@ export interface ControlRenderCtx {
   onApplyEnum: (token: string, style: Record<string, string>) => void;
   onReset: (spec: ResetSpec) => void;
   onSetSide: (type: BoxType, side: Side, value: SpacingValue) => void;
-  onStepGap: (dir: 1 | -1) => void;
+  onStepGap: (dir: 1 | -1, step?: number) => void;
   /** Rendered colors (getComputedStyle) keyed by CSS prop, to seed color pickers. */
   computed?: Record<string, string | undefined>;
 }

--- a/src/components/edit/SpacingBox.tsx
+++ b/src/components/edit/SpacingBox.tsx
@@ -7,7 +7,12 @@
  * Live preview + write-back are handled by the hook's `setBoxSide`.
  */
 
-import { useRef, useState, type PointerEvent as ReactPointerEvent } from 'react';
+import {
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
 import {
   boxSide,
   readLayer,
@@ -63,9 +68,10 @@ function dragBaseOf(
 }
 
 /**
- * One side value. Three ways to change it:
+ * One side value. Four ways to change it:
  *  - drag along the bar's own axis (pulls outward to grow) — like a design tool,
  *  - scroll to scrub,
+ *  - ArrowUp/Down to step (Shift ×10, Alt fine),
  *  - click (selects all) then type a value or unit (10rem, 50%); Enter/blur applies.
  * Bad input (`40xyz`) marks the field invalid and isn't applied.
  */
@@ -94,6 +100,21 @@ function SideField({ value, onSet, cssProp, label, className, dir, inherited }: 
     setInvalid(false);
     onSet(parsed);
     return true;
+  };
+
+  /** One keyboard step: ArrowUp/Down = one drag tick, Shift ×10, Alt = fine
+   *  (÷10 on unit values; the Tailwind scale stays on whole steps). Steps the
+   *  typed text when it parses, else the live value — same commit path as drag. */
+  const onArrowStep = (e: ReactKeyboardEvent<HTMLInputElement>) => {
+    const parsed = parseSpacingInput(text, cssProp);
+    const cur = parsed.kind === 'invalid' ? value : parsed;
+    const base = dragBaseOf(cur);
+    if (!base) return; // non-numeric (calc(…)) — leave the caret alone
+    e.preventDefault();
+    const fine = cur?.kind === 'arbitrary' ? 0.1 : 1;
+    const step = e.shiftKey ? 10 : e.altKey ? fine : 1;
+    const dir = e.key === 'ArrowUp' ? 1 : -1;
+    onSet(base.build(Math.round((base.magnitude + dir * step) * 100) / 100));
   };
 
   const onPointerDown = (e: ReactPointerEvent<HTMLInputElement>) => {
@@ -145,6 +166,7 @@ function SideField({ value, onSet, cssProp, label, className, dir, inherited }: 
       onFocus={(e) => e.target.select()}
       onKeyDown={(e) => {
         if (e.key === 'Enter') commit();
+        else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') onArrowStep(e);
       }}
       onBlur={() => {
         // Apply if valid; otherwise drop the bad text back to the live value.

--- a/src/components/edit/VisualEditorPanel.test.tsx
+++ b/src/components/edit/VisualEditorPanel.test.tsx
@@ -476,6 +476,141 @@ describe('VisualEditorPanel', () => {
     vi.unstubAllGlobals();
   });
 
+  // ── Arrow-key stepping (ArrowUp/Down; Shift ×10, Alt fine) ──
+
+  it('steps a padding side with ArrowUp/ArrowDown (Shift ×10)', () => {
+    const onSetSide = vi.fn();
+    renderPanel(
+      resolvedSelection,
+      'p-3',
+      BASE_BREAKPOINT,
+      vi.fn(),
+      false,
+      false,
+      vi.fn(),
+      vi.fn(),
+      onSetSide
+    );
+    const pt = screen.getByLabelText('Padding top');
+    fireEvent.keyDown(pt, { key: 'ArrowUp' });
+    expect(onSetSide).toHaveBeenLastCalledWith('padding', 'top', { kind: 'scale', n: 4 });
+    fireEvent.keyDown(pt, { key: 'ArrowDown' });
+    expect(onSetSide).toHaveBeenLastCalledWith('padding', 'top', { kind: 'scale', n: 2 });
+    fireEvent.keyDown(pt, { key: 'ArrowUp', shiftKey: true });
+    expect(onSetSide).toHaveBeenLastCalledWith('padding', 'top', { kind: 'scale', n: 13 });
+  });
+
+  it('clamps arrow-key stepping at zero for the spacing scale', () => {
+    const onSetSide = vi.fn();
+    renderPanel(
+      resolvedSelection,
+      'p-0',
+      BASE_BREAKPOINT,
+      vi.fn(),
+      false,
+      false,
+      vi.fn(),
+      vi.fn(),
+      onSetSide
+    );
+    fireEvent.keyDown(screen.getByLabelText('Padding top'), { key: 'ArrowDown' });
+    expect(onSetSide).toHaveBeenLastCalledWith('padding', 'top', { kind: 'scale', n: 0 });
+  });
+
+  it('steps an arbitrary spacing value preserving its unit (Alt = fine step)', () => {
+    const onSetSide = vi.fn();
+    renderPanel(
+      resolvedSelection,
+      'pt-[10rem]',
+      BASE_BREAKPOINT,
+      vi.fn(),
+      false,
+      false,
+      vi.fn(),
+      vi.fn(),
+      onSetSide
+    );
+    const pt = screen.getByLabelText('Padding top');
+    fireEvent.keyDown(pt, { key: 'ArrowUp' });
+    expect(onSetSide).toHaveBeenLastCalledWith('padding', 'top', {
+      kind: 'arbitrary',
+      raw: '11rem',
+    });
+    fireEvent.keyDown(pt, { key: 'ArrowUp', altKey: true });
+    expect(onSetSide).toHaveBeenLastCalledWith('padding', 'top', {
+      kind: 'arbitrary',
+      raw: '10.1rem',
+    });
+  });
+
+  it('steps the gap with arrow keys through the same stepper as the −/＋ buttons', () => {
+    const onStepGap = vi.fn();
+    render(
+      <VisualEditorPanel
+        {...mk()}
+        selection={resolvedSelection}
+        currentClass="gap-4"
+        onStepGap={onStepGap}
+      />
+    );
+    const gap = screen.getByLabelText('Gap');
+    fireEvent.keyDown(gap, { key: 'ArrowUp' });
+    expect(onStepGap).toHaveBeenLastCalledWith(1, 1);
+    fireEvent.keyDown(gap, { key: 'ArrowDown' });
+    expect(onStepGap).toHaveBeenLastCalledWith(-1, 1);
+    fireEvent.keyDown(gap, { key: 'ArrowUp', shiftKey: true });
+    expect(onStepGap).toHaveBeenLastCalledWith(1, 10);
+  });
+
+  it('steps a scale length (width) with arrow keys', () => {
+    const onApplyEnum = vi.fn();
+    render(
+      <VisualEditorPanel
+        {...mk()}
+        selection={resolvedSelection}
+        currentClass="w-64"
+        onApplyEnum={onApplyEnum}
+      />
+    );
+    fireEvent.keyDown(screen.getByLabelText('Width'), { key: 'ArrowUp' });
+    expect(onApplyEnum).toHaveBeenLastCalledWith('w-65', { width: '16.25rem' });
+  });
+
+  it('steps an arbitrary length preserving its unit', () => {
+    vi.stubGlobal('CSS', { supports: () => true });
+    const onApplyEnum = vi.fn();
+    render(
+      <VisualEditorPanel
+        {...mk()}
+        selection={resolvedSelection}
+        currentClass="w-[480px]"
+        onApplyEnum={onApplyEnum}
+      />
+    );
+    const width = screen.getByLabelText('Width');
+    fireEvent.keyDown(width, { key: 'ArrowUp' });
+    expect(onApplyEnum).toHaveBeenLastCalledWith('w-[481px]', { width: '481px' });
+    fireEvent.keyDown(width, { key: 'ArrowUp', shiftKey: true });
+    expect(onApplyEnum).toHaveBeenLastCalledWith('w-[491px]', { width: '491px' });
+    vi.unstubAllGlobals();
+  });
+
+  it('leaves keyword lengths alone on arrow keys', () => {
+    const onApplyEnum = vi.fn();
+    render(
+      <VisualEditorPanel
+        {...mk()}
+        selection={resolvedSelection}
+        currentClass="w-full"
+        onApplyEnum={onApplyEnum}
+      />
+    );
+    const width = screen.getByLabelText<HTMLInputElement>('Width');
+    fireEvent.keyDown(width, { key: 'ArrowUp' });
+    expect(onApplyEnum).not.toHaveBeenCalled();
+    expect(width.value).toBe('full');
+  });
+
   // ── Image section (asset replacement) ──
 
   const imgSelection: Selection = {

--- a/src/components/edit/VisualEditorPanel.tsx
+++ b/src/components/edit/VisualEditorPanel.tsx
@@ -267,8 +267,8 @@ interface Props {
   autoSave: boolean;
   /** Toggle auto-save on/off. */
   onToggleAutoSave: () => void;
-  /** Step the gap utility one notch up (1) or down (-1). */
-  onStepGap: (dir: 1 | -1) => void;
+  /** Step the gap utility up (1) or down (-1), by `step` notches (default 1). */
+  onStepGap: (dir: 1 | -1, step?: number) => void;
   /** Set one side of padding/margin to a scale step or arbitrary value. */
   onSetSide: (type: BoxType, side: Side, value: SpacingValue) => void;
   /** Apply an enum option's token + inline-style preview. */

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -1475,7 +1475,7 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
               }}
               autoSave={editor.autoSave}
               onToggleAutoSave={editor.toggleAutoSave}
-              onStepGap={(dir) => editor.stepSpacing('gap', dir)}
+              onStepGap={(dir, step) => editor.stepSpacing('gap', dir, step)}
               onSetSide={editor.setBoxSide}
               onApplyEnum={editor.applyEnum}
               onReset={editor.reset}

--- a/src/hooks/useVisualEditor.ts
+++ b/src/hooks/useVisualEditor.ts
@@ -476,16 +476,16 @@ export function useVisualEditor({
     [postMutate, setLiveClass, activeBreakpoint, known]
   );
 
-  /** Step a spacing utility (padding/margin/gap) by one unit at the active
-   *  breakpoint, computed from that layer's current value (so stepping `md:` reads
-   *  the md value, not base). Steps the scale integer, or a numeric arbitrary
+  /** Step a spacing utility (padding/margin/gap) by `step` units (default 1) at the
+   *  active breakpoint, computed from that layer's current value (so stepping `md:`
+   *  reads the md value, not base). Steps the scale integer, or a numeric arbitrary
    *  value's magnitude (keeping its unit). Drives a breakpoint-scoped preview rule. */
   const stepSpacing = useCallback(
-    (kind: SpacingKind, dir: 1 | -1) => {
+    (kind: SpacingKind, dir: 1 | -1, step = 1) => {
       const ctrl = SPACING_CONTROLS.find((c) => c.kind === kind);
       if (!ctrl) return;
       const scoped = tokensForVariant(currentClassRef.current, activeBreakpoint.prefix, known);
-      const next = stepSpacingValue(spacingValue(scoped, ctrl.prefix), dir);
+      const next = stepSpacingValue(spacingValue(scoped, ctrl.prefix), dir * step);
       applyToken(spacingTokenFor(ctrl.prefix, next), { [ctrl.css]: spacingCss(next) });
     },
     [applyToken, activeBreakpoint, known]

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -527,7 +527,9 @@ export function parseSpacingInput(input: string, cssProp: string): ParsedSpacing
  *  arbitraries (e.g. `calc(…)`) are returned unchanged. */
 export function stepSpacingValue(v: SpacingValue | null, delta: number): SpacingValue {
   if (!v || v.kind === 'scale') {
-    return { kind: 'scale', n: Math.max(0, (v?.kind === 'scale' ? v.n : 0) + delta) };
+    // The scale is integer-stepped — round so a fine (fractional) delta can't
+    // mint an invalid token like `gap-4.1`.
+    return { kind: 'scale', n: Math.max(0, Math.round((v?.kind === 'scale' ? v.n : 0) + delta)) };
   }
   const m = /^(-?\d*\.?\d+)(.*)$/.exec(v.raw.trim());
   if (!m) return v;


### PR DESCRIPTION
## What

User feedback: *"Why not be able to use arrow keys to lower or raise the value instead of typing the right value?"*

ArrowUp/ArrowDown now step the number in every live editor value input, matching the existing drag-scrub conventions. `preventDefault` keeps the caret from jumping, and each keypress is a complete gesture (previews and commits the same way that control's existing edit paths do).

## Modifiers

- **Plain arrow** — one step (one drag tick in the Tailwind controls; the magnitude-aware step in the CSS cascade editor, so `12px` → `13px` and `1.5rem` → `1.6rem`)
- **Shift** — ×10 (coarse)
- **Alt** — fine step (÷10) on unit values; Tailwind scale values stay on whole steps (the scale is integer-granular)

Non-numeric values — keywords (`full`, `auto`), fractions (`1/2`), `calc(…)`, colors — are left untouched: no `preventDefault`, arrows keep their default caret behavior.

## Controls covered

**Tailwind editor (VisualEditorPanel):**
- `SpacingBox` side fields (padding/margin) — steps through the same `dragBaseOf` + `onSet` path the pointer scrub uses, preserving arbitrary-value units (`10rem` → `11rem`)
- `GapControl` field — arrows drive the same `onStepGap` stepper as the −/＋ buttons; `stepSpacing` gained an optional step magnitude for Shift/Alt
- `LengthControl` (width / height / max-width / min-height) — steps bare scale steps (`w-64` → `w-65`) and number+unit values (`480px` → `481px`), keeping the unit; keywords/fractions ignored

**CSS cascade editor (CssCascadePanel):**
- `EditPopover` value input — magnitude-aware stepping reusing the same `parseNumericValue` / `magnitudeStep` / `formatNumericValue` helpers as drag-to-scrub, live-applying each press. Only steps when the suggestion menu is closed — when the autocomplete menu is open, arrows keep navigating the menu.

Also hardened `stepSpacingValue` to round scale results so a fractional delta can never mint an invalid token like `gap-4.1` (no behavior change for the existing integer deltas).

## Tests

- New arrow-key cases in `VisualEditorPanel.test.tsx`: plain step, Shift ×10, Alt fine, zero clamp, unit preserved, keyword untouched, gap stepper wiring
- New `EditPopover.test.tsx`: plain step + live-apply, Shift ×10 / Alt ÷10, magnitude-aware step, unit preserved, menu-open arrows still navigate the menu, keyword untouched
- `pnpm test:run` — 88 files, 1218 passed; `tsc --noEmit` and `eslint --max-warnings 0` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ArrowUp/ArrowDown keyboard stepping across multiple editor fields, including padding, gap, spacing, width, length, and edit popovers.
  * Support now includes faster/finer adjustments with Shift and Alt, while preserving units and handling numeric values more consistently.

* **Bug Fixes**
  * Improved stepping behavior for scale-based values so results stay valid and rounded correctly.
  * Keyword values and non-numeric inputs are left unchanged when stepped with the keyboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->