### PR TITLE
Editor: length presets use the app's styled dropdown, not the OS datalist

### DIFF
--- a/src/components/edit/CascadeRuleCard.tsx
+++ b/src/components/edit/CascadeRuleCard.tsx
@@ -388,7 +388,7 @@ function NestedSelectorInput({
 }
 
 /** A click-to-edit `@media` condition chip (shows the compact label, edits the raw
- *  condition with a native datalist of common conditions). */
+ *  condition with a styled SuggestionPopover of common conditions). */
 function MediaChip({
   condition,
   onCommit,

--- a/src/components/edit/LengthControl.tsx
+++ b/src/components/edit/LengthControl.tsx
@@ -2,12 +2,14 @@
  * Sizing control (width / height / max-width / min-height). A single free-form
  * field that accepts a Tailwind keyword (`full`, `screen`, `auto`), a fraction
  * (`1/2`), a scale step (`64`), or any CSS length (`480px`, `clamp(…)` → `w-[…]`),
- * with a datalist of common presets for discoverability. Always prefers the named
+ * with a styled preset dropdown for discoverability (the app's own SuggestionPopover,
+ * not the OS datalist popup, which ignores the theme). Always prefers the named
  * token, falling back to an arbitrary value only when off-scale.
  */
 
 import { useId, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { ResettableLabel } from './ResettableLabel';
+import { SuggestionPopover, suggestionOptionId, type Suggestion } from './SuggestionPopover';
 import {
   lengthValue,
   parseLengthInput,
@@ -28,6 +30,10 @@ interface Props {
   onReset: (spec: ResetSpec) => void;
 }
 
+/** True when the field holds a plain number or number+unit — the arrow keys step
+ *  those, so the preset menu stays out of the way. */
+const isNumericText = (s: string) => /^(-?\d*\.?\d+)\s*([a-z%]*)$/i.test(s.trim());
+
 export function LengthControl({
   label,
   prefix,
@@ -44,11 +50,25 @@ export function LengthControl({
   const [text, setText] = useState(display);
   const [lastDisplay, setLastDisplay] = useState(display);
   const [invalid, setInvalid] = useState(false);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [active, setActive] = useState(0);
   // Sync the field when the value changes externally (reselect, breakpoint switch).
   if (display !== lastDisplay && !invalid) {
     setLastDisplay(display);
     setText(display);
   }
+
+  // Preset suggestions: everything on empty text (discoverability), prefix-filtered
+  // while typing a keyword/fraction, suppressed entirely on numeric text so the
+  // arrow keys keep their stepping meaning.
+  const matches: Suggestion[] =
+    menuOpen && !isNumericText(text)
+      ? LENGTH_PRESETS.filter(
+          (p) => text.trim() === '' || p.startsWith(text.trim().toLowerCase())
+        ).map((p) => ({ value: p, label: p }))
+      : [];
+  const menuVisible = matches.length > 0;
 
   const commit = () => {
     if (text.trim() === '') return true; // empty = leave unset (no-op)
@@ -60,6 +80,15 @@ export function LengthControl({
     setInvalid(false);
     onApplyEnum(parsed.token, { [css]: parsed.css });
     return true;
+  };
+
+  const pick = (v: string) => {
+    const parsed = parseLengthInput(v, prefix, css);
+    setMenuOpen(false);
+    if (parsed.kind === 'invalid') return;
+    setText(v);
+    setInvalid(false);
+    onApplyEnum(parsed.token, { [css]: parsed.css });
   };
 
   /** ArrowUp/Down step a numeric value (bare scale step or number+unit, keeping
@@ -96,8 +125,13 @@ export function LengthControl({
         inputMode="text"
         autoCorrect="off"
         autoCapitalize="off"
+        autoComplete="off"
         spellCheck={false}
-        list={listId}
+        role="combobox"
+        aria-expanded={menuVisible}
+        aria-controls={listId}
+        aria-activedescendant={menuVisible ? suggestionOptionId(listId, active) : undefined}
+        aria-autocomplete="list"
         aria-label={label}
         aria-invalid={invalid}
         placeholder="auto"
@@ -107,25 +141,55 @@ export function LengthControl({
         value={text}
         onChange={(e) => {
           setText(e.target.value);
+          setMenuOpen(true);
+          setActive(0);
           if (invalid) setInvalid(false);
         }}
-        onFocus={(e) => e.target.select()}
+        onFocus={(e) => {
+          e.target.select();
+          setAnchorEl(e.currentTarget);
+          setMenuOpen(true);
+          setActive(0);
+        }}
         onBlur={() => {
+          setMenuOpen(false);
           if (!commit()) {
             setText(display);
             setInvalid(false);
           }
         }}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' && commit()) e.currentTarget.blur();
-          else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') onArrowStep(e);
+          if (e.key === 'Enter') {
+            if (menuVisible) {
+              e.preventDefault();
+              pick(matches[active]?.value ?? text);
+            } else if (commit()) {
+              e.currentTarget.blur();
+            }
+          } else if (e.key === 'Escape' && menuVisible) {
+            e.preventDefault();
+            setMenuOpen(false);
+          } else if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && menuVisible) {
+            // Menu open: arrows navigate the presets (same convention as the
+            // cascade editor's popover). Numeric text suppresses the menu, so
+            // stepping below still owns the arrows there.
+            e.preventDefault();
+            setActive((a) =>
+              e.key === 'ArrowDown' ? Math.min(a + 1, matches.length - 1) : Math.max(a - 1, 0)
+            );
+          } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+            onArrowStep(e);
+          }
         }}
       />
-      <datalist id={listId}>
-        {LENGTH_PRESETS.map((p) => (
-          <option key={p} value={p} />
-        ))}
-      </datalist>
+      <SuggestionPopover
+        anchor={anchorEl}
+        items={menuVisible ? matches : []}
+        active={active}
+        onPick={pick}
+        width={180}
+        listId={listId}
+      />
     </div>
   );
 }

--- a/src/components/edit/VisualEditorPanel.test.tsx
+++ b/src/components/edit/VisualEditorPanel.test.tsx
@@ -611,6 +611,63 @@ describe('VisualEditorPanel', () => {
     expect(width.value).toBe('full');
   });
 
+  // ── Length preset menu (styled SuggestionPopover, not the OS datalist) ──
+
+  it('opens a styled preset menu on focus and picks with Enter', () => {
+    const onApplyEnum = vi.fn();
+    render(
+      <VisualEditorPanel
+        {...mk()}
+        selection={resolvedSelection}
+        currentClass=""
+        onApplyEnum={onApplyEnum}
+      />
+    );
+    const width = screen.getByLabelText<HTMLInputElement>('Width');
+    fireEvent.focus(width);
+
+    // The app's own listbox renders (portaled), showing the presets.
+    const menu = screen.getByRole('listbox');
+    expect(menu).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'full' })).toBeInTheDocument();
+
+    // Arrows navigate the menu while it's open; Enter picks the active preset.
+    fireEvent.keyDown(width, { key: 'ArrowDown' });
+    fireEvent.keyDown(width, { key: 'Enter' });
+    expect(onApplyEnum).toHaveBeenCalledTimes(1);
+    const [token] = onApplyEnum.mock.calls[0] as [string];
+    expect(token.startsWith('w-')).toBe(true);
+  });
+
+  it('filters presets while typing a keyword', () => {
+    render(<VisualEditorPanel {...mk()} selection={resolvedSelection} currentClass="" />);
+    const width = screen.getByLabelText<HTMLInputElement>('Width');
+    fireEvent.focus(width);
+    fireEvent.change(width, { target: { value: 'fu' } });
+
+    expect(screen.getByRole('option', { name: 'full' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'screen' })).not.toBeInTheDocument();
+  });
+
+  it('suppresses the preset menu on numeric text so arrows keep stepping', () => {
+    const onApplyEnum = vi.fn();
+    render(
+      <VisualEditorPanel
+        {...mk()}
+        selection={resolvedSelection}
+        currentClass="w-64"
+        onApplyEnum={onApplyEnum}
+      />
+    );
+    const width = screen.getByLabelText<HTMLInputElement>('Width');
+    fireEvent.focus(width);
+
+    // Numeric value: no menu, arrows step the number instead of navigating.
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    fireEvent.keyDown(width, { key: 'ArrowUp' });
+    expect(onApplyEnum).toHaveBeenLastCalledWith('w-65', { width: '16.25rem' });
+  });
+
   // ── Image section (asset replacement) ──
 
   const imgSelection: Selection = {


### PR DESCRIPTION
## What

The SIZE & SPACING length fields (Width / Height / Max width / Min height) offered their presets through a `<datalist>`, which macOS renders as the OS's own light-gray popup — ignoring the app theme and clashing with every other dropdown in the panel (which use the app's styled menus).

They now use the same `SuggestionPopover` the cascade editor's chip inputs use:

- Opens on focus showing all presets (`full`, `screen`, `auto`, fractions…)
- Prefix-filters while typing a keyword
- ↑/↓ navigate the menu while it's open; Enter picks
- **Numeric text suppresses the menu entirely**, so the new arrow-key stepping (#213) keeps owning ↑/↓ there — same convention as the cascade editor's popover
- Full combobox ARIA (`aria-expanded`/`aria-activedescendant`)

Also fixes a stale doc comment claiming MediaChip uses a "native datalist" (it already uses SuggestionPopover) — after this PR there are zero datalists in the app.

## Tests

3 new tests: menu opens on focus + Enter picks, prefix filtering, numeric-text suppression keeps stepping. Full panel suite green (38), tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)