### PR TITLE
Make the dashboard scan cheap: no forks for branches, cached status, less noise

### DIFF
--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -37,10 +37,18 @@ pub struct GitCache {
     has_changes: Mutex<HashMap<String, CacheEntry<bool>>>,
     /// Cache for changed files per project
     changed_files: Mutex<HashMap<String, CacheEntry<Vec<crate::types::ChangedFile>>>>,
+    /// Cache for the dashboard scan's uncommitted count per project. Stores
+    /// failures too (`None`) so a repo that errors or times out isn't
+    /// re-forked on every dashboard load within the TTL window.
+    scan_status: Mutex<HashMap<String, CacheEntry<Option<u32>>>>,
     /// TTL for branch cache (longer, branch changes less frequently)
     branch_ttl: Duration,
     /// TTL for status cache (shorter, status changes more frequently)
     status_ttl: Duration,
+    /// TTL for the dashboard scan status cache — deliberately long; the
+    /// dashboard tolerates a slightly stale count, and write operations
+    /// invalidate it anyway.
+    scan_status_ttl: Duration,
 }
 
 impl GitCache {
@@ -49,8 +57,33 @@ impl GitCache {
             current_branch: Mutex::new(HashMap::new()),
             has_changes: Mutex::new(HashMap::new()),
             changed_files: Mutex::new(HashMap::new()),
+            scan_status: Mutex::new(HashMap::new()),
             branch_ttl: Duration::from_secs(5),
             status_ttl: Duration::from_secs(5),
+            scan_status_ttl: Duration::from_secs(30),
+        }
+    }
+
+    /// Get the cached dashboard-scan uncommitted count for a project.
+    /// Outer `None` = cache miss; inner `None` = cached failure.
+    pub fn get_scan_status(&self, project_path: &str) -> Option<Option<u32>> {
+        let cache = self.scan_status.lock().ok()?;
+        let entry = cache.get(project_path)?;
+        if entry.is_expired() {
+            None
+        } else {
+            Some(entry.value)
+        }
+    }
+
+    /// Cache the dashboard-scan uncommitted count (or failure) for a project.
+    pub fn set_scan_status(&self, project_path: &str, count: Option<u32>) {
+        if let Ok(mut cache) = self.scan_status.lock() {
+            cache.retain(|_, entry| !entry.is_expired());
+            cache.insert(
+                project_path.to_string(),
+                CacheEntry::new(count, self.scan_status_ttl),
+            );
         }
     }
 
@@ -148,6 +181,9 @@ impl GitCache {
         if let Ok(mut cache) = self.changed_files.lock() {
             cache.remove(project_path);
         }
+        if let Ok(mut cache) = self.scan_status.lock() {
+            cache.remove(project_path);
+        }
     }
 
     /// Invalidate status caches (branch stays valid, but status changes)
@@ -157,6 +193,9 @@ impl GitCache {
             cache.remove(project_path);
         }
         if let Ok(mut cache) = self.changed_files.lock() {
+            cache.remove(project_path);
+        }
+        if let Ok(mut cache) = self.scan_status.lock() {
             cache.remove(project_path);
         }
     }
@@ -170,6 +209,9 @@ impl GitCache {
             cache.retain(|_, entry| !entry.is_expired());
         }
         if let Ok(mut cache) = self.changed_files.lock() {
+            cache.retain(|_, entry| !entry.is_expired());
+        }
+        if let Ok(mut cache) = self.scan_status.lock() {
             cache.retain(|_, entry| !entry.is_expired());
         }
     }

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -76,34 +76,55 @@ async fn run_scan_command(
     .ok()
 }
 
