### PR TITLE
Fix cross-project thumbnail contamination and dev-server port collisions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -224,6 +224,7 @@ function AppContents({ initialProjectPath }: AppProps) {
     devServerRef,
     healthPanelRef,
     devServerPort,
+    knownDevServerPort,
     setDevServerPort,
     projectType,
     isRestartingDevServer,
@@ -310,7 +311,9 @@ function AppContents({ initialProjectPath }: AppProps) {
     clearScreenshotInterval,
   } = useScreenshotManagement({
     previewRef,
-    devServerPort,
+    // Thumbnail capture must only ever target a port that provably belongs
+    // to the current project — null (skip) beats the 3000 fallback here.
+    devServerPort: knownDevServerPort,
     pasteToActiveTerminal,
     currentProjectPathRef,
   });

--- a/src/hooks/useDevServer.test.ts
+++ b/src/hooks/useDevServer.test.ts
@@ -63,6 +63,9 @@ describe('useDevServer', () => {
     const { result } = renderHook(() => useDevServer('/path/to/project'));
 
     expect(result.current.devServerPort).toBe(3000);
+    // No reservation, bind, or announcement yet — 3000 is a placeholder, not
+    // a port that belongs to this project.
+    expect(result.current.knownDevServerPort).toBeNull();
     expect(result.current.projectType).toBe('unknown');
     expect(result.current.isRestartingDevServer).toBe(false);
     expect(result.current.devServerOutputVersion).toBe(0);
@@ -137,6 +140,84 @@ describe('useDevServer', () => {
       });
 
       expect(result.current.devServerPort).toBe(8080);
+      expect(result.current.knownDevServerPort).toBe(8080);
+    });
+  });
+
+  describe('announced-port adoption', () => {
+    /** Start a PTY dev server and capture its output callback so tests can
+     *  feed it framework banner lines. */
+    async function startWithCapturedOutput(result: {
+      current: ReturnType<typeof useDevServer>;
+    }): Promise<(data: string) => void> {
+      const project = await import('../lib/project');
+      let onOutput: ((data: string) => void) | undefined;
+      vi.mocked(project.startDevServer).mockImplementation((_cwd, _port, _label, out) => {
+        onOutput = out;
+        return Promise.resolve({
+          pty: { kill: vi.fn(), onExit: vi.fn() } as never,
+          stop: vi.fn().mockResolvedValue(undefined),
+        } as never);
+      });
+      await act(async () => {
+        await result.current.startServerForProject('/path/to/project', 'proj', 3100, 'main');
+      });
+      expect(onOutput).toBeDefined();
+      return onOutput!;
+    }
+
+    it('adopts the port the dev server announces in its own output', async () => {
+      const { result } = renderHook(() => useDevServer('/path/to/project'));
+      const onOutput = await startWithCapturedOutput(result);
+
+      expect(result.current.devServerPort).toBe(3100);
+      expect(result.current.knownDevServerPort).toBe(3100);
+
+      // The requested port was taken — the framework auto-incremented.
+      act(() => {
+        onOutput('  ➜  Local:   http://localhost:3101/\n');
+      });
+
+      expect(result.current.devServerPort).toBe(3101);
+      expect(result.current.knownDevServerPort).toBe(3101);
+    });
+
+    it('strips ANSI colors before reading the announcement', async () => {
+      const { result } = renderHook(() => useDevServer('/path/to/project'));
+      const onOutput = await startWithCapturedOutput(result);
+
+      act(() => {
+        onOutput(
+          '  \x1b[32m➜\x1b[0m  \x1b[1mLocal\x1b[0m:   \x1b[36mhttp://localhost:4444/\x1b[0m\n'
+        );
+      });
+
+      expect(result.current.devServerPort).toBe(4444);
+    });
+
+    it('does not move the port for incidental localhost mentions', async () => {
+      const { result } = renderHook(() => useDevServer('/path/to/project'));
+      const onOutput = await startWithCapturedOutput(result);
+
+      act(() => {
+        onOutput('proxying api requests to http://localhost:8080\n');
+      });
+
+      expect(result.current.devServerPort).toBe(3100);
+    });
+
+    it('handles announcements split across PTY chunks', async () => {
+      const { result } = renderHook(() => useDevServer('/path/to/project'));
+      const onOutput = await startWithCapturedOutput(result);
+
+      act(() => {
+        onOutput('  - Local:        http://loc');
+      });
+      expect(result.current.devServerPort).toBe(3100);
+      act(() => {
+        onOutput('alhost:3102\n');
+      });
+      expect(result.current.devServerPort).toBe(3102);
     });
   });
 

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -83,6 +83,7 @@ import { trackEvent } from '../lib/analytics';
 import { getWindowLabel } from '../lib/window';
 import type { HealthTabPanelRef } from '../components/code/HealthTabPanel';
 import { stripAnsi } from '../lib/ansi';
