### PR TITLE
Visual editor: make class-less elements stylable (insert first class + no_class state)

### DIFF
--- a/src-tauri/src/commands/edit.rs
+++ b/src-tauri/src/commands/edit.rs
@@ -119,6 +119,11 @@ pub enum Resolution {
         /// The shared class string (identical at every location; the drift baseline).
         class_name: String,
     },
+    /// The element has no class attribute at all — nothing to resolve or replace.
+    /// Distinct from `ReadOnly` (a dynamic/computed class the editor mustn't touch):
+    /// frontends offer the insert-a-class path (`insert_class_attr`) here instead
+    /// of a dead end with a misleading "dynamic class" message.
+    NoClass,
     /// No static source match — dynamic className, or a generated/runtime class.
     ReadOnly { reason: String },
 }
@@ -376,6 +381,11 @@ fn resolved(o: &Occurrence, confidence: &str) -> Resolution {
 
 /// Core resolution logic, separated from the Tauri command for unit testing.
 fn resolve(occurrences: &[Occurrence], sig: &ElementSignature) -> Resolution {
+    // No class at all is its own state, not "dynamic": there's no literal to
+    // match OR to rewrite, but a class can be *inserted* (`insert_class_attr`).
+    if sig.class_name.trim().is_empty() {
+        return Resolution::NoClass;
+    }
     let exact: Vec<&Occurrence> = occurrences
         .iter()
         .filter(|o| o.class_name == sig.class_name)
@@ -629,6 +639,356 @@ pub fn apply_classname_edit_multi(
         .count();
     invalidate_index_cache(&root);
     Ok(applied)
+}
+
+// ───────────────────── Class attribute insertion ("Add class") ───────────────
+//
+// The resolver above anchors on an element's EXISTING static class literal, and
+// the write-back can only replace a literal's bytes. An element with no class
+// attribute therefore has nothing to anchor on and nothing to rewrite — which
+// used to make unstyled elements structurally unstylable from the editor. This
+// path locates the element's open tag by the signature's *other* signals — a
+// unique-in-source ancestor class pins the file, the element's text content pins
+// the tag — and INSERTS a fresh `className="…"` (JSX) / `class="…"` attribute
+// right after the tag name. Zero or multiple confident candidates fail with a
+// specific, actionable error; the editor never guesses an insert target.
+
+/// A candidate open tag for class insertion: matches the clicked element's tag
+/// name and carries no `class`/`className` attribute in any form.
+#[derive(Debug, Clone)]
+struct InsertCandidate {
+    /// Project-relative POSIX path.
+    file: String,
+    /// Byte offset just past the tag name — where ` class="…"` is spliced in.
+    insert_at: usize,
+    /// 1-based line of the tag's `<`.
+    line: usize,
+}
+
+/// Every open tag in `src` named `tag_name` (lowercased, like [`nearest_tag`])
+/// that has NO `class`/`className` attribute — static or dynamic. A tag with a
+/// dynamic `className={…}` is excluded too: inserting a second class attribute
+/// next to it would produce a duplicate-attribute bug, not a fix. Comments are
+/// skipped wholesale so markup inside them can't become an insert target.
+fn find_classless_tag_sites(src: &str, tag_name: &str) -> Vec<(usize, usize)> {
+    let bytes = src.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'<' {
+            i += 1;
+            continue;
+        }
+        if src[i..].starts_with("<!--") {
+            match src[i..].find("-->") {
+                Some(rel) => i += rel + 3,
+                None => break,
+            }
+            continue;
+        }
+        let Some(t) = tag_at(src, i) else {
+            i += 1;
+            continue;
+        };
+        if t.closing || t.name != tag_name {
+            i += 1;
+            continue;
+        }
+        // The byte right after the name must end an identifier — this rejects a
+        // member-expression component (`<Foo.Bar`) whose parsed name is only the
+        // `foo` prefix. (`tag_at` names are ASCII, so byte length == char length.)
+        let name_end = i + 1 + t.name.len();
+        if !matches!(
+            bytes.get(name_end),
+            Some(b' ' | b'\t' | b'\n' | b'\r' | b'/' | b'>')
+        ) {
+            i += 1;
+            continue;
+        }
+        // The tag's real `>` — quote- AND `{…}`-aware, unlike `tag_at`'s, so an
+        // arrow function in a handler (`onClick={() => a > b}`) can't truncate
+        // the attribute scan below.
+        let Some(gt) = open_tag_end(src, name_end) else {
+            i += 1;
+            continue;
+        };
+        let tag_slice = &src[i..gt + 1];
+        if has_attr_name(tag_slice, "class") || has_attr_name(tag_slice, "className") {
+            i = gt + 1;
+            continue;
+        }
+        out.push((name_end, line_col(src, i).0));
+        i = gt + 1;
+    }
+    out
+}
+
+/// Every indexed source file under `root` as (project-relative POSIX path,
+/// contents) — the same walk/filters the className index uses.
+fn source_files(root: &Path) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let exts = source_exts(root);
+    let walker = ignore::WalkBuilder::new(root)
+        .standard_filters(true)
+        .build();
+    for entry in walker.flatten() {
+        let path = entry.path();
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_ascii_lowercase())
+            .unwrap_or_default();
+        if !exts.contains(&ext.as_str()) {
+            continue;
+        }
+        let Ok(src) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        out.push((rel, src));
+    }
+    out
+}
+
+/// The element's text as a bounded match probe (whitespace-normalized, first 60
+/// chars), or None when it's too short to be distinctive — the same thresholds
+/// [`disambiguate_by_text`] uses.
+fn text_probe(text: Option<&str>) -> Option<String> {
+    let needle = normalize_ws(text?);
+    if needle.chars().count() < 8 {
+        return None;
+    }
+    Some(needle.chars().take(60).collect())
+}
+
+/// True when `probe` appears in the (whitespace-normalized) window from the
+/// candidate tag's line through a bounded look-ahead — i.e. the clicked element's
+/// text sits in/near this tag's body.
+fn probe_matches_at(src: &str, line: usize, probe: &str) -> bool {
+    let lines: Vec<&str> = src.lines().collect();
+    let start = line.saturating_sub(1);
+    if start >= lines.len() {
+        return false;
+    }
+    let end = (start + 30).min(lines.len());
+    normalize_ws(&lines[start..end].join(" ")).contains(probe)
+}
+
+/// Locate the single open tag a class attribute should be inserted on, or fail
+/// with a specific error saying exactly what was searched and why it's ambiguous.
+///
+/// Ladder (mirrors `resolve`'s philosophy — a unique match wins, ambiguity never
+/// guesses): candidates are classless same-name tags; a unique-in-source ancestor
+/// class narrows them to its file; the element's text content pins one tag.
+fn locate_insert_site(
+    root: &Path,
+    occurrences: &[Occurrence],
+    sig: &ElementSignature,
+) -> Result<(InsertCandidate, String), CommandError> {
+    let tag = sig.tag_name.trim().to_ascii_lowercase();
+    if tag.is_empty() || !tag.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-') {
+        return Err(CommandError::Validation {
+            field: "signature".into(),
+            reason: format!("`{}` isn't a valid element tag name.", sig.tag_name),
+        });
+    }
+
+    let files = source_files(root);
+    let mut all: Vec<InsertCandidate> = Vec::new();
+    for (rel, src) in &files {
+        for (insert_at, line) in find_classless_tag_sites(src, &tag) {
+            all.push(InsertCandidate {
+                file: rel.clone(),
+                insert_at,
+                line,
+            });
+        }
+    }
+
+    let src_of = |file: &str| -> &str {
+        files
+            .iter()
+            .find(|(rel, _)| rel == file)
+            .map(|(_, s)| s.as_str())
+            .unwrap_or("")
+    };
+    let done = |c: &InsertCandidate| Ok((c.clone(), src_of(&c.file).to_string()));
+
+    // Ancestor anchor: the nearest ancestor whose class literal is unique in
+    // source pins the component file the element was authored in.
+    let anchor_file = sig.ancestor_classes.iter().find_map(|anc| {
+        let occ: Vec<&Occurrence> = occurrences
+            .iter()
+            .filter(|o| &o.class_name == anc)
+            .collect();
+        (occ.len() == 1).then(|| occ[0].file.clone())
+    });
+    let anchored: Vec<&InsertCandidate> = match &anchor_file {
+        Some(f) => all.iter().filter(|c| &c.file == f).collect(),
+        None => Vec::new(),
+    };
+    let pool: Vec<&InsertCandidate> = if anchored.is_empty() {
+        all.iter().collect()
+    } else {
+        anchored
+    };
+
+    if let [only] = pool.as_slice() {
+        return done(only);
+    }
+
+    // Text anchor: the clicked element's text content near a candidate tag is the
+    // strong per-element signal (same approach as `disambiguate_by_text`).
+    let probe = text_probe(sig.text.as_deref());
+    if let Some(probe) = &probe {
+        let by_text: Vec<&InsertCandidate> = pool
+            .iter()
+            .copied()
+            .filter(|c| probe_matches_at(src_of(&c.file), c.line, probe))
+            .collect();
+        if let [only] = by_text.as_slice() {
+            return done(only);
+        }
+        // The ancestor may have pinned the wrong file (the element can live in a
+        // child component) — retry the text anchor across every candidate.
+        if pool.len() != all.len() {
+            let by_text_all: Vec<&InsertCandidate> = all
+                .iter()
+                .filter(|c| probe_matches_at(src_of(&c.file), c.line, probe))
+                .collect();
+            if let [only] = by_text_all.as_slice() {
+                return done(only);
+            }
+        }
+    }
+
+    // Zero or multiple confident candidates — report exactly what was searched.
+    let text_note = match (&probe, &sig.text) {
+        (Some(p), _) => format!(" and its text (\"{p}\") didn't pin exactly one"),
+        (None, Some(t)) if !t.trim().is_empty() => {
+            " and its text is too short to tell them apart".to_string()
+        }
+        _ => " and it has no text to tell them apart".to_string(),
+    };
+    if all.is_empty() {
+        return Err(CommandError::Validation {
+            field: "element".into(),
+            reason: format!(
+                "Couldn't find a <{tag}> without a class in source to add a class to — searched {} source file(s). \
+                 It may be rendered by a component under a different tag name, or its markup may be generated. \
+                 Add a class to it in code once, then the editor can manage it.",
+                files.len()
+            ),
+        });
+    }
+    let mut seen_files: Vec<&str> = Vec::new();
+    for c in &pool {
+        if !seen_files.contains(&c.file.as_str()) {
+            seen_files.push(&c.file);
+        }
+    }
+    let shown = seen_files
+        .iter()
+        .take(4)
+        .copied()
+        .collect::<Vec<_>>()
+        .join(", ");
+    let more = seen_files.len().saturating_sub(4);
+    let file_list = if more > 0 {
+        format!("{shown}, +{more} more")
+    } else {
+        shown
+    };
+    Err(CommandError::Validation {
+        field: "element".into(),
+        reason: format!(
+            "Couldn't tell which <{tag}> in source to add the class to — {} classless <{tag}> tag(s) matched in {file_list}{text_note}. \
+             Add a class to it in code once, then the editor can manage it.",
+            pool.len()
+        ),
+    })
+}
+
+/// Class values are spliced into a fresh quoted attribute, so anything that could
+/// terminate the quote or read as markup/JSX is rejected outright.
+fn invalid_class_value(s: &str) -> bool {
+    s.trim().is_empty()
+        || s.chars()
+            .any(|c| matches!(c, '"' | '\'' | '`' | '<' | '>' | '{' | '}' | '\\') || c.is_control())
+}
+
+/// Splice ` className="…"`/` class="…"` into `src` at the candidate's insert
+/// offset, write the file, and return the new literal's location. The attribute
+/// name follows the file type (JSX authors `className`; Astro/HTML/Liquid/Vue/
+/// Svelte use `class`) and the quote style follows the file's dominant one.
+fn write_class_attr_insert(
+    root: &Path,
+    cand: &InsertCandidate,
+    src: &str,
+    new_class: &str,
+) -> Result<Location, CommandError> {
+    let ext = cand
+        .file
+        .rsplit('.')
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let attr = if ext == "tsx" || ext == "jsx" {
+        "className"
+    } else {
+        "class"
+    };
+    // Match the file's quoting style: single quotes only when they clearly dominate.
+    let quote = if src.matches("='").count() > src.matches("=\"").count() {
+        '\''
+    } else {
+        '"'
+    };
+    let inserted = format!(" {attr}={quote}{new_class}{quote}");
+    let mut updated = String::with_capacity(src.len() + inserted.len());
+    updated.push_str(&src[..cand.insert_at]);
+    updated.push_str(&inserted);
+    updated.push_str(&src[cand.insert_at..]);
+
+    std::fs::write(root.join(&cand.file), &updated).map_err(CommandError::from)?;
+    invalidate_index_cache(root);
+
+    // 1-based line/column of the inserted literal's value in the updated file.
+    let value_start = cand.insert_at + 1 + attr.len() + 2; // space + attr + `="`
+    let (line, column) = line_col(&updated, value_start);
+    Ok(Location {
+        file: cand.file.clone(),
+        line,
+        column,
+    })
+}
+
+/// Insert a `class`/`className` attribute on an element that has NO class in
+/// source — the "Add class" path for unstyled elements, which the replace-only
+/// write-back can't serve. Locates the open tag via ancestor-file + text
+/// anchoring and fails with a specific error rather than guess when zero or
+/// multiple tags match. Returns the inserted literal's location.
+#[tauri::command]
+#[tracing::instrument(skip(signature), fields(project = %project_path, tag = %signature.tag_name))]
+pub fn insert_class_attr(
+    project_path: String,
+    signature: ElementSignature,
+    new_class: String,
+) -> Result<Location, CommandError> {
+    if invalid_class_value(&new_class) {
+        return Err(CommandError::Validation {
+            field: "new_class".into(),
+            reason: "Class names can't be empty or contain quotes, braces, backslashes, or angle brackets.".into(),
+        });
+    }
+    let root = validate_project_path(&project_path)?;
+    let occurrences = index_occurrences_cached(&root);
+    let (cand, src) = locate_insert_site(&root, occurrences.as_slice(), &signature)?;
+    write_class_attr_insert(&root, &cand, &src, &new_class)
 }
 
 // ───────────────────────────── Text content ─────────────────────────────────