-/// Helper to get git branch for a project (time-bounded; `None` on timeout).
+/// Resolve the checked-out branch by reading `.git/HEAD` directly — a
+/// microsecond fs read instead of a `git rev-parse` fork per project per
+/// dashboard load (those forks timed out over 1,100 times in 12 days of
+/// real-usage logs). Handles worktree/submodule `.git` *files*
+/// (`gitdir: <path>`). Returns `None` for detached HEAD and non-git dirs,
+/// matching the old rev-parse behavior.
+fn branch_from_head_file(project_path: &Path) -> Option<String> {
+    let dot_git = project_path.join(".git");
+    let git_dir = if dot_git.is_file() {
+        let contents = std::fs::read_to_string(&dot_git).ok()?;
+        let target = contents.strip_prefix("gitdir:")?.trim();
+        let target = Path::new(target);
+        if target.is_absolute() {
+            target.to_path_buf()
+        } else {
+            project_path.join(target)
+        }
+    } else if dot_git.is_dir() {
+        dot_git
+    } else {
+        return None;
+    };
+    let head = std::fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    let name = head.trim().strip_prefix("ref: refs/heads/")?;
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+/// Helper to get git branch for a project. Reads `.git/HEAD` — no subprocess.
 async fn get_git_branch(project_path: &Path) -> Option<String> {
-    let output = run_scan_command(
-        "git",
-        &["rev-parse", "--abbrev-ref", "HEAD"],
-        project_path,
-        GIT_SCAN_TIMEOUT_SECS,
-    )
-    .await?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if branch == "HEAD" || branch.is_empty() {
-        return None;
-    }
-
-    Some(branch)
+    branch_from_head_file(project_path)
 }
 
 /// Helper to count uncommitted changes (tracked files only; time-bounded,
-/// `None` on timeout).
+/// `None` on timeout). Results — including failures — are cached in
+/// `GIT_CACHE` for 30s, so git write operations invalidate them and a repo
+/// that errors or times out isn't re-forked on every dashboard load.
 async fn get_uncommitted_count(project_path: &Path) -> Option<u32> {
     let git_dir = project_path.join(".git");
     if !git_dir.exists() {
         return None;
+    }
+
+    let cache_key = project_path.to_string_lossy().to_string();
+    if let Some(cached) = crate::cache::GIT_CACHE.get_scan_status(&cache_key) {
+        return cached;
     }
 
     // Use -uno to ignore untracked files like .DS_Store
@@ -113,14 +134,14 @@ async fn get_uncommitted_count(project_path: &Path) -> Option<u32> {
         project_path,
         GIT_SCAN_TIMEOUT_SECS,
     )
-    .await?;
+    .await;
 
-    if output.status.success() {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let count = stdout.lines().filter(|l| !l.trim().is_empty()).count() as u32;
-        return Some(count);
-    }
-    None
+    let count = output.filter(|o| o.status.success()).map(|o| {
+        let stdout = String::from_utf8_lossy(&o.stdout);
+        stdout.lines().filter(|l| !l.trim().is_empty()).count() as u32
+    });
+    crate::cache::GIT_CACHE.set_scan_status(&cache_key, count);
+    count
 }
 
 /// Collects git metadata (current branch + uncommitted count) for many
@@ -138,16 +159,53 @@ async fn scan_git_info(paths: Vec<PathBuf>) -> Vec<(Option<String>, Option<u32>)
         .await
 }
 
+/// Exclusions already warned about this session, so the loud warn fires once
+/// per (path, reason) instead of once per dashboard scan — the same dozen
+/// directories used to produce 4,000+ identical warn lines in a day's logs.
+static EXCLUSION_WARNED: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashSet<(PathBuf, String)>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+
 /// Issue #162: a project silently missing from the dashboard is
 /// indistinguishable from data loss to users. Every filter that hides a
 /// directory from the project list must log through here so the exclusion
