### PR TITLE
Windows starts agent-led onboarding by default

### DIFF
--- a/src/components/setup/OnboardingRouter.test.tsx
+++ b/src/components/setup/OnboardingRouter.test.tsx
@@ -37,19 +37,19 @@ describe('OnboardingRouter', () => {
     expect(screen.queryByTestId('classic-screen')).not.toBeInTheDocument();
   });
 
-  it('defaults Windows to the classic wizard (agent-led stays opt-in)', () => {
+  it('defaults Windows to the agent-led experience too', () => {
     isWindowsMock.mockReturnValue(true);
-    render(<OnboardingRouter onComplete={vi.fn()} />);
-    expect(screen.getByTestId('classic-screen')).toBeInTheDocument();
-    // The opt-in toggle into agent-led is still pinned in view.
-    expect(screen.getByRole('button', { name: 'Try agent-guided setup' })).toBeInTheDocument();
-  });
-
-  it('a stored agent choice on Windows overrides the classic default', () => {
-    isWindowsMock.mockReturnValue(true);
-    localStorage.setItem('shipstudio.onboardingMode', 'agent');
     render(<OnboardingRouter onComplete={vi.fn()} />);
     expect(screen.getByTestId('agent-screen')).toBeInTheDocument();
+    // The classic escape hatch stays pinned in view.
+    expect(screen.getByRole('button', { name: 'Try classic onboarding' })).toBeInTheDocument();
+  });
+
+  it('a stored classic choice on Windows overrides the agent default', () => {
+    isWindowsMock.mockReturnValue(true);
+    localStorage.setItem('shipstudio.onboardingMode', 'classic');
+    render(<OnboardingRouter onComplete={vi.fn()} />);
+    expect(screen.getByTestId('classic-screen')).toBeInTheDocument();
   });
 
   it('always shows the classic escape hatch in agent mode', () => {

--- a/src/components/setup/OnboardingRouter.tsx
+++ b/src/components/setup/OnboardingRouter.tsx
@@ -13,18 +13,18 @@ import { OnboardingScreen } from './OnboardingScreen';
 import { AgentOnboardingScreen } from './agent-led/AgentOnboardingScreen';
 import { trackEvent } from '../../lib/analytics';
 import { logger } from '../../lib/logger';
-import { isWindows } from '../../lib/setup';
 
 export type OnboardingMode = 'agent' | 'classic';
 
 const MODE_STORAGE_KEY = 'shipstudio.onboardingMode';
 
 function readStoredMode(): OnboardingMode {
-  // Windows defaults to the classic wizard until the agent-led flow gets a
-  // real Windows pass — a broken first run is the one place the "classic is
-  // one click away" fallback isn't enough, because a brand-new user doesn't
-  // know it's the fix. "Try agent-guided setup" stays available as an opt-in.
-  const fallback: OnboardingMode = isWindows() ? 'classic' : 'agent';
+  // Agent-led is the default on every platform. Windows briefly defaulted to
+  // the classic wizard while the agent-led flow was runtime-untested there;
+  // with the Windows terminal-spawn fix (#218) landed and the flow's winget/
+  // PowerShell paths in place, both platforms start agent-led. "Try classic
+  // onboarding" stays pinned as the always-available escape hatch.
+  const fallback: OnboardingMode = 'agent';
   try {
     const stored = localStorage.getItem(MODE_STORAGE_KEY);
     if (stored === 'classic' || stored === 'agent') return stored;


### PR DESCRIPTION
## Summary

Flips the Windows onboarding default from the classic wizard back to the agent-led flow, per Julian.

The classic-first gate (bb28e71) existed because agent-led was **runtime-untested on Windows** — and the known blocker underneath it, the broken Windows terminal spawn shell path, was fixed in #218. The agent-led flow's Windows pathways were already implemented: winget install commands (Node/Git/GitHub CLI + the App Installer guidance), a PowerShell terminal for the "Other" agent path, and cmd-shim handling in the guided prompt builder.

Behavior:
- Both platforms now default to `agent` mode; a stored `shipstudio.onboardingMode` choice still wins.
- "Try classic onboarding" stays pinned as the always-available escape hatch.

## Test plan
- [x] Router tests updated: Windows defaults to agent-led (with the classic escape hatch visible); a stored classic choice on Windows overrides the default
- [x] Full frontend suite passes (1296 tests)
- [ ] ⚠️ Real-Windows smoke test of the guided flow still wanted before the next Windows release tag — this flip restores default exposure but doesn't substitute for a runtime pass (#79 is the help-wanted channel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding now defaults to the agent-led experience across all platforms.
  * Windows users can still switch to the classic onboarding flow using the escape-hatch option.
  * Previously selected onboarding modes are preserved, including classic mode on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->