### PR TITLE
feat(dashboard): cap project list at 30 with a View all button

### DIFF
--- a/src/components/dashboard/ProjectList.tsx
+++ b/src/components/dashboard/ProjectList.tsx
@@ -55,6 +55,7 @@ import { ProjectBulkActionConfirm } from './ProjectBulkActionConfirm';
 import { DashboardPreferencesCard } from './DashboardPreferencesCard';
 import { DashboardCommunityBanner } from './DashboardCommunityBanner';
 import { Spinner } from '../primitives/Spinner';
+import { Button } from '../primitives/Button';
 import { GitHubCalendar } from './GitHubCalendar';
 import { useModal } from '../../contexts/ModalContext';
 import {
@@ -87,6 +88,9 @@ interface ProjectWithThumbnail extends DashboardProject {
 
 /** Available sort options for the project list */
 type SortOption = 'last_opened' | 'name';
+
+/** Projects shown before the list truncates behind a "View all" button. */
+const PROJECT_DISPLAY_LIMIT = 30;
 
 const PROJECT_VIEW_MODE_STORAGE_KEY = 'ship-studio-project-view-mode';
 
@@ -200,6 +204,7 @@ export function ProjectList({
   // dead useState.
   const searchQuery: string = '';
   const [sortBy, setSortBy] = useState<SortOption>('last_opened');
+  const [showAllProjects, setShowAllProjects] = useState(false);
   const [projectViewMode, setProjectViewMode] =
     useState<ProjectViewMode>(getInitialProjectViewMode);
 
@@ -338,6 +343,20 @@ export function ProjectList({
     return result;
   }, [projects, displayedProjects, searchQuery, sortBy]);
 
+  // Re-collapse the list when the visible collection changes (folder
+  // navigation or workspace switch) so each view starts truncated.
+  useEffect(() => {
+    setShowAllProjects(false);
+  }, [currentFolderId, activeAccountId]);
+
+  // Cap the rendered list so large dashboards don't force endless scrolling;
+  // "View all" lifts the cap for the current view.
+  const visibleProjects = useMemo(
+    () => (showAllProjects ? filteredProjects : filteredProjects.slice(0, PROJECT_DISPLAY_LIMIT)),
+    [filteredProjects, showAllProjects]
+  );
+  const hiddenProjectCount = filteredProjects.length - visibleProjects.length;
+
   // Filter folders by search query
   const filteredFolders = useMemo(() => {
     if (!searchQuery || currentFolderId) return folders;
@@ -361,7 +380,7 @@ export function ProjectList({
     handleBeginBulkProjectAction,
     handleBulkProjectAction,
   } = useProjectBulkActions({
-    filteredProjects,
+    filteredProjects: visibleProjects,
     pinnedSet,
     onTogglePin,
     loadAll,
@@ -678,7 +697,7 @@ export function ProjectList({
           searchQuery={searchQuery}
           totalCount={totalCount}
           filteredFolders={filteredFolders}
-          filteredProjects={filteredProjects}
+          filteredProjects={visibleProjects}
           selectedProjectPaths={selectedProjectPaths}
           allVisibleSelected={allVisibleSelected}
           someVisibleSelected={someVisibleSelected}
@@ -702,6 +721,14 @@ export function ProjectList({
           onTogglePin={onTogglePin}
           onCreateProject={onCreateProject}
         />
+
+        {hiddenProjectCount > 0 && (
+          <div className="project-list-view-all">
+            <Button variant="secondary" onClick={() => setShowAllProjects(true)}>
+              + View all {filteredProjects.length} projects
+            </Button>
+          </div>
+        )}
 
         <AgentsPanel />
 

--- a/src/styles/features/project-list.css
+++ b/src/styles/features/project-list.css
@@ -128,6 +128,13 @@
   margin-bottom: 32px;
 }
 
+.project-list-view-all {
+  display: flex;
+  justify-content: center;
+  margin-top: 16px;
+  margin-bottom: 32px;
+}
+
 .project-list-empty {
   text-align: center;
   padding: 60px 24px;


### PR DESCRIPTION
## Summary

Large dashboards currently render every project card, forcing a long scroll past the grid to reach the Agents/Preferences/Machine Tools panels below. This caps the rendered project list at 30 and shows a centered **"+ View all N projects"** button (`<Button variant="secondary">`) that lifts the cap for the current view.

Details:
- The cap re-applies when navigating into/out of a folder or switching workspaces, so each view starts truncated.
- The "All Projects" header count still reflects the true total.
- `useProjectBulkActions` now receives the visible slice, so "select all visible" in list view matches what's actually rendered instead of silently selecting hidden projects.
- Truncation lives in `ProjectList` as a `useMemo` slice over the already-filtered/sorted list; `ProjectGridView` is unchanged.

## Test plan

- [x] Verified in `pnpm tauri dev` with 30+ projects: grid stops at 30, button shows correct total, clicking expands the full list
- [x] Folder navigation and workspace switching re-collapse the list; folders and header counts unaffected
- [x] `pnpm typecheck`, `pnpm lint:strict`, `pnpm format:check`, `pnpm check:patterns`, `pnpm check:loc` (ProjectList.tsx at 888/900), `pnpm test:run` (1345 passed) all pass locally

## CI gates

- [ ] `pnpm check:all && pnpm test:run && pnpm rust:test` passes locally — frontend gates all pass (see above); `rust:test`/clippy not re-run locally as no Rust files are touched

<details>
<summary><strong>Patterns checklist</strong></summary>

**Frontend**
- [x] New buttons use `<Button variant=…>` (no new `foo-btn` classes)
- ~~New modals use `<ModalFrame>`~~ (no modals added)
- ~~New async state uses `useAsyncState` / `useInvoke`~~ (no async state added)
- ~~New polling uses `usePolling`~~ (no polling added)
- ~~Modal state uses `useModal('id')`~~ (no modal state added)

**CSS**
- [x] No raw hex colors or z-index values; `.project-list-view-all` uses px margins consistent with the rest of `project-list.css`
- [x] Styles added to existing `src/styles/features/project-list.css`

**Rust**
- ~~Not applicable — no Rust changes~~

**Tests**
- [ ] No new tests: the change is a render-cap slice in a component with no existing test harness; happy to add a `ProjectList` truncation test if maintainers want one

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project lists now display a limited number of projects by default for easier browsing.
  * Added a “View all” button to reveal additional projects when available.
  * The list resets to its default collapsed view when navigating between folders or workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->