-/// shows up loudly in the logs (logging only — no behavior change).
+/// shows up loudly in the logs (logging only — no behavior change). Repeat
+/// occurrences within one app session demote to debug.
 fn warn_project_excluded(path: &Path, reason: &str) {
-    tracing::warn!(
-        path = %path.display(),
-        reason,
-        "project directory excluded from dashboard list"
-    );
+    let first_time = EXCLUSION_WARNED
+        .lock()
+        .map(|mut seen| seen.insert((path.to_path_buf(), reason.to_string())))
+        .unwrap_or(true);
+    if first_time {
+        tracing::warn!(
+            path = %path.display(),
+            reason,
+            "project directory excluded from dashboard list"
+        );
+    } else {
+        tracing::debug!(
+            path = %path.display(),
+            reason,
+            "project directory excluded from dashboard list"
+        );
+    }
+}
+
+/// Directories whose `.gitignore` has already been checked this session.
+/// The check/write used to run for every project on every dashboard scan.
+static GITIGNORE_ENSURED: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashSet<PathBuf>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+
+/// Ensure `.shipstudio/` is gitignored, once per project per app session.
+fn ensure_gitignore_once(project: &Path) {
+    let first_time = GITIGNORE_ENSURED
+        .lock()
+        .map(|mut seen| seen.insert(project.to_path_buf()))
+        .unwrap_or(true);
+    if first_time {
+        let _ = ensure_gitignore_has_shipstudio_sync(project);
+    }
 }
 
 /// Sync helper for ensuring .shipstudio/ is in gitignore
@@ -587,8 +645,8 @@ pub async fn get_dashboard_projects() -> Result<Vec<DashboardProject>, CommandEr
                 metadata.as_ref().and_then(|m| m.hide_main_branch_warning);
             let workspace_subpath = metadata.as_ref().and_then(|m| m.workspace_subpath.clone());
 
