### PR TITLE
Plugins: fix install failing silently on Windows

### DIFF
--- a/src-tauri/src/commands/plugins/mod.rs
+++ b/src-tauri/src/commands/plugins/mod.rs
@@ -22,7 +22,7 @@ pub use plugin_lifecycle::*;
 pub use plugin_storage::*;
 
 use crate::errors::CommandError;
-use crate::utils::{create_command, get_extended_path, validate_project_path};
+use crate::utils::{create_command, find_executable, get_extended_path, validate_project_path};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -312,7 +312,13 @@ pub(crate) fn read_manifest(plugin_dir: &std::path::Path) -> Result<PluginManife
 
 /// Read the HEAD commit hash from a git repo directory
 pub(crate) fn read_git_head(repo_dir: &PathBuf) -> String {
-    let output = create_command("git")
+    // Resolve git to a full path — a bare "git" with an overridden PATH can fail
+    // to spawn on Windows even when git is installed. A missing commit hash is
+    // non-fatal here (update checks fall back to "update available").
+    let Some(git) = find_executable("git") else {
+        return String::new();
+    };
+    let output = create_command(&git)
         .args(["rev-parse", "HEAD"])
         .current_dir(repo_dir)
         .env("PATH", get_extended_path())

--- a/src-tauri/src/commands/plugins/plugin_lifecycle.rs
+++ b/src-tauri/src/commands/plugins/plugin_lifecycle.rs
@@ -2,9 +2,9 @@
  * Plugin lifecycle commands: listing, installing, uninstalling, updating, and toggling plugins.
  */
 use crate::errors::CommandError;
-use crate::utils::{create_command, get_extended_path};
+use crate::utils::{create_command, find_executable, get_extended_path};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::AppHandle;
 
 use super::{
@@ -42,6 +42,66 @@ fn validate_clone_url(url: &str) -> Result<(), CommandError> {
         );
     }
     Ok(())
+}
+
+/// Resolve the `git` executable to an absolute path, mirroring how the setup
+/// wizard checks for git. Spawning bare `"git"` with an overridden `PATH` can
+/// fail to resolve on Windows even when git is installed; resolving the full
+/// path first avoids that and lets us return a clear "install git" error.
+fn resolve_git() -> Result<PathBuf, CommandError> {
+    find_executable("git").ok_or_else(|| {
+        "Git isn't installed or couldn't be located. Install Git (https://git-scm.com) \
+         and restart Ship Studio, then try again."
+            .to_string()
+            .into()
+    })
+}
+
+/// `fs::rename` with a few retries. On Windows a rename briefly fails with a
+/// sharing violation while antivirus / the search indexer scan files git just
+/// wrote; a moment later the same rename succeeds.
+fn rename_with_retry(from: &Path, to: &Path) -> std::io::Result<()> {
+    let mut result = fs::rename(from, to);
+    for _ in 0..4 {
+        if result.is_ok() {
+            return Ok(());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(120));
+        result = fs::rename(from, to);
+    }
+    result
+}
+
+/// `fs::remove_dir_all` that first clears read-only attributes. Git marks pack
+/// files under `.git` read-only, which makes a plain `remove_dir_all` fail on
+/// Windows with "Access is denied".
+fn remove_dir_all_relaxed(dir: &Path) -> std::io::Result<()> {
+    #[cfg(windows)]
+    clear_readonly_recursive(dir);
+    fs::remove_dir_all(dir)
+}
+
+/// Recursively clear the read-only flag on every file under `dir` so it can be
+/// deleted. Best-effort: unreadable entries are skipped.
+#[cfg(windows)]
+fn clear_readonly_recursive(dir: &Path) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        if metadata.is_dir() {
+            clear_readonly_recursive(&entry.path());
+        } else {
+            let mut perms = metadata.permissions();
+            if perms.readonly() {
+                perms.set_readonly(false);
+                let _ = fs::set_permissions(entry.path(), perms);
+            }
+        }
+    }
 }
 
 /// Normalize a git remote URL to a comparable `host/path` form: trims
