### PR TITLE
Fix worktree sidebar duplication: anchor families to git truth

### DIFF
--- a/src-tauri/src/commands/git/worktree.rs
+++ b/src-tauri/src/commands/git/worktree.rs
@@ -5,9 +5,12 @@
 //! branch, and dirty-tree refusals bubble up so the UI can offer `--force`.
 //!
 //! App-managed worktrees are created under
-//! `<projects_root>/.worktrees/<parent_dir_name>/<sanitized_branch>` — inside
-//! the allowed projects root (so `validate_project_path` accepts them) but
-//! dot-prefixed so the dashboard scan never lists the container as a project.
+//! `<projects_root>/.worktrees/<main_worktree_dir_name>/<sanitized_branch>` —
+//! inside the allowed projects root (so `validate_project_path` accepts them)
+//! but dot-prefixed so the dashboard scan never lists the container as a
+//! project. The container is always named after the repository's MAIN
+//! worktree, no matter which checkout the add was invoked from, so one
+//! repository's worktrees stay in one family folder.
 
 use crate::cache::GIT_CACHE;
 use crate::errors::CommandError;
@@ -194,6 +197,20 @@ fn canon(path: &str) -> PathBuf {
     dunce::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path))
 }
 
+/// The repository's main worktree path as seen from any checkout — the first
+/// entry of `git worktree list --porcelain`. None when `cwd` isn't a git
+/// repository or git fails.
+fn main_worktree_path(cwd: &Path) -> Option<PathBuf> {
+    let output = run_worktree_git(cwd, &["worktree", "list", "--porcelain"]).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_worktree_porcelain(&stdout)
+        .first()
+        .map(|w| PathBuf::from(&w.path))
+}
+
 /// Resolves commit timestamps (ms) for a set of shas in one git call:
 /// `git show -s --format='%H %ct' <shas…>`. Best-effort — an empty map on
 /// any failure just leaves `last_commit_date` unset.
@@ -284,7 +301,13 @@ pub async fn add_worktree(
         guard_ref_name(base, "base_ref")?;
     }
 
-    let parent_dir_name = validated_path
+    // Anchor naming, metadata, and .env copies to the repository's MAIN
+    // worktree: `project_path` may itself be a linked worktree (creating a
+    // worktree while working inside one), and using the invoking directory
+    // would scatter one repository's worktrees across differently-named
+    // container folders.
+    let anchor = main_worktree_path(&validated_path).unwrap_or_else(|| validated_path.clone());
+    let parent_dir_name = anchor
         .file_name()
         .map(|n| n.to_string_lossy().to_string())
         .ok_or_else(|| CommandError::Validation {
@@ -326,10 +349,11 @@ pub async fn add_worktree(
         return Err(process_error(&args, &output));
     }
 
-    // Seed the worktree's own .shipstudio/project.json from the parent so the
-    // dev server behaves identically (command, monorepo subpath, workspace) —
-    // but on its own port, since every project otherwise defaults to 3000.
-    let parent_meta = load_project_metadata(&validated_path);
+    // Seed the worktree's own .shipstudio/project.json from the main worktree
+    // so the dev server behaves identically (command, monorepo subpath,
+    // workspace) — but on its own port, since every project otherwise
+    // defaults to 3000.
+    let parent_meta = load_project_metadata(&anchor);
     let mut meta = crate::types::ProjectMetadata {
         custom_dev_command: parent_meta.custom_dev_command.clone(),
         workspace_subpath: parent_meta.workspace_subpath.clone(),
@@ -349,7 +373,7 @@ pub async fn add_worktree(
     }
 
     if copy_env {
-        copy_env_files(&validated_path, &dest);
+        copy_env_files(&anchor, &dest);
     }
 
     // Plugins need no copying: all worktrees of one repository resolve to the
@@ -567,5 +591,54 @@ branch refs/heads/feature
         }
         let picked = pick_free_port(bound - 1).expect("a free port should exist");
         assert_ne!(picked, bound, "picker must not return a bound port");
+    }
+
+    /// Adding a worktree while inside another worktree must anchor to the
+    /// repository's main worktree — the regression scattered one repo's
+    /// worktrees across container folders named after whichever checkout
+    /// the user happened to invoke from.
+    #[test]
+    fn main_worktree_path_resolves_from_linked_worktree() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let main = tmp.path().join("myrepo");
+        std::fs::create_dir(&main).unwrap();
+        let git = |cwd: &Path, args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .env("GIT_CONFIG_NOSYSTEM", "1")
+                .env("HOME", tmp.path())
+                .output()
+                .expect("git runs");
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&main, &["init", "-b", "main"]);
+        git(&main, &["config", "user.email", "t@t"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["commit", "--allow-empty", "-m", "init"]);
+        let linked = tmp.path().join("linked-wt");
+        git(
+            &main,
+            &["worktree", "add", "-b", "side", linked.to_str().unwrap()],
+        );
+
+        let from_main = main_worktree_path(&main).expect("resolves from main");
+        let from_linked = main_worktree_path(&linked).expect("resolves from linked");
+        assert_eq!(from_main.file_name(), main.file_name());
+        assert_eq!(
+            from_linked.file_name(),
+            main.file_name(),
+            "linked worktree must resolve to the main worktree, not itself"
+        );
+
+        // Non-git directory: no resolution, caller falls back to the input.
+        let plain = tmp.path().join("plain");
+        std::fs::create_dir(&plain).unwrap();
+        assert!(main_worktree_path(&plain).is_none());
     }
 }

