### PR TITLE
Pull button: optically balance horizontal padding

### DIFF
--- a/src/styles/features/branches/main.css
+++ b/src/styles/features/branches/main.css
@@ -15,7 +15,9 @@
   justify-content: center;
   gap: 6px;
   height: 28px;
-  padding: 0 var(--spacing-md);
+  /* Optically balanced: the icon glyph carries ~2px of built-in air on its
+     left while the text ends flush right, so equal padding reads lopsided. */
+  padding: 0 var(--spacing-md) 0 var(--spacing-sm);
   flex-shrink: 0;
   background: var(--bg-tertiary);
   border: 1px solid var(--border);


### PR DESCRIPTION
The header Pull button's symmetric 12px padding read lopsided — the icon's artwork has ~2px of built-in air on its left while the text ends flush right. Left padding drops to `--spacing-sm` so the visual insets match. The icon-only breakpoint variant (padding 0, centered in a 28px square) is unaffected.

Before/after is easiest to judge live: the space left of the ⤓ icon now matches the space right of "Pull".

🤖 Generated with [Claude Code](https://claude.com/claude-code)