@@ -2422,9 +2782,15 @@ fn locate_element(
                 reason: "This element appears in several identical places, so editing its markup here could change the wrong one. Ask your agent to edit it instead.".into(),
             })
         }
+        Resolution::NoClass => {
+            return Err(CommandError::Validation {
+                field: "element".into(),
+                reason: "This element has no class in source to anchor its markup on. Add a class to it first (the Add class action), then its markup becomes editable.".into(),
+            })
+        }
         // The class resolver couldn't anchor this element to source (its classes
-        // are dynamic/generated, or it has none). The markup editor is
-        // class-anchored, so phrase it for *markup*, not the class-string reason.
+        // are dynamic/generated). The markup editor is class-anchored, so phrase
+        // it for *markup*, not the class-string reason.
         Resolution::ReadOnly { .. } => {
             return Err(CommandError::Validation {
                 field: "element".into(),
@@ -2791,6 +3157,24 @@ const items = [];
             resolve(&occs, &sig("bg-red-500 dynamic", "div", &[])),
             Resolution::ReadOnly { .. }
         ));
+    }
+
+    #[test]
+    fn classless_element_resolves_to_no_class_not_read_only() {
+        // An element with NO class isn't "dynamic" — it's insertable. The distinct
+        // status lets frontends offer "Add class" instead of a dead-end banner.
+        let occs = vec![occ("flex", "a.tsx", 1, "div")];
+        assert!(matches!(
+            resolve(&occs, &sig("", "div", &[])),
+            Resolution::NoClass
+        ));
+        assert!(matches!(
+            resolve(&occs, &sig("   ", "p", &[])),
+            Resolution::NoClass
+        ));
+        // Serialized shape matches the TS mirror (`{ status: 'no_class' }`).
+        let json = serde_json::to_string(&Resolution::NoClass).unwrap();
+        assert_eq!(json, r#"{"status":"no_class"}"#);
     }
 
     #[test]
@@ -3555,5 +3939,254 @@ const items = [];
         assert!(invalid_src_value("/a<b>.png"));
         assert!(!invalid_src_value("/images/My Logo (1).png"));
         assert!(!invalid_src_value("/hero.png?v=2"));
+    }
+
+    // ───────────── insert_class_attr (add class on a classless element) ─────────
+
+    fn classless_sig(tag: &str, text: Option<&str>, ancestors: &[&str]) -> ElementSignature {
+        ElementSignature {
+            class_name: String::new(),
+            tag_name: tag.into(),
+            text: text.map(str::to_string),
+            ancestor_classes: ancestors.iter().map(|s| s.to_string()).collect(),
+            attr_src: None,
+        }
+    }
+
+    /// Locate + write, like the command does, but on a plain temp dir (bypassing
+    /// `validate_project_path`, which only admits ~/ShipStudio paths).
+    fn insert_class(
+        root: &Path,
+        sig: &ElementSignature,
+        class: &str,
+    ) -> Result<Location, CommandError> {
+        let occ = index_occurrences(root);
+        let (cand, src) = locate_insert_site(root, &occ, sig)?;
+        write_class_attr_insert(root, &cand, &src, class)
+    }
+
+    #[test]
+    fn insert_unique_classless_tag_jsx_with_other_attributes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("Hero.tsx"),
+            "export function Hero() {\n  return (\n    <div id=\"hero\" data-x onClick={() => a > b}>\n      Hello\n    </div>\n  );\n}\n",
+        )
+        .unwrap();
+
+        let loc = insert_class(root, &classless_sig("div", None, &[]), "mt-4").unwrap();
+        assert_eq!(loc.file, "Hero.tsx");
+        let updated = std::fs::read_to_string(root.join("Hero.tsx")).unwrap();
+        // JSX file → `className`, inserted right after the tag name; other
+        // attributes (including the `>`-bearing arrow handler) are untouched.
+        assert!(
+            updated.contains("<div className=\"mt-4\" id=\"hero\" data-x onClick={() => a > b}>"),
+            "got: {updated}"
+        );
+        // The returned location points at the inserted literal's value.
+        let line = updated.lines().nth(loc.line - 1).unwrap();
+        assert!(line.contains("className=\"mt-4\""));
+    }
+
+    #[test]
+    fn insert_pins_by_unique_text_among_candidates() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("About.tsx"),
+            "export function About() {\n  return (\n    <p>\n      With over 65 years of proven performance.\n    </p>\n  );\n}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("Services.tsx"),
+            "export function Services() {\n  return (\n    <p>\n      Custom cabinets built to last for decades.\n    </p>\n  );\n}\n",
+        )
+        .unwrap();
+
+        let sig = classless_sig("p", Some("With over 65 years of proven performance."), &[]);
+        let loc = insert_class(root, &sig, "lead").unwrap();
+        assert_eq!(loc.file, "About.tsx");
+        let updated = std::fs::read_to_string(root.join("About.tsx")).unwrap();
+        assert!(updated.contains("<p className=\"lead\">"), "got: {updated}");
+        // The other file is untouched.
+        assert!(!std::fs::read_to_string(root.join("Services.tsx"))
+            .unwrap()
+            .contains("className"));
+    }
+
+    #[test]
+    fn insert_narrows_by_unique_ancestor_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        // A classless <div> in each file; only the ancestor class pins file A.
+        std::fs::write(
+            root.join("A.tsx"),
+            "export function A() {\n  return (\n    <section className=\"wrapper-a\">\n      <div />\n    </section>\n  );\n}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("B.tsx"),
+            "export function B() {\n  return (\n    <section className=\"wrapper-b\">\n      <div />\n    </section>\n  );\n}\n",
+        )
+        .unwrap();
+
+        let sig = classless_sig("div", None, &["wrapper-a"]);
+        let loc = insert_class(root, &sig, "grid").unwrap();
+        assert_eq!(loc.file, "A.tsx");
+        assert!(std::fs::read_to_string(root.join("A.tsx"))
+            .unwrap()
+            .contains("<div className=\"grid\" />"));
+        assert!(!std::fs::read_to_string(root.join("B.tsx"))
+            .unwrap()
+            .contains("grid"));
+    }
+
+    #[test]
+    fn insert_rejects_multiple_candidates_with_specific_error() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("A.tsx"),
+            "export const A = () => <div><span /></div>;\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("B.tsx"),
+            "export const B = () => <div><span /></div>;\n",
+        )
+        .unwrap();
+
+        // Two classless <div>s, no text, no ancestor — must refuse, not guess.
+        let err = insert_class(root, &classless_sig("div", None, &[]), "x").unwrap_err();
+        match err {
+            CommandError::Validation { reason, .. } => {
+                assert!(reason.contains("2 classless <div>"), "got: {reason}");
+                assert!(
+                    reason.contains("A.tsx") && reason.contains("B.tsx"),
+                    "got: {reason}"
+                );
+                assert!(reason.contains("no text"), "got: {reason}");
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
+        // Neither file was written.
+        assert!(!std::fs::read_to_string(root.join("A.tsx"))
+            .unwrap()
+            .contains("className"));
+        assert!(!std::fs::read_to_string(root.join("B.tsx"))
+            .unwrap()
+            .contains("className"));
+    }
+
+    #[test]
+    fn insert_rejects_when_no_classless_tag_exists() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        // The only <div> already has a class — a DOM <div> without one must be
+        // coming from elsewhere (a component, generated markup), so refuse.
+        std::fs::write(
+            root.join("A.tsx"),
+            "export const A = () => <div className=\"x\">hi</div>;\n",
+        )
+        .unwrap();
+
+        let err = insert_class(root, &classless_sig("div", None, &[]), "x").unwrap_err();
+        match err {
+            CommandError::Validation { reason, .. } => {
+                assert!(reason.contains("Couldn't find a <div>"), "got: {reason}");
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn insert_uses_class_for_astro_and_matches_single_quote_style() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("index.astro"),
+            "---\nconst x = 1;\n---\n<section class=\"hero\">\n  <h1>Welcome to the site</h1>\n</section>\n",
+        )
+        .unwrap();
+        let loc = insert_class(root, &classless_sig("h1", None, &[]), "title").unwrap();
+        assert_eq!(loc.file, "index.astro");
+        let updated = std::fs::read_to_string(root.join("index.astro")).unwrap();
+        // Astro → `class`, double quotes (the file's dominant style).
+        assert!(updated.contains("<h1 class=\"title\">"), "got: {updated}");
+
+        // A static-HTML project whose attributes use single quotes keeps them.
+        let dir2 = tempfile::TempDir::new().unwrap();
+        let root2 = dir2.path();
+        std::fs::write(
+            root2.join("index.html"),
+            "<div id='a' data-role='main'>\n  <p>Some paragraph text</p>\n</div>\n",
+        )
+        .unwrap();
+        insert_class(root2, &classless_sig("p", None, &[]), "lead").unwrap();
+        let updated2 = std::fs::read_to_string(root2.join("index.html")).unwrap();
+        assert!(updated2.contains("<p class='lead'>"), "got: {updated2}");
+    }
+
+    #[test]
+    fn insert_handles_self_closing_tags() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("Pic.tsx"),
+            "export const Pic = () => <img src=\"/a.png\" alt=\"a\" />;\n",
+        )
+        .unwrap();
+        insert_class(root, &classless_sig("img", None, &[]), "rounded").unwrap();
+        let updated = std::fs::read_to_string(root.join("Pic.tsx")).unwrap();
+        assert!(
+            updated.contains("<img className=\"rounded\" src=\"/a.png\" alt=\"a\" />"),
+            "got: {updated}"
+        );
+    }
+
+    #[test]
+    fn classless_sites_skip_static_and_dynamic_class_and_comments() {
+        let src = r#"
+            export function C() {
+              return (
+                <div className="x">
+                  <div className={cn("a", b)}>y</div>
+                  {/* comment */}
+                  <div id="target">z</div>
+                </div>
+              );
+            }
+            // <!-- <div>in an HTML comment</div> --> is skipped in .html-style sources
+        "#;
+        let sites = find_classless_tag_sites(src, "div");
+        // Only the `id="target"` div has no class handling at all.
+        assert_eq!(sites.len(), 1);
+        let (insert_at, _line) = sites[0];
+        assert_eq!(&src[insert_at - 4..insert_at + 12], "<div id=\"target\"");
+
+        let html = "<!-- <div>commented out</div> -->\n<div>real</div>\n";
+        assert_eq!(find_classless_tag_sites(html, "div").len(), 1);
+    }
+
+    #[test]
+    fn classless_sites_ignore_member_expression_components() {
+        // `<Select.Option>`'s parsed name is only the `select` prefix — must not
+        // be treated as a classless <select>.
+        let src = "export const C = () => <Select.Option value=\"1\">one</Select.Option>;\n";
+        assert!(find_classless_tag_sites(src, "select").is_empty());
+    }
+
+    #[test]
+    fn insert_rejects_markup_breaking_class_values() {
+        assert!(invalid_class_value(""));
+        assert!(invalid_class_value("   "));
+        assert!(invalid_class_value("a\"b"));
+        assert!(invalid_class_value("a'b"));
+        assert!(invalid_class_value("a<b"));
+        assert!(invalid_class_value("a{b}"));
+        assert!(invalid_class_value("a\\b"));
+        assert!(!invalid_class_value("mt-4 text-[oklch(0.62_0.18_39)]"));
+        assert!(!invalid_class_value("hover:bg-red-500/50"));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -380,6 +380,7 @@ pub fn run() {
             commands::edit::resolve_classname_source,
             commands::edit::apply_classname_edit,
             commands::edit::apply_classname_edit_multi,
+            commands::edit::insert_class_attr,
             commands::edit::resolve_text_source,
             commands::edit::apply_text_edit,
             commands::edit::resolve_image_source,

--- a/src/components/edit/VisualEditorPanel.test.tsx
+++ b/src/components/edit/VisualEditorPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { VisualEditorPanel } from './VisualEditorPanel';
 import {
   BASE_BREAKPOINT,
@@ -546,5 +546,59 @@ describe('VisualEditorPanel', () => {
     // Styles genuinely aren't editable here — that's worth surfacing alongside Image.
     expect(screen.getByText(/aren’t a static string/)).toBeInTheDocument();
     expect(screen.getByText('Image')).toBeInTheDocument();
+  });
+
+  // ── Class-less elements (no_class → Add class) ──
+
+  const noClassSelection: Selection = {
+    signature: { className: '', tagName: 'div', ancestorClasses: [] },
+    resolution: { status: 'no_class' },
+    instanceCount: 1,
+  };
+
+  it('offers "Add class" instead of a read-only dead end for a class-less element', () => {
+    render(
+      <VisualEditorPanel
+        {...mk()}
+        selection={noClassSelection}
+        currentClass=""
+        onAddFirstClass={vi.fn()}
+      />
+    );
+    // The add-a-class state, not the misleading "dynamic classes" banner…
+    expect(screen.getByText(/has no classes yet/)).toBeInTheDocument();
+    expect(screen.queryByText(/aren’t a static string/)).not.toBeInTheDocument();
+    // …and no style controls or footer (there's nothing to write to yet).
+    expect(screen.queryByTestId('spacing-box')).not.toBeInTheDocument();
+    expect(screen.queryByRole('switch', { name: /auto-save/i })).not.toBeInTheDocument();
+    // The action is disabled until a name is typed.
+    expect(screen.getByRole('button', { name: 'Add class' })).toBeDisabled();
+  });
+
+  it('submits the typed first class (leading dot stripped) via onAddFirstClass', async () => {
+    const onAddFirstClass = vi.fn(async () => {});
+    render(
+      <VisualEditorPanel
+        {...mk()}
+        selection={noClassSelection}
+        currentClass=""
+        onAddFirstClass={onAddFirstClass}
+      />
+    );
+    const input = screen.getByLabelText('First class name');
+    fireEvent.change(input, { target: { value: '.hero-title' } });
+    // Flush the async submit so the busy flag releases before the next attempt.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Add class' }));
+      await Promise.resolve();
+    });
+    expect(onAddFirstClass).toHaveBeenCalledWith('hero-title');
+    // Enter in the input submits too.
+    fireEvent.change(input, { target: { value: 'flex gap-4' } });
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+      await Promise.resolve();
+    });
+    expect(onAddFirstClass).toHaveBeenCalledWith('flex gap-4');
   });
 });

