### PR TITLE
Worktrees: work on multiple branches of one project simultaneously

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -133,6 +133,10 @@ property), `bulk` (count, from the Code view's save), or `created_rule`.
 | `branch_created` | `from_branch` |
 | `branch_switched` | — |
 | `branch_deleted` | — |
+| `worktree_created` | `created_branch` (new vs existing branch), `copied_env` |
+| `worktree_switched` | `via` (`branches_tab` / `branch_switch_redirect`) |
+| `worktree_removed` | `forced` |
+| `worktree_pruned` | — |
 | `branch_published` | `is_main`, `branch`, `time_since_last_publish_seconds` |
 | `git_pulled` | `result` (`pulled` / `up_to_date` / `merge_conflict`) |
 | `pr_created` | `base_branch`, `used_ai`, `title_length`, `description_length` |

--- a/scripts/check-loc-limits.sh
+++ b/scripts/check-loc-limits.sh
@@ -54,7 +54,10 @@ echo "Components (.tsx limit 1200):"
 # Bumped again (small) for the pull-latest button: isPulling/handlePullLatest
 # threaded from useBranchManagement to BranchIndicator + the git.push/git.pull
 # palette params. Pure wiring; the pull logic lives in useBranchManagement.
-check_file src/components/workspace/WorkspaceView.tsx 1625
+# Bumped again (small) for worktrees: the hook call + worktree props threaded
+# to the sidebar, Branches tab, and create modal. Pure wiring; the logic lives
+# in useWorktreeWorkflow/useWorktrees.
+check_file src/components/workspace/WorkspaceView.tsx 1650
 check_file src/components/dashboard/ProjectList.tsx 900
 check_file src/components/plugins/PluginManager.tsx 700
 check_file src/components/dashboard/ImportProject.tsx 500

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -13,12 +13,14 @@ mod graph;
 mod stash;
 mod status;
 mod sync;
+mod worktree;
 
 pub use branches::*;
 pub use graph::*;
 pub use stash::*;
 pub use status::*;
 pub use sync::*;
+pub use worktree::*;
 
 use crate::errors::CommandError;
 use crate::external_command::run_with_timeout;

--- a/src-tauri/src/commands/git/worktree.rs
+++ b/src-tauri/src/commands/git/worktree.rs
@@ -34,6 +34,8 @@ pub struct WorktreeInfo {
     pub locked: Option<String>,
     /// Prune reason when git considers the entry prunable.
     pub prunable: Option<String>,
+    /// Unix timestamp (ms) of the checked-out HEAD commit, when resolvable.
+    pub last_commit_date: Option<u64>,
 }
 
 #[derive(Serialize, Clone, Debug)]
@@ -88,8 +90,9 @@ fn parse_worktree_porcelain(output: &str) -> Vec<ParsedWorktree> {
             });
         } else if let Some(wt) = current.as_mut() {
             if let Some(sha) = line.strip_prefix("HEAD ") {
-                // Short sha for display; git prints the full 40-char sha.
-                wt.head = sha.chars().take(7).collect();
+                // Full sha here — needed for commit-date lookup; shortened for
+                // display when building the public WorktreeInfo.
+                wt.head = sha.to_string();
             } else if let Some(branch_ref) = line.strip_prefix("branch ") {
                 wt.branch = Some(
                     branch_ref
@@ -191,6 +194,31 @@ fn canon(path: &str) -> PathBuf {
     dunce::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path))
 }
 
+/// Resolves commit timestamps (ms) for a set of shas in one git call:
+/// `git show -s --format='%H %ct' <shas…>`. Best-effort — an empty map on
+/// any failure just leaves `last_commit_date` unset.
+fn commit_timestamps_ms(cwd: &Path, shas: &[&str]) -> std::collections::HashMap<String, u64> {
+    let mut map = std::collections::HashMap::new();
+    if shas.is_empty() {
+        return map;
+    }
+    let mut args: Vec<&str> = vec!["show", "-s", "--format=%H %ct"];
+    args.extend(shas);
+    if let Ok(output) = run_worktree_git(cwd, &args) {
+        if output.status.success() {
+            for line in String::from_utf8_lossy(&output.stdout).lines() {
+                let mut parts = line.split_whitespace();
+                if let (Some(sha), Some(secs)) = (parts.next(), parts.next()) {
+                    if let Ok(secs) = secs.parse::<u64>() {
+                        map.insert(sha.to_string(), secs * 1000);
+                    }
+                }
+            }
+        }
+    }
+    map
+}
+
 /// Lists all worktrees of the repository containing `project_path`, main
 /// worktree first (git's porcelain order). Returns an empty list for
 /// non-git directories so callers can simply hide the feature.
@@ -208,7 +236,14 @@ pub async fn list_worktrees(project_path: String) -> Result<Vec<WorktreeInfo>, C
 
     let current = canon(&validated_path.to_string_lossy());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let worktrees = parse_worktree_porcelain(&stdout)
+    let parsed = parse_worktree_porcelain(&stdout);
+    let shas: Vec<&str> = parsed
+        .iter()
+        .map(|w| w.head.as_str())
+        .filter(|s| !s.is_empty())
+        .collect();
+    let timestamps = commit_timestamps_ms(&validated_path, &shas);
+    let worktrees = parsed
         .into_iter()
         .enumerate()
         .map(|(i, wt)| {
@@ -216,8 +251,9 @@ pub async fn list_worktrees(project_path: String) -> Result<Vec<WorktreeInfo>, C
             WorktreeInfo {
                 is_main: i == 0,
                 is_current,
+                last_commit_date: timestamps.get(&wt.head).copied(),
                 path: wt.path,
-                head: wt.head,
+                head: wt.head.chars().take(7).collect(),
                 branch: wt.branch,
                 locked: wt.locked,
                 prunable: wt.prunable,
@@ -315,6 +351,9 @@ pub async fn add_worktree(
     if copy_env {
         copy_env_files(&validated_path, &dest);
     }
+
+    // Plugins need no copying: all worktrees of one repository resolve to the
+    // main worktree's plugin store (see `plugins_owner_root` in commands::plugins).
 
     GIT_CACHE.invalidate(&project_path);
 
@@ -432,7 +471,7 @@ branch refs/heads/feature-x
         let parsed = parse_worktree_porcelain(porcelain);
         assert_eq!(parsed.len(), 2);
         assert_eq!(parsed[0].path, "/Users/me/ShipStudio/myapp");
-        assert_eq!(parsed[0].head, "1234567");
+        assert_eq!(parsed[0].head, "1234567890abcdef1234567890abcdef12345678");
         assert_eq!(parsed[0].branch.as_deref(), Some("main"));
         assert_eq!(parsed[1].branch.as_deref(), Some("feature-x"));
         assert!(parsed[1].locked.is_none());

--- a/src-tauri/src/commands/git/worktree.rs
+++ b/src-tauri/src/commands/git/worktree.rs
@@ -1,0 +1,532 @@
+//! Git worktree management — list, add, remove, prune.
+//!
+//! Surfaces native `git worktree` semantics rather than abstracting them: the
+//! list mirrors `git worktree list` (main worktree included), removal keeps the
+//! branch, and dirty-tree refusals bubble up so the UI can offer `--force`.
+//!
+//! App-managed worktrees are created under
+//! `<projects_root>/.worktrees/<parent_dir_name>/<sanitized_branch>` — inside
+//! the allowed projects root (so `validate_project_path` accepts them) but
+//! dot-prefixed so the dashboard scan never lists the container as a project.
+
+use crate::cache::GIT_CACHE;
+use crate::errors::CommandError;
+use crate::utils::{create_command, projects_root, validate_project_path};
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use tracing::{info, instrument, warn};
+
+use super::{load_project_metadata, save_project_metadata};
+
+/// One entry from `git worktree list --porcelain`.
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub struct WorktreeInfo {
+    pub path: String,
+    /// Short commit sha of the checked-out HEAD.
+    pub head: String,
+    /// Branch name with `refs/heads/` stripped; `None` when detached.
+    pub branch: Option<String>,
+    /// True for the repository's main worktree (first porcelain entry).
+    pub is_main: bool,
+    /// True when this entry is the directory the query was made from.
+    pub is_current: bool,
+    /// Lock reason when locked (empty string if locked without a reason).
+    pub locked: Option<String>,
+    /// Prune reason when git considers the entry prunable.
+    pub prunable: Option<String>,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct AddWorktreeResult {
+    pub path: String,
+    /// Dev-server port persisted into the new worktree's metadata, when a free
+    /// one was found.
+    pub port: Option<u16>,
+}
+
+/// Intermediate parse result, before path comparison decorates it.
+#[derive(Debug, PartialEq)]
+struct ParsedWorktree {
+    path: String,
+    head: String,
+    branch: Option<String>,
+    locked: Option<String>,
+    prunable: Option<String>,
+}
+
+/// Parses `git worktree list --porcelain` output: blank-line-separated blocks
+/// of `worktree <path>` / `HEAD <sha>` / `branch <ref>` | `detached` /
+/// `locked[ <reason>]` / `prunable[ <reason>]`. Bare-repo entries are skipped.
+fn parse_worktree_porcelain(output: &str) -> Vec<ParsedWorktree> {
+    let mut result = Vec::new();
+    let mut current: Option<ParsedWorktree> = None;
+    let mut is_bare = false;
+
+    let mut flush = |wt: &mut Option<ParsedWorktree>, bare: &mut bool| {
+        if let Some(w) = wt.take() {
+            if !*bare {
+                result.push(w);
+            }
+        }
+        *bare = false;
+    };
+
+    for line in output.lines() {
+        let line = line.trim_end();
+        if line.is_empty() {
+            flush(&mut current, &mut is_bare);
+            continue;
+        }
+        if let Some(path) = line.strip_prefix("worktree ") {
+            flush(&mut current, &mut is_bare);
+            current = Some(ParsedWorktree {
+                path: path.to_string(),
+                head: String::new(),
+                branch: None,
+                locked: None,
+                prunable: None,
+            });
+        } else if let Some(wt) = current.as_mut() {
+            if let Some(sha) = line.strip_prefix("HEAD ") {
+                // Short sha for display; git prints the full 40-char sha.
+                wt.head = sha.chars().take(7).collect();
+            } else if let Some(branch_ref) = line.strip_prefix("branch ") {
+                wt.branch = Some(
+                    branch_ref
+                        .strip_prefix("refs/heads/")
+                        .unwrap_or(branch_ref)
+                        .to_string(),
+                );
+            } else if line == "detached" {
+                wt.branch = None;
+            } else if line == "bare" {
+                is_bare = true;
+            } else if line == "locked" {
+                wt.locked = Some(String::new());
+            } else if let Some(reason) = line.strip_prefix("locked ") {
+                wt.locked = Some(reason.to_string());
+            } else if line == "prunable" {
+                wt.prunable = Some(String::new());
+            } else if let Some(reason) = line.strip_prefix("prunable ") {
+                wt.prunable = Some(reason.to_string());
+            }
+        }
+    }
+    flush(&mut current, &mut is_bare);
+    result
+}
+
+/// Turns a branch name into a filesystem-safe folder name: path separators
+/// become `-`, Windows-illegal characters are dropped, and leading `-`/`.` are
+/// stripped so the result can't be parsed as a flag or hide the folder.
+fn sanitize_worktree_folder(branch: &str) -> String {
+    let mut out: String = branch
+        .chars()
+        .map(|c| if c == '/' || c == '\\' { '-' } else { c })
+        .filter(|c| !matches!(c, ':' | '*' | '?' | '"' | '<' | '>' | '|') && !c.is_control())
+        .collect();
+    while out.starts_with('-') || out.starts_with('.') {
+        out.remove(0);
+    }
+    while out.ends_with('.') || out.ends_with(' ') {
+        out.pop();
+    }
+    out.truncate(64);
+    if out.is_empty() {
+        "worktree".to_string()
+    } else {
+        out
+    }
+}
+
+/// Rejects ref names git could parse as an option (argument injection) — the
+/// same guard `create_branch`/`switch_branch` apply.
+fn guard_ref_name(name: &str, field: &str) -> Result<(), CommandError> {
+    if name.is_empty() || name.starts_with('-') || name.contains("..") {
+        return Err(CommandError::Validation {
+            field: field.to_string(),
+            reason: "Invalid ref name".to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// First TCP-bindable port in `(start+1)..=(start+100)` that isn't already
+/// reserved by a live `(window, project)` pair. `None` when the range is
+/// exhausted — callers leave the metadata port unset in that case.
+fn pick_free_port(start: u16) -> Option<u16> {
+    use std::net::TcpListener;
+    for port in (start.saturating_add(1))..=start.saturating_add(100) {
+        if crate::state::is_port_reserved(port) {
+            continue;
+        }
+        if TcpListener::bind(("127.0.0.1", port)).is_ok() {
+            return Some(port);
+        }
+    }
+    None
+}
+
+fn run_worktree_git(cwd: &Path, args: &[&str]) -> Result<std::process::Output, CommandError> {
+    create_command("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .map_err(|e| CommandError::Io {
+            message: e.to_string(),
+        })
+}
+
+fn process_error(args: &[&str], output: &std::process::Output) -> CommandError {
+    CommandError::Process {
+        cmd: format!("git {}", args.join(" ")),
+        exit_code: output.status.code().unwrap_or(-1),
+        stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+    }
+}
+
+/// Canonical form for path equality checks (worktree paths reported by git are
+/// already resolved, but the queried project path may differ in symlinks/case).
+fn canon(path: &str) -> PathBuf {
+    dunce::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path))
+}
+
+/// Lists all worktrees of the repository containing `project_path`, main
+/// worktree first (git's porcelain order). Returns an empty list for
+/// non-git directories so callers can simply hide the feature.
+#[tauri::command]
+#[instrument(name = "list_worktrees", skip(project_path), fields(project = %project_path))]
+pub async fn list_worktrees(project_path: String) -> Result<Vec<WorktreeInfo>, CommandError> {
+    let validated_path = validate_project_path(&project_path)?;
+
+    let args = ["worktree", "list", "--porcelain"];
+    let output = run_worktree_git(&validated_path, &args)?;
+    if !output.status.success() {
+        // Not a git repository (or too old a git) — the UI hides the section.
+        return Ok(Vec::new());
+    }
+
+    let current = canon(&validated_path.to_string_lossy());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let worktrees = parse_worktree_porcelain(&stdout)
+        .into_iter()
+        .enumerate()
+        .map(|(i, wt)| {
+            let is_current = canon(&wt.path) == current;
+            WorktreeInfo {
+                is_main: i == 0,
+                is_current,
+                path: wt.path,
+                head: wt.head,
+                branch: wt.branch,
+                locked: wt.locked,
+                prunable: wt.prunable,
+            }
+        })
+        .collect();
+
+    Ok(worktrees)
+}
+
+/// Creates a worktree under `<projects_root>/.worktrees/<parent>/<branch>`,
+/// checking out `branch` (created from `base_ref`/HEAD when `create_branch`).
+/// Seeds the new directory's `.shipstudio/project.json` from the parent
+/// (dev command, monorepo subpath, workspace) with a distinct dev-server port,
+/// and optionally copies the parent's untracked root `.env*` files.
+#[tauri::command]
+#[instrument(name = "add_worktree", skip(project_path), fields(project = %project_path, branch = %branch))]
+pub async fn add_worktree(
+    project_path: String,
+    branch: String,
+    create_branch: bool,
+    base_ref: Option<String>,
+    copy_env: bool,
+) -> Result<AddWorktreeResult, CommandError> {
+    let validated_path = validate_project_path(&project_path)?;
+    guard_ref_name(&branch, "branch")?;
+    if let Some(base) = base_ref.as_deref() {
+        guard_ref_name(base, "base_ref")?;
+    }
+
+    let parent_dir_name = validated_path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .ok_or_else(|| CommandError::Validation {
+            field: "project_path".to_string(),
+            reason: "Project path has no directory name".to_string(),
+        })?;
+
+    let container = projects_root()?.join(".worktrees").join(&parent_dir_name);
+    let dest = container.join(sanitize_worktree_folder(&branch));
+    if dest.exists() {
+        return Err(CommandError::Validation {
+            field: "branch".to_string(),
+            reason: format!("A worktree folder already exists at {}", dest.display()),
+        });
+    }
+    std::fs::create_dir_all(&container).map_err(|e| CommandError::Io {
+        message: format!("Failed to create worktrees folder: {e}"),
+    })?;
+
+    let dest_str = dest.to_string_lossy().to_string();
+    let mut args: Vec<&str> = vec!["worktree", "add"];
+    if create_branch {
+        args.extend(["-b", &branch]);
+    }
+    args.push(&dest_str);
+    if create_branch {
+        if let Some(base) = base_ref.as_deref() {
+            args.push(base);
+        }
+    } else {
+        args.push(&branch);
+    }
+
+    info!(dest = %dest.display(), create_branch, "Adding git worktree");
+    let output = run_worktree_git(&validated_path, &args)?;
+    if !output.status.success() {
+        // Pass git's own message through — it covers "already checked out",
+        // "already exists", unknown refs, etc. faithfully.
+        return Err(process_error(&args, &output));
+    }
+
+    // Seed the worktree's own .shipstudio/project.json from the parent so the
+    // dev server behaves identically (command, monorepo subpath, workspace) —
+    // but on its own port, since every project otherwise defaults to 3000.
+    let parent_meta = load_project_metadata(&validated_path);
+    let mut meta = crate::types::ProjectMetadata {
+        custom_dev_command: parent_meta.custom_dev_command.clone(),
+        workspace_subpath: parent_meta.workspace_subpath.clone(),
+        force_static_serve: parent_meta.force_static_serve,
+        assets_root: parent_meta.assets_root.clone(),
+        account_id: parent_meta.account_id.clone(),
+        default_base_branch: parent_meta.default_base_branch.clone(),
+        ..Default::default()
+    };
+    let port = pick_free_port(parent_meta.dev_server_port.unwrap_or(3000));
+    meta.dev_server_port = port;
+    if port.is_none() {
+        warn!("No free dev-server port found for new worktree; leaving unset");
+    }
+    if let Err(e) = save_project_metadata(&dest, &meta) {
+        warn!("Failed to seed worktree metadata: {e}");
+    }
+
+    if copy_env {
+        copy_env_files(&validated_path, &dest);
+    }
+
+    GIT_CACHE.invalidate(&project_path);
+
+    Ok(AddWorktreeResult {
+        path: dest_str,
+        port,
+    })
+}
+
+/// Copies root-level `.env*` files git didn't check out (they're normally
+/// gitignored, so a fresh worktree lacks them and the dev server breaks).
+/// Never overwrites a file the checkout already produced.
+fn copy_env_files(from: &Path, to: &Path) {
+    let entries = match std::fs::read_dir(from) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if !name_str.starts_with(".env") {
+            continue;
+        }
+        if !entry.path().is_file() {
+            continue;
+        }
+        let target = to.join(&name);
+        if target.exists() {
+            continue;
+        }
+        if let Err(e) = std::fs::copy(entry.path(), &target) {
+            warn!(file = %name_str, "Failed to copy env file to worktree: {e}");
+        }
+    }
+}
+
+/// Removes a linked worktree via `git worktree remove`. Refuses the main
+/// worktree. A dirty tree makes git refuse without `force` — the resulting
+/// `Process` error carries git's stderr so the UI can offer force-removal.
+/// The branch is left alone, matching git's own semantics.
+#[tauri::command]
+#[instrument(name = "remove_worktree", skip(project_path, worktree_path), fields(project = %project_path, worktree = %worktree_path))]
+pub async fn remove_worktree(
+    project_path: String,
+    worktree_path: String,
+    force: bool,
+) -> Result<(), CommandError> {
+    let validated_path = validate_project_path(&project_path)?;
+    let validated_worktree = validate_project_path(&worktree_path)?;
+
+    // Never remove the main worktree — that's the project itself.
+    let list_output = run_worktree_git(&validated_path, &["worktree", "list", "--porcelain"])?;
+    if list_output.status.success() {
+        let stdout = String::from_utf8_lossy(&list_output.stdout);
+        if let Some(main) = parse_worktree_porcelain(&stdout).first() {
+            if canon(&main.path) == canon(&validated_worktree.to_string_lossy()) {
+                return Err(CommandError::Validation {
+                    field: "worktree_path".to_string(),
+                    reason: "Cannot remove the main worktree".to_string(),
+                });
+            }
+        }
+    }
+
+    let worktree_str = validated_worktree.to_string_lossy().to_string();
+    let mut args: Vec<&str> = vec!["worktree", "remove"];
+    if force {
+        // Twice: once for a dirty tree, once more in case the entry is locked.
+        args.extend(["--force", "--force"]);
+    }
+    args.push(&worktree_str);
+
+    info!(force, "Removing git worktree");
+    let output = run_worktree_git(&validated_path, &args)?;
+    if !output.status.success() {
+        return Err(process_error(&args, &output));
+    }
+
+    GIT_CACHE.invalidate(&project_path);
+    GIT_CACHE.invalidate(&worktree_path);
+    Ok(())
+}
+
+/// Runs `git worktree prune` — clears entries whose directories are gone.
+#[tauri::command]
+#[instrument(name = "prune_worktrees", skip(project_path), fields(project = %project_path))]
+pub async fn prune_worktrees(project_path: String) -> Result<(), CommandError> {
+    let validated_path = validate_project_path(&project_path)?;
+
+    let args = ["worktree", "prune"];
+    let output = run_worktree_git(&validated_path, &args)?;
+    if !output.status.success() {
+        return Err(process_error(&args, &output));
+    }
+
+    GIT_CACHE.invalidate(&project_path);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_main_and_linked_worktrees() {
+        let porcelain = "\
+worktree /Users/me/ShipStudio/myapp
+HEAD 1234567890abcdef1234567890abcdef12345678
+branch refs/heads/main
+
+worktree /Users/me/ShipStudio/.worktrees/myapp/feature-x
+HEAD abcdef7890abcdef1234567890abcdef12345678
+branch refs/heads/feature-x
+";
+        let parsed = parse_worktree_porcelain(porcelain);
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].path, "/Users/me/ShipStudio/myapp");
+        assert_eq!(parsed[0].head, "1234567");
+        assert_eq!(parsed[0].branch.as_deref(), Some("main"));
+        assert_eq!(parsed[1].branch.as_deref(), Some("feature-x"));
+        assert!(parsed[1].locked.is_none());
+        assert!(parsed[1].prunable.is_none());
+    }
+
+    #[test]
+    fn parses_detached_locked_and_prunable() {
+        let porcelain = "\
+worktree /repo
+HEAD 1111111890abcdef1234567890abcdef12345678
+branch refs/heads/main
+
+worktree /wt/detached
+HEAD 2222222890abcdef1234567890abcdef12345678
+detached
+
+worktree /wt/locked
+HEAD 3333333890abcdef1234567890abcdef12345678
+branch refs/heads/frozen
+locked working on my laptop
+
+worktree /wt/locked-no-reason
+HEAD 4444444890abcdef1234567890abcdef12345678
+branch refs/heads/cold
+locked
+
+worktree /wt/gone
+HEAD 5555555890abcdef1234567890abcdef12345678
+branch refs/heads/stale
+prunable gitdir file points to non-existent location
+";
+        let parsed = parse_worktree_porcelain(porcelain);
+        assert_eq!(parsed.len(), 5);
+        assert_eq!(parsed[1].branch, None, "detached HEAD has no branch");
+        assert_eq!(parsed[2].locked.as_deref(), Some("working on my laptop"));
+        assert_eq!(parsed[3].locked.as_deref(), Some(""));
+        assert_eq!(
+            parsed[4].prunable.as_deref(),
+            Some("gitdir file points to non-existent location")
+        );
+    }
+
+    #[test]
+    fn parses_single_main_worktree_and_skips_bare() {
+        let single = "worktree /repo\nHEAD 9999999890abcdef1234567890abcdef12345678\nbranch refs/heads/main\n";
+        assert_eq!(parse_worktree_porcelain(single).len(), 1);
+
+        let bare = "\
+worktree /repo.git
+bare
+
+worktree /wt/feature
+HEAD 1234567890abcdef1234567890abcdef12345678
+branch refs/heads/feature
+";
+        let parsed = parse_worktree_porcelain(bare);
+        assert_eq!(parsed.len(), 1, "bare entry must be skipped");
+        assert_eq!(parsed[0].path, "/wt/feature");
+    }
+
+    #[test]
+    fn sanitizes_branch_names_into_folder_names() {
+        assert_eq!(sanitize_worktree_folder("feature-x"), "feature-x");
+        assert_eq!(
+            sanitize_worktree_folder("julian/fix-thing"),
+            "julian-fix-thing"
+        );
+        assert_eq!(sanitize_worktree_folder("-leading-dash"), "leading-dash");
+        assert_eq!(sanitize_worktree_folder(".hidden"), "hidden");
+        assert_eq!(sanitize_worktree_folder("what?is:this*"), "whatisthis");
+        assert_eq!(sanitize_worktree_folder("trailing."), "trailing");
+        assert_eq!(sanitize_worktree_folder("---"), "worktree");
+    }
+
+    #[test]
+    fn guards_reject_option_like_and_traversal_refs() {
+        assert!(guard_ref_name("feature-x", "branch").is_ok());
+        assert!(guard_ref_name("-rf", "branch").is_err());
+        assert!(guard_ref_name("a..b", "branch").is_err());
+        assert!(guard_ref_name("", "branch").is_err());
+    }
+
+    #[test]
+    fn pick_free_port_skips_bound_port() {
+        use std::net::TcpListener;
+        // Bind an ephemeral port, then ask for the range starting just below it:
+        // the picker must skip the bound port and return a different free one.
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind ephemeral");
+        let bound = listener.local_addr().unwrap().port();
+        if bound == 0 || bound == u16::MAX {
+            return; // pathological ephemeral port; skip
+        }
+        let picked = pick_free_port(bound - 1).expect("a free port should exist");
+        assert_ne!(picked, bound, "picker must not return a bound port");
+    }
+}

--- a/src-tauri/src/commands/plugins/mod.rs
+++ b/src-tauri/src/commands/plugins/mod.rs
@@ -277,6 +277,14 @@ static PLUGINS_OWNER_CACHE: std::sync::LazyLock<std::sync::Mutex<HashMap<PathBuf
 /// of them, exactly like git shares refs/config via the common dir. Non-git
 /// directories and main worktrees resolve to themselves.
 fn plugins_owner_root(validated: &Path) -> PathBuf {
+    // Only a LINKED git worktree has a `.git` pointer file; main checkouts
+    // have a `.git` directory and everything else has none. Anything that
+    // isn't a linked worktree owns its own plugins — resolving via git for
+    // those would walk up to an unrelated enclosing repo (e.g. a dotfiles
+    // repo at $HOME) and relocate plugin storage there.
+    if !validated.join(".git").is_file() {
+        return validated.to_path_buf();
+    }
     if let Ok(cache) = PLUGINS_OWNER_CACHE.lock() {
         if let Some(owner) = cache.get(validated) {
             return owner.clone();
@@ -556,5 +564,10 @@ mod tests {
         let plain = tmp.path().join("plain");
         std::fs::create_dir_all(&plain).unwrap();
         assert_eq!(plugins_owner_root(&canon(&plain)), canon(&plain));
+        // ...even when that non-git directory sits INSIDE a repo (dotfiles
+        // repos at $HOME): plugins must not relocate to the enclosing repo.
+        let nested = main.join("not-a-repo-itself");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert_eq!(plugins_owner_root(&canon(&nested)), canon(&nested));
     }
 }

--- a/src-tauri/src/commands/plugins/mod.rs
+++ b/src-tauri/src/commands/plugins/mod.rs
@@ -2,7 +2,9 @@
  * Plugin management commands for Ship Studio.
  *
  * Plugins are project-level: each project has its own plugins directory
- * at <project>/.shipstudio/plugins/.
+ * at <project>/.shipstudio/plugins/. Git worktrees of one repository all
+ * resolve to the MAIN worktree's directory (see `plugins_owner_root`), so
+ * installing a plugin from any worktree makes it available in every one.
  *
  * Provides commands for:
  * - Listing, installing, uninstalling, and updating plugins
@@ -26,7 +28,7 @@ use crate::utils::{create_command, find_executable, get_extended_path, validate_
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex};
 use tauri::AppHandle;
 
@@ -264,10 +266,62 @@ pub struct ShellResult {
 
 // ── Shared helpers ──────────────────────────────────────────────────────────
 
-/// Get the plugins directory for a project: <project>/.shipstudio/plugins/
+/// Maps a checkout path to the directory that owns its plugins. Cached
+/// forever: a path's main worktree never changes while the path exists.
+static PLUGINS_OWNER_CACHE: std::sync::LazyLock<std::sync::Mutex<HashMap<PathBuf, PathBuf>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+
+/// Resolves the project directory that owns plugins for this checkout: the
+/// repository's MAIN worktree. Plugins belong to the project, not the
+/// checkout — an install from any linked git worktree must be visible in all
+/// of them, exactly like git shares refs/config via the common dir. Non-git
+/// directories and main worktrees resolve to themselves.
+fn plugins_owner_root(validated: &Path) -> PathBuf {
+    if let Ok(cache) = PLUGINS_OWNER_CACHE.lock() {
+        if let Some(owner) = cache.get(validated) {
+            return owner.clone();
+        }
+    }
+    let resolved = (|| {
+        let output = create_command("git")
+            .args(["rev-parse", "--git-common-dir"])
+            .current_dir(validated)
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if raw.is_empty() {
+            return None;
+        }
+        // The common dir may be reported relative to the cwd.
+        let common = if Path::new(&raw).is_absolute() {
+            PathBuf::from(raw)
+        } else {
+            validated.join(raw)
+        };
+        // <main>/.git → <main>. Anything else (bare repos) keeps per-dir plugins.
+        if common.file_name().is_some_and(|n| n == ".git") {
+            common.parent().map(Path::to_path_buf)
+        } else {
+            None
+        }
+    })()
+    .unwrap_or_else(|| validated.to_path_buf());
+    if let Ok(mut cache) = PLUGINS_OWNER_CACHE.lock() {
+        cache.insert(validated.to_path_buf(), resolved.clone());
+    }
+    resolved
+}
+
+/// Get the plugins directory for a project: `<main worktree>/.shipstudio/plugins/`.
+/// All git worktrees of one repository share a single plugin store.
 pub(crate) fn get_plugins_dir(project_path: &str) -> Result<PathBuf, String> {
     let validated = validate_project_path(project_path)?;
-    Ok(validated.join(".shipstudio").join("plugins"))
+    Ok(plugins_owner_root(&validated)
+        .join(".shipstudio")
+        .join("plugins"))
 }
 
 /// Read the plugin registry for a project
@@ -467,5 +521,40 @@ mod tests {
 
         let result = get_storage_path(".hidden", "/tmp/test");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn plugins_owner_root_resolves_worktrees_to_main() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let main = tmp.path().join("repo");
+        std::fs::create_dir_all(&main).unwrap();
+        let run = |args: &[&str], cwd: &std::path::Path| {
+            assert!(std::process::Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .output()
+                .expect("git")
+                .status
+                .success());
+        };
+        run(&["init", "-q", "-b", "main"], &main);
+        run(&["config", "user.email", "t@t"], &main);
+        run(&["config", "user.name", "t"], &main);
+        run(&["commit", "-q", "--allow-empty", "-m", "init"], &main);
+        let wt = tmp.path().join("wt-feature");
+        run(
+            &["worktree", "add", "-b", "feature", wt.to_str().unwrap()],
+            &main,
+        );
+
+        let canon = |p: &std::path::Path| dunce::canonicalize(p).unwrap();
+        // A linked worktree resolves to the main worktree...
+        assert_eq!(canon(&plugins_owner_root(&canon(&wt))), canon(&main));
+        // ...the main worktree resolves to itself...
+        assert_eq!(canon(&plugins_owner_root(&canon(&main))), canon(&main));
+        // ...and a non-git directory falls back to itself.
+        let plain = tmp.path().join("plain");
+        std::fs::create_dir_all(&plain).unwrap();
+        assert_eq!(plugins_owner_root(&canon(&plain)), canon(&plain));
     }
 }

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -197,6 +197,27 @@ pub(crate) fn is_valid_project(path: &std::path::Path) -> bool {
             || path.join(".git").exists())
 }
 
+/// Counts app-managed git worktrees for a project: subdirectories of
+/// `<projects_root>/.worktrees/<project_dir_name>`. Filesystem-only (no git)
+/// so the dashboard scan stays cheap; `None` when there are none.
+fn count_managed_worktrees(project_path: &std::path::Path) -> Option<usize> {
+    let dir_name = project_path.file_name()?;
+    let container = crate::utils::projects_root()
+        .ok()?
+        .join(".worktrees")
+        .join(dir_name);
+    let count = std::fs::read_dir(container)
+        .ok()?
+        .flatten()
+        .filter(|e| e.path().is_dir())
+        .count();
+    if count > 0 {
+        Some(count)
+    } else {
+        None
+    }
+}
+
 /// Whether a project should be shown on the dashboard for the given active
 /// Workspace (Account). Resolves through the shared `effective_account_id_in`
 /// helper so visibility and credential routing never disagree: a project is
@@ -581,6 +602,7 @@ pub async fn get_dashboard_projects() -> Result<Vec<DashboardProject>, CommandEr
                 hide_main_branch_warning,
                 is_external: false,
                 workspace_subpath,
+                worktree_count: count_managed_worktrees(&path),
             });
             scan_paths.push(path);
         } else if path.is_dir() && !entry.file_name().to_string_lossy().starts_with('.') {
@@ -645,6 +667,7 @@ pub async fn get_dashboard_projects() -> Result<Vec<DashboardProject>, CommandEr
                     hide_main_branch_warning,
                     is_external: true,
                     workspace_subpath,
+                    worktree_count: count_managed_worktrees(&path),
                 });
                 scan_paths.push(path);
             } else {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -369,6 +369,10 @@ pub fn run() {
             commands::git::git_pull,
             commands::git::pull_and_merge,
             commands::git::delete_branch,
+            commands::git::list_worktrees,
+            commands::git::add_worktree,
+            commands::git::remove_worktree,
+            commands::git::prune_worktrees,
             commands::git::get_backups,
             commands::git::restore_backup,
             // Projects

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -75,6 +75,9 @@ pub struct DashboardProject {
     /// single-package projects. Surfaced on the dashboard card so the user
     /// can tell two imports of the same repo apart.
     pub workspace_subpath: Option<String>,
+    /// Number of linked git worktrees under `<projects_root>/.worktrees/<name>`.
+    /// None when the project has none — the card shows no hint.
+    pub worktree_count: Option<usize>,
 }
 
 /// Next.js page route information

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -752,6 +752,7 @@ function AppContents({ initialProjectPath }: AppProps) {
       needsInstall,
       devServerUnexpectedExit,
       onRunInstall: handleRunInstallCurrent,
+      onRunInstallFor: handleRunInstall,
       onDevServerInput: writeToDevServer,
       onDevServerResize: resizeDevServer,
     }),
@@ -770,6 +771,7 @@ function AppContents({ initialProjectPath }: AppProps) {
       needsInstall,
       devServerUnexpectedExit,
       handleRunInstallCurrent,
+      handleRunInstall,
       writeToDevServer,
       resizeDevServer,
     ]

--- a/src/commands/useWorkspaceCommands.tsx
+++ b/src/commands/useWorkspaceCommands.tsx
@@ -24,6 +24,10 @@ export interface UseWorkspaceCommandsParams {
   handlePullLatest: () => void;
   /** Push/pull commands only make sense with a connected GitHub repo */
   isGitHubConnected: boolean;
+  /** Opens the "New worktree" modal. */
+  openWorktreeCreate: () => void;
+  /** Worktree commands only make sense in a git repo (list is empty otherwise). */
+  hasWorktreeData: boolean;
 }
 
 const PullRequestGlyph = () => (
@@ -72,6 +76,8 @@ export function useWorkspaceCommands({
   openPushDropdown,
   handlePullLatest,
   isGitHubConnected,
+  openWorktreeCreate,
+  hasWorktreeData,
 }: UseWorkspaceCommandsParams) {
   useCommands(
     () => [
@@ -141,6 +147,25 @@ export function useWorkspaceCommands({
         run: () => setWorkspaceTab('prs'),
       },
       {
+        id: 'worktree.create',
+        title: 'New worktree…',
+        subtitle: 'Work on another branch side by side',
+        icon: <BranchIcon size={14} />,
+        category: 'branch',
+        when: ({ kind }) => kind === 'project' && hasWorktreeData,
+        keywords: ['worktree', 'parallel', 'branch', 'git', 'side by side'],
+        run: openWorktreeCreate,
+      },
+      {
+        id: 'worktree.manage',
+        title: 'Manage worktrees',
+        icon: <BranchIcon size={14} />,
+        category: 'branch',
+        when: ({ kind }) => kind === 'project' && hasWorktreeData,
+        keywords: ['worktree', 'remove', 'prune', 'git'],
+        run: () => setWorkspaceTab('branches'),
+      },
+      {
         id: 'branch.resolveConflicts',
         title: 'Resolve merge conflicts',
         icon: <AlertGlyph />,
@@ -160,6 +185,8 @@ export function useWorkspaceCommands({
       openPushDropdown,
       handlePullLatest,
       isGitHubConnected,
+      openWorktreeCreate,
+      hasWorktreeData,
     ]
   );
 }

--- a/src/components/branches/BranchesTab.tsx
+++ b/src/components/branches/BranchesTab.tsx
@@ -30,7 +30,9 @@ import {
   sanitizeBranchName,
 } from '../../lib/branches';
 import { gitPull } from '../../lib/git';
-import { BranchIcon, PlusIcon, TrashIcon } from '../icons';
+import { removeWorktree, pruneWorktrees, type WorktreeInfo } from '../../lib/worktrees';
+import { openProjectInNewWindow } from '../../lib/project';
+import { BranchIcon, PlusIcon, TrashIcon, ExternalLinkIcon } from '../icons';
 import { Spinner } from '../primitives/Spinner';
 import { BranchGraph } from './BranchGraph';
 import { UnsavedChangesModal } from './UnsavedChangesModal';
@@ -99,6 +101,16 @@ interface BranchesTabProps {
   onRefresh: () => void;
   /** Paste a prompt into the agent terminal (used to hand off a merge conflict). */
   onSendToAgent?: (prompt: string) => void;
+  /** Current `git worktree list` for this repository (main worktree first). */
+  worktrees?: WorktreeInfo[];
+  /** Switch the workspace to a worktree's path (in-place, session stays hot). */
+  onOpenWorktree?: (path: string) => void;
+  /** Tear down a worktree's hot session (dev server, PTYs) before removal. */
+  onCloseWorktreeSession?: (path: string) => void;
+  /** Re-query the worktree list after add/remove/prune. */
+  onWorktreesChanged?: () => void;
+  /** Open the "New worktree" modal. */
+  onCreateWorktree?: () => void;
 }
 
 export function BranchesTab({
@@ -112,6 +124,11 @@ export function BranchesTab({
   onViewPR,
   onRefresh,
   onSendToAgent,
+  worktrees = [],
+  onOpenWorktree,
+  onCloseWorktreeSession,
+  onWorktreesChanged,
+  onCreateWorktree,
 }: BranchesTabProps) {
   const { showToast } = useOptionalToast();
   const onToast = (message: string, type?: 'success' | 'error') => showToast(message, type);
@@ -224,6 +241,16 @@ export function BranchesTab({
   );
 
   const handleSwitch = async (branchName: string) => {
+    // Git refuses to check out a branch that's already checked out in another
+    // worktree — the faithful move is to go where the branch already lives.
+    const homeWorktree = worktrees.find((w) => !w.isCurrent && w.branch === branchName);
+    if (homeWorktree && onOpenWorktree) {
+      onToast?.(`${branchName} is checked out in a worktree — opening it`, 'success');
+      void trackEvent('worktree_switched', { via: 'branch_switch_redirect' });
+      onOpenWorktree(homeWorktree.path);
+      return;
+    }
+
     // A paused merge with unresolved conflicts blocks switching. Catch that
     // explicitly and voice it, rather than failing with a raw git error or the
     // misleading "unsaved changes / publish & switch" flow (which would commit
@@ -267,6 +294,67 @@ export function BranchesTab({
       if (isBranchGoneError(errText(e))) onRefresh();
     } finally {
       setSwitchingBranch(null);
+    }
+  };
+
+  // ---- Worktrees (git worktree remove / prune) ----
+  const [worktreeToRemove, setWorktreeToRemove] = useState<WorktreeInfo | null>(null);
+  const [isRemovingWorktree, setIsRemovingWorktree] = useState(false);
+  const [worktreeRemoveError, setWorktreeRemoveError] = useState<string | null>(null);
+  const [isPruningWorktrees, setIsPruningWorktrees] = useState(false);
+
+  /** Git refuses to remove a dirty worktree without `--force` — detect its
+   *  phrasing so the confirm modal can escalate to a Force Remove button. */
+  const isDirtyWorktreeError = (e: unknown): boolean => {
+    const text = typeof e === 'string' ? e : errText(e);
+    return /contains modified or untracked files|use --force/i.test(text);
+  };
+
+  // Anchor mutation commands at the main worktree: removing the worktree the
+  // command's cwd sits inside would fail (or leave a dangling cwd).
+  const mainWorktreePath = worktrees.find((w) => w.isMain)?.path ?? projectPath;
+
+  const handleRemoveWorktree = async (force: boolean) => {
+    if (!worktreeToRemove) return;
+    const wt = worktreeToRemove;
+    setIsRemovingWorktree(true);
+    setWorktreeRemoveError(null);
+    try {
+      // Removing the worktree we're standing in: move the workspace to the
+      // main worktree first so the teardown below runs on a background path.
+      if (wt.isCurrent && onOpenWorktree) {
+        onOpenWorktree(mainWorktreePath);
+      }
+      // Stop its dev server / PTYs and drop the session before the folder goes.
+      onCloseWorktreeSession?.(wt.path);
+      await removeWorktree(mainWorktreePath, wt.path, force);
+      void trackEvent('worktree_removed', { forced: force });
+      onToast?.(
+        wt.branch ? `Removed worktree — branch ${wt.branch} is kept` : 'Removed worktree',
+        'success'
+      );
+      setWorktreeToRemove(null);
+      onWorktreesChanged?.();
+    } catch (e) {
+      trackError('worktree_remove', e, 'Workspace');
+      setWorktreeRemoveError(errText(e));
+    } finally {
+      setIsRemovingWorktree(false);
+    }
+  };
+
+  const handlePruneWorktrees = async () => {
+    setIsPruningWorktrees(true);
+    try {
+      await pruneWorktrees(mainWorktreePath);
+      void trackEvent('worktree_pruned', { $screen_name: 'Workspace' });
+      onToast?.('Cleared stale worktree entries', 'success');
+      onWorktreesChanged?.();
+    } catch (e) {
+      trackError('worktree_prune', e, 'Workspace');
+      onToast?.(errText(e), 'error');
+    } finally {
+      setIsPruningWorktrees(false);
     }
   };
 
@@ -619,6 +707,100 @@ export function BranchesTab({
         </div>
       )}
 
+      {/* Worktrees — parallel working folders of this repo (`git worktree`).
+          Shown whenever the repo has worktree data, so the feature is
+          discoverable even with only the main worktree. */}
+      {worktrees.length > 0 && (
+        <div className="branches-tab-section">
+          <div className="branches-tab-section-header worktrees-section-header">
+            <span>Worktrees</span>
+            <div className="worktrees-section-actions">
+              {worktrees.some((w) => w.prunable !== null) && (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => void handlePruneWorktrees()}
+                  disabled={isPruningWorktrees}
+                  title="git worktree prune — clears entries whose folders are gone"
+                >
+                  {isPruningWorktrees ? 'Pruning…' : 'Prune stale'}
+                </Button>
+              )}
+              {onCreateWorktree && (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  leftIcon={<PlusIcon size={12} />}
+                  onClick={onCreateWorktree}
+                >
+                  New worktree
+                </Button>
+              )}
+            </div>
+          </div>
+          {worktrees.map((wt) => (
+            <div key={wt.path} className={`worktree-row ${wt.isCurrent ? 'is-current' : ''}`}>
+              <div className="worktree-row-info">
+                <div className="worktree-row-title">
+                  <BranchIcon size={12} />
+                  <span className="worktree-row-branch">
+                    {wt.branch ?? `detached @ ${wt.head}`}
+                  </span>
+                  {wt.isMain && <span className="worktree-chip">main worktree</span>}
+                  {wt.isCurrent && <span className="worktree-chip is-current-chip">current</span>}
+                  {wt.locked !== null && <span className="worktree-chip">locked</span>}
+                  {wt.prunable !== null && (
+                    <span className="worktree-chip is-prunable-chip">stale</span>
+                  )}
+                </div>
+                <div className="worktree-row-path" title={wt.path}>
+                  {wt.path}
+                </div>
+              </div>
+              <div className="worktree-row-actions">
+                {!wt.isCurrent && onOpenWorktree && wt.prunable === null && (
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => {
+                      void trackEvent('worktree_switched', { via: 'branches_tab' });
+                      onOpenWorktree(wt.path);
+                    }}
+                  >
+                    Open
+                  </Button>
+                )}
+                {wt.prunable === null && (
+                  <button
+                    type="button"
+                    className="worktree-row-icon-btn"
+                    onClick={() => void openProjectInNewWindow(wt.path, wt.branch ?? 'worktree')}
+                    title="Open in new window"
+                    aria-label="Open worktree in new window"
+                  >
+                    <ExternalLinkIcon size={12} />
+                  </button>
+                )}
+                {!wt.isMain && (
+                  <button
+                    type="button"
+                    className="worktree-row-icon-btn is-danger"
+                    onClick={() => {
+                      setWorktreeRemoveError(null);
+                      setWorktreeToRemove(wt);
+                    }}
+                    title="Remove worktree (git worktree remove)"
+                    aria-label={`Remove worktree ${wt.branch ?? wt.path}`}
+                  >
+                    <TrashIcon size={12} />
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
       {/* Branch graph — collapsed by default; building it shells out to git
           per branch, so it only loads when someone opens it. */}
       {branches.length > 0 && (
@@ -664,6 +846,78 @@ export function BranchesTab({
             >
               {deletingBranch ? 'Deleting...' : 'Delete'}
             </Button>
+          </div>
+        </ModalFrame>
+      )}
+
+      {/* Remove-worktree confirm. Mirrors git: the folder goes, the branch stays.
+          A dirty tree makes git refuse — the error escalates the button to Force. */}
+      {worktreeToRemove && (
+        <ModalFrame
+          isOpen
+          onClose={() => {
+            setWorktreeToRemove(null);
+            setWorktreeRemoveError(null);
+          }}
+          dismissable={!isRemovingWorktree}
+          title="Remove Worktree?"
+          className="post-merge-content"
+        >
+          <div className="post-merge-body">
+            <p>
+              This deletes the folder <strong>{worktreeToRemove.path}</strong>
+              {worktreeToRemove.branch && (
+                <>
+                  {' '}
+                  where <strong>{worktreeToRemove.branch}</strong> is checked out
+                </>
+              )}
+              .
+            </p>
+            <p>
+              The branch itself is <strong>kept</strong> — only the working folder goes away, same
+              as <code>git worktree remove</code>.
+            </p>
+            {worktreeRemoveError && (
+              <div className="worktree-remove-error">
+                <p>{worktreeRemoveError}</p>
+                {isDirtyWorktreeError(worktreeRemoveError) && (
+                  <p>
+                    <strong>The worktree has uncommitted changes.</strong> Force-removing discards
+                    them permanently.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+          <div className="post-merge-footer">
+            <Button
+              variant="secondary"
+              onClick={() => {
+                setWorktreeToRemove(null);
+                setWorktreeRemoveError(null);
+              }}
+              disabled={isRemovingWorktree}
+            >
+              Cancel
+            </Button>
+            {worktreeRemoveError && isDirtyWorktreeError(worktreeRemoveError) ? (
+              <Button
+                variant="danger"
+                onClick={() => void handleRemoveWorktree(true)}
+                disabled={isRemovingWorktree}
+              >
+                {isRemovingWorktree ? 'Removing...' : 'Force Remove'}
+              </Button>
+            ) : (
+              <Button
+                variant="danger"
+                onClick={() => void handleRemoveWorktree(false)}
+                disabled={isRemovingWorktree}
+              >
+                {isRemovingWorktree ? 'Removing...' : 'Remove'}
+              </Button>
+            )}
           </div>
         </ModalFrame>
       )}

--- a/src/components/branches/BranchesTab.tsx
+++ b/src/components/branches/BranchesTab.tsx
@@ -747,7 +747,9 @@ export function BranchesTab({
                     {wt.branch ?? `detached @ ${wt.head}`}
                   </span>
                   {wt.isMain && <span className="worktree-chip">main worktree</span>}
-                  {wt.isCurrent && <span className="worktree-chip is-current-chip">current</span>}
+                  {wt.isCurrent && (
+                    <span className="worktree-chip is-current-chip">you are here</span>
+                  )}
                   {wt.locked !== null && <span className="worktree-chip">locked</span>}
                   {wt.prunable !== null && (
                     <span className="worktree-chip is-prunable-chip">stale</span>

--- a/src/components/branches/WorktreeCreateModal.tsx
+++ b/src/components/branches/WorktreeCreateModal.tsx
@@ -145,6 +145,10 @@ function WorktreeCreateForm({
                 onChange={(e) => setBranchName(e.target.value)}
                 placeholder="feature-x"
                 autoFocus
+                autoCorrect="off"
+                autoCapitalize="off"
+                autoComplete="off"
+                spellCheck={false}
                 disabled={isCreating}
               />
               {branchName && sanitizeBranchName(branchName) !== branchName.trim() && (

--- a/src/components/branches/WorktreeCreateModal.tsx
+++ b/src/components/branches/WorktreeCreateModal.tsx
@@ -1,0 +1,236 @@
+/**
+ * "New worktree" modal — a UI over `git worktree add`.
+ *
+ * Two modes: create a new branch (name + base ref) or check out an existing
+ * local branch that isn't already checked out in another worktree (git refuses
+ * that, faithfully surfaced here by omitting those branches from the picker).
+ * Shows the exact destination folder it will create and offers to copy the
+ * parent's untracked `.env*` files (gitignored, so a fresh worktree lacks
+ * them and the dev server would break without this).
+ */
+
+import { useMemo, useState, type FormEvent } from 'react';
+import { ModalFrame } from '../primitives/ModalFrame';
+import { Button } from '../primitives/Button';
+import { Spinner } from '../primitives/Spinner';
+import { useModal } from '../../contexts/ModalContext';
+import { sanitizeBranchName, type BranchInfo } from '../../lib/branches';
+import { addWorktree, worktreeFolderName, type WorktreeInfo } from '../../lib/worktrees';
+import { asCommandError, formatCommandError } from '../../lib/errors';
+import { trackEvent, trackError } from '../../lib/analytics';
+import { basename } from '../../lib/paths';
+
+interface Props {
+  projectPath: string;
+  currentBranch: string;
+  /** Local + remote branches (from useBranchManagement). */
+  branches: BranchInfo[];
+  /** Current `git worktree list` — used to exclude checked-out branches. */
+  worktrees: WorktreeInfo[];
+  /** Called with the new worktree's path after a successful add. */
+  onCreated: (path: string) => void;
+}
+
+type Mode = 'new' | 'existing';
+
+export function WorktreeCreateModal(props: Props) {
+  const modal = useModal('worktreeCreate');
+  // The form mounts fresh on every open (isOpen gates it below), so its
+  // useState initials are the per-open reset — no effect needed.
+  if (!modal.isOpen) return null;
+  return <WorktreeCreateForm {...props} onClose={modal.close} />;
+}
+
+function WorktreeCreateForm({
+  projectPath,
+  currentBranch,
+  branches,
+  worktrees,
+  onCreated,
+  onClose,
+}: Props & { onClose: () => void }) {
+  const [mode, setMode] = useState<Mode>('new');
+  const [branchName, setBranchName] = useState('');
+  const [baseRef, setBaseRef] = useState(currentBranch);
+  const [existingBranch, setExistingBranch] = useState('');
+  const [copyEnv, setCopyEnv] = useState(true);
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const checkedOutBranches = useMemo(
+    () => new Set(worktrees.map((w) => w.branch).filter(Boolean) as string[]),
+    [worktrees]
+  );
+  const localBranches = useMemo(() => branches.filter((b) => !b.isRemote), [branches]);
+  // Git refuses to check out a branch that's already checked out in another
+  // worktree — don't offer those.
+  const availableExisting = useMemo(
+    () => localBranches.filter((b) => !checkedOutBranches.has(b.name)),
+    [localBranches, checkedOutBranches]
+  );
+
+  const effectiveBranch = mode === 'new' ? sanitizeBranchName(branchName) : existingBranch;
+  const destinationHint = effectiveBranch
+    ? `~/ShipStudio/.worktrees/${basename(projectPath)}/${worktreeFolderName(effectiveBranch)}`
+    : null;
+  const canSubmit = !isCreating && effectiveBranch.length > 0;
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setIsCreating(true);
+    setError(null);
+    try {
+      const result = await addWorktree(projectPath, {
+        branch: effectiveBranch,
+        createBranch: mode === 'new',
+        baseRef: mode === 'new' && baseRef ? baseRef : undefined,
+        copyEnv,
+      });
+      void trackEvent('worktree_created', {
+        created_branch: mode === 'new',
+        copied_env: copyEnv,
+      });
+      onClose();
+      onCreated(result.path);
+    } catch (err) {
+      void trackError('worktree_create_failed', err);
+      setError(formatCommandError(asCommandError(err)));
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <ModalFrame
+      isOpen
+      onClose={onClose}
+      title="New worktree"
+      dismissable={!isCreating}
+      className="worktree-create-modal"
+    >
+      <form onSubmit={(e) => void handleSubmit(e)} className="worktree-create-form">
+        <p className="worktree-create-intro">
+          A worktree is a second working folder of this repository, so another branch can run side
+          by side — its own terminal, dev server, and preview.
+        </p>
+
+        <div className="worktree-mode-toggle" role="tablist" aria-label="Branch source">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'new'}
+            className={`worktree-mode-btn ${mode === 'new' ? 'is-active' : ''}`}
+            onClick={() => setMode('new')}
+          >
+            New branch
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'existing'}
+            className={`worktree-mode-btn ${mode === 'existing' ? 'is-active' : ''}`}
+            onClick={() => setMode('existing')}
+          >
+            Existing branch
+          </button>
+        </div>
+
+        {mode === 'new' ? (
+          <>
+            <label className="worktree-field">
+              <span className="worktree-field-label">Branch name</span>
+              <input
+                type="text"
+                value={branchName}
+                onChange={(e) => setBranchName(e.target.value)}
+                placeholder="feature-x"
+                autoFocus
+                disabled={isCreating}
+              />
+              {branchName && sanitizeBranchName(branchName) !== branchName.trim() && (
+                <span className="worktree-field-hint">
+                  Will be created as “{sanitizeBranchName(branchName)}”
+                </span>
+              )}
+            </label>
+            <label className="worktree-field">
+              <span className="worktree-field-label">Based on</span>
+              <select
+                value={baseRef}
+                onChange={(e) => setBaseRef(e.target.value)}
+                disabled={isCreating}
+              >
+                {localBranches.map((b) => (
+                  <option key={b.name} value={b.name}>
+                    {b.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </>
+        ) : (
+          <label className="worktree-field">
+            <span className="worktree-field-label">Branch</span>
+            <select
+              value={existingBranch}
+              onChange={(e) => setExistingBranch(e.target.value)}
+              disabled={isCreating}
+            >
+              <option value="" disabled>
+                Choose a branch…
+              </option>
+              {availableExisting.map((b) => (
+                <option key={b.name} value={b.name}>
+                  {b.name}
+                </option>
+              ))}
+            </select>
+            {availableExisting.length === 0 && (
+              <span className="worktree-field-hint">
+                Every local branch is already checked out in a worktree.
+              </span>
+            )}
+          </label>
+        )}
+
+        <label className="worktree-checkbox">
+          <input
+            type="checkbox"
+            checked={copyEnv}
+            onChange={(e) => setCopyEnv(e.target.checked)}
+            disabled={isCreating}
+          />
+          <span>
+            Copy <code>.env</code> files
+            <span className="worktree-checkbox-hint">
+              They're not in git, so the new worktree won't have them otherwise
+            </span>
+          </span>
+        </label>
+
+        {destinationHint && (
+          <div className="worktree-destination">
+            Creates <code>{destinationHint}</code>
+          </div>
+        )}
+
+        {error && <div className="worktree-create-error">{error}</div>}
+
+        <div className="worktree-create-actions">
+          <Button variant="secondary" onClick={onClose} disabled={isCreating}>
+            Cancel
+          </Button>
+          <Button variant="primary" type="submit" disabled={!canSubmit}>
+            {isCreating ? (
+              <>
+                <Spinner size="sm" /> Creating…
+              </>
+            ) : (
+              'Create worktree'
+            )}
+          </Button>
+        </div>
+      </form>
+    </ModalFrame>
+  );
+}

--- a/src/components/dashboard/Changelog.tsx
+++ b/src/components/dashboard/Changelog.tsx
@@ -26,6 +26,14 @@ interface ChangelogEntry {
 // Keep ~15 most recent versions for the sidebar
 const CHANGELOG: ChangelogEntry[] = [
   {
+    version: '0.17.0', // v0.17.0
+    items: [
+      "Worktrees — work on multiple branches of the same project at the same time. Create a worktree from the sidebar or Cmd+K and it opens as its own workspace: its own agent, terminal, dev server on its own port, and preview, while your other branches keep running. Switch between them from the sidebar with everything staying hot. It's real git underneath (git worktree), so your terminal and the app always agree",
+      'Worktrees come ready to work — dependencies auto-install, your .env files are copied over (they never leave your machine), and plugins are shared across every worktree of a project, so installing one anywhere makes it available everywhere',
+      'Removing a worktree follows git faithfully: the folder goes, the branch stays — and if there are uncommitted changes it refuses first and asks before force-removing. Stale entries (folder deleted by hand) show up marked and one click prunes them',
+    ],
+  },
+  {
     version: '0.16.0', // v0.16.0
     items: [
       'Build pages visually: add, duplicate, and delete elements right on the canvas — a floating toolbar on your selection (plus a right-click menu in the element tree and Cmd+K commands) inserts headings, paragraphs, buttons, images and more, before/after/inside the selected element, written straight into your source and immediately styleable. Community feature by Benoît!',

--- a/src/components/dashboard/ProjectCard.tsx
+++ b/src/components/dashboard/ProjectCard.tsx
@@ -107,6 +107,11 @@ export const ProjectCard = memo(function ProjectCard({
             {hasChanges && (
               <span className="project-card-changes">{project.uncommitted_count} uncommitted</span>
             )}
+            {project.worktree_count != null && project.worktree_count > 0 && (
+              <span className="project-card-worktrees">
+                · {project.worktree_count} {project.worktree_count === 1 ? 'worktree' : 'worktrees'}
+              </span>
+            )}
           </div>
         </div>
         <ProjectCardMenu

--- a/src/components/workspace/BranchPRTabContainer.tsx
+++ b/src/components/workspace/BranchPRTabContainer.tsx
@@ -10,6 +10,7 @@ import { BranchesTab } from '../branches/BranchesTab';
 import { PullRequestsTab } from '../branches/PullRequestsTab';
 import { ConnectOverlay } from '../ConnectOverlay';
 import type { BranchInfo, PullRequestInfo } from '../../lib/branches';
+import type { WorktreeInfo } from '../../lib/worktrees';
 import type { IntegrationState } from '../../hooks/useIntegrationStatus';
 
 export interface BranchPRTabContainerProps {
@@ -37,6 +38,16 @@ export interface BranchPRTabContainerProps {
   handleGitHubConnect: () => void;
   /** Paste a prompt into the agent terminal (for merge-conflict hand-off). */
   onSendToAgent: (prompt: string) => void;
+  /** Current `git worktree list` for this repository. */
+  worktrees: WorktreeInfo[];
+  /** Switch the workspace to a worktree path (in-place, session stays hot). */
+  onOpenWorktree: (path: string) => void;
+  /** Tear down a worktree's hot session before `git worktree remove`. */
+  onCloseWorktreeSession: (path: string) => void;
+  /** Re-query the worktree list after a mutation. */
+  onWorktreesChanged: () => void;
+  /** Open the "New worktree" modal. */
+  onCreateWorktree: () => void;
 }
 
 export function BranchPRTabContainer({
@@ -56,6 +67,11 @@ export function BranchPRTabContainer({
   handleResolveConflicts,
   handleGitHubConnect,
   onSendToAgent,
+  worktrees,
+  onOpenWorktree,
+  onCloseWorktreeSession,
+  onWorktreesChanged,
+  onCreateWorktree,
 }: BranchPRTabContainerProps) {
   const showBranchesPane =
     workspaceTab === 'branches' ||
@@ -80,6 +96,11 @@ export function BranchPRTabContainer({
             onViewPR={() => setWorkspaceTab('prs')}
             onRefresh={() => void fetchBranchInfo(projectPath)}
             onSendToAgent={onSendToAgent}
+            worktrees={worktrees}
+            onOpenWorktree={onOpenWorktree}
+            onCloseWorktreeSession={onCloseWorktreeSession}
+            onWorktreesChanged={onWorktreesChanged}
+            onCreateWorktree={onCreateWorktree}
           />
         ) : (
           <div style={{ position: 'relative', flex: 1 }}>

--- a/src/components/workspace/WorkspaceModals.tsx
+++ b/src/components/workspace/WorkspaceModals.tsx
@@ -25,6 +25,7 @@ import { ProjectSettingsModal } from './ProjectSettingsModal';
 import { ShopifyStoreModal } from '../shopify/ShopifyStoreModal';
 import { GitErrorHandler } from '../branches/GitErrorHandler';
 import { SubmitReviewModal } from '../branches/SubmitReviewModal';
+import { WorktreeCreateModal } from '../branches/WorktreeCreateModal';
 import { ConflictResolutionModal } from '../branches/ConflictResolutionModal';
 import { OnboardingTerminal } from '../setup';
 import { DownloadIcon, ZapIcon } from '../icons';
@@ -33,6 +34,7 @@ import type { Toast } from '../../hooks/useToasts';
 import type { NotificationSettings } from '../../lib/sounds';
 import type { AgentConfig } from '../../lib/agent';
 import type { BranchInfo } from '../../lib/branches';
+import type { WorktreeInfo } from '../../lib/worktrees';
 import type { AuthTerminalConfig, IntegrationState } from '../../hooks/useIntegrationStatus';
 import type { LoadedPlugin } from '../../hooks/usePlugins';
 import { Spinner } from '../primitives/Spinner';
@@ -147,6 +149,11 @@ export interface WorkspaceModalsProps {
   isShopifyTheme: boolean;
   onShopifyStoreSaved: () => void;
 
+  // Worktree create modal — read state via useModal('worktreeCreate')
+  currentBranch: string;
+  worktrees: WorktreeInfo[];
+  onWorktreeCreated: (path: string) => void;
+
   // Plugin terminal
   pluginTerminal: { command: string; args: string[]; title: string } | null;
   pluginTerminalExited: boolean;
@@ -214,6 +221,9 @@ export function WorkspaceModals({
   isWebProject,
   isShopifyTheme,
   onShopifyStoreSaved,
+  currentBranch,
+  worktrees,
+  onWorktreeCreated,
   pluginTerminal,
   pluginTerminalExited,
   onClosePluginTerminal,
@@ -232,6 +242,14 @@ export function WorkspaceModals({
       />
 
       <AssetsPanel projectPath={projectPath} />
+
+      <WorktreeCreateModal
+        projectPath={projectPath}
+        currentBranch={currentBranch}
+        branches={branches}
+        worktrees={worktrees}
+        onCreated={onWorktreeCreated}
+      />
 
       {/* Education Mode Overlay */}
       {isEducationMode && <EducationOverlay onClose={onCloseEducation} />}

--- a/src/components/workspace/WorkspaceSidebar.tsx
+++ b/src/components/workspace/WorkspaceSidebar.tsx
@@ -15,7 +15,8 @@ import { Button } from '../primitives/Button';
 import { BrowserDropdown } from '../preview/BrowserDropdown';
 import { useOpenPalette } from '../CommandPalette/paletteContext';
 import { ALL_AGENTS, TERMINAL, getAgentById, type AgentConfig } from '../../lib/agent';
-import { isManagedWorktreePath, type WorktreeInfo } from '../../lib/worktrees';
+import { worktreeParentPath, type WorktreeInfo } from '../../lib/worktrees';
+import { formatRelativeTime } from '../../lib/branches';
 import type { TerminalTab } from '../../hooks/useTerminalManagement';
 import type { PinnedProjectRow } from '../../hooks/usePinnedProjects';
 import { useActiveAccount } from '../../hooks/useActiveAccount';
@@ -445,11 +446,26 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
         label: wt.branch ?? wt.head,
         isActive: wt.isCurrent,
         dotState: wt.isCurrent || hasLiveSession ? 'active' : 'muted',
-        meta: wt.isMain ? 'main' : wt.prunable !== null ? 'prunable' : undefined,
+        // Meta: state problems first (stale/locked), else how fresh the
+        // checked-out commit is — same language as the branch cards.
+        meta:
+          wt.prunable !== null
+            ? 'stale'
+            : wt.locked !== null
+              ? 'locked'
+              : wt.lastCommitDate !== null
+                ? formatRelativeTime(wt.lastCommitDate)
+                : undefined,
         onSelect: wt.isCurrent ? undefined : () => onSelectProject(wt.path),
+        // Live background worktree sessions can be shut down from here — the
+        // family close on the project row does all of them at once.
+        onClose:
+          !wt.isCurrent && hasLiveSession && onCloseProject
+            ? () => onCloseProject(wt.path)
+            : undefined,
       };
     });
-  }, [worktrees, registryVersion, onSelectProject]);
+  }, [worktrees, registryVersion, onSelectProject, onCloseProject]);
 
   const filterLower = filter.trim().toLowerCase();
   const matchesFilter = (label: string) =>
@@ -470,41 +486,64 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
   // the session registry, which tracks every project that's been opened
   // this launch. Dev servers stay alive for these rows until the user hits
   // the close button.
+  // A "family" is one repository: the main checkout plus its worktrees. The
+  // sidebar shows ONE row per family — worktree sessions never appear as
+  // separate top-level rows; they live inside the family row's body.
+  const familyKeyOf = (path: string) => worktreeParentPath(path) ?? path;
+  const currentFamily = currentProjectPath !== null ? familyKeyOf(currentProjectPath) : null;
+
   const activeRows: PinnedProjectRow[] = useMemo(() => {
     // `registryVersion` is the reactivity trigger — snapshots are read below.
     void registryVersion;
     const snaps = sessionRegistry.snapshotAll();
-    const rows: PinnedProjectRow[] = [];
+    const families = new Map<string, typeof snaps>();
     for (const snap of snaps) {
-      if (pinnedPaths.has(snap.projectPath)) continue;
-      rows.push({
-        projectPath: snap.projectPath,
-        fallbackName: basename(snap.projectPath) || 'Project',
-        status: snap.status,
-        agentStatus: snap.lastAgentStatus,
-        unreadCount: snap.unreadCount,
-        memoryBytes: snap.memoryBytes,
-        isCurrent: snap.projectPath === currentProjectPath,
-      });
+      const family = familyKeyOf(snap.projectPath);
+      // Families whose root is pinned render under Pinned, not Active —
+      // their worktree sessions show inside the pinned row's body.
+      if (pinnedPaths.has(snap.projectPath) || pinnedPaths.has(family)) continue;
+      const list = families.get(family);
+      if (list) list.push(snap);
+      else families.set(family, [snap]);
     }
-    // Registry order is activation order; stabilize by path so swapping
+    const rows: PinnedProjectRow[] = [...families.entries()].map(([family, members]) => {
+      const root = members.find((m) => m.projectPath === family);
+      const primary = root ?? members[0];
+      return {
+        projectPath: family,
+        fallbackName: basename(family) || 'Project',
+        status: members.some((m) => m.status === 'active') ? 'active' : primary.status,
+        agentStatus: primary.lastAgentStatus,
+        unreadCount: members.reduce((n, m) => n + m.unreadCount, 0),
+        memoryBytes: members.reduce((n, m) => n + m.memoryBytes, 0),
+        isCurrent: currentFamily === family,
+      };
+    });
+    // Stable name order (matches useProjectNumberShortcuts) so swapping
     // between two active projects doesn't reorder rows.
-    rows.sort((a, b) => a.projectPath.localeCompare(b.projectPath));
+    rows.sort(
+      (a, b) =>
+        a.fallbackName.localeCompare(b.fallbackName) || a.projectPath.localeCompare(b.projectPath)
+    );
     return rows;
-  }, [pinnedPaths, currentProjectPath, registryVersion]);
+  }, [pinnedPaths, currentFamily, registryVersion]);
 
   // Edge case: current project isn't in pinned or active (e.g. the session
   // registry hasn't picked it up yet during the initial open). Synthesize
   // a row so the workspace still has a sidebar entry.
   const currentIsKnown =
-    currentProjectPath !== null &&
-    (pinnedPaths.has(currentProjectPath) ||
-      activeRows.some((p) => p.projectPath === currentProjectPath));
+    currentFamily !== null &&
+    (pinnedRows.some((r) => familyKeyOf(r.projectPath) === currentFamily) ||
+      activeRows.some((p) => p.projectPath === currentFamily));
   const currentExternalRow: PinnedProjectRow | null =
-    currentProjectPath && !currentIsKnown
+    currentProjectPath && currentFamily && !currentIsKnown
       ? {
-          projectPath: currentProjectPath,
-          fallbackName: currentProjectName ?? (basename(currentProjectPath) || 'Project'),
+          projectPath: currentFamily,
+          fallbackName:
+            basename(currentFamily) ||
+            currentProjectName ||
+            basename(currentProjectPath) ||
+            'Project',
           status: 'active',
           agentStatus: 'idle',
           unreadCount: 0,
@@ -520,11 +559,12 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
 
   // Force-open the group containing the current project. We honor the
   // user's manual collapsed state for the OTHER group.
-  const currentInPinned = currentProjectPath !== null && pinnedPaths.has(currentProjectPath);
+  const currentInPinned =
+    currentFamily !== null && pinnedRows.some((r) => familyKeyOf(r.projectPath) === currentFamily);
   const currentInActive =
-    currentProjectPath !== null &&
+    currentFamily !== null &&
     !currentInPinned &&
-    (currentExternalRow !== null || activeRows.some((r) => r.projectPath === currentProjectPath));
+    (currentExternalRow !== null || activeRows.some((r) => r.projectPath === currentFamily));
   const pinnedOpen = currentInPinned || !groupCollapsed.pinned;
   const activeOpen = currentInActive || !groupCollapsed.projects;
 
@@ -548,11 +588,42 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
   // live agent/terminal/command sections; anyone else gets the read-only
   // InactiveProjectSections view fed from the session registry.
   const renderProjectRow = (row: PinnedProjectRow) => {
-    const isCurrent = row.projectPath === currentProjectPath;
+    // A row is "current" when the current project is any member of its
+    // family — being inside a worktree still highlights the project row.
+    const isCurrent = currentFamily !== null && familyKeyOf(row.projectPath) === currentFamily;
     const expanded = isProjectExpanded(row.projectPath);
     // Only rows with a live session can be closed. Pinned rows that have
     // never been opened this launch show status 'inactive' and get no X.
     const canClose = !!onCloseProject && row.status !== 'inactive';
+    // Closing a family row shuts down every member session (main checkout
+    // and worktrees alike) — leaving invisible hot sessions behind would
+    // silently keep dev servers and PTYs running.
+    const closeFamily = () => {
+      if (!onCloseProject) return;
+      const members = sessionRegistry
+        .snapshotAll()
+        .filter((s) => familyKeyOf(s.projectPath) === familyKeyOf(row.projectPath))
+        .map((s) => s.projectPath);
+      for (const path of members.length > 0 ? members : [row.projectPath]) {
+        onCloseProject(path);
+      }
+    };
+    // Hot sessions in this family other than the row's own path — rendered
+    // as a Worktrees section inside non-current rows' bodies.
+    const familyWorktreeItems: SidebarItem[] = sessionRegistry
+      .snapshotAll()
+      .filter(
+        (s) =>
+          s.projectPath !== row.projectPath &&
+          familyKeyOf(s.projectPath) === familyKeyOf(row.projectPath)
+      )
+      .map((s) => ({
+        key: `bg-wt-${s.projectPath}`,
+        label: basename(s.projectPath) || s.projectPath,
+        dotState: s.status === 'active' ? ('active' as const) : ('muted' as const),
+        onSelect: () => onSelectProject(s.projectPath),
+        onClose: onCloseProject ? () => onCloseProject(s.projectPath) : undefined,
+      }));
     return (
       <ProjectGroup
         key={row.projectPath}
@@ -562,11 +633,24 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
         shortcutNumber={shortcutNumberFor(row)}
         onToggleExpand={() => toggleProjectExpanded(row.projectPath)}
         onSelectProject={onSelectProject}
-        onClose={canClose ? () => onCloseProject(row.projectPath) : undefined}
+        onClose={canClose ? closeFamily : undefined}
       >
         {expanded &&
           (isCurrent ? (
             <div key="current-body" className="sidebar-project-body-inner">
+              {worktreeItems.length > 0 && (
+                <SidebarSection
+                  id="worktrees"
+                  label="Worktrees"
+                  total={worktreeItems.length}
+                  collapsed={collapsed.worktrees}
+                  onToggle={() => toggleSection('worktrees')}
+                  onAdd={onAddWorktree ? () => onAddWorktree() : undefined}
+                  addLabel="New worktree"
+                  items={worktreeItems.filter((i) => matchesFilter(i.label))}
+                  emptyHint={filter ? 'No matches' : 'No worktrees'}
+                />
+              )}
               <SidebarSection
                 id="agents"
                 label="Agents"
@@ -592,19 +676,6 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
                 items={filteredTerminals}
                 emptyHint={filter ? 'No matches' : 'No terminals'}
               />
-              {worktreeItems.length > 0 && (
-                <SidebarSection
-                  id="worktrees"
-                  label="Worktrees"
-                  total={worktreeItems.length}
-                  collapsed={collapsed.worktrees}
-                  onToggle={() => toggleSection('worktrees')}
-                  onAdd={onAddWorktree ? () => onAddWorktree() : undefined}
-                  addLabel="New worktree"
-                  items={worktreeItems.filter((i) => matchesFilter(i.label))}
-                  emptyHint={filter ? 'No matches' : 'No worktrees'}
-                />
-              )}
               <SidebarSection
                 id="commands"
                 label="Dev server"
@@ -619,6 +690,7 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
             <div key="inactive-body" className="sidebar-project-body-inner">
               <InactiveProjectSections
                 snapshot={sessionRegistry.snapshot(row.projectPath)}
+                worktreeItems={familyWorktreeItems}
                 filterLower={filterLower}
                 hasLiveDevServer={isProjectDevServerRunning?.(row.projectPath) ?? false}
                 onSelectTab={(sessionId) => {
@@ -781,11 +853,14 @@ function SidebarGroupHeader({
  */
 function InactiveProjectSections({
   snapshot,
+  worktreeItems,
   filterLower,
   hasLiveDevServer,
   onSelectTab,
 }: {
   snapshot: SessionSnapshot | undefined;
+  /** Hot worktree sessions in this project's family (empty when none). */
+  worktreeItems?: SidebarItem[];
   filterLower: string;
   /** True if a dev server is currently tracked for this project path. */
   hasLiveDevServer: boolean;
@@ -826,6 +901,17 @@ function InactiveProjectSections({
 
   return (
     <>
+      {worktreeItems && worktreeItems.length > 0 && (
+        <SidebarSection
+          id="worktrees"
+          label="Worktrees"
+          total={worktreeItems.length}
+          collapsed={false}
+          onToggle={() => {}}
+          items={worktreeItems.filter((i) => matches(i.label))}
+          emptyHint={filterLower ? 'No matches' : 'No worktrees'}
+        />
+      )}
       <SidebarSection
         id="agents"
         label="Agents"
@@ -857,6 +943,29 @@ function InactiveProjectSections({
   );
 }
 
+/**
+ * Project-row label. Worktree names ("project / branch") ellipsize the
+ * PROJECT part and always keep the branch visible — end-truncation would
+ * render every worktree of one project as the same "myproject…" string,
+ * which reads as duplicate rows.
+ */
+function ProjectRowName({ name }: { name: string }) {
+  const slash = name.indexOf(' / ');
+  if (slash === -1) {
+    return (
+      <span className="sidebar-project-name" title={name}>
+        {name}
+      </span>
+    );
+  }
+  return (
+    <span className="sidebar-project-name sidebar-project-name-split" title={name}>
+      <span className="sidebar-project-name-repo">{name.slice(0, slash)}</span>
+      <span className="sidebar-project-name-branch">{name.slice(slash)}</span>
+    </span>
+  );
+}
+
 function ProjectGroup({
   row,
   isCurrent,
@@ -882,7 +991,10 @@ function ProjectGroup({
   // Parent WorkspaceSidebar subscribes to the registry; this snapshot is
   // therefore re-read on every relevant change.
   const snap = sessionRegistry.snapshot(row.projectPath);
-  const dot = projectDotState(row, snap?.terminalTabs);
+  const baseDot = projectDotState(row, snap?.terminalTabs);
+  // Family rows can be live purely through a worktree session (the root path
+  // itself has no tabs) — the aggregated row status is authoritative then.
+  const dot = baseDot === 'muted' && row.status === 'active' ? 'active' : baseDot;
   const memoryLabel =
     row.memoryBytes > 0 ? `${Math.round(row.memoryBytes / (1024 * 1024))}MB` : null;
 
@@ -926,12 +1038,7 @@ function ProjectGroup({
         >
           {shortcutNumber !== null ? kbd('mod', String(shortcutNumber)) : initials}
         </span>
-        <span className="sidebar-project-name" title={row.fallbackName}>
-          {row.fallbackName}
-        </span>
-        {isManagedWorktreePath(row.projectPath) && (
-          <span className="sidebar-project-meta">worktree</span>
-        )}
+        <ProjectRowName name={row.fallbackName} />
         {memoryLabel && <span className="sidebar-project-meta">{memoryLabel}</span>}
         {onClose && (
           <button

--- a/src/components/workspace/WorkspaceSidebar.tsx
+++ b/src/components/workspace/WorkspaceSidebar.tsx
@@ -15,6 +15,7 @@ import { Button } from '../primitives/Button';
 import { BrowserDropdown } from '../preview/BrowserDropdown';
 import { useOpenPalette } from '../CommandPalette/paletteContext';
 import { ALL_AGENTS, TERMINAL, getAgentById, type AgentConfig } from '../../lib/agent';
+import { isManagedWorktreePath, type WorktreeInfo } from '../../lib/worktrees';
 import type { TerminalTab } from '../../hooks/useTerminalManagement';
 import type { PinnedProjectRow } from '../../hooks/usePinnedProjects';
 import { useActiveAccount } from '../../hooks/useActiveAccount';
@@ -29,7 +30,7 @@ import {
   type TabStatus,
 } from '../../lib/sessionRegistry';
 
-type SectionId = 'agents' | 'terminals' | 'commands';
+type SectionId = 'agents' | 'terminals' | 'worktrees' | 'commands';
 type GroupId = 'pinned' | 'projects';
 
 interface SidebarItem {
@@ -112,6 +113,13 @@ interface Props {
    *  can reflect the live state. Evaluated on each render. */
   isProjectDevServerRunning?: (projectPath: string) => boolean;
 
+  // Worktrees
+  /** All worktrees of the current project's repository (`git worktree list`,
+   *  main first). Empty for non-git projects — the section hides itself. */
+  worktrees?: WorktreeInfo[];
+  /** Open the "New worktree" modal. When omitted, the section has no "+". */
+  onAddWorktree?: () => void;
+
   /** Open the "Switch Workspace" picker. When omitted, the footer button
    *  showing the active Workspace is not rendered. */
   onSwitchAccount?: () => void;
@@ -127,7 +135,7 @@ function readCollapsed(): Record<SectionId, boolean> {
   } catch {
     // ignore
   }
-  return { agents: false, terminals: false, commands: false };
+  return { agents: false, terminals: false, worktrees: false, commands: false };
 }
 
 function writeCollapsed(state: Record<SectionId, boolean>) {
@@ -250,6 +258,8 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
   onRestartDevServer,
   devServerUrl,
   isProjectDevServerRunning,
+  worktrees,
+  onAddWorktree,
   onSwitchAccount,
 }: Props) {
   const { activeAccount, accounts } = useActiveAccount(currentProjectPath);
@@ -421,6 +431,26 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
     devServerUrl,
   ]);
 
+  // Worktree rows for the current project. Clicking a non-current worktree
+  // performs the same in-place project switch as any other sidebar row — the
+  // previous worktree's session (PTYs + dev server) stays hot in "Active".
+  const worktreeItems = useMemo<SidebarItem[]>(() => {
+    void registryVersion;
+    const list = worktrees ?? [];
+    return list.map((wt) => {
+      const snap = sessionRegistry.snapshot(wt.path);
+      const hasLiveSession = snap?.status === 'active';
+      return {
+        key: `worktree-${wt.path}`,
+        label: wt.branch ?? wt.head,
+        isActive: wt.isCurrent,
+        dotState: wt.isCurrent || hasLiveSession ? 'active' : 'muted',
+        meta: wt.isMain ? 'main' : wt.prunable !== null ? 'prunable' : undefined,
+        onSelect: wt.isCurrent ? undefined : () => onSelectProject(wt.path),
+      };
+    });
+  }, [worktrees, registryVersion, onSelectProject]);
+
   const filterLower = filter.trim().toLowerCase();
   const matchesFilter = (label: string) =>
     !filterLower || label.toLowerCase().includes(filterLower);
@@ -562,6 +592,19 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
                 items={filteredTerminals}
                 emptyHint={filter ? 'No matches' : 'No terminals'}
               />
+              {worktreeItems.length > 0 && (
+                <SidebarSection
+                  id="worktrees"
+                  label="Worktrees"
+                  total={worktreeItems.length}
+                  collapsed={collapsed.worktrees}
+                  onToggle={() => toggleSection('worktrees')}
+                  onAdd={onAddWorktree ? () => onAddWorktree() : undefined}
+                  addLabel="New worktree"
+                  items={worktreeItems.filter((i) => matchesFilter(i.label))}
+                  emptyHint={filter ? 'No matches' : 'No worktrees'}
+                />
+              )}
               <SidebarSection
                 id="commands"
                 label="Dev server"
@@ -886,6 +929,9 @@ function ProjectGroup({
         <span className="sidebar-project-name" title={row.fallbackName}>
           {row.fallbackName}
         </span>
+        {isManagedWorktreePath(row.projectPath) && (
+          <span className="sidebar-project-meta">worktree</span>
+        )}
         {memoryLabel && <span className="sidebar-project-meta">{memoryLabel}</span>}
         {onClose && (
           <button

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -21,7 +21,8 @@ import {
 } from 'react';
 import { listen } from '@tauri-apps/api/event';
 import { logger } from '../../lib/logger';
-import { setTerminalState } from '../../lib/project';
+import { setTerminalState, checkDependenciesInstalled } from '../../lib/project';
+import { detectPackageManager } from '../../lib/github';
 import { Terminal } from '../terminal/Terminal';
 import { StaleEnvBanner } from '../terminal/StaleEnvBanner';
 import { DevServerLogs } from '../terminal/DevServerLogs';
@@ -141,6 +142,9 @@ interface DevServerProps {
    *  (crash / external kill). Lets the Preview offer a real process restart. */
   devServerUnexpectedExit: DevServerUnexpectedExit | null;
   onRunInstall: () => void;
+  /** Path-scoped install trigger — used to auto-install a fresh worktree's
+   *  dependencies without waiting for the Preview CTA click. */
+  onRunInstallFor: (projectPath: string, packageManager: string) => void;
   /** Type into the dev-server PTY (interactive CLI prompts in the logs pane). */
   onDevServerInput: (data: string) => void;
   /** Sync the dev-server PTY size to the logs terminal. */
@@ -467,6 +471,7 @@ export const WorkspaceView = memo(function WorkspaceView({
     needsInstall,
     devServerUnexpectedExit,
     onRunInstall,
+    onRunInstallFor,
     onDevServerInput,
     onDevServerResize,
   } = devServer;
@@ -1629,6 +1634,18 @@ export const WorkspaceView = memo(function WorkspaceView({
             showToast('Worktree created', 'success');
             void refreshWorktrees();
             onSelectProject(path);
+            // A fresh worktree checkout never has node_modules — start the
+            // install immediately instead of waiting for the Preview CTA.
+            void checkDependenciesInstalled(path)
+              .then(async (status) => {
+                if (status.hasPackageJson && !status.installed) {
+                  const pm = await detectPackageManager(path).catch(() => 'npm');
+                  onRunInstallFor(path, pm);
+                }
+              })
+              .catch(() => {
+                // Detection failure just falls back to the existing CTA flow.
+              });
           }}
           customDevCommand={customDevCommand}
           onSaveDevCommand={handleSaveDevCommand}

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -21,8 +21,7 @@ import {
 } from 'react';
 import { listen } from '@tauri-apps/api/event';
 import { logger } from '../../lib/logger';
-import { setTerminalState, checkDependenciesInstalled } from '../../lib/project';
-import { detectPackageManager } from '../../lib/github';
+import { setTerminalState } from '../../lib/project';
 import { Terminal } from '../terminal/Terminal';
 import { StaleEnvBanner } from '../terminal/StaleEnvBanner';
 import { DevServerLogs } from '../terminal/DevServerLogs';
@@ -57,7 +56,7 @@ import {
   RedoIcon,
 } from '../icons';
 import { useSnapshots } from '../../hooks/useSnapshots';
-import { useWorktrees } from '../../hooks/useWorktrees';
+import { useWorktreeWorkflow } from '../../hooks/useWorktreeWorkflow';
 import { ToolbarDropdown } from './ToolbarDropdown';
 import { TerminalSplitHeaders } from './TerminalSplitHeaders';
 import { TerminalSplitDividers } from './TerminalSplitDividers';
@@ -432,12 +431,6 @@ export const WorkspaceView = memo(function WorkspaceView({
   const devCommandModal = useModal('devCommand');
   const projectSettingsModal = useModal('projectSettings');
   const pluginManagerModal = useModal('pluginManager');
-  const worktreeCreateModal = useModal('worktreeCreate');
-
-  // Worktrees of the current project's repository (main worktree first).
-  // Refreshed alongside branch info so the sidebar/Branches tab stay in sync
-  // with `git worktree` state.
-  const { worktrees, refresh: refreshWorktrees } = useWorktrees(currentProject.path);
   useEffect(() => {
     const cleanups = [
       envEditorModal.registerOnClose(focusActiveTerminal),
@@ -561,6 +554,16 @@ export const WorkspaceView = memo(function WorkspaceView({
   const { isEducationMode, closeEducation } = modals;
 
   const { toasts: toastList, showToast, dismissToast } = toasts;
+
+  // Worktrees of the current project's repository (state, create-modal
+  // trigger, post-create open + auto-install). Logic lives in the hook.
+  const worktree = useWorktreeWorkflow({
+    projectPath: currentProject.path,
+    showToast,
+    onSelectProject,
+    onCloseProject,
+    onRunInstallFor,
+  });
 
   const {
     currentBranch,
@@ -747,8 +750,8 @@ export const WorkspaceView = memo(function WorkspaceView({
     openPushDropdown: () => setForcePublishOpen(true),
     handlePullLatest: () => void handlePullLatest(),
     isGitHubConnected: integrations.projectGithub?.status === 'connected',
-    openWorktreeCreate: () => worktreeCreateModal.open(),
-    hasWorktreeData: worktrees.length > 0,
+    openWorktreeCreate: worktree.openCreate,
+    hasWorktreeData: worktree.worktrees.length > 0,
   });
 
   // Shopify themes: preview gate state + palette commands.
@@ -1034,7 +1037,7 @@ export const WorkspaceView = memo(function WorkspaceView({
     onPublishStatusChange: () => {
       void handleGitHubStatusChange();
       void fetchBranchInfo(currentProject.path);
-      void refreshWorktrees();
+      void worktree.refresh();
     },
     onCreatePR: () => setShowSubmitReview(currentBranch || 'main'),
     forcePublishOpen,
@@ -1131,8 +1134,8 @@ export const WorkspaceView = memo(function WorkspaceView({
                 isWebProject && devServerPort > 0 ? `http://localhost:${devServerPort}` : undefined
               }
               isProjectDevServerRunning={isProjectDevServerRunning}
-              worktrees={worktrees}
-              onAddWorktree={() => worktreeCreateModal.open()}
+              worktrees={worktree.worktrees}
+              onAddWorktree={worktree.openCreate}
               onSwitchAccount={onSwitchAccount}
             />
             <div className="workspace-main">
@@ -1531,11 +1534,7 @@ export const WorkspaceView = memo(function WorkspaceView({
                         handleResolveConflicts={handleResolveConflicts}
                         handleGitHubConnect={handleGitHubConnect}
                         onSendToAgent={sendToClaude}
-                        worktrees={worktrees}
-                        onOpenWorktree={onSelectProject}
-                        onCloseWorktreeSession={onCloseProject}
-                        onWorktreesChanged={() => void refreshWorktrees()}
-                        onCreateWorktree={() => worktreeCreateModal.open()}
+                        {...worktree.tabProps}
                       />
                     </div>
                   }
@@ -1629,24 +1628,8 @@ export const WorkspaceView = memo(function WorkspaceView({
           onCloseInstallTerminal={onCloseInstallTerminal}
           onInstallTerminalExit={onInstallTerminalExit}
           currentBranch={currentBranch || 'main'}
-          worktrees={worktrees}
-          onWorktreeCreated={(path) => {
-            showToast('Worktree created', 'success');
-            void refreshWorktrees();
-            onSelectProject(path);
-            // A fresh worktree checkout never has node_modules — start the
-            // install immediately instead of waiting for the Preview CTA.
-            void checkDependenciesInstalled(path)
-              .then(async (status) => {
-                if (status.hasPackageJson && !status.installed) {
-                  const pm = await detectPackageManager(path).catch(() => 'npm');
-                  onRunInstallFor(path, pm);
-                }
-              })
-              .catch(() => {
-                // Detection failure just falls back to the existing CTA flow.
-              });
-          }}
+          worktrees={worktree.worktrees}
+          onWorktreeCreated={worktree.handleCreated}
           customDevCommand={customDevCommand}
           onSaveDevCommand={handleSaveDevCommand}
           devServerPort={devServerPort}

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -56,6 +56,7 @@ import {
   RedoIcon,
 } from '../icons';
 import { useSnapshots } from '../../hooks/useSnapshots';
+import { useWorktrees } from '../../hooks/useWorktrees';
 import { ToolbarDropdown } from './ToolbarDropdown';
 import { TerminalSplitHeaders } from './TerminalSplitHeaders';
 import { TerminalSplitDividers } from './TerminalSplitDividers';
@@ -427,6 +428,12 @@ export const WorkspaceView = memo(function WorkspaceView({
   const devCommandModal = useModal('devCommand');
   const projectSettingsModal = useModal('projectSettings');
   const pluginManagerModal = useModal('pluginManager');
+  const worktreeCreateModal = useModal('worktreeCreate');
+
+  // Worktrees of the current project's repository (main worktree first).
+  // Refreshed alongside branch info so the sidebar/Branches tab stay in sync
+  // with `git worktree` state.
+  const { worktrees, refresh: refreshWorktrees } = useWorktrees(currentProject.path);
   useEffect(() => {
     const cleanups = [
       envEditorModal.registerOnClose(focusActiveTerminal),
@@ -735,6 +742,8 @@ export const WorkspaceView = memo(function WorkspaceView({
     openPushDropdown: () => setForcePublishOpen(true),
     handlePullLatest: () => void handlePullLatest(),
     isGitHubConnected: integrations.projectGithub?.status === 'connected',
+    openWorktreeCreate: () => worktreeCreateModal.open(),
+    hasWorktreeData: worktrees.length > 0,
   });
 
   // Shopify themes: preview gate state + palette commands.
@@ -1020,6 +1029,7 @@ export const WorkspaceView = memo(function WorkspaceView({
     onPublishStatusChange: () => {
       void handleGitHubStatusChange();
       void fetchBranchInfo(currentProject.path);
+      void refreshWorktrees();
     },
     onCreatePR: () => setShowSubmitReview(currentBranch || 'main'),
     forcePublishOpen,
@@ -1116,6 +1126,8 @@ export const WorkspaceView = memo(function WorkspaceView({
                 isWebProject && devServerPort > 0 ? `http://localhost:${devServerPort}` : undefined
               }
               isProjectDevServerRunning={isProjectDevServerRunning}
+              worktrees={worktrees}
+              onAddWorktree={() => worktreeCreateModal.open()}
               onSwitchAccount={onSwitchAccount}
             />
             <div className="workspace-main">
@@ -1514,6 +1526,11 @@ export const WorkspaceView = memo(function WorkspaceView({
                         handleResolveConflicts={handleResolveConflicts}
                         handleGitHubConnect={handleGitHubConnect}
                         onSendToAgent={sendToClaude}
+                        worktrees={worktrees}
+                        onOpenWorktree={onSelectProject}
+                        onCloseWorktreeSession={onCloseProject}
+                        onWorktreesChanged={() => void refreshWorktrees()}
+                        onCreateWorktree={() => worktreeCreateModal.open()}
                       />
                     </div>
                   }
@@ -1606,6 +1623,13 @@ export const WorkspaceView = memo(function WorkspaceView({
           installTerminalExited={installTerminalExited}
           onCloseInstallTerminal={onCloseInstallTerminal}
           onInstallTerminalExit={onInstallTerminalExit}
+          currentBranch={currentBranch || 'main'}
+          worktrees={worktrees}
+          onWorktreeCreated={(path) => {
+            showToast('Worktree created', 'success');
+            void refreshWorktrees();
+            onSelectProject(path);
+          }}
           customDevCommand={customDevCommand}
           onSaveDevCommand={handleSaveDevCommand}
           devServerPort={devServerPort}

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -40,7 +40,8 @@ export type ModalId =
   | 'diff'
   | 'quitConfirm'
   | 'commandPalette'
-  | 'shopifyStore';
+  | 'shopifyStore'
+  | 'worktreeCreate';
 
 interface ModalContextValue {
   isOpen: (id: ModalId) => boolean;

--- a/src/hooks/usePinnedProjects.ts
+++ b/src/hooks/usePinnedProjects.ts
@@ -36,6 +36,7 @@ import { logger } from '../lib/logger';
 import { trackEvent } from '../lib/analytics';
 import { getProjectId } from '../lib/projectIdentity';
 import { basename } from '../lib/paths';
+import { worktreeDisplayName } from '../lib/worktrees';
 
 /** A pinned project as the rail wants to render it. */
 export interface PinnedProjectRow {
@@ -98,7 +99,7 @@ function buildRows(
     const snap = snapshotByPath.get(projectPath);
     return {
       projectPath,
-      fallbackName: lastPathSegment(projectPath),
+      fallbackName: worktreeDisplayName(projectPath) ?? lastPathSegment(projectPath),
       status: snap?.status ?? 'inactive',
       agentStatus: snap?.lastAgentStatus ?? 'idle',
       unreadCount: snap?.unreadCount ?? 0,

--- a/src/hooks/usePlugins.ts
+++ b/src/hooks/usePlugins.ts
@@ -163,11 +163,15 @@ export function usePlugins(
   // Reload when project changes
   useEffect(() => {
     mountedRef.current = true;
+    // Unload the previous project's plugins under the path they were loaded
+    // with — the module cache is keyed by (path, id), so unloading with the
+    // NEW path is a silent no-op that leaves the old modules' timers and
+    // hooks alive, firing backend calls against a project where the plugin
+    // isn't installed ("Plugin 'x' not found" toasts on project switch).
+    const previousPath = currentPathRef.current;
     currentPathRef.current = projectPath;
-
-    // Unload previous plugins
     plugins.forEach((p) =>
-      unloadPluginModule(currentPathRef.current || '', p.info.manifest.id, handleLifecycleError)
+      unloadPluginModule(previousPath || '', p.info.manifest.id, handleLifecycleError)
     );
 
     void loadAllPlugins(projectPath);

--- a/src/hooks/useProjectBulkActions.test.ts
+++ b/src/hooks/useProjectBulkActions.test.ts
@@ -38,6 +38,7 @@ function makeProject(overrides: Partial<DashboardProject> = {}): DashboardProjec
     hide_main_branch_warning: null,
     is_external: false,
     workspace_subpath: null,
+    worktree_count: null,
     ...overrides,
   };
 }

--- a/src/hooks/useProjectNumberShortcuts.ts
+++ b/src/hooks/useProjectNumberShortcuts.ts
@@ -3,6 +3,7 @@ import type { Project } from '../lib/project';
 import { sessionRegistry } from '../lib/sessionRegistry';
 import { useModal } from '../contexts/ModalContext';
 import { basename } from '../lib/paths';
+import { worktreeParentPath } from '../lib/worktrees';
 
 interface Params {
   /** Pinned-row paths, in sidebar order. */
@@ -38,11 +39,16 @@ export function useProjectNumberShortcuts({ pinnedPaths, handleSelectProject }: 
       const { pinnedPaths: pins, handleSelectProject: open, closePalette } = latest.current;
 
       const pinSet = new Set(pins);
+      // One entry per repository family (a project and its worktrees are one
+      // sidebar row), name-ordered — must mirror WorkspaceSidebar's grouping.
+      const familyKeyOf = (p: string) => worktreeParentPath(p) ?? p;
+      const seen = new Set<string>();
       const activePaths = sessionRegistry
         .snapshotAll()
-        .map((s) => s.projectPath)
+        .map((s) => familyKeyOf(s.projectPath))
         .filter((p) => !pinSet.has(p))
-        .sort((a, b) => a.localeCompare(b));
+        .filter((p) => (seen.has(p) ? false : (seen.add(p), true)))
+        .sort((a, b) => (basename(a) || a).localeCompare(basename(b) || b) || a.localeCompare(b));
 
       const ordered = [...pins, ...activePaths];
       const path = ordered[index];

--- a/src/hooks/useProjectRail.ts
+++ b/src/hooks/useProjectRail.ts
@@ -17,6 +17,7 @@ import { usePinnedProjects, type UsePinnedProjectsReturn } from './usePinnedProj
 import { logger } from '../lib/logger';
 import { asCommandError, formatCommandError } from '../lib/errors';
 import { basename } from '../lib/paths';
+import { worktreeDisplayName } from '../lib/worktrees';
 
 export interface UseProjectRailParams {
   /** Path of the project the workspace is currently showing, or `null`. */
@@ -74,7 +75,7 @@ export function useProjectRail({
       // Clicking a pin cold-starts the project today (it's a launcher,
       // not background sessions). Phase 2d–2f will swap this for
       // in-place activation when the session is already alive.
-      const projectName = basename(projectPath) || 'project';
+      const projectName = worktreeDisplayName(projectPath) ?? (basename(projectPath) || 'project');
       void handleSelectProject({ name: projectName, path: projectPath, thumbnail: null });
     },
     [handleSelectProject]

--- a/src/hooks/useWorktreeWorkflow.ts
+++ b/src/hooks/useWorktreeWorkflow.ts
@@ -1,0 +1,77 @@
+import { useCallback, useMemo } from 'react';
+import { useWorktrees } from './useWorktrees';
+import { useModal } from '../contexts/ModalContext';
+import { checkDependenciesInstalled } from '../lib/project';
+import { detectPackageManager } from '../lib/github';
+import type { WorktreeInfo } from '../lib/worktrees';
+
+interface Params {
+  projectPath: string;
+  showToast: (message: string, type?: 'success' | 'error') => void;
+  /** In-place workspace switch — the same handler the sidebar rail uses. */
+  onSelectProject: (path: string) => void;
+  /** Tear down a session (dev server + PTYs) before a worktree is removed. */
+  onCloseProject: (path: string) => void;
+  /** Path-scoped dependency install (opens the install terminal overlay). */
+  onRunInstallFor: (path: string, packageManager: string) => void;
+}
+
+/** Worktree props consumed by BranchPRTabContainer / BranchesTab. */
+export interface WorktreeTabProps {
+  worktrees: WorktreeInfo[];
+  onOpenWorktree: (path: string) => void;
+  onCloseWorktreeSession: (path: string) => void;
+  onWorktreesChanged: () => void;
+  onCreateWorktree: () => void;
+}
+
+/**
+ * Owns the workspace's worktree wiring: the `git worktree list` state, the
+ * create-modal trigger, and the post-create flow (open the new worktree,
+ * auto-install its dependencies). WorkspaceView stays a pure orchestrator.
+ */
+export function useWorktreeWorkflow({
+  projectPath,
+  showToast,
+  onSelectProject,
+  onCloseProject,
+  onRunInstallFor,
+}: Params) {
+  const modal = useModal('worktreeCreate');
+  const { worktrees, refresh } = useWorktrees(projectPath);
+  const openCreate = modal.open;
+
+  const handleCreated = useCallback(
+    (path: string) => {
+      showToast('Worktree created', 'success');
+      void refresh();
+      onSelectProject(path);
+      // A fresh worktree checkout never has node_modules — start the install
+      // immediately instead of waiting for the Preview CTA click.
+      void checkDependenciesInstalled(path)
+        .then(async (status) => {
+          if (status.hasPackageJson && !status.installed) {
+            const pm = await detectPackageManager(path).catch(() => 'npm');
+            onRunInstallFor(path, pm);
+          }
+        })
+        .catch(() => {
+          // Detection failure just falls back to the existing install CTA.
+        });
+    },
+    [showToast, refresh, onSelectProject, onRunInstallFor]
+  );
+
+  const tabProps: WorktreeTabProps = useMemo(
+    () => ({
+      worktrees,
+      onOpenWorktree: onSelectProject,
+      onCloseWorktreeSession: onCloseProject,
+      onWorktreesChanged: () => void refresh(),
+      onCreateWorktree: openCreate,
+    }),
+    [worktrees, onSelectProject, onCloseProject, refresh, openCreate]
+  );
+
+  return { worktrees, refresh, openCreate, handleCreated, tabProps };
+}

--- a/src/hooks/useWorktrees.ts
+++ b/src/hooks/useWorktrees.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useAsyncState } from './useAsyncState';
+import { listWorktrees, type WorktreeInfo } from '../lib/worktrees';
+
+export interface UseWorktreesReturn {
+  /** All worktrees of the current project's repository (main first). */
+  worktrees: WorktreeInfo[];
+  isLoading: boolean;
+  /** Re-query `git worktree list` — call after add/remove/prune or branch ops. */
+  refresh: () => Promise<WorktreeInfo[] | null>;
+}
+
+/**
+ * Worktree list for a project path. Loads on mount / path change; callers
+ * refresh after mutations (add/remove/prune) and alongside branch refreshes.
+ */
+export function useWorktrees(projectPath: string | null): UseWorktreesReturn {
+  const { data, isLoading, execute } = useAsyncState<WorktreeInfo[]>(async () =>
+    projectPath ? listWorktrees(projectPath) : []
+  );
+
+  useEffect(() => {
+    void execute();
+  }, [projectPath, execute]);
+
+  return { worktrees: data ?? [], isLoading, refresh: execute };
+}

--- a/src/lib/project.test.ts
+++ b/src/lib/project.test.ts
@@ -75,6 +75,7 @@ describe('lib/project', () => {
           hide_main_branch_warning: false,
           is_external: false,
           workspace_subpath: null,
+          worktree_count: null,
         },
       ];
       invokeMock.mockResolvedValue(projects);
@@ -99,6 +100,7 @@ describe('lib/project', () => {
           hide_main_branch_warning: null,
           is_external: true,
           workspace_subpath: null,
+          worktree_count: null,
         },
       ];
       invokeMock.mockResolvedValue(projects);

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -53,6 +53,8 @@ export interface DashboardProject {
   is_external: boolean;
   /** Active monorepo workspace subpath (e.g. `apps/admin`), or null. */
   workspace_subpath: string | null;
+  /** Number of linked git worktrees under `~/ShipStudio/.worktrees/<name>`, or null. */
+  worktree_count: number | null;
 }
 
 /**

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the git worktree Tauri wrappers (src/lib/worktrees.ts):
+ * snake_case → camelCase mapping, argument passthrough, and the
+ * managed-path helper.
+ */
+
+import { mockIPC } from '@tauri-apps/api/mocks';
+import { describe, it, expect } from 'vitest';
+import {
+  listWorktrees,
+  addWorktree,
+  removeWorktree,
+  pruneWorktrees,
+  isManagedWorktreePath,
+} from './worktrees';
+
+describe('listWorktrees', () => {
+  it('maps snake_case backend fields to camelCase', async () => {
+    mockIPC((cmd, args) => {
+      expect(cmd).toBe('list_worktrees');
+      expect(args).toEqual({ projectPath: '/p/app' });
+      return [
+        {
+          path: '/p/app',
+          head: '1234567',
+          branch: 'main',
+          is_main: true,
+          is_current: true,
+          locked: null,
+          prunable: null,
+        },
+        {
+          path: '/p/.worktrees/app/feature-x',
+          head: 'abcdef0',
+          branch: null,
+          is_main: false,
+          is_current: false,
+          locked: 'on my laptop',
+          prunable: 'gitdir file points to non-existent location',
+        },
+      ];
+    });
+
+    const result = await listWorktrees('/p/app');
+    expect(result).toEqual([
+      {
+        path: '/p/app',
+        head: '1234567',
+        branch: 'main',
+        isMain: true,
+        isCurrent: true,
+        locked: null,
+        prunable: null,
+      },
+      {
+        path: '/p/.worktrees/app/feature-x',
+        head: 'abcdef0',
+        branch: null,
+        isMain: false,
+        isCurrent: false,
+        locked: 'on my laptop',
+        prunable: 'gitdir file points to non-existent location',
+      },
+    ]);
+  });
+});
+
+describe('addWorktree', () => {
+  it('passes options through and defaults baseRef to null', async () => {
+    mockIPC((cmd, args) => {
+      expect(cmd).toBe('add_worktree');
+      expect(args).toEqual({
+        projectPath: '/p/app',
+        branch: 'feature-x',
+        createBranch: true,
+        baseRef: null,
+        copyEnv: true,
+      });
+      return { path: '/p/.worktrees/app/feature-x', port: 3001 };
+    });
+
+    const result = await addWorktree('/p/app', {
+      branch: 'feature-x',
+      createBranch: true,
+      copyEnv: true,
+    });
+    expect(result).toEqual({ path: '/p/.worktrees/app/feature-x', port: 3001 });
+  });
+
+  it('forwards an explicit baseRef', async () => {
+    mockIPC((_cmd, args) => {
+      expect((args as { baseRef: string }).baseRef).toBe('main');
+      return { path: '/p/.worktrees/app/fix', port: null };
+    });
+    const result = await addWorktree('/p/app', {
+      branch: 'fix',
+      createBranch: true,
+      baseRef: 'main',
+      copyEnv: false,
+    });
+    expect(result.port).toBeNull();
+  });
+});
+
+describe('removeWorktree / pruneWorktrees', () => {
+  it('sends force flag (default false)', async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    mockIPC((cmd, args) => {
+      calls.push({ cmd, ...(args as Record<string, unknown>) });
+      return undefined;
+    });
+
+    await removeWorktree('/p/app', '/p/.worktrees/app/feature-x');
+    await removeWorktree('/p/app', '/p/.worktrees/app/feature-x', true);
+    await pruneWorktrees('/p/app');
+
+    expect(calls).toEqual([
+      {
+        cmd: 'remove_worktree',
+        projectPath: '/p/app',
+        worktreePath: '/p/.worktrees/app/feature-x',
+        force: false,
+      },
+      {
+        cmd: 'remove_worktree',
+        projectPath: '/p/app',
+        worktreePath: '/p/.worktrees/app/feature-x',
+        force: true,
+      },
+      { cmd: 'prune_worktrees', projectPath: '/p/app' },
+    ]);
+  });
+});
+
+describe('isManagedWorktreePath', () => {
+  it('detects paths under a .worktrees container on both separators', () => {
+    expect(isManagedWorktreePath('/Users/me/ShipStudio/.worktrees/app/feature-x')).toBe(true);
+    expect(isManagedWorktreePath('C:\\Users\\me\\ShipStudio\\.worktrees\\app\\fix')).toBe(true);
+    expect(isManagedWorktreePath('/Users/me/ShipStudio/app')).toBe(false);
+  });
+});

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -12,6 +12,7 @@ import {
   removeWorktree,
   pruneWorktrees,
   isManagedWorktreePath,
+  worktreeDisplayName,
 } from './worktrees';
 
 describe('listWorktrees', () => {
@@ -28,6 +29,7 @@ describe('listWorktrees', () => {
           is_current: true,
           locked: null,
           prunable: null,
+          last_commit_date: 1750000000000,
         },
         {
           path: '/p/.worktrees/app/feature-x',
@@ -37,6 +39,7 @@ describe('listWorktrees', () => {
           is_current: false,
           locked: 'on my laptop',
           prunable: 'gitdir file points to non-existent location',
+          last_commit_date: null,
         },
       ];
     });
@@ -51,6 +54,7 @@ describe('listWorktrees', () => {
         isCurrent: true,
         locked: null,
         prunable: null,
+        lastCommitDate: 1750000000000,
       },
       {
         path: '/p/.worktrees/app/feature-x',
@@ -60,6 +64,7 @@ describe('listWorktrees', () => {
         isCurrent: false,
         locked: 'on my laptop',
         prunable: 'gitdir file points to non-existent location',
+        lastCommitDate: null,
       },
     ]);
   });
@@ -129,6 +134,22 @@ describe('removeWorktree / pruneWorktrees', () => {
       },
       { cmd: 'prune_worktrees', projectPath: '/p/app' },
     ]);
+  });
+});
+
+describe('worktreeDisplayName', () => {
+  it('renders "<project> / <branch>" for managed worktree paths', () => {
+    expect(worktreeDisplayName('/Users/me/ShipStudio/.worktrees/myapp/feature-x')).toBe(
+      'myapp / feature-x'
+    );
+    expect(worktreeDisplayName('C:\\Users\\me\\ShipStudio\\.worktrees\\myapp\\fix')).toBe(
+      'myapp / fix'
+    );
+  });
+
+  it('returns null for regular project paths', () => {
+    expect(worktreeDisplayName('/Users/me/ShipStudio/myapp')).toBeNull();
+    expect(worktreeDisplayName('/Users/me/code/feature-x')).toBeNull();
   });
 });
 

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -1,0 +1,132 @@
+/**
+ * Git worktree management utilities.
+ *
+ * Thin wrappers over the backend `git worktree` commands. The feature surfaces
+ * native git semantics: the list mirrors `git worktree list` (main worktree
+ * included), removal keeps the branch, and prune clears stale entries.
+ *
+ * @module lib/worktrees
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+
+/** One entry from `git worktree list` */
+export interface WorktreeInfo {
+  /** Absolute path of the worktree directory */
+  path: string;
+  /** Short commit sha of the checked-out HEAD */
+  head: string;
+  /** Branch name (refs/heads/ stripped); null when detached */
+  branch: string | null;
+  /** True for the repository's main worktree */
+  isMain: boolean;
+  /** True when this entry is the directory the query was made from */
+  isCurrent: boolean;
+  /** Lock reason when locked (empty string if locked without a reason) */
+  locked: string | null;
+  /** Prune reason when git considers the entry stale */
+  prunable: string | null;
+}
+
+export interface AddWorktreeOptions {
+  /** Branch to check out in the new worktree */
+  branch: string;
+  /** Create the branch (from baseRef or HEAD) instead of checking out an existing one */
+  createBranch: boolean;
+  /** Base ref for a newly created branch (defaults to HEAD when omitted) */
+  baseRef?: string;
+  /** Copy the parent's untracked root .env* files into the worktree */
+  copyEnv: boolean;
+}
+
+export interface AddWorktreeResult {
+  /** Absolute path of the created worktree */
+  path: string;
+  /** Dev-server port persisted into the worktree's metadata, if one was free */
+  port: number | null;
+}
+
+interface RawWorktreeInfo {
+  path: string;
+  head: string;
+  branch: string | null;
+  is_main: boolean;
+  is_current: boolean;
+  locked: string | null;
+  prunable: string | null;
+}
+
+/**
+ * List all worktrees of the repository containing the project, main worktree
+ * first. Returns an empty array for non-git projects.
+ */
+export async function listWorktrees(projectPath: string): Promise<WorktreeInfo[]> {
+  const result = await invoke<RawWorktreeInfo[]>('list_worktrees', { projectPath });
+  return result.map((w) => ({
+    path: w.path,
+    head: w.head,
+    branch: w.branch,
+    isMain: w.is_main,
+    isCurrent: w.is_current,
+    locked: w.locked,
+    prunable: w.prunable,
+  }));
+}
+
+/**
+ * Create a worktree under `~/ShipStudio/.worktrees/<project>/<branch>` and
+ * seed its Ship Studio metadata (dev command, monorepo subpath, distinct port).
+ */
+export async function addWorktree(
+  projectPath: string,
+  options: AddWorktreeOptions
+): Promise<AddWorktreeResult> {
+  return invoke<AddWorktreeResult>('add_worktree', {
+    projectPath,
+    branch: options.branch,
+    createBranch: options.createBranch,
+    baseRef: options.baseRef ?? null,
+    copyEnv: options.copyEnv,
+  });
+}
+
+/**
+ * Remove a linked worktree (`git worktree remove`). Git refuses dirty trees
+ * unless `force` — the rejection surfaces as a Process error whose stderr
+ * explains why. The branch is kept, matching git.
+ */
+export async function removeWorktree(
+  projectPath: string,
+  worktreePath: string,
+  force = false
+): Promise<void> {
+  return invoke<void>('remove_worktree', { projectPath, worktreePath, force });
+}
+
+/** Clear worktree entries whose directories no longer exist (`git worktree prune`). */
+export async function pruneWorktrees(projectPath: string): Promise<void> {
+  return invoke<void>('prune_worktrees', { projectPath });
+}
+
+/**
+ * Frontend mirror of the backend folder sanitizer (`sanitize_worktree_folder`
+ * in `src-tauri/src/commands/git/worktree.rs`) — used only to preview the
+ * destination path; the backend computes the real one.
+ */
+export function worktreeFolderName(branch: string): string {
+  let out = branch
+    .replace(/[/\\]/g, '-')
+    .replace(/[:*?"<>|]/g, '')
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x1f]/g, '');
+  out = out
+    .replace(/^[-.]+/, '')
+    .replace(/[. ]+$/, '')
+    .slice(0, 64);
+  return out || 'worktree';
+}
+
+/** True when a path lives inside a Ship Studio-managed `.worktrees` container. */
+export function isManagedWorktreePath(path: string): boolean {
+  return path.includes('/.worktrees/') || path.includes('\\.worktrees\\');
+}

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -26,6 +26,8 @@ export interface WorktreeInfo {
   locked: string | null;
   /** Prune reason when git considers the entry stale */
   prunable: string | null;
+  /** Unix timestamp (ms) of the checked-out HEAD commit, when resolvable */
+  lastCommitDate: number | null;
 }
 
 export interface AddWorktreeOptions {
@@ -54,6 +56,7 @@ interface RawWorktreeInfo {
   is_current: boolean;
   locked: string | null;
   prunable: string | null;
+  last_commit_date: number | null;
 }
 
 /**
@@ -70,6 +73,7 @@ export async function listWorktrees(projectPath: string): Promise<WorktreeInfo[]
     isCurrent: w.is_current,
     locked: w.locked,
     prunable: w.prunable,
+    lastCommitDate: w.last_commit_date,
   }));
 }
 
@@ -124,6 +128,28 @@ export function worktreeFolderName(branch: string): string {
     .replace(/[. ]+$/, '')
     .slice(0, 64);
   return out || 'worktree';
+}
+
+/**
+ * Display name for a managed worktree path: `"<project> / <branch-folder>"`,
+ * derived from the `.worktrees/<project>/<branch>` layout. Null for paths
+ * outside a managed container — callers fall back to `basename(path)`,
+ * which for a worktree alone would misleadingly show just the branch name.
+ */
+export function worktreeDisplayName(path: string): string | null {
+  const match = path.match(/[/\\]\.worktrees[/\\]([^/\\]+)[/\\]([^/\\]+)[/\\]?$/);
+  return match ? `${match[1]} / ${match[2]}` : null;
+}
+
+/**
+ * For a managed worktree path, the parent project's path (the main worktree):
+ * `<root>/.worktrees/<project>/<branch>` → `<root>/<project>`. Null for
+ * regular project paths. Used to group all checkouts of one repository into
+ * a single sidebar "family".
+ */
+export function worktreeParentPath(path: string): string | null {
+  const match = path.match(/^(.*)([/\\])\.worktrees[/\\]([^/\\]+)[/\\][^/\\]+[/\\]?$/);
+  return match ? `${match[1]}${match[2]}${match[3]}` : null;
 }
 
 /** True when a path lives inside a Ship Studio-managed `.worktrees` container. */

--- a/src/styles/features/branches/worktrees.css
+++ b/src/styles/features/branches/worktrees.css
@@ -1,0 +1,264 @@
+/* Worktrees — Branches-tab section rows + the "New worktree" modal. */
+
+/* ---- Branches tab section ---- */
+
+.worktrees-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.worktrees-section-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  /* The uppercase header styling shouldn't leak into the action buttons. */
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.worktree-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md);
+  margin-bottom: var(--spacing-sm);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.worktree-row.is-current {
+  border-color: var(--accent);
+}
+
+.worktree-row-info {
+  min-width: 0;
+  flex: 1;
+}
+
+.worktree-row-title {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  color: var(--text-primary);
+  font-size: var(--font-size-md);
+  font-weight: 500;
+}
+
+.worktree-row-branch {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.worktree-chip {
+  flex-shrink: 0;
+  padding: 1px var(--spacing-sm);
+  border-radius: var(--radius-pill);
+  background: var(--tint-subtle);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+}
+
+.worktree-chip.is-current-chip {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: transparent;
+}
+
+.worktree-chip.is-prunable-chip {
+  color: var(--warning);
+  border-color: rgba(var(--warning-rgb), 0.4);
+  background: rgba(var(--warning-rgb), 0.1);
+}
+
+.worktree-row-path {
+  margin-top: var(--spacing-xs);
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl; /* ellipsize the front — the tail of a path is the useful part */
+  text-align: left;
+}
+
+.worktree-row-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  flex-shrink: 0;
+}
+
+.worktree-row-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition:
+    background-color var(--transition),
+    color var(--transition);
+}
+
+.worktree-row-icon-btn:hover {
+  background: var(--tint);
+  color: var(--text-primary);
+}
+
+.worktree-row-icon-btn.is-danger:hover {
+  background: rgba(var(--error-rgb), 0.1);
+  color: var(--error);
+}
+
+.worktree-remove-error {
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  background: rgba(var(--error-rgb), 0.1);
+  border: 1px solid rgba(var(--error-rgb), 0.3);
+  color: var(--text-primary);
+  font-size: var(--font-size-md);
+  word-break: break-word;
+}
+
+/* ---- Create modal ---- */
+
+.worktree-create-modal {
+  width: 440px;
+  max-width: 90vw;
+}
+
+.worktree-create-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  padding: var(--spacing-lg);
+}
+
+.worktree-create-intro {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-md);
+  line-height: 1.5;
+}
+
+.worktree-mode-toggle {
+  display: flex;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs);
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-md);
+}
+
+.worktree-mode-btn {
+  flex: 1;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: var(--font-size-base);
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background-color var(--transition),
+    color var(--transition);
+}
+
+.worktree-mode-btn.is-active {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.worktree-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.worktree-field-label {
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+}
+
+.worktree-field input[type='text'],
+.worktree-field select {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: var(--font-size-md);
+}
+
+.worktree-field input[type='text']:focus,
+.worktree-field select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.worktree-field-hint {
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.worktree-checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+  color: var(--text-primary);
+  font-size: var(--font-size-md);
+  cursor: pointer;
+}
+
+.worktree-checkbox input {
+  margin-top: 2px;
+}
+
+.worktree-checkbox-hint {
+  display: block;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.worktree-destination {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  word-break: break-all;
+}
+
+.worktree-destination code {
+  color: var(--text-secondary);
+}
+
+.worktree-create-error {
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  background: rgba(var(--error-rgb), 0.1);
+  border: 1px solid rgba(var(--error-rgb), 0.3);
+  color: var(--text-primary);
+  font-size: var(--font-size-md);
+  word-break: break-word;
+}
+
+.worktree-create-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-xs);
+}

--- a/src/styles/features/branches/worktrees.css
+++ b/src/styles/features/branches/worktrees.css
@@ -30,7 +30,7 @@
 }
 
 .worktree-row.is-current {
-  border-color: var(--accent);
+  background: var(--tint-subtle);
 }
 
 .worktree-row-info {
@@ -65,8 +65,7 @@
 }
 
 .worktree-chip.is-current-chip {
-  color: var(--accent);
-  border-color: var(--accent);
+  border: none;
   background: transparent;
 }
 
@@ -203,6 +202,22 @@
   font-size: var(--font-size-md);
 }
 
+.worktree-field select {
+  /* Native selects render the OS control — restyle to match text inputs. */
+  appearance: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+  padding-right: var(--spacing-2xl);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right var(--spacing-md) center;
+}
+
+.worktree-field select option {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
 .worktree-field input[type='text']:focus,
 .worktree-field select:focus {
   outline: none;
@@ -223,8 +238,43 @@
   cursor: pointer;
 }
 
-.worktree-checkbox input {
-  margin-top: 2px;
+.worktree-checkbox input[type='checkbox'] {
+  /* Native checkbox is the OS-blue control — restyle to the app's accent. */
+  appearance: none;
+  -webkit-appearance: none;
+  flex-shrink: 0;
+  width: 15px;
+  height: 15px;
+  margin: 2px 0 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-tertiary);
+  cursor: pointer;
+  transition:
+    background-color var(--transition),
+    border-color var(--transition);
+}
+
+.worktree-checkbox input[type='checkbox']:hover {
+  border-color: var(--text-muted);
+}
+
+.worktree-checkbox input[type='checkbox']:checked {
+  background: var(--accent);
+  border-color: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.worktree-checkbox input[type='checkbox']:checked::after {
+  content: '';
+  width: 4px;
+  height: 8px;
+  border: solid var(--bg-deep);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+  margin-top: -2px;
 }
 
 .worktree-checkbox-hint {

--- a/src/styles/features/dashboard/projects.css
+++ b/src/styles/features/dashboard/projects.css
@@ -242,6 +242,12 @@
   white-space: nowrap;
 }
 
+.project-card-worktrees {
+  color: var(--text-muted);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 .project-card-deployment {
   display: flex;
   align-items: center;

--- a/src/styles/features/workspace/sidebar.css
+++ b/src/styles/features/workspace/sidebar.css
@@ -341,6 +341,31 @@
   text-overflow: ellipsis;
 }
 
+/* Worktree names ("project / branch"): the repo part ellipsizes, the branch
+   part never does — otherwise every worktree of one repo truncates to the
+   same string and reads as duplicate rows. */
+.sidebar-project-name-split {
+  display: flex;
+  align-items: baseline;
+}
+
+.sidebar-project-name-repo {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-project-name-branch {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  font-weight: 500;
+  max-width: 70%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .sidebar-project-meta {
   font-size: var(--font-size-xs);
   color: var(--text-muted);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -58,6 +58,7 @@
 @import './features/branches/pr-list.css';
 @import './features/branches/branch-actions.css';
 @import './features/branches/branch-graph.css';
+@import './features/branches/worktrees.css';
 @import './features/conflicts.css';
 @import './features/health.css';
 @import './features/health-tab.css';


### PR DESCRIPTION
## What

A UI on native git worktrees (`git worktree add/list/remove/prune`) — surfacing git's semantics, not abstracting them. Each worktree is a first-class workspace: its own agent terminal, dev server on its own auto-assigned port, and preview, with sessions staying hot when you switch.

## How it works

**Creating** — sidebar Worktrees "+" or ⌘K → "New worktree…". New branch (with base ref) or existing branch; worktrees land in `~/ShipStudio/.worktrees/<project>/<branch>` (inside the allowed projects root, hidden from the dashboard scan). On creation: `.shipstudio/project.json` is seeded from the parent (dev command, monorepo subpath) with a distinct free dev-server port, `.env*` files are optionally copied (gitignored, so a fresh checkout lacks them), and dependencies auto-install via the existing install terminal (lockfile-detected package manager).

**Switching** — the sidebar shows one row per repository "family" (main checkout + its worktrees). Worktree checkouts are listed in a Worktrees section inside the project row with live dots and last-commit ages; clicking swaps the workspace in place while the previous session (PTYs + dev server) stays hot. ⌘1–9 ordering matches. Trying to switch to a branch that's checked out in another worktree redirects there instead of surfacing git's refusal.

**Managing** — the Branches tab lists all worktrees with open / open-in-new-window / remove; removal follows git (folder goes, branch stays), dirty trees refuse first and escalate to Force Remove, and stale entries (folder deleted by hand) get a one-click Prune.

**Plugins are repository-level** — all worktrees resolve their plugin store to the main worktree via `git rev-parse --git-common-dir` (the same mechanism git uses to share refs/config), so an install from any worktree is visible in all. Resolution only applies to linked worktrees (`.git` pointer *file*); main checkouts and plain folders resolve to themselves without invoking git.

## Also fixes

- Pre-existing `usePlugins` bug: switching projects unloaded the old project's plugins under the **new** path (a silent no-op), leaving stale plugin modules running and firing "Plugin 'x' not found" errors against the new project. Now unloads under the path they were loaded with.

## Backend

New `src-tauri/src/commands/git/worktree.rs` following house rules (CommandError, validate_project_path, ref-name injection guards, `#[instrument]`, GIT_CACHE invalidation). Porcelain parser handles detached/locked/prunable/bare. Colocated unit tests (parser, folder sanitizer, port picker, plugin-owner resolution incl. nested-repo and worktree cases).

## Testing

- `cargo test`: 726 passed · `pnpm test:run`: 1352 passed · lint, typecheck, `check:patterns` clean
- Manual: create/switch/remove/prune, plugin sharing, auto-install, hot side-by-side dev servers
- CLI-verified: dirty-remove refusal message (drives the Force escalation), `--force --force`, prunable detection

## Known v1 limits

- One preview per window (proxy/static server stay window-keyed); switching re-points it — matches the sidebar-switching model
- `node_modules` is per-worktree (a git/npm reality) — first open pays an install
- Windows: code handles `\` paths and illegal folder chars, but untested on a real Windows machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Git worktree management in the workspace: list, create (from new or existing branches), open/switch, remove, and prune.
  * Added Worktrees UI across the sidebar, command palette, and Branches tab, including a “New worktree” modal and worktree-specific session handling.
  * Show worktree counts on project cards and group rail/sidebar display by worktree family.
* **Bug Fixes**
  * Improved plugin unloading when changing projects and ensured plugins are shared consistently across worktrees.
* **Documentation**
  * Expanded analytics taxonomy with new worktree-related events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->