-            // Ensure .shipstudio/ is gitignored
-            let _ = ensure_gitignore_has_shipstudio_sync(&path);
+            // Ensure .shipstudio/ is gitignored (once per project per session)
+            ensure_gitignore_once(&path);
 
             projects.push(DashboardProject {
                 name: entry.file_name().to_string_lossy().to_string(),
@@ -1519,6 +1577,45 @@ mod tests {
                 .lock()
                 .unwrap_or_else(|e| e.into_inner()) = None;
         }
+    }
+
+    #[test]
+    fn branch_from_head_file_reads_normal_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let git_dir = tmp.path().join(".git");
+        std::fs::create_dir(&git_dir).unwrap();
+        std::fs::write(git_dir.join("HEAD"), "ref: refs/heads/feature/foo-bar\n").unwrap();
+        assert_eq!(
+            branch_from_head_file(tmp.path()),
+            Some("feature/foo-bar".to_string())
+        );
+    }
+
+    #[test]
+    fn branch_from_head_file_none_for_detached_and_non_git() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(branch_from_head_file(tmp.path()), None);
+        let git_dir = tmp.path().join(".git");
+        std::fs::create_dir(&git_dir).unwrap();
+        std::fs::write(
+            git_dir.join("HEAD"),
+            "1234567890abcdef1234567890abcdef12345678\n",
+        )
+        .unwrap();
+        assert_eq!(branch_from_head_file(tmp.path()), None);
+    }
+
+    #[test]
+    fn branch_from_head_file_follows_gitdir_pointer() {
+        // Linked worktrees have a `.git` FILE pointing at the real git dir.
+        let tmp = tempfile::tempdir().unwrap();
+        let real_git = tmp.path().join("repo-git");
+        std::fs::create_dir(&real_git).unwrap();
+        std::fs::write(real_git.join("HEAD"), "ref: refs/heads/wt-branch\n").unwrap();
+        let wt = tmp.path().join("worktree");
+        std::fs::create_dir(&wt).unwrap();
+        std::fs::write(wt.join(".git"), "gitdir: ../repo-git\n").unwrap();
+        assert_eq!(branch_from_head_file(&wt), Some("wt-branch".to_string()));
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,7 +39,6 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/ship-studio/releases/releases/latest/download/latest-{{target}}.json",
         "https://github.com/ship-studio/releases/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDkwOERENTAzOURDNjlFNkYKUldSdm5zYWRBOVdOa0VQQ09QckxabTA3ejVOSHBlSUs3d1I2NG02TmkzOVBmVUZ5OUp3L3QwbUkK"

--- a/src/hooks/useScreenshotManagement.test.ts
+++ b/src/hooks/useScreenshotManagement.test.ts
@@ -216,7 +216,7 @@ describe('useScreenshotManagement auto-capture consent gate', () => {
 
   it('non-denial failure keeps the retry behavior', async () => {
     vi.mocked(getThumbnailsEnabled).mockResolvedValue(true);
-    invokeMock.mockRejectedValue('Dev server not responding, skipping thumbnail capture');
+    invokeMock.mockRejectedValue('playwright screenshot crashed');
     const { result } = renderHook(() => useScreenshotManagement(makeParams()));
 
     await triggerAutoCapture(result);
@@ -227,6 +227,23 @@ describe('useScreenshotManagement auto-capture consent gate', () => {
       await vi.advanceTimersByTimeAsync(3_000);
     });
     expect(invokeMock).toHaveBeenCalledTimes(2);
+    expect(setThumbnailsEnabled).not.toHaveBeenCalled();
+  });
+
+  it('dead dev server: gives up immediately instead of burning the retry loop', async () => {
+    vi.mocked(getThumbnailsEnabled).mockResolvedValue(true);
+    invokeMock.mockRejectedValue('Dev server not responding, skipping thumbnail capture');
+    const { result } = renderHook(() => useScreenshotManagement(makeParams()));
+
+    await triggerAutoCapture(result);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+
+    // No retry is scheduled — the next scheduled capture will try again when
+    // the server is actually up. Thumbnails stay enabled.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000);
+    });
+    expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(setThumbnailsEnabled).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useScreenshotManagement.ts
+++ b/src/hooks/useScreenshotManagement.ts
@@ -11,7 +11,11 @@ import { invoke } from '@tauri-apps/api/core';
 import { logger } from '../lib/logger';
 import { trackEvent } from '../lib/analytics';
 import { getThumbnailsEnabled, setThumbnailsEnabled } from '../lib/settings';
-import { decideAutoCapture, isPermissionDenialError } from '../lib/thumbnailGate';
+import {
+  decideAutoCapture,
+  isPermissionDenialError,
+  isServerNotRespondingError,
+} from '../lib/thumbnailGate';
 
 /** Delay after page load before capturing screenshot (8 seconds to allow Next.js/Vite to fully compile) */
 const SCREENSHOT_DELAY_MS = 8000;
@@ -193,6 +197,14 @@ export function useScreenshotManagement({
         }
         if (captureSessionIdRef.current !== sessionId) {
           logger.info('[Thumbnail] Skipping retry - session cancelled');
+          return;
+        }
+        // A dev server that isn't answering its port won't start answering
+        // because we retry — the next scheduled capture (preview-ready or the
+        // periodic interval) will get it once the server is really up. Retrying
+        // here burned ~15s of health checks per burst against dead servers.
+        if (isServerNotRespondingError(error)) {
+          logger.info('[Thumbnail] Dev server not responding - skipping retries', { attempt });
           return;
         }
         if (attempt < SCREENSHOT_MAX_RETRIES) {

--- a/src/lib/thumbnailGate.test.ts
+++ b/src/lib/thumbnailGate.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { decideAutoCapture, isPermissionDenialError } from './thumbnailGate';
+import {
+  decideAutoCapture,
+  isPermissionDenialError,
+  isServerNotRespondingError,
+} from './thumbnailGate';
 
 describe('decideAutoCapture', () => {
   it('defers and asks on first run (consent never given)', () => {
@@ -63,5 +67,24 @@ describe('isPermissionDenialError', () => {
   it('handles null/undefined without throwing', () => {
     expect(isPermissionDenialError(null)).toBe(false);
     expect(isPermissionDenialError(undefined)).toBe(false);
+  });
+});
+
+describe('isServerNotRespondingError', () => {
+  it('detects the backend health-check refusal, in Error and CommandError shapes', () => {
+    expect(
+      isServerNotRespondingError(new Error('Dev server not responding, skipping thumbnail capture'))
+    ).toBe(true);
+    expect(
+      isServerNotRespondingError({
+        type: 'Other',
+        message: 'Dev server not responding, skipping thumbnail capture',
+      })
+    ).toBe(true);
+  });
+
+  it('does not flag other capture failures', () => {
+    expect(isServerNotRespondingError(new Error('playwright is not installed'))).toBe(false);
+    expect(isServerNotRespondingError(null)).toBe(false);
   });
 });

--- a/src/lib/thumbnailGate.ts
+++ b/src/lib/thumbnailGate.ts
@@ -44,3 +44,14 @@ export function isPermissionDenialError(error: unknown): boolean {
     /screen recording|screen capture|screencapturekit|scstream|tcc|cgdisplay|record/.test(message);
   return denial && screen;
 }
+
+/**
+ * The backend's pre-capture TCP health check found nothing listening on the
+ * dev-server port (`capture_project_thumbnail` in thumbnail.rs). Retrying a
+ * capture against a dead server can't succeed — callers should skip their
+ * retry loop and wait for the next scheduled capture instead.
+ */
+export function isServerNotRespondingError(error: unknown): boolean {
+  const message = formatCommandError(asCommandError(error)).toLowerCase();
+  return message.includes('dev server not responding');
+}


### PR DESCRIPTION
## Why

Mining 12 days of `~/Library/Logs/ShipStudio` from daily heavy use showed the dashboard scan as the app's biggest source of slowness and log spam:

- `get_dashboard_projects`: 2.7s median when slow, 13s max (234 slow runs)
- `git rev-parse --abbrev-ref HEAD (dashboard scan)`: **1,136 timeouts** (3s each); `git status --porcelain -uno`: **696 timeouts**
- 460 thumbnail captures ≥1s + 138 "failed after 5 retries" bursts against dev servers that weren't running
- 4,024 identical "project directory excluded from dashboard list" warns (same dirs, every scan)
- 175 updater errors from an endpoint that has never existed

## What changed

1. **Branch without a subprocess** — `branch_from_head_file` parses `.git/HEAD` directly (incl. worktree/submodule `gitdir:` pointer files, detached HEAD → `None` like before). Every project used to fork `git rev-parse` on every scan — including plain-HTML projects with no repo at all.
2. **Status counts cached in `GIT_CACHE` (30s TTL, failures included)** — a repo that errors or times out isn't re-forked on every dashboard load; git write ops invalidate the entry through the existing `invalidate`/`invalidate_status` paths.
3. **`.gitignore` ensure once per project per session** — was a read (and sometimes write) per project per scan.
4. **Exclusion warns dedup to once per (path, reason) per session**, then demote to debug — the issue #162 "loud on first occurrence" contract is preserved.
5. **Thumbnail retries skip dead servers** — the backend's TCP health check error is now non-retryable (new `isServerNotRespondingError`); the periodic capture picks things up once the server is actually running.
6. **Updater endpoint cleanup** — removed `latest-{{target}}.json` (never published; `latest.json` is what works and remains).

## Tests

New Rust tests for `branch_from_head_file` (normal repo, detached HEAD, non-git, worktree `gitdir:` pointer); updated + new frontend tests for the thumbnail retry policy and `isServerNotRespondingError`. Full suites green: 729 Rust, 1361 frontend, `check:patterns` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Dashboard loading is faster by reducing repeated Git operations and reusing recent scan results.
  - Git branch detection now works more reliably for worktrees and detached repositories.
  - Project dashboard setup and exclusion messages are less repetitive.

- **Bug Fixes**
  - Screenshot capture no longer repeatedly retries when the development server is unavailable.
  - Automatic updates now use a more consistent release metadata endpoint.

- **Tests**
  - Added coverage for repository branch detection and screenshot failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->