--- a/src/components/edit/VisualEditorPanel.tsx
+++ b/src/components/edit/VisualEditorPanel.tsx
@@ -210,6 +210,59 @@ function DynamicTextHelp({
   );
 }
 
+/** Shown when the selected element has NO class at all (`no_class` resolution):
+ *  instead of a dead-end read-only banner, offer inserting its first class — the
+ *  backend writes a fresh class attribute into the element's source tag, after
+ *  which the selection re-resolves and the full controls appear. */
+function NoClassState({
+  tag,
+  onAddClass,
+}: {
+  tag: string;
+  onAddClass: (name: string) => void | Promise<void>;
+}) {
+  const [name, setName] = useState('');
+  const [busy, setBusy] = useState(false);
+  const trimmed = name.trim().replace(/^\./, '');
+  const submit = async () => {
+    if (!trimmed || busy) return;
+    setBusy(true);
+    try {
+      await onAddClass(trimmed);
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <div className="ss-edit-panel__noclass">
+      <p>
+        This <code>&lt;{tag}&gt;</code> has no classes yet. Add one to start styling it — it&apos;s
+        written straight into your source.
+      </p>
+      <input
+        type="text"
+        value={name}
+        placeholder="e.g. hero-title or flex gap-4"
+        aria-label="First class name"
+        spellCheck={false}
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') void submit();
+        }}
+      />
+      <Button
+        variant="primary"
+        size="sm"
+        block
+        disabled={!trimmed || busy}
+        onClick={() => void submit()}
+      >
+        {busy ? 'Adding…' : 'Add class'}
+      </Button>
+    </div>
+  );
+}
+
 /** Subtle info dot shown by the source line when the element is styled by a custom
  *  CSS class — its tooltip explains that edits use `!important` to win the cascade. */
 function CustomCssHint() {
@@ -290,6 +343,10 @@ interface Props {
   onApplyClass?: (name: string) => void | Promise<void>;
   onUnapplyClass?: (name: string) => void | Promise<void>;
   onCreateClass?: (name: string) => void;
+  /** Insert the FIRST class on a class-less element (`no_class` resolution) — the
+   *  backend writes a fresh class attribute into source, then the caller
+   *  re-resolves so the panel gains full controls. */
+  onAddFirstClass?: (name: string) => void | Promise<void>;
   /** Where the selected element's component is used project-wide (scope hint). */
   usage: UsageReport | null;
   /** Jump to a source file:line in the Code tab. */
@@ -339,6 +396,7 @@ export function VisualEditorPanel({
   onApplyClass = () => {},
   onUnapplyClass = () => {},
   onCreateClass = () => {},
+  onAddFirstClass,
   usage,
   onOpenInCode,
   onCommit,
@@ -364,7 +422,10 @@ export function VisualEditorPanel({
   // Show the controls as soon as an element is selected — they only need the class
   // string (available instantly). The source badge + Save fill in once resolved, so
   // the panel doesn't flicker through a "Resolving…" collapse on every click.
-  const controlsVisible = !!selection && resolution?.status !== 'read_only';
+  // `no_class` (element has no class at all) shows the add-a-class state instead:
+  // there's nothing for the style controls to write to yet.
+  const controlsVisible =
+    !!selection && resolution?.status !== 'read_only' && resolution?.status !== 'no_class';
 
   // Cascade-resolution context for the active breakpoint, threaded to each control
   // so they show the effective value at this layer and which breakpoint set it.
@@ -532,6 +593,13 @@ export function VisualEditorPanel({
             resolution={resolution}
             pulseKey={textBlockedNonce}
           />
+        )}
+
+        {/* No class at all: offer inserting the first one (writes a fresh class
+            attribute to source) instead of a dead-end banner. Classless images
+            skip it — the Image section already carries their state. */}
+        {resolution?.status === 'no_class' && selection && !isImage && onAddFirstClass && (
+          <NoClassState tag={selection.signature.tagName} onAddClass={onAddFirstClass} />
         )}
 
         {/* For a classless image the class resolver's "not a static string" verdict is

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -1489,6 +1489,7 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
               onApplyClass={(name) => editor.applyClass(name)}
               onUnapplyClass={(name) => editor.unapplyClass(name)}
               onCreateClass={(name) => void editor.createClassFromStyles(name)}
+              onAddFirstClass={(name) => editor.addFirstClass(name)}
               usage={editor.usage}
               onOpenInCode={onOpenInCode}
               onCommit={() => void editor.commit()}

--- a/src/hooks/useElementSettings.test.ts
+++ b/src/hooks/useElementSettings.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Element Settings — the CLASSES editor's two add-class paths.
+ *
+ * Focus: the regression where an element with NO class couldn't be styled at all —
+ * `addClass` resolved via the class-literal resolver (which has nothing to anchor
+ * on for a classless element) and dead-ended with a generic toast. The classless
+ * path must now INSERT a fresh class attribute (`insertClassAttr`), while elements
+ * WITH classes keep the resolve + replace path. Only the Tauri-backed lib calls
+ * are mocked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+vi.mock('../lib/edit', async (importActual) => {
+  const actual = await importActual<typeof import('../lib/edit')>();
+  return {
+    ...actual,
+    resolveClassnameSource: vi.fn(),
+    applyClassnameEdit: vi.fn(),
+    applyClassnameEditMulti: vi.fn(),
+    insertClassAttr: vi.fn(),
+  };
+});
+vi.mock('../lib/edit-html', () => ({
+  resolveElementHtml: vi.fn(),
+  applyElementHtml: vi.fn(),
+}));
+// trackEvent would otherwise reach for a real Tauri IPC on a saved edit.
+vi.mock('../lib/analytics', () => ({ trackEvent: vi.fn().mockResolvedValue(undefined) }));
+
+import { useElementSettings } from './useElementSettings';
+import {
+  resolveClassnameSource,
+  applyClassnameEdit,
+  insertClassAttr,
+  type ElementSignature,
+} from '../lib/edit';
+import { resolveElementHtml } from '../lib/edit-html';
+
+type Fn = ReturnType<typeof vi.fn>;
+
+function fakeIframeRef() {
+  return {
+    current: { contentWindow: { postMessage: vi.fn() } },
+  } as unknown as React.RefObject<HTMLIFrameElement | null>;
+}
+
+/** Calls posted to the iframe, as `{type, ...}` objects. */
+function posts(iframeRef: React.RefObject<HTMLIFrameElement | null>) {
+  // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the postMessage mock's calls, not invoking it bound
+  const fn = iframeRef.current!.contentWindow!.postMessage as Fn;
+  return (fn.mock.calls as Array<[{ type?: string }]>).map((c) => c[0]);
+}
+
+function setup(signature: ElementSignature) {
+  const iframeRef = fakeIframeRef();
+  const onToast = vi.fn();
+  const hook = renderHook(() =>
+    useElementSettings({ iframeRef, projectPath: '/proj', enabled: true, signature, onToast })
+  );
+  return { ...hook, iframeRef, onToast };
+}
+
+/** Run the fire-and-forget `addClass` and flush its promise chain. */
+async function add(result: { current: { addClass: (n: string) => void } }, name: string) {
+  await act(async () => {
+    result.current.addClass(name);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+const CLASSLESS: ElementSignature = {
+  className: '',
+  tagName: 'div',
+  text: 'Hello there world',
+  ancestorClasses: ['wrapper'],
+};
+const CLASSED: ElementSignature = { className: 'p-3', tagName: 'div', ancestorClasses: [] };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Attributes panel resolve is irrelevant here — let it fail (attributes hidden).
+  (resolveElementHtml as Fn).mockRejectedValue(new Error('not anchored'));
+  (insertClassAttr as Fn).mockResolvedValue({ file: 'Hero.tsx', line: 3, column: 6 });
+  (resolveClassnameSource as Fn).mockResolvedValue({
+    status: 'resolved',
+    file: 'Hero.tsx',
+    line: 3,
+    column: 6,
+    class_name: 'p-3',
+    confidence: 'unique',
+  });
+  (applyClassnameEdit as Fn).mockResolvedValue(undefined);
+});
+
+describe('useElementSettings addClass', () => {
+  it('inserts a fresh class attribute for an element with NO class (the classless regression)', async () => {
+    const { result, iframeRef } = setup(CLASSLESS);
+
+    await add(result, 'mt-4');
+
+    // The insert path runs INSTEAD of resolve + replace (which has no literal to
+    // anchor on for a classless element and used to dead-end with a toast).
+    expect(insertClassAttr).toHaveBeenCalledWith('/proj', CLASSLESS, 'mt-4');
+    expect(resolveClassnameSource).not.toHaveBeenCalled();
+    expect(applyClassnameEdit).not.toHaveBeenCalled();
+    expect(result.current.classes).toEqual(['mt-4']);
+
+    // Same live-preview protocol as a successful class rewrite.
+    const sent = posts(iframeRef);
+    expect(sent).toContainEqual({ type: 'ss:suppressReload' });
+    expect(sent).toContainEqual({ type: 'ss:mutate', className: 'mt-4', rules: [] });
+    expect(sent).toContainEqual({ type: 'ss:commit' });
+  });
+
+  it("surfaces the backend's specific reason when the classless insert is rejected", async () => {
+    (insertClassAttr as Fn).mockRejectedValue({
+      type: 'Validation',
+      field: 'element',
+      reason:
+        "Couldn't tell which <div> in source to add the class to — 3 classless <div> tag(s) matched",
+    });
+    const { result, onToast } = setup(CLASSLESS);
+
+    await add(result, 'mt-4');
+
+    expect(onToast).toHaveBeenCalledWith(
+      expect.stringContaining("Couldn't tell which <div> in source"),
+      'error'
+    );
+    // Nothing was written — the class list stays empty.
+    expect(result.current.classes).toEqual([]);
+  });
+
+  it('keeps the resolve + replace path for an element that already has classes', async () => {
+    const { result } = setup(CLASSED);
+
+    await add(result, 'mt-4');
+
+    expect(insertClassAttr).not.toHaveBeenCalled();
+    expect(resolveClassnameSource).toHaveBeenCalledWith('/proj', CLASSED);
+    expect(applyClassnameEdit).toHaveBeenCalledWith('/proj', 'Hero.tsx', 3, 'p-3', 'p-3 mt-4');
+    expect(result.current.classes).toEqual(['p-3', 'mt-4']);
+  });
+});

--- a/src/hooks/useElementSettings.ts
+++ b/src/hooks/useElementSettings.ts
@@ -21,6 +21,7 @@ import {
   resolveClassnameSource,
   applyClassnameEdit,
   applyClassnameEditMulti,
+  insertClassAttr,
   type ElementSignature,
 } from '../lib/edit';
 import { resolveElementHtml, applyElementHtml } from '../lib/edit-html';
@@ -224,6 +225,24 @@ export function useElementSettings({
     [projectPath, onToast, post]
   );
 
+  /** Add the FIRST class to an element that has none: there's no class literal in
+   *  source to resolve or replace, so the backend INSERTS a fresh class attribute
+   *  on the element's open tag (located by ancestor/text anchoring). On success,
+   *  proceed exactly like a successful `writeClassAttr` (live mutate + commit). */
+  const insertFirstClass = useCallback(
+    async (name: string): Promise<boolean> => {
+      const sig = sigRef.current;
+      if (!sig) return false;
+      post({ type: 'ss:suppressReload' });
+      await insertClassAttr(projectPath, sig, name);
+      sigRef.current = { ...sig, className: name };
+      post({ type: 'ss:mutate', className: name, rules: [] });
+      post({ type: 'ss:commit' });
+      return true;
+    },
+    [projectPath, post]
+  );
+
   const addClass = useCallback(
     async (name: string) => {
       const n = name.trim().replace(/^\./, '');
@@ -231,7 +250,11 @@ export function useElementSettings({
       setBusy(true);
       try {
         const next = [...classes, n];
-        if (await writeClassAttr(next.join(' '))) {
+        // No existing classes → insert a fresh attribute; otherwise rewrite the
+        // existing literal. Failures throw with the backend's specific reason.
+        const written =
+          classes.length === 0 ? await insertFirstClass(n) : await writeClassAttr(next.join(' '));
+        if (written) {
           setClasses(next);
           void trackEvent('visual_class_added', { mode: 'css-code' });
         }
@@ -242,7 +265,7 @@ export function useElementSettings({
         setBusy(false);
       }
     },
-    [classes, writeClassAttr, onToast]
+    [classes, writeClassAttr, insertFirstClass, onToast]
   );
 
   const removeClass = useCallback(

--- a/src/hooks/useVisualEditor.test.ts
+++ b/src/hooks/useVisualEditor.test.ts
@@ -16,6 +16,7 @@ vi.mock('../lib/edit', async (importActual) => {
     resolveClassnameSource: vi.fn(),
     applyClassnameEdit: vi.fn(),
     applyClassnameEditMulti: vi.fn(),
+    insertClassAttr: vi.fn(),
   };
 });
 
@@ -36,6 +37,7 @@ import {
   resolveClassnameSource,
   applyClassnameEdit,
   applyClassnameEditMulti,
+  insertClassAttr,
   BASE_BREAKPOINT,
   DEFAULT_BREAKPOINTS,
 } from '../lib/edit';
@@ -186,6 +188,54 @@ describe('useVisualEditor auto-save', () => {
     expect(localStorage.getItem('ss:visualEditor:autoSave')).toBe('1');
     act(() => result.current.toggleAutoSave());
     expect(localStorage.getItem('ss:visualEditor:autoSave')).toBe('0');
+  });
+});
+
+describe('useVisualEditor addFirstClass (class-less elements)', () => {
+  it('inserts the first class, then re-resolves so the panel gains full controls', async () => {
+    // Mirror the backend: an empty className resolves to `no_class`; once a class
+    // exists, it resolves normally.
+    (resolveClassnameSource as Fn).mockImplementation((_p: string, sig: { className: string }) =>
+      Promise.resolve(
+        sig.className.trim() === ''
+          ? { status: 'no_class' }
+          : {
+              status: 'resolved',
+              file: 'app/page.tsx',
+              line: 1,
+              column: 1,
+              class_name: sig.className,
+              confidence: 'unique',
+            }
+      )
+    );
+    (insertClassAttr as Fn).mockResolvedValue({ file: 'app/page.tsx', line: 1, column: 6 });
+    const { result, iframeRef } = setup();
+    act(() => result.current.toggleEditMode());
+    await select('', iframeRef.current!.contentWindow!);
+    expect(result.current.selection?.resolution).toEqual({ status: 'no_class' });
+
+    await act(async () => {
+      await result.current.addFirstClass('mt-4');
+    });
+
+    expect(insertClassAttr).toHaveBeenCalledWith(
+      '/proj',
+      expect.objectContaining({ className: '' }),
+      'mt-4'
+    );
+    // Re-resolved with the inserted class as the new source anchor.
+    expect(result.current.selection?.resolution).toMatchObject({
+      status: 'resolved',
+      class_name: 'mt-4',
+    });
+    expect(result.current.currentClass).toBe('mt-4');
+    // The live preview received the mutate + commit for the new class.
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the postMessage mock's calls, not invoking it bound
+    const post = iframeRef.current!.contentWindow!.postMessage as Fn;
+    const calls = post.mock.calls as Array<[{ type?: string; className?: string }]>;
+    expect(calls.some((c) => c[0]?.type === 'ss:mutate' && c[0]?.className === 'mt-4')).toBe(true);
+    expect(calls.some((c) => c[0]?.type === 'ss:commit')).toBe(true);
   });
 });
 

--- a/src/hooks/useVisualEditor.ts
+++ b/src/hooks/useVisualEditor.ts
@@ -38,6 +38,7 @@ import {
   resolveClassnameSource,
   applyClassnameEdit,
   applyClassnameEditMulti,
+  insertClassAttr,
   resolveImageSource,
   applySrcEdit,
   findComponentUsage,
@@ -630,6 +631,39 @@ export function useVisualEditor({
     [selection, projectPath, onToast, post, setLiveClass]
   );
 
+  /** Add the FIRST class to a class-less element (a `no_class` resolution): the
+   *  element has no class literal in source to resolve or replace, so the backend
+   *  INSERTS a fresh class attribute on its open tag (located by ancestor/text
+   *  anchoring — it rejects with a specific reason rather than guess). On success,
+   *  re-resolve so the panel transitions from the no-class state to full controls. */
+  const addFirstClass = useCallback(
+    async (name: string) => {
+      const sig = selectedSigRef.current;
+      const n = name.trim().replace(/^\./, '');
+      if (!sig || !n) return;
+      // Arm reload suppression before writing (same reasoning as a class commit).
+      post({ type: 'ss:suppressReload' });
+      try {
+        await insertClassAttr(projectPath, sig, n);
+        const nextSig = { ...sig, className: n };
+        selectedSigRef.current = nextSig;
+        setLiveClass(n);
+        post({ type: 'ss:mutate', className: n, rules: [] });
+        post({ type: 'ss:commit' });
+        // The inserted literal is now the element's source anchor — re-resolve so
+        // the selection gains a real location and the full controls appear.
+        const resolution = await resolveClassnameSource(projectPath, nextSig);
+        setSelection((prev) => (prev ? { ...prev, signature: nextSig, resolution } : prev));
+        recordCommit('visual_class_added', { mode: 'tailwind', first: true });
+        onToast?.('Class added', 'success');
+      } catch (err) {
+        logger.error('[VisualEditor] add first class failed', { error: String(err) });
+        onToast?.(formatCommandError(asCommandError(err)), 'error');
+      }
+    },
+    [projectPath, post, setLiveClass, onToast, recordCommit]
+  );
+
   /** The selected element's current className — read from the live class in
    *  element mode, or the (kept-fresh) signature while a class is being edited.
    *  The structural gestures below operate on THIS, never on a class's @apply. */
@@ -859,6 +893,8 @@ export function useVisualEditor({
     customClasses,
     /** Whether a writable Tailwind entry stylesheet exists (gates create). */
     classEntryReady,
+    /** Insert the first class on a class-less element, then re-resolve. */
+    addFirstClass,
     /** Append an existing custom class to the element and edit it. */
     applyClass,
     /** Remove a custom class from the element (keeps it defined in CSS). */

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -56,6 +56,12 @@ export type Resolution =
       locations: SourceLocation[];
       class_name: string;
     }
+  | {
+      /** The element has no class attribute at all — nothing to resolve or replace,
+       *  but a class can be INSERTED via `insertClassAttr`. Distinct from
+       *  `read_only` (a dynamic/computed class the editor mustn't touch). */
+      status: 'no_class';
+    }
   | { status: 'read_only'; reason: string };
 
 /** Resolve a clicked element to its source `className` location. */
@@ -64,6 +70,19 @@ export function resolveClassnameSource(
   signature: ElementSignature
 ): Promise<Resolution> {
   return invoke<Resolution>('resolve_classname_source', { projectPath, signature });
+}
+
+/** Insert a fresh `class`/`className` attribute on an element that has NO class in
+ *  source — the "Add class" path for unstyled elements, which the replace-only
+ *  write-back can't serve. The backend locates the open tag by ancestor-file and
+ *  text anchoring, and rejects (with a specific reason) rather than guess when
+ *  zero or multiple tags match. Resolves to the inserted literal's location. */
+export function insertClassAttr(
+  projectPath: string,
+  signature: ElementSignature,
+  newClass: string
+): Promise<SourceLocation> {
+  return invoke<SourceLocation>('insert_class_attr', { projectPath, signature, newClass });
 }
 
 // ───────────────────────────── Text content ─────────────────────────────────

--- a/src/styles/features/visual-editor.css
+++ b/src/styles/features/visual-editor.css
@@ -498,6 +498,37 @@
   }
 }
 
+/* "No class yet" state — offers inserting the element's FIRST class so unstyled
+   elements aren't a dead end (the resolver has no class literal to anchor on). */
+.ss-edit-panel__noclass {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-md);
+}
+.ss-edit-panel__noclass p {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+.ss-edit-panel__noclass input {
+  width: 100%;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-mono);
+}
+.ss-edit-panel__noclass input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
 /* Set-vs-inherited indicator: a filled dot when the value is set on the active
    breakpoint, a hollow ring when inherited from a smaller one. */
 .ss-layer-dot {


### PR DESCRIPTION
## The bug

In the visual editor, selecting an element that has **no class** and clicking **Add class** failed with the toast *"Can't edit this element's classes in source — change them in code."* — the user couldn't style unstyled elements at all. The Tailwind editor was even worse off: a class-less selection hid **all** controls and showed only the misleading banner *"These classes aren't a static string in source (dynamic or generated) — not editable in v1."* with no affordance whatsoever.

## Root cause

The class resolver (`resolve()` in `src-tauri/src/commands/edit.rs`) matches elements by their **existing** static `className`/`class` string literal. With an empty class there is no literal to match → `ReadOnly`. And the write primitive (`apply_classname_edit`) can only **replace** an existing literal's bytes — there was no insert path. Class-less elements were structurally unstylable.

## The fix

### Backend

- **New `insert_class_attr` command**: locates the element's open tag in source and inserts a fresh `className="…"` (`.tsx`/`.jsx`) or `class="…"` (`.astro`/`.html`/`.liquid`) attribute right after the tag name, matching the file's dominant quote style. Candidates are same-name open tags with **no** class handling of any form (a dynamic `className={…}` tag is excluded — inserting next to it would create a duplicate attribute, not a fix).
- **Anchoring ladder** (mirrors the resolver's philosophy — unique wins, ambiguity never guesses):
  1. All class-less `<tag>` candidates across indexed source files; **exactly one** → done.
  2. A **unique-in-source ancestor class** pins the component file; one candidate in that file → done.
  3. The element's **text content** (whitespace-normalized, ≥8 chars, 60-char probe in a bounded window after the tag line — same thresholds as `disambiguate_by_text`) pins one tag; if the ancestor pinned the wrong file (element lives in a child component), the text anchor retries across all candidates.
- **Honest failure mode**: zero or multiple confident candidates return a `Validation` error stating exactly what was searched — the tag, the candidate count, the files they're in, and whether the text probe helped — e.g. *"Couldn't tell which \<div\> in source to add the class to — 2 classless \<div\> tag(s) matched in A.tsx, B.tsx and it has no text to tell them apart. Add a class to it in code once, then the editor can manage it."* Nothing is ever written on ambiguity.
- **New `Resolution::NoClass` status** (`{ status: "no_class" }`): an element with no class at all is now distinguishable from a dynamic/computed class (`ReadOnly`), so frontends can offer *Add class* instead of a dead end with a wrong explanation. `resolve_element_html`/`apply_element_html` translate it to a specific "add a class first" error.

### Frontend

- `src/lib/edit.ts`: `insertClassAttr` wrapper + `no_class` added to the `Resolution` TS mirror.
- **Cascade editor** (`useElementSettings`): `addClass` on an element with an empty class list calls the insert command; on success it follows the exact same live-preview protocol as a class rewrite (`ss:suppressReload` → `ss:mutate` → `ss:commit`). Elements **with** classes keep the untouched resolve+replace path. Failures surface the backend's specific reason via the existing toast path.
- **Tailwind editor** (`useVisualEditor` + `VisualEditorPanel`): a `no_class` selection now renders a small "no classes yet" state with an input + **Add class** button (panel idiom, design tokens) instead of hiding everything. On success the hook re-resolves the element — the inserted literal is now its source anchor — and the panel transitions to the full controls. Class-less **images** keep their existing behavior (the Image section carries the state).

## Tests

- **Rust** (11 new unit tests): unique-tag insert with other attributes and a `>`-bearing arrow handler, text pinning among candidates, ancestor-file narrowing, multi-candidate rejection with the specific message, zero-candidate rejection, JSX vs Astro attribute naming + single-quote style matching, self-closing tags, static/dynamic-class/comment skipping, member-expression component (`<Select.Option>`) rejection, class-value validation, `NoClass` resolution + serialized shape.
- **Frontend** (6 new tests): `useElementSettings` insert-vs-replace branching and error surfacing, `useVisualEditor` add-first-class → re-resolve flow, `VisualEditorPanel` no-class state rendering and submit behavior.

## Verification

- `cargo test`: **680 passed, 0 failed**
- `tsc --noEmit`: clean
- `vitest run` (full suite): **88 files, 1210 passed**
- `eslint <touched files> --max-warnings 0`: clean; `pnpm check:patterns`: OK

## Known limitations of the anchoring strategy

- An element rendered by a **component under a different tag name** (e.g. a DOM `<div>` produced by `<Card>`) has no matching source tag — this correctly errors rather than guessing, with guidance to add a class in code once.
- Text anchoring uses a bounded 30-line window after the tag, so two identical-tag candidates within the same window can both match → rejected as ambiguous (safe, but requires a manual class in code).
- Elements whose only distinguishing signal is short text (<8 chars) or no text can only be pinned by uniqueness or an ancestor file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)