+import { extractAnnouncedPort } from '../lib/ports';
 
 /** Record of a dev-server process that died without Ship Studio stopping it. */
 export interface DevServerUnexpectedExit {
@@ -97,6 +98,13 @@ export interface DevServerUnexpectedExit {
 interface ProjectServerState {
   handle: DevServerHandle | null;
   port: number;
+  /** False until `port` holds a value that affirmatively belongs to THIS
+   *  project — a reservation, a static-server bind, or a port the server
+   *  announced in its own output. While false, `port` is just the 3000
+   *  placeholder and must not be used for anything that writes per-project
+   *  artifacts (thumbnail capture targets the port and saves under the
+   *  project — a guessed port screenshots someone else's server). */
+  portKnown: boolean;
   type: ProjectType;
   customCommand: string | null;
   outputBuffer: string;
@@ -161,6 +169,7 @@ function makeState(): ProjectServerState {
   return {
     handle: null,
     port: DEFAULT_PORT,
+    portKnown: false,
     type: 'unknown',
     customCommand: null,
     outputBuffer: '',
@@ -275,6 +284,11 @@ export function useDevServer(currentProjectPath: string | null) {
   );
 
   const devServerPort = activeState?.port ?? DEFAULT_PORT;
+  // Null until the current project's port is affirmatively its own (reserved,
+  // static-bound, or announced by the server). Consumers that write
+  // per-project artifacts (thumbnail capture) must use this and skip on null
+  // rather than fall back to the 3000 placeholder.
+  const knownDevServerPort = activeState?.portKnown ? activeState.port : null;
   const projectType = activeState?.type ?? 'unknown';
   const customDevCommand = activeState?.customCommand ?? null;
   const needsInstall = activeState?.needsInstall ?? null;
@@ -343,6 +357,7 @@ export function useDevServer(currentProjectPath: string | null) {
       if (!path) return;
       const s = getOrCreateState(path);
       s.port = port;
+      s.portKnown = true;
       bump();
     },
     [bump, getOrCreateState]
@@ -463,6 +478,26 @@ export function useDevServer(currentProjectPath: string | null) {
         const { kept, pending } = filterProbeChunk(s.pendingOutputLine, data);
         s.pendingOutputLine = pending;
         if (!kept) return; // chunk was entirely buffered or entirely filtered
+        // Frameworks silently auto-increment when their requested port is
+        // taken, so the "Local: http://localhost:XXXX" line in their own
+        // output is the ground truth for which port THIS server bound —
+        // adopt it over the port we asked for. (Cheap substring pre-filter:
+        // every announcement shape contains "local" or "url:".)
+        if (/local|url:/i.test(kept)) {
+          for (const line of kept.split('\n')) {
+            const announced = line ? extractAnnouncedPort(stripAnsi(line)) : null;
+            if (announced !== null && (announced !== s.port || !s.portKnown)) {
+              logger.info('[DevServer] Adopting port announced by dev server', {
+                projectPath,
+                announced,
+                previous: s.port,
+              });
+              s.port = announced;
+              s.portKnown = true;
+              if (projectPath === currentPathRef.current) bump();
+            }
+          }
+        }
         s.outputBuffer += kept;
         if (s.outputBuffer.length > OUTPUT_BUFFER_MAX) {
           s.outputBuffer = s.outputBuffer.slice(-OUTPUT_BUFFER_MAX);
@@ -522,6 +557,7 @@ export function useDevServer(currentProjectPath: string | null) {
       // Re-enable output handling for the (possibly new) server on this path.
       s.suppressed = false;
       s.port = port;
+      s.portKnown = true;
       // A fresh spawn supersedes any prior death — clear the record so the
       // Preview pane doesn't keep reporting a stale "process stopped".
       s.unexpectedExit = null;
@@ -659,6 +695,7 @@ export function useDevServer(currentProjectPath: string | null) {
         try {
           const staticPort = await startStaticServer(windowLabel, cwd);
           s.port = staticPort;
+          s.portKnown = true;
           bump();
           void trackEvent('dev_server_started', {
             project_type: 'statichtml',
@@ -878,6 +915,8 @@ export function useDevServer(currentProjectPath: string | null) {
         if (!s.handle) {
           logger.error('Failed to start dev server: spawn timed out');
         } else {
+          s.port = effectivePort;
+          s.portKnown = true;
           wireExitWatcher(projectPath, s);
         }
       };
@@ -926,6 +965,7 @@ export function useDevServer(currentProjectPath: string | null) {
           await delay(300);
           const newPort = await startStaticServer(windowLabel, cwd);
           s.port = newPort;
+          s.portKnown = true;
           bump();
         } else {
           try {
@@ -1038,6 +1078,7 @@ export function useDevServer(currentProjectPath: string | null) {
 
     // Current-project scalars
     devServerPort,
+    knownDevServerPort,
     setDevServerPort,
     projectType,
     setProjectType,

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -71,9 +71,7 @@ import { startProjectSession, endProjectSession } from '../lib/session';
 import { basename } from '../lib/paths';
 
 import type { AppView } from '../lib/types';
-
-/** Preferred port for Next.js dev server (will find available port if taken) */
-const PREFERRED_DEV_SERVER_PORT = 3000;
+import { preferredPortForProject } from '../lib/ports';
 
 export interface UseProjectLifecycleParams {
   currentProject: Project | null;
@@ -587,9 +585,12 @@ export function useProjectLifecycle({
       return;
     }
 
-    // Load saved dev server port preference
+    // Load saved dev server port preference. Absent an explicit per-project
+    // setting, the preference is derived from the project path — every
+    // project preferring 3000 meant reservation order (not the project)
+    // decided who got which port, and any desync previewed the wrong server.
     stepStart = performance.now();
-    let preferredPort = PREFERRED_DEV_SERVER_PORT;
+    let preferredPort = preferredPortForProject(project.path);
     try {
       const savedPort = await invoke<number | null>('get_dev_server_port', {
         projectPath: project.path,

--- a/src/hooks/useScreenshotManagement.test.ts
+++ b/src/hooks/useScreenshotManagement.test.ts
@@ -174,6 +174,46 @@ describe('useScreenshotManagement auto-capture consent gate', () => {
     expect(invokeMock).toHaveBeenCalledTimes(1);
   });
 
+  it('unknown port: skips capture instead of guessing a fallback', async () => {
+    vi.mocked(getThumbnailsEnabled).mockResolvedValue(true);
+    const { result } = renderHook(() =>
+      useScreenshotManagement({ ...makeParams(), devServerPort: null })
+    );
+
+    await triggerAutoCapture(result);
+
+    // No capture and no consent prompt — a guessed port could screenshot a
+    // different project's server into this project's thumbnail.
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(result.current.showThumbnailConsent).toBe(false);
+  });
+
+  it('captures with the port current at capture time, not schedule time', async () => {
+    vi.mocked(getThumbnailsEnabled).mockResolvedValue(true);
+    const base = makeParams();
+    let port: number | null = 3100;
+    const { result, rerender } = renderHook(() =>
+      useScreenshotManagement({ ...base, devServerPort: port })
+    );
+
+    act(() => {
+      result.current.handlePreviewReady(PROJECT);
+    });
+
+    // The dev server announces it actually bound a different port while the
+    // 8s capture delay is pending.
+    port = 3101;
+    rerender();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8_000);
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith('capture_project_thumbnail', {
+      projectPath: PROJECT,
+      url: 'http://localhost:3101',
+    });
+  });
+
   it('non-denial failure keeps the retry behavior', async () => {
     vi.mocked(getThumbnailsEnabled).mockResolvedValue(true);
     invokeMock.mockRejectedValue('Dev server not responding, skipping thumbnail capture');

--- a/src/hooks/useScreenshotManagement.ts
+++ b/src/hooks/useScreenshotManagement.ts
@@ -24,7 +24,12 @@ const SCREENSHOT_INTERVAL_MS = 5 * 60 * 1000;
 
 interface UseScreenshotManagementParams {
   previewRef: RefObject<PreviewHandle | null>;
-  devServerPort: number;
+  /** The current project's dev-server port, or null when no port is
+   *  affirmatively known for it. Capture writes into the project's own
+   *  `.shipstudio/thumbnail.png`, so a guessed/fallback port here would
+   *  screenshot whatever server happens to answer it — possibly another
+   *  project's — and file it under the wrong project. Null skips capture. */
+  devServerPort: number | null;
   pasteToActiveTerminal: (text: string) => void;
   currentProjectPathRef: RefObject<string | null>;
 }
@@ -35,6 +40,12 @@ export function useScreenshotManagement({
   pasteToActiveTerminal,
   currentProjectPathRef,
 }: UseScreenshotManagementParams) {
+  // Read the port through a ref at capture time. The 5-minute interval and
+  // its retry timers hold long-lived closures — a closed-over port would go
+  // stale the moment the server moves, and the stale port may belong to a
+  // different project by then.
+  const devServerPortRef = useRef(devServerPort);
+  devServerPortRef.current = devServerPort;
   // Capture state
   const [isCapturing, setIsCapturing] = useState(false);
   const [isCropMode, setIsCropMode] = useState(false);
@@ -138,6 +149,13 @@ export function useScreenshotManagement({
         });
         return;
       }
+      const port = devServerPortRef.current;
+      if (port === null) {
+        logger.info('[Thumbnail] Skipping - no port affirmatively known for project', {
+          projectPath,
+        });
+        return;
+      }
       const decision = decideAutoCapture(await getThumbnailsEnabled());
       if (decision === 'skip') {
         logger.info('[Thumbnail] Skipping - thumbnails disabled in Settings');
@@ -154,13 +172,13 @@ export function useScreenshotManagement({
       try {
         logger.info('[Thumbnail] Capturing now', {
           projectPath,
-          port: devServerPort,
+          port,
           attempt,
           sessionId,
         });
         await invoke('capture_project_thumbnail', {
           projectPath,
-          url: `http://localhost:${devServerPort}`,
+          url: `http://localhost:${port}`,
         });
         logger.info('Thumbnail captured successfully', { projectPath, attempt });
       } catch (error) {
@@ -195,7 +213,7 @@ export function useScreenshotManagement({
         }
       }
     },
-    [devServerPort, previewRef, currentProjectPathRef]
+    [previewRef, currentProjectPathRef]
   );
 
   // Called when preview server signals it's ready

--- a/src/lib/ports.test.ts
+++ b/src/lib/ports.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for dev-server port helpers.
+ *
+ * `extractAnnouncedPort` is the ground-truth reader for which port a dev
+ * server actually bound (frameworks auto-increment when their requested port
+ * is taken) — false negatives mean the preview trusts a wrong port, false
+ * positives mean random log lines move the preview. Both directions matter.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  extractAnnouncedPort,
+  preferredPortForProject,
+  DEV_PORT_RANGE_START,
+  DEV_PORT_RANGE_SIZE,
+} from './ports';
+
+describe('preferredPortForProject', () => {
+  it('is deterministic for the same path', () => {
+    const path = '/Users/test/ShipStudio/my-app';
+    expect(preferredPortForProject(path)).toBe(preferredPortForProject(path));
+  });
+
+  it('stays within the assigned range', () => {
+    const paths = [
+      '/Users/test/ShipStudio/a',
+      '/Users/test/ShipStudio/b',
+      '/Users/other/Projects/deeply/nested/project-name',
+      '',
+    ];
+    for (const p of paths) {
+      const port = preferredPortForProject(p);
+      expect(port).toBeGreaterThanOrEqual(DEV_PORT_RANGE_START);
+      expect(port).toBeLessThan(DEV_PORT_RANGE_START + DEV_PORT_RANGE_SIZE);
+    }
+  });
+
+  it('spreads distinct projects to distinct ports (typical case)', () => {
+    expect(preferredPortForProject('/Users/test/ShipStudio/storefront')).not.toBe(
+      preferredPortForProject('/Users/test/ShipStudio/dashboard')
+    );
+  });
+});
+
+describe('extractAnnouncedPort', () => {
+  it('reads the Next.js 13+ banner', () => {
+    expect(extractAnnouncedPort('   - Local:        http://localhost:3000')).toBe(3000);
+  });
+
+  it('reads the Vite banner (trailing slash)', () => {
+    expect(extractAnnouncedPort('  ➜  Local:   http://localhost:5173/')).toBe(5173);
+  });
+
+  it('reads the Astro banner (no colon after Local)', () => {
+    expect(extractAnnouncedPort('┃ Local    http://localhost:4321/')).toBe(4321);
+  });
+
+  it('reads the CRA / webpack-dev-server banner', () => {
+    expect(extractAnnouncedPort('  Local:            http://localhost:3000')).toBe(3000);
+  });
+
+  it('reads the Next.js ≤12 "started server" banner', () => {
+    expect(
+      extractAnnouncedPort('ready - started server on 0.0.0.0:3000, url: http://localhost:3001')
+    ).toBe(3001);
+  });
+
+  it('accepts 127.0.0.1 and 0.0.0.0 hosts', () => {
+    expect(extractAnnouncedPort('Local:   http://127.0.0.1:8080/')).toBe(8080);
+    expect(extractAnnouncedPort('Local:   http://0.0.0.0:4000')).toBe(4000);
+  });
+
+  it('ignores localhost URLs without a Local announcement label', () => {
+    expect(extractAnnouncedPort('proxying request to http://localhost:8080')).toBeNull();
+    expect(extractAnnouncedPort('connect to http://localhost:9000 for devtools')).toBeNull();
+    expect(extractAnnouncedPort('Last request was GET / 200')).toBeNull();
+  });
+
+  it('ignores the Network (LAN) URL line', () => {
+    expect(extractAnnouncedPort('  ➜  Network: http://192.168.1.5:5173/')).toBeNull();
+  });
+
+  it('does not treat "localhost" itself as the Local label', () => {
+    // "local" is a prefix of "localhost" — the separator requirement must
+    // keep a bare URL from matching as its own announcement.
+    expect(extractAnnouncedPort('http://localhost:3000')).toBeNull();
+  });
+
+  it('rejects out-of-range ports', () => {
+    expect(extractAnnouncedPort('Local: http://localhost:99999')).toBeNull();
+  });
+
+  it('returns null for empty and unrelated lines', () => {
+    expect(extractAnnouncedPort('')).toBeNull();
+    expect(extractAnnouncedPort('webpack compiled successfully')).toBeNull();
+  });
+});

--- a/src/lib/ports.ts
+++ b/src/lib/ports.ts
@@ -1,0 +1,69 @@
+/**
+ * Dev-server port helpers.
+ *
+ * Two jobs, one theme — keeping the port Ship Studio *believes* a project is
+ * on tied to the server that's actually running:
+ *
+ * - `preferredPortForProject` spreads projects across a deterministic port
+ *   range instead of having every project fight over 3000. Same path → same
+ *   port, every launch, no persistence needed.
+ * - `extractAnnouncedPort` reads the port a dev server *says* it bound from
+ *   its own startup output. Frameworks silently auto-increment when their
+ *   requested port is taken (Next/Vite bind 3001 when 3000 is busy), so the
+ *   announced URL is the only ground truth — trusting the requested port is
+ *   how previews and thumbnails end up pointed at a different project's
+ *   server.
+ *
+ * @module lib/ports
+ */
+
+/** Start of the auto-assigned dev port range. Deliberately clear of 3000 —
+ *  the port user- and agent-started servers grab by convention — so Ship
+ *  Studio's own servers don't race them for it. */
+export const DEV_PORT_RANGE_START = 3100;
+/** Ports DEV_PORT_RANGE_START .. START+SIZE-1 are handed out by hash. */
+export const DEV_PORT_RANGE_SIZE = 900;
+
+/**
+ * Deterministic preferred dev-server port for a project, derived from its
+ * path (FNV-1a, same scheme as `lib/projectIdentity`). Collisions between
+ * two projects are possible (~900 slots) but harmless — `findAndReservePort`
+ * still probes upward from the preference and guarantees uniqueness among
+ * live servers.
+ */
+export function preferredPortForProject(projectPath: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < projectPath.length; i++) {
+    h ^= projectPath.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return DEV_PORT_RANGE_START + ((h >>> 0) % DEV_PORT_RANGE_SIZE);
+}
+
+/* Matches the localhost URL in a dev server's startup banner, anchored on the
+   "Local" label so request logs and proxy chatter that merely *mention* a
+   localhost URL don't match:
+     Next.js   `- Local:        http://localhost:3000`
+     Vite      `➜  Local:   http://localhost:5173/`
+     Astro     `┃ Local    http://localhost:4321/`
+     CRA       `Local:            http://localhost:3000`
+   `\blocal` cannot match inside "localhost" because the required `:? \s+`
+   separator fails against the trailing "host". */
+const ANNOUNCED_LOCAL_URL =
+  /\blocal:?\s+https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1?\]):(\d{1,5})(?=[/\s]|$)/i;
+
+/* Next.js ≤12 banner has no "Local" label:
+   `ready - started server on 0.0.0.0:3000, url: http://localhost:3000` */
+const ANNOUNCED_URL_FIELD =
+  /\bstarted server on\s+\S+,\s*url:\s*https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(\d{1,5})(?=[/\s]|$)/i;
+
+/**
+ * Extract the port a dev server announces it actually bound, from one line of
+ * its (ANSI-stripped) output. Returns null when the line announces nothing.
+ */
+export function extractAnnouncedPort(line: string): number | null {
+  const match = ANNOUNCED_LOCAL_URL.exec(line) ?? ANNOUNCED_URL_FIELD.exec(line);
+  if (!match) return null;
+  const port = Number(match[1]);
+  return port >= 1 && port <= 65535 ? port : null;
+}


### PR DESCRIPTION
## Problem

Two user-visible bugs with one root cause — **the port a project's dev server was assumed to be on was never verified against the server actually listening there**:

1. Dashboard thumbnails sometimes showed a *different project's* page.
2. Dev servers collided because every project preferred port 3000.

## Changes

- **Announced-port adoption** (`useDevServer`): parse the `Local: http://localhost:XXXX` banner from the dev server's own output (Next.js old/new, Vite, Astro, CRA formats; ANSI- and chunk-split-safe) and adopt it as ground truth. Frameworks silently bind port+1 when their requested port is taken — previously the preview, proxy, and thumbnail capture kept pointing at the reserved port, i.e. at whatever server happened to hold it. Also fixes previews for custom dev commands, which never received our `--port` flag.
- **Deterministic per-project ports** (`src/lib/ports.ts`): preferred port is derived from the project path hash into 3100–3999 instead of everyone fighting over 3000. An explicitly saved `dev_server_port` still wins; the existing reservation system still resolves hash collisions.
- **Thumbnail capture requires an affirmatively-known port** (`knownDevServerPort`): no more silent 3000 fallback during project switches, and the capture interval reads the port through a ref so a stale closure can't screenshot another project's server into this project's `thumbnail.png`.

## Verified

- 1,323 tests pass (~20 new: banner parsing, port adoption incl. ANSI/chunk-split, capture skip/freshness guards).
- Live-tested in `pnpm tauri dev`: two hot projects got distinct hash ports (3350/3503), thumbnails captured on the correct project-owned port on first attempt, saved-port project untouched.

## Rollout note

Projects whose own config hardcodes `http://localhost:3000` (NEXTAUTH_URL, OAuth callback registrations, CORS allowlists) will come up on a new port after this ships. The in-app per-project port setting is the remedy (set it back to 3000). **Release checklist: add a "projects now get their own dedicated port" entry to `Changelog.tsx`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development server port detection and tracking, including ports announced by supported frameworks.
  * Prevented screenshots and thumbnails from using unconfirmed or outdated server ports.
  * Ensured screenshot capture uses the latest confirmed port when delayed.
  * Reduced port conflicts by assigning project-specific preferred ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->