@@ -147,13 +207,15 @@ pub async fn install_plugin(
     let plugins_dir = get_plugins_dir(&project_path)?;
     fs::create_dir_all(&plugins_dir).map_err(|e| format!("Failed to create plugins dir: {e}"))?;
 
+    let git = resolve_git()?;
+
     // Clone into a temp directory first, then move
     let temp_dir = plugins_dir.join(".tmp-install");
     if temp_dir.exists() {
-        let _ = fs::remove_dir_all(&temp_dir);
+        let _ = remove_dir_all_relaxed(&temp_dir);
     }
 
-    let output = create_command("git")
+    let output = create_command(&git)
         .args([
             "clone",
             "--depth",
@@ -168,7 +230,7 @@ pub async fn install_plugin(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        let _ = fs::remove_dir_all(&temp_dir);
+        let _ = remove_dir_all_relaxed(&temp_dir);
         return Err((format!("Git clone failed: {stderr}")).into());
     }
 
@@ -176,7 +238,7 @@ pub async fn install_plugin(
     let manifest = match read_manifest(&temp_dir) {
         Ok(m) => m,
         Err(e) => {
-            let _ = fs::remove_dir_all(&temp_dir);
+            let _ = remove_dir_all_relaxed(&temp_dir);
             return Err((format!("Invalid plugin: {e}")).into());
         }
     };
@@ -185,7 +247,7 @@ pub async fn install_plugin(
 
     // Validate manifest has required fields
     if manifest.id.is_empty() || manifest.name.is_empty() {
-        let _ = fs::remove_dir_all(&temp_dir);
+        let _ = remove_dir_all_relaxed(&temp_dir);
         return Err(("Plugin manifest must have 'id' and 'name' fields".to_string()).into());
     }
 
@@ -195,44 +257,46 @@ pub async fn install_plugin(
         || manifest.id.contains("..")
         || manifest.id.starts_with('.')
     {
-        let _ = fs::remove_dir_all(&temp_dir);
+        let _ = remove_dir_all_relaxed(&temp_dir);
         return Err(("Plugin ID contains invalid characters".to_string()).into());
     }
 
     // Check min_app_version compatibility
     if let Err(e) = check_min_app_version(&manifest, &app) {
-        let _ = fs::remove_dir_all(&temp_dir);
+        let _ = remove_dir_all_relaxed(&temp_dir);
         return Err(e.into());
     }
 
     // Validate required_commands are all in the allowed set
     if let Err(e) = validate_required_commands(&manifest) {
-        let _ = fs::remove_dir_all(&temp_dir);
+        let _ = remove_dir_all_relaxed(&temp_dir);
         return Err(e.into());
+    }
+
+    // Read the commit hash and strip `.git` while still in the temp dir, BEFORE
+    // the move. On Windows the move (rename) fails if any handle is open in the
+    // source tree, and git leaves read-only pack files under `.git` that scanners
+    // briefly hold — moving a directory with no `.git` avoids both problems.
+    let commit_hash = read_git_head(&temp_dir);
+    let temp_git_dir = temp_dir.join(".git");
+    if temp_git_dir.exists() {
+        let _ = remove_dir_all_relaxed(&temp_git_dir);
     }
 
     let plugin_dir = plugins_dir.join(&manifest.id);
 
     // Remove existing version if present
     if plugin_dir.exists() {
-        fs::remove_dir_all(&plugin_dir)
+        remove_dir_all_relaxed(&plugin_dir)
             .map_err(|e| format!("Failed to remove existing plugin: {e}"))?;
     }
 
-    // Move temp to final location
-    fs::rename(&temp_dir, &plugin_dir).map_err(|e| {
-        let _ = fs::remove_dir_all(&temp_dir);
+    // Move temp to final location (retried — Windows scanners transiently lock
+    // freshly written files).
+    rename_with_retry(&temp_dir, &plugin_dir).map_err(|e| {
+        let _ = remove_dir_all_relaxed(&temp_dir);
         format!("Failed to move plugin to final location: {e}")
     })?;
-
-    // Read commit hash before removing .git
-    let commit_hash = read_git_head(&plugin_dir);
-
-    // Remove .git directory (no need to keep it)
-    let git_dir = plugin_dir.join(".git");
-    if git_dir.exists() {
-        let _ = fs::remove_dir_all(&git_dir);
-    }
 
     // Update registry
     let mut registry = read_registry(&project_path)?;
@@ -338,16 +402,19 @@ pub async fn update_plugin(
 
     validate_clone_url(&source_url)?;
 
+    let git = resolve_git()?;
+
     // Re-install from source (clean install)
     let plugins_dir = get_plugins_dir(&project_path)?;
     let plugin_dir = plugins_dir.join(&plugin_id);
 
     if plugin_dir.exists() {
-        fs::remove_dir_all(&plugin_dir).map_err(|e| format!("Failed to remove old plugin: {e}"))?;
+        remove_dir_all_relaxed(&plugin_dir)
+            .map_err(|e| format!("Failed to remove old plugin: {e}"))?;
     }
 
     // Clone fresh
-    let output = create_command("git")
+    let output = create_command(&git)
         .args([
             "clone",
             "--depth",
@@ -368,10 +435,11 @@ pub async fn update_plugin(
     // Read commit hash before removing .git
     let commit_hash = read_git_head(&plugin_dir);
 
-    // Remove .git directory
+    // Remove .git directory (relaxed — git leaves read-only pack files that a
+    // plain remove_dir_all can't delete on Windows).
     let git_dir = plugin_dir.join(".git");
     if git_dir.exists() {
-        let _ = fs::remove_dir_all(&git_dir);
+        let _ = remove_dir_all_relaxed(&git_dir);
     }
 
     let manifest = read_manifest(&plugin_dir)?;
@@ -438,7 +506,8 @@ pub async fn check_plugin_update(
     let installed_version = manifest.version.clone();
 
     // Get remote HEAD commit via git ls-remote
-    let output = create_command("git")
+    let git = resolve_git()?;
+    let output = create_command(&git)
         .args(["ls-remote", &source_url, "HEAD"])
         .env("PATH", get_extended_path())
         .output()
@@ -496,7 +565,11 @@ pub fn toggle_plugin(
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_repo_url, repo_urls_match, validate_clone_url};
+    use super::{
+        normalize_repo_url, remove_dir_all_relaxed, rename_with_retry, repo_urls_match,
+        validate_clone_url,
+    };
+    use std::fs;
 
     #[test]
     fn accepts_normal_remotes() {
@@ -566,6 +639,36 @@ mod tests {
         // Dev plugins have empty source URLs — never match
         assert!(!repo_urls_match("", ""));
         assert!(!repo_urls_match("", "https://github.com/a/b"));
+    }
+
+    #[test]
+    fn removes_dir_with_readonly_files() {
+        // Mirrors what git leaves under `.git`: read-only files that a plain
+        // remove_dir_all can't delete on Windows.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("repo");
+        fs::create_dir_all(root.join("objects")).unwrap();
+        let file = root.join("objects").join("pack");
+        fs::write(&file, b"data").unwrap();
+        let mut perms = fs::metadata(&file).unwrap().permissions();
+        perms.set_readonly(true);
+        fs::set_permissions(&file, perms).unwrap();
+
+        remove_dir_all_relaxed(&root).unwrap();
+        assert!(!root.exists());
+    }
+
+    #[test]
+    fn rename_with_retry_moves_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let from = tmp.path().join("src");
+        let to = tmp.path().join("dst");
+        fs::create_dir_all(&from).unwrap();
+        fs::write(from.join("f.txt"), b"x").unwrap();
+
+        rename_with_retry(&from, &to).unwrap();
+        assert!(!from.exists());
+        assert!(to.join("f.txt").exists());
     }
 
     #[test]

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -222,12 +222,16 @@ fn build_extended_path() -> String {
 
         if let Ok(program_files) = std::env::var("ProgramFiles") {
             windows_paths.push(format!("{}\\GitHub CLI", program_files));
+            // Git for Windows ships git.exe in both \cmd and \bin — list both so
+            // resolution never depends on the inherited system PATH.
+            windows_paths.push(format!("{}\\Git\\cmd", program_files));
             windows_paths.push(format!("{}\\Git\\bin", program_files));
             windows_paths.push(format!("{}\\nodejs", program_files));
         }
 
         if let Ok(program_files_x86) = std::env::var("ProgramFiles(x86)") {
             windows_paths.push(format!("{}\\GitHub CLI", program_files_x86));
+            windows_paths.push(format!("{}\\Git\\cmd", program_files_x86));
             windows_paths.push(format!("{}\\Git\\bin", program_files_x86));
             windows_paths.push(format!("{}\\nodejs", program_files_x86));
         }
@@ -235,6 +239,7 @@ fn build_extended_path() -> String {
         // User-specific paths
         if let Some(home) = dirs::home_dir() {
             let home_str = home.to_string_lossy();
+            windows_paths.push(format!("{}\\AppData\\Local\\Programs\\Git\\cmd", home_str));
             windows_paths.push(format!("{}\\AppData\\Local\\Programs\\Git\\bin", home_str));
             windows_paths.push(format!("{}\\AppData\\Roaming\\npm", home_str));
             windows_paths.push(format!(r"{}\.local\bin", home_str));
@@ -408,6 +413,12 @@ pub fn find_executable(cmd: &str) -> Option<std::path::PathBuf> {
                     .join("nodejs")
                     .join(&cmd_exe),
             );
+            // Git for Windows ships git.exe in both \cmd and \bin.
+            windows_paths.push(
+                std::path::PathBuf::from(&program_files)
+                    .join("Git\\cmd")
+                    .join(&cmd_exe),
+            );
             windows_paths.push(
                 std::path::PathBuf::from(&program_files)
                     .join("Git\\bin")
@@ -428,6 +439,11 @@ pub fn find_executable(cmd: &str) -> Option<std::path::PathBuf> {
             );
             windows_paths.push(
                 std::path::PathBuf::from(&program_files_x86)
+                    .join("Git\\cmd")
+                    .join(&cmd_exe),
+            );
+            windows_paths.push(
+                std::path::PathBuf::from(&program_files_x86)
                     .join("Git\\bin")
                     .join(&cmd_exe),
             );
@@ -435,6 +451,10 @@ pub fn find_executable(cmd: &str) -> Option<std::path::PathBuf> {
 
         // User-specific paths
         if let Some(home) = dirs::home_dir() {
+            windows_paths.push(
+                home.join("AppData\\Local\\Programs\\Git\\cmd")
+                    .join(&cmd_exe),
+            );
             windows_paths.push(
                 home.join("AppData\\Local\\Programs\\Git\\bin")
                     .join(&cmd_exe),

--- a/src/components/plugins/PluginManager.tsx
+++ b/src/components/plugins/PluginManager.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../lib/plugins';
 import type { LoadedPlugin } from '../../hooks/usePlugins';
 import { useModal } from '../../contexts/ModalContext';
+import { useOptionalToast } from '../../contexts/ToastContext';
 import { PluginInstallForm } from './PluginInstallForm';
 import { Spinner } from '../primitives/Spinner';
 import { PluginStatusGrid } from './PluginStatusGrid';
@@ -47,6 +48,7 @@ export function PluginManager({
   loadedPlugins = [],
 }: PluginManagerProps) {
   const { isOpen, close: onClose } = useModal('pluginManager');
+  const { showToast } = useOptionalToast();
   const [activeTab, setActiveTab] = useState<Tab>('installed');
   const [plugins, setPlugins] = useState<PluginInfo[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -258,7 +260,11 @@ export function PluginManager({
       logger.error('Failed to install plugin', {
         error: err instanceof Error ? err.message : String(err),
       });
-      setError(formatCommandError(asCommandError(err)));
+      const msg = formatCommandError(asCommandError(err));
+      setError(msg);
+      // Toast too — the inline error renders below the plugin list, off-screen
+      // in a long library, so a failure otherwise looks like nothing happened.
+      showToast(msg, 'error');
       setInstallingId(null);
     }
   };
@@ -285,7 +291,9 @@ export function PluginManager({
       logger.error('Failed to install plugin from URL', {
         error: err instanceof Error ? err.message : String(err),
       });
-      setError(formatCommandError(asCommandError(err)));
+      const msg = formatCommandError(asCommandError(err));
+      setError(msg);
+      showToast(msg, 'error');
     } finally {
       setIsInstallingUrl(false);
     }


### PR DESCRIPTION
## Summary

Installing a plugin from the Plugin Manager could fail silently on Windows: the button showed "Installing…", reverted to "Install", and nothing installed — with no visible error. Reported by a Windows 11 user installing "Webflow to code".

The install path shells out to `git clone` into a temp dir, then `fs::rename`s it into place. Two Windows-specific failure modes weren't handled, and when either threw, the error was rendered below the plugin list (off-screen), so the failure looked like nothing happening.

**Backend**
- **git resolution** — install/update/check-update/`read_git_head` spawned bare `"git"` with an overridden `PATH`, which can fail to resolve on Windows even when git is installed (the setup wizard resolves it differently, so onboarding could report "git ✓" while install couldn't spawn it). Now resolves the full path via `find_executable("git")` and returns a clear "install Git" error when missing.
- Added `\Git\cmd` alongside `\Git\bin` in the extended `PATH` and executable search (Git for Windows ships `git.exe` in both).
- **temp→final move** — strip `.git` and read the commit hash *before* the move (so it carries no git-locked/read-only files), retry the rename to absorb transient AV/Search-indexer sharing violations, and clear read-only attributes before removing dirs (git's read-only pack files break `remove_dir_all` on Windows).

**Frontend**
- Surface install failures via a toast (`useOptionalToast`) so they're never off-screen — this is what made the failure invisible.

## Test plan
- [x] `cargo test plugins::` — added `removes_dir_with_readonly_files` and `rename_with_retry_moves_dir`; all 11 plugin tests pass
- [x] `pnpm test:run` — 1290 frontend tests pass (PluginManager change)
- [ ] Manual: install a plugin on Windows 11 with the built app (I don't have a Windows machine — would appreciate a maintainer/reporter verifying the end-to-end install there)

## CI gates
- [x] `pnpm check:all && pnpm test:run && pnpm rust:test` passes locally

<details>
<summary><strong>Patterns checklist</strong></summary>

**Rust**
- [x] Added tests for the new helpers
- Reused the existing plugin git-invocation pattern (no new `#[tauri::command]`s); the git calls here are not the `run_with_timeout` network-call pattern.

**Frontend**
- [x] Cross-cutting toast via `useOptionalToast()` (no `onToast?:` prop chain)
- No new modals / buttons / async-state triples / polling introduced.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin installation and updates on Windows, including better handling of Git detection, read-only files, and temporary file locks.
  * Added support for finding Git in additional standard installation locations.
  * Plugin installation errors now appear as toast notifications for clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->