### PR TITLE
Show the preview for static sites whose HTML lives in public/

### DIFF
--- a/src-tauri/src/commands/external_projects.rs
+++ b/src-tauri/src/commands/external_projects.rs
@@ -307,9 +307,11 @@ fn looks_like_project_root(path: &Path) -> bool {
         "composer.json",
         "index.html",
     ];
-    // Mirror register_external_project's picker check: any .html file counts as a
-    // project, so static sites whose entry isn't index.html still auto-register.
-    MARKERS.iter().any(|m| path.join(m).exists()) || crate::commands::projects::has_html_files(path)
+    // Mirror register_external_project's picker check: any .html file (root or
+    // Vercel-style public/) counts as a project, so static sites whose entry
+    // isn't a root index.html still auto-register.
+    MARKERS.iter().any(|m| path.join(m).exists())
+        || crate::commands::projects::static_site_dir(path).is_some()
 }
 
 /// Register an external project by path (no folder picker dialog).

--- a/src-tauri/src/commands/projects/detection.rs
+++ b/src-tauri/src/commands/projects/detection.rs
@@ -46,6 +46,9 @@ fn detection_signature(project_path: &std::path::Path) -> u128 {
         // Shopify theme signals (nested paths work — metadata() takes any path)
         "layout/theme.liquid",
         "config/settings_schema.json",
+        // Static-site signals (root or Vercel-style public/)
+        "index.html",
+        "public/index.html",
     ];
     let mut max_nanos: u128 = 0;
     for name in SENTINELS {
@@ -231,6 +234,22 @@ pub(crate) fn is_shopify_theme_project(project_path: &std::path::Path) -> bool {
             .exists()
 }
 
+/// Resolve the directory a packageless static site serves from: the project
+/// root itself, or — mirroring Vercel's static-deploy convention — a `public/`
+/// subdirectory when the root has no HTML of its own. Agents routinely
+/// restructure plain HTML projects into `public/index.html` because that's
+/// what Vercel serves, so the local preview must accept the same layout.
+pub fn static_site_dir(project_path: &std::path::Path) -> Option<std::path::PathBuf> {
+    if has_html_files(project_path) {
+        return Some(project_path.to_path_buf());
+    }
+    let public = project_path.join("public");
+    if has_html_files(&public) {
+        return Some(public);
+    }
+    None
+}
+
 /// Check if a directory contains HTML files in its root
 pub fn has_html_files(project_path: &std::path::Path) -> bool {
     if let Ok(entries) = std::fs::read_dir(project_path) {
@@ -325,8 +344,8 @@ fn detect_project_type_uncached(project_path: &std::path::Path) -> ProjectType {
         return ProjectType::Generic;
     }
 
-    // Check for HTML files in root (static HTML project)
-    if has_html_files(project_path) {
+    // Check for HTML files in root or public/ (static HTML project)
+    if static_site_dir(project_path).is_some() {
         return ProjectType::Statichtml;
     }
 
@@ -875,6 +894,46 @@ mod tests {
         assert_eq!(
             detect_project_type_uncached(tmp.path()),
             ProjectType::Statichtml
+        );
+    }
+
+    #[test]
+    fn detects_static_html_in_public_dir() {
+        // Agents restructure plain sites into public/ (Vercel's static-deploy
+        // layout); the preview must classify these as static, not Unknown.
+        let tmp = TempDir::new().unwrap();
+        let public = tmp.path().join("public");
+        std::fs::create_dir_all(&public).unwrap();
+        std::fs::write(public.join("index.html"), "<html></html>").unwrap();
+        assert_eq!(
+            detect_project_type_uncached(tmp.path()),
+            ProjectType::Statichtml
+        );
+        assert_eq!(static_site_dir(tmp.path()), Some(public));
+    }
+
+    #[test]
+    fn static_site_dir_prefers_root_html() {
+        let tmp = TempDir::new().unwrap();
+        let public = tmp.path().join("public");
+        std::fs::create_dir_all(&public).unwrap();
+        std::fs::write(public.join("index.html"), "").unwrap();
+        std::fs::write(tmp.path().join("index.html"), "").unwrap();
+        assert_eq!(static_site_dir(tmp.path()), Some(tmp.path().to_path_buf()));
+    }
+
+    #[test]
+    fn public_html_does_not_make_framework_projects_static() {
+        // A framework app's public/ assets (or a Generic tooling project) must
+        // not be reclassified: package.json is checked before the static rule.
+        let tmp = TempDir::new().unwrap();
+        let public = tmp.path().join("public");
+        std::fs::create_dir_all(&public).unwrap();
+        std::fs::write(public.join("index.html"), "<html></html>").unwrap();
+        std::fs::write(tmp.path().join("package.json"), r#"{"name":"x"}"#).unwrap();
+        assert_eq!(
+            detect_project_type_uncached(tmp.path()),
+            ProjectType::Generic
         );
     }
 

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -206,7 +206,7 @@ pub(crate) fn is_valid_project(path: &std::path::Path) -> bool {
     ];
     path.is_dir()
         && (path.join("package.json").exists()
-            || detection::has_html_files(path)
+            || detection::static_site_dir(path).is_some()
             || path.join(".gitignore").exists()
             || path.join(".shipstudio").exists()
             || path.join(".git").exists()
@@ -766,7 +766,10 @@ pub async fn list_pages(project_path: String) -> Result<Vec<PageInfo>, CommandEr
             Ok(Vec::new())
         }
         ProjectType::Statichtml => {
-            let mut pages = detection::scan_html_pages(&project, &project)?;
+            // Scan the directory the static server actually serves from (the
+            // root, or Vercel-style public/) so routes match served URLs.
+            let site_dir = detection::static_site_dir(&project).unwrap_or(project.clone());
+            let mut pages = detection::scan_html_pages(&site_dir, &site_dir)?;
             detection::sort_pages(&mut pages);
             Ok(pages)
         }

--- a/src-tauri/src/commands/projects/templates.rs
+++ b/src-tauri/src/commands/projects/templates.rs
@@ -3,7 +3,7 @@
 //! Handles creating new projects from zip templates and exporting
 //! existing projects as zip template files.
 
-use super::detection::has_html_files;
+use super::detection::static_site_dir;
 use crate::errors::CommandError;
 use tauri::AppHandle;
 use tauri_plugin_dialog::DialogExt;
@@ -69,10 +69,10 @@ pub async fn extract_template_zip(
         return Err(e);
     }
 
-    // Verify it's a valid project (has package.json, HTML files, or a
-    // Shopify theme layout)
+    // Verify it's a valid project (has package.json, HTML files at the root
+    // or in public/, or a Shopify theme layout)
     if !project_path.join("package.json").exists()
-        && !has_html_files(&project_path)
+        && static_site_dir(&project_path).is_none()
         && !project_path.join("layout").join("theme.liquid").exists()
     {
         // Clean up invalid project

--- a/src-tauri/src/static_server.rs
+++ b/src-tauri/src/static_server.rs
@@ -119,8 +119,15 @@ pub async fn start_static_server(
         ));
     }
 
+    // Serve from `public/` (Vercel's static-deploy convention) when the project
+    // root has no HTML of its own — the same rule `detect_project_type` uses to
+    // classify the project as static in the first place. Falls back to the root
+    // so force-static projects with unusual layouts still serve something.
+    let serve_root =
+        crate::commands::projects::static_site_dir(&project_root).unwrap_or(project_root.clone());
+
     // Canonicalize once at startup for path traversal checks
-    let canonical_root = dunce::canonicalize(&project_root)
+    let canonical_root = dunce::canonicalize(&serve_root)
         .map_err(|e| format!("Failed to canonicalize project path: {e}"))?;
 
     // Bind to a random available port on localhost
@@ -499,6 +506,24 @@ mod tests {
         let result = resolve_file_path(&canonical_root, "/");
         assert!(result.is_some());
         assert!(result.unwrap().ends_with("index.html"));
+    }
+
+    #[test]
+    fn test_serves_from_public_when_root_has_no_html() {
+        // Vercel-style layout: all site files under public/, nothing at root.
+        let dir = TempDir::new().unwrap();
+        let public = dir.path().join("public");
+        fs::create_dir_all(&public).unwrap();
+        fs::write(public.join("index.html"), "<html></html>").unwrap();
+        fs::write(public.join("styles.css"), "body {}").unwrap();
+
+        let serve_root = crate::commands::projects::static_site_dir(dir.path())
+            .expect("public/ html must yield a serve root");
+        let canonical = dunce::canonicalize(&serve_root).unwrap();
+        let index = resolve_file_path(&canonical, "/").unwrap();
+        assert!(index.ends_with("public/index.html"));
+        let css = resolve_file_path(&canonical, "/styles.css").unwrap();
+        assert!(css.ends_with("public/styles.css"));
     }
 
     #[test]

--- a/src/components/workspace/ProjectSettingsModal.tsx
+++ b/src/components/workspace/ProjectSettingsModal.tsx
@@ -221,9 +221,10 @@ export function ProjectSettingsModal({
                       lineHeight: 1.4,
                     }}
                   >
-                    Serve files directly even though a <code>package.json</code> is present. Use
-                    this for plain HTML/CSS sites that keep a <code>package.json</code> only for
-                    build tooling. Reopen the project to apply.
+                    Serve this project's files directly with the built-in static server. Use this
+                    for plain HTML/CSS sites that weren't recognized automatically — e.g. ones that
+                    keep a <code>package.json</code> only for build tooling. Reopen the project to
+                    apply.
                   </span>
                 </span>
               </label>

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -584,18 +584,20 @@ export function useDevServer(currentProjectPath: string | null) {
 
       // A plain static site that carries a root `package.json` only for build
       // tooling (PostCSS, autoprefixer, a CSS minifier) is detected as `generic`
-      // and would start no server. The user can opt into static serving via
+      // and would start no server; a site whose HTML lives somewhere detection
+      // doesn't look is `unknown`. The user can opt into static serving via
       // `.shipstudio/project.json` → `force_static_serve`; when set, treat it as
       // a static-HTML project so it serves over the static server and the
-      // Preview pane renders (it gates out `generic`). Scoped to `generic` —
-      // the override is specifically for the package.json-present case.
+      // Preview pane renders (it gates out `generic`/`unknown`). Never applied
+      // to detected web frameworks — the override exists only for the two
+      // "no server would start" outcomes.
       let forceStatic = false;
       try {
         forceStatic = await getForceStaticServe(projectPath);
       } catch {
         /* default: respect detection */
       }
-      if (forceStatic && detectedType === 'generic') {
+      if (forceStatic && (detectedType === 'generic' || detectedType === 'unknown')) {
         logger.info('[OpenProject] force_static_serve set; serving as static HTML', {
           projectPath,
           detectedType,


### PR DESCRIPTION
## Problem

User report (Pia): a plain HTML/CSS/JS project created from the starter shows the preview, but her real project doesn't — no preview button at all, restarting didn't help. Her zip shows why: the agent had restructured the site into `public/index.html` + `public/styles.css` + `public/script.js` (Vercel's static-deploy layout — which is exactly why the *deployed* site worked while the local preview didn't). With no root-level `.html` and no `package.json`, `detect_project_type` returned `Unknown`, which the Preview pane gates out entirely.

## Fix

New `static_site_dir()` helper in detection: a static site serves from the project root, or — mirroring Vercel — from `public/` when the root has no HTML of its own. Applied consistently everywhere the old root-only check lived:

- **`detect_project_type`** — `public/index.html`-style sites classify as `Statichtml` (and therefore get edit mode, whose source scanner keys off the same detection). Framework/tooling projects are unaffected: `package.json` is checked first, so a Next/Vite app's `public/` assets can't reclassify it.
- **Static server** — serves from the resolved site dir, so `/` resolves to `public/index.html` and relative asset paths work. The live-reload watcher still watches the whole project.
- **Page scanner** — routes computed relative to the served dir, so the pages dropdown matches served URLs.
- **`is_valid_project`, template zip validation, external-project registration** — same rule, so these projects are recognized everywhere.
- **Detection cache** — `index.html` / `public/index.html` added to the mtime signature sentinels.

Secondary bug, same report class: the **"Serve as a static site"** settings toggle renders for any non-web project but `useDevServer` only honored it for `generic` — for `unknown` projects it saved and silently did nothing. Now honored for both, with the settings copy updated.

## Tests

- `cargo test`: 730 passed — new coverage for public-only detection, root-preference, framework non-reclassification, and static-server resolution from `public/`.
- `pnpm test:run`: 1358 passed; `pnpm check:patterns` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for static sites served from a `public/` directory (including `public/index.html`, CSS, and other assets).
  * Static-site detection now prefers root `index.html` when both root and `public/` content exist.
  * “Serve as a static site” can now start the built-in server for additional project types.

* **Bug Fixes**
  * Improved project recognition and page listing so discovered routes match what the built-in static server serves.
  * Enhanced template validation after ZIP extraction for static-site layouts.
  * Improved cleanup retry behavior and updated related user guidance text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->