--- a/src/components/dashboard/Changelog.tsx
+++ b/src/components/dashboard/Changelog.tsx
@@ -26,6 +26,13 @@ interface ChangelogEntry {
 // Keep ~15 most recent versions for the sidebar
 const CHANGELOG: ChangelogEntry[] = [
   {
+    version: '0.17.1', // v0.17.1
+    items: [
+      'Worktree fix — the sidebar no longer shows duplicate rows for a project when its worktrees are open. Grouping now asks git which repository a worktree belongs to, so it works for imported projects living outside ~/ShipStudio too',
+      'Creating a worktree while working inside another worktree now files it under the project itself instead of nesting it under the worktree you happened to be in',
+    ],
+  },
+  {
     version: '0.17.0', // v0.17.0
     items: [
       "Worktrees — work on multiple branches of the same project at the same time. Create a worktree from the sidebar or Cmd+K and it opens as its own workspace: its own agent, terminal, dev server on its own port, and preview, while your other branches keep running. Switch between them from the sidebar with everything staying hot. It's real git underneath (git worktree), so your terminal and the app always agree",

--- a/src/components/workspace/WorkspaceSidebar.tsx
+++ b/src/components/workspace/WorkspaceSidebar.tsx
@@ -15,7 +15,13 @@ import { Button } from '../primitives/Button';
 import { BrowserDropdown } from '../preview/BrowserDropdown';
 import { useOpenPalette } from '../CommandPalette/paletteContext';
 import { ALL_AGENTS, TERMINAL, getAgentById, type AgentConfig } from '../../lib/agent';
-import { worktreeParentPath, type WorktreeInfo } from '../../lib/worktrees';
+import { type WorktreeInfo } from '../../lib/worktrees';
+import {
+  familyRootOf,
+  ensureFamilyRoot,
+  subscribeFamilyRoots,
+  familyRootsVersion,
+} from '../../lib/worktreeFamilies';
 import { formatRelativeTime } from '../../lib/branches';
 import type { TerminalTab } from '../../hooks/useTerminalManagement';
 import type { PinnedProjectRow } from '../../hooks/usePinnedProjects';
@@ -320,6 +326,22 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
     () => 0
   );
 
+  // Git-truth family roots for worktree sessions. The `.worktrees/<name>/…`
+  // path guess can't locate the real parent for external projects (the repo
+  // lives outside ~/ShipStudio), so each worktree path is resolved via
+  // `list_worktrees` — this subscription re-renders when a resolution lands
+  // and the grouping below snaps to the correct family.
+  const familiesVersion = useSyncExternalStore(
+    subscribeFamilyRoots,
+    familyRootsVersion,
+    familyRootsVersion
+  );
+  useEffect(() => {
+    void registryVersion;
+    for (const s of sessionRegistry.snapshotAll()) ensureFamilyRoot(s.projectPath);
+    if (currentProjectPath) ensureFamilyRoot(currentProjectPath);
+  }, [registryVersion, currentProjectPath]);
+
   const toggleSection = (id: SectionId) => {
     setCollapsed((prev) => {
       const next = { ...prev, [id]: !prev[id] };
@@ -489,12 +511,15 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
   // A "family" is one repository: the main checkout plus its worktrees. The
   // sidebar shows ONE row per family — worktree sessions never appear as
   // separate top-level rows; they live inside the family row's body.
-  const familyKeyOf = (path: string) => worktreeParentPath(path) ?? path;
+  const familyKeyOf = (path: string) => familyRootOf(path);
   const currentFamily = currentProjectPath !== null ? familyKeyOf(currentProjectPath) : null;
 
   const activeRows: PinnedProjectRow[] = useMemo(() => {
     // `registryVersion` is the reactivity trigger — snapshots are read below.
+    // `familiesVersion` re-groups rows when an async family-root resolution
+    // lands (a worktree session merging into its parent's row).
     void registryVersion;
+    void familiesVersion;
     const snaps = sessionRegistry.snapshotAll();
     const families = new Map<string, typeof snaps>();
     for (const snap of snaps) {
@@ -526,7 +551,7 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
         a.fallbackName.localeCompare(b.fallbackName) || a.projectPath.localeCompare(b.projectPath)
     );
     return rows;
-  }, [pinnedPaths, currentFamily, registryVersion]);
+  }, [pinnedPaths, currentFamily, registryVersion, familiesVersion]);
 
   // Edge case: current project isn't in pinned or active (e.g. the session
   // registry hasn't picked it up yet during the initial open). Synthesize

--- a/src/hooks/useProjectNumberShortcuts.ts
+++ b/src/hooks/useProjectNumberShortcuts.ts
@@ -3,7 +3,7 @@ import type { Project } from '../lib/project';
 import { sessionRegistry } from '../lib/sessionRegistry';
 import { useModal } from '../contexts/ModalContext';
 import { basename } from '../lib/paths';
-import { worktreeParentPath } from '../lib/worktrees';
+import { familyRootOf, ensureFamilyRoot } from '../lib/worktreeFamilies';
 
 interface Params {
   /** Pinned-row paths, in sidebar order. */
@@ -41,11 +41,13 @@ export function useProjectNumberShortcuts({ pinnedPaths, handleSelectProject }: 
       const pinSet = new Set(pins);
       // One entry per repository family (a project and its worktrees are one
       // sidebar row), name-ordered — must mirror WorkspaceSidebar's grouping.
-      const familyKeyOf = (p: string) => worktreeParentPath(p) ?? p;
+      // Roots come from the shared git-truth cache; kick off resolution for
+      // any session path not yet resolved so the ordering converges.
+      const snaps = sessionRegistry.snapshotAll();
+      for (const s of snaps) ensureFamilyRoot(s.projectPath);
       const seen = new Set<string>();
-      const activePaths = sessionRegistry
-        .snapshotAll()
-        .map((s) => familyKeyOf(s.projectPath))
+      const activePaths = snaps
+        .map((s) => familyRootOf(s.projectPath))
         .filter((p) => !pinSet.has(p))
         .filter((p) => (seen.has(p) ? false : (seen.add(p), true)))
         .sort((a, b) => (basename(a) || a).localeCompare(basename(b) || b) || a.localeCompare(b));

--- a/src/lib/worktreeFamilies.test.ts
+++ b/src/lib/worktreeFamilies.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the git-truth family-root cache (src/lib/worktreeFamilies.ts):
+ * the regression it guards against is a worktree of an EXTERNAL project —
+ * the repo lives outside ~/ShipStudio, so no path surgery on the managed
+ * `.worktrees/<name>/<branch>` layout can ever reconstruct the parent, and
+ * every worktree session used to render as its own phantom sidebar row.
+ */
+
+import { mockIPC, clearMocks } from '@tauri-apps/api/mocks';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  familyRootOf,
+  ensureFamilyRoot,
+  subscribeFamilyRoots,
+  familyRootsVersion,
+  resetFamilyRootsForTest,
+} from './worktreeFamilies';
+
+const ROOT = '/Users/me/ShipStudio';
+const WT = `${ROOT}/.worktrees/wrong-name/more-faqs`;
+const EXTERNAL_MAIN = '/Users/me/Desktop/Projects/marketing-site';
+
+function mockFamily() {
+  mockIPC((cmd) => {
+    expect(cmd).toBe('list_worktrees');
+    return [
+      {
+        path: EXTERNAL_MAIN,
+        head: '1234567',
+        branch: 'main',
+        is_main: true,
+        is_current: false,
+        locked: null,
+        prunable: null,
+        last_commit_date: null,
+      },
+      {
+        path: WT,
+        head: 'abcdef0',
+        branch: 'more-faqs',
+        is_main: false,
+        is_current: true,
+        locked: null,
+        prunable: null,
+        last_commit_date: null,
+      },
+    ];
+  });
+}
+
+async function flush() {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe('worktreeFamilies', () => {
+  beforeEach(() => resetFamilyRootsForTest());
+  afterEach(() => clearMocks());
+
+  it('returns non-worktree paths as their own root without any lookup', () => {
+    expect(familyRootOf(`${ROOT}/my-app`)).toBe(`${ROOT}/my-app`);
+    expect(familyRootOf(EXTERNAL_MAIN)).toBe(EXTERNAL_MAIN);
+  });
+
+  it('falls back to the path-derived guess before resolution lands', () => {
+    expect(familyRootOf(WT)).toBe(`${ROOT}/wrong-name`);
+  });
+
+  it('resolves a managed worktree to its real main worktree via git truth', async () => {
+    mockFamily();
+    ensureFamilyRoot(WT);
+    await flush();
+    // The external parent is unreachable by string surgery — only the
+    // list_worktrees answer can produce it.
+    expect(familyRootOf(WT)).toBe(EXTERNAL_MAIN);
+    // The whole family is cached from one lookup, main included.
+    expect(familyRootOf(EXTERNAL_MAIN)).toBe(EXTERNAL_MAIN);
+  });
+
+  it('notifies subscribers and bumps the version when a resolution lands', async () => {
+    mockFamily();
+    let notified = 0;
+    const unsubscribe = subscribeFamilyRoots(() => {
+      notified += 1;
+    });
+    const before = familyRootsVersion();
+    ensureFamilyRoot(WT);
+    await flush();
+    expect(notified).toBe(1);
+    expect(familyRootsVersion()).toBe(before + 1);
+    unsubscribe();
+  });
+
+  it('does not re-query already-resolved or non-worktree paths', async () => {
+    let calls = 0;
+    mockIPC(() => {
+      calls += 1;
+      return [
+        {
+          path: EXTERNAL_MAIN,
+          head: '1234567',
+          branch: 'main',
+          is_main: true,
+          is_current: false,
+          locked: null,
+          prunable: null,
+          last_commit_date: null,
+        },
+        {
+          path: WT,
+          head: 'abcdef0',
+          branch: 'more-faqs',
+          is_main: false,
+          is_current: true,
+          locked: null,
+          prunable: null,
+          last_commit_date: null,
+        },
+      ];
+    });
+    ensureFamilyRoot(`${ROOT}/regular-project`);
+    expect(calls).toBe(0);
+    ensureFamilyRoot(WT);
+    await flush();
+    ensureFamilyRoot(WT);
+    await flush();
+    expect(calls).toBe(1);
+  });
+
+  it('keeps the fallback when the lookup fails', async () => {
+    mockIPC(() => {
+      throw new Error('not a git repository');
+    });
+    ensureFamilyRoot(WT);
+    await flush();
+    expect(familyRootOf(WT)).toBe(`${ROOT}/wrong-name`);
+  });
+});

--- a/src/lib/worktreeFamilies.ts
+++ b/src/lib/worktreeFamilies.ts
@@ -1,0 +1,79 @@
+/**
+ * Family-root resolution for worktree sessions — maps any checkout path to
+ * its repository's MAIN worktree path ("family root"), using git as the
+ * source of truth.
+ *
+ * The sidebar groups a repository's main checkout and all of its worktrees
+ * into one row. Guessing the root by string surgery on the
+ * `.worktrees/<project>/<branch>` layout breaks for external projects (the
+ * repo doesn't live at `<root>/<project>`) and for containers created under
+ * a wrong name — so each managed-worktree path is resolved once via
+ * `list_worktrees` and cached here. The path-derived guess is only a
+ * placeholder until the async resolution lands.
+ *
+ * @module lib/worktreeFamilies
+ */
+
+import { listWorktrees, isManagedWorktreePath, worktreeParentPath } from './worktrees';
+
+/** Any member path (main or linked worktree) → the repo's main worktree path. */
+const roots = new Map<string, string>();
+/** Paths with a resolution in flight — dedupes concurrent lookups. */
+const pending = new Set<string>();
+const listeners = new Set<() => void>();
+let version = 0;
+
+/**
+ * Synchronous family root for a path. Non-worktree paths are their own root.
+ * Managed worktree paths return the cached git-resolved main worktree when
+ * available, else the path-derived guess until `ensureFamilyRoot` resolves.
+ */
+export function familyRootOf(path: string): string {
+  const cached = roots.get(path);
+  if (cached !== undefined) return cached;
+  if (!isManagedWorktreePath(path)) return path;
+  return worktreeParentPath(path) ?? path;
+}
+
+/**
+ * Kick off (once per path) the git-truth resolution for a managed worktree
+ * path. No-op for regular project paths or already-resolved ones. Notifies
+ * subscribers when the cache gains entries.
+ */
+export function ensureFamilyRoot(path: string): void {
+  if (!isManagedWorktreePath(path) || roots.has(path) || pending.has(path)) return;
+  pending.add(path);
+  listWorktrees(path)
+    .then((list) => {
+      const main = list.find((w) => w.isMain);
+      if (!main) return;
+      // One lookup resolves the whole family — cache every member.
+      for (const w of list) roots.set(w.path, main.path);
+      version += 1;
+      for (const listener of listeners) listener();
+    })
+    .catch(() => {
+      // Non-git / unreadable: leave the path-derived fallback in place.
+    })
+    .finally(() => {
+      pending.delete(path);
+    });
+}
+
+/** Subscribe to cache updates (for `useSyncExternalStore`). */
+export function subscribeFamilyRoots(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/** Monotonic cache version (the `useSyncExternalStore` snapshot). */
+export function familyRootsVersion(): number {
+  return version;
+}
+
+/** Test-only: reset the module-level cache between test cases. */
+export function resetFamilyRootsForTest(): void {
+  roots.clear();
+  pending.clear();
+  version = 0;
+}


### PR DESCRIPTION
## Problem

Using worktrees live showed the same project duplicated in the sidebar — one phantom row per worktree (screenshot in report: a top-level row literally named "main"). Two root causes:

1. **`add_worktree` named the `.worktrees/<name>/` container after whichever checkout invoked it.** Creating a worktree from *inside* another worktree nested it under the worktree's folder name (`.worktrees/main/more-faqs` on the reporter's disk).
2. **Sidebar family grouping reconstructed the parent by string surgery** (`<root>/.worktrees/<name>/… → <root>/<name>`). That can never resolve **external projects** — the repo lives outside `~/ShipStudio`, so every worktree session became its own top-level "project" row.

## Fix

- **Backend**: `add_worktree` now resolves the repository's main worktree (first entry of `git worktree list --porcelain`) and anchors the container name, metadata seeding, and `.env` copies to it — no matter which checkout the add was invoked from.
- **Frontend**: new `src/lib/worktreeFamilies.ts` — a git-truth cache mapping any checkout path to its main worktree via `list_worktrees` (one lookup caches the whole family). `WorkspaceSidebar` and `useProjectNumberShortcuts` group by this instead of path surgery; a `useSyncExternalStore` subscription re-groups rows the moment a resolution lands. The path-derived guess remains only as a momentary placeholder.

Existing misplaced worktrees (created under wrong container names by the old code) group correctly too, since grouping no longer depends on folder names.

## Tests

- Rust: `main_worktree_path_resolves_from_linked_worktree` — real temp repo, verifies resolution from a linked worktree and the non-git fallback (726 passing)
- Vitest: 6 new tests for the family cache — external-parent resolution, fallback before/after failure, dedupe, subscriber notification (1364 passing)
- `check:patterns`, `check:loc`, `tsc`, `eslint` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Worktree sessions are now grouped consistently under their repository’s main worktree.
  - Keyboard shortcuts recognize related worktrees as a single project family.
  - New worktrees inherit project metadata and root-level environment files from the main worktree.

- **Bug Fixes**
  - Fixed inconsistent worktree folder placement when creating worktrees from linked checkouts.
  - Improved sidebar grouping as worktree relationships are detected.

- **Documentation**
  - Added release notes for version 0.17.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->