### PR TITLE
Add project container detection to the workspace sidebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Ship Studio is a desktop app for web developers that provides:
 - **Live Preview** - Responsive breakpoints, zoom, fullscreen mode, and a locale switcher for multilingual projects
 - **Visual Editing** - Point-and-click edit mode on the preview with a pinnable editor panel and a Webflow-style element tree (fullscreen)
 - **Mobile App Preview** - Build and mirror Expo / React Native / Flutter apps on the iOS simulator inside the workspace
+- **Container Detection** - Detect the project's Docker containers (Compose / devcontainers) in the workspace sidebar, with start/stop/restart actions
 - **Branch Management** - Create, switch, and manage git branches
 - **Pull Request Creation** - Submit PRs with AI-generated titles and descriptions
 - **Merge Conflict Resolution** - Visual UI for resolving git merge conflicts
@@ -67,6 +68,7 @@ Single-file domains:
 - `claude.rs` - Claude Code binary detection and version checking
 - `code.rs` - Code mode (in-app file browsing/editing)
 - `conflicts.rs` - Merge conflict detection, parsing, and resolution
+- `containers.rs` - Project container detection (Docker): label-based attribution (Compose `working_dir` / devcontainer `local_folder`), engine status, start/stop/restart
 - `edit.rs` - Visual editor backend (mutations, committing edits back to source)
 - `env.rs` - Environment variable management
 - `external_projects.rs` - Registry for projects outside `~/ShipStudio`
@@ -127,6 +129,7 @@ Key modules in `src/lib/` (not exhaustive — `ls src/lib` for the full list):
 - `branches.ts` - Branch operations and PR status management
 - `claude.ts` - Claude Code detection and availability checking
 - `conflicts.ts` - Conflict resolution operations
+- `containers.ts` - Project container detection wrappers + row-display helpers (paired with `hooks/useContainers.ts` polling)
 - `edit.ts` / `editControls.ts` / `inspectStore.ts` - Visual editor state and iframe protocol
 - `errors.ts` - TypeScript mirror of `CommandError` + `asCommandError`/`formatCommandError` helpers
 - `external-projects.ts` / `folders.ts` / `pins.ts` - Dashboard organization (external repos, folders, pinned rail)

--- a/src-tauri/src/commands/containers.rs
+++ b/src-tauri/src/commands/containers.rs
@@ -1,0 +1,523 @@
+//! # Project Container Detection
+//!
+//! Detects Docker containers that belong to a project, the same way the dev
+//! server is tracked per-project. Association is label-based and conservative
+//! (see the "Never Assume Data" principle in CLAUDE.md): a container is only
+//! attributed to a project when a path-carrying label proves it —
+//! `com.docker.compose.project.working_dir` (Docker Compose) or
+//! `devcontainer.local_folder` (Dev Containers). Plain `docker run` containers
+//! carry no reliable project association and are deliberately not shown.
+//!
+//! Works with any engine that fronts the `docker` CLI (Docker Desktop,
+//! OrbStack, Colima). Podman support can be layered on later.
+
+use crate::errors::CommandError;
+use crate::external_command::run_with_timeout;
+use crate::utils::{create_command, find_executable, get_extended_path, validate_project_path};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Listing all containers is a local API call; keep it snappy so a wedged
+/// daemon can't stall the sidebar poll.
+const LIST_TIMEOUT_SECS: u64 = 10;
+/// `docker stop` waits up to 10s (default grace period) before SIGKILL, and
+/// `restart` pays that twice-ish; give lifecycle actions generous headroom.
+const ACTION_TIMEOUT_SECS: u64 = 45;
+
+const COMPOSE_WORKING_DIR_LABEL: &str = "com.docker.compose.project.working_dir";
+const COMPOSE_SERVICE_LABEL: &str = "com.docker.compose.service";
+const COMPOSE_PROJECT_LABEL: &str = "com.docker.compose.project";
+const DEVCONTAINER_FOLDER_LABEL: &str = "devcontainer.local_folder";
+
+/// Availability of the Docker engine on this machine.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum EngineStatus {
+    /// CLI present and the daemon answered.
+    Ok,
+    /// No `docker` binary on the (extended) PATH.
+    NotInstalled,
+    /// CLI present but the daemon isn't reachable (Docker Desktop closed…).
+    NotRunning,
+}
+
+/// A single host→container published port.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct PortMapping {
+    pub host_port: u16,
+    pub container_port: u16,
+    pub protocol: String,
+}
+
+/// A container attributed to the project.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct ContainerInfo {
+    /// Full (untruncated) container id.
+    pub id: String,
+    pub name: String,
+    pub image: String,
+    /// Engine state: `running`, `exited`, `paused`, `restarting`, `created`…
+    pub state: String,
+    /// Human status line from `docker ps`, e.g. "Up 2 hours".
+    pub status: String,
+    /// Compose service name, when the container came from a compose file.
+    pub service: Option<String>,
+    /// Compose project name, when applicable.
+    pub compose_project: Option<String>,
+    pub ports: Vec<PortMapping>,
+}
+
+/// Result of a project container scan. `engine` lets the frontend distinguish
+/// "no containers" from "Docker isn't even running" without a second command.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct ProjectContainers {
+    pub engine: EngineStatus,
+    pub containers: Vec<ContainerInfo>,
+}
+
+/// One line of `docker ps --format '{{json .}}'` output.
+#[derive(Deserialize, Debug)]
+struct DockerPsLine {
+    #[serde(rename = "ID")]
+    id: String,
+    #[serde(rename = "Names")]
+    names: String,
+    #[serde(rename = "Image")]
+    image: String,
+    #[serde(rename = "State")]
+    state: String,
+    #[serde(rename = "Status")]
+    status: String,
+    #[serde(rename = "Ports", default)]
+    ports: String,
+    #[serde(rename = "Labels", default)]
+    labels: String,
+}
+
+fn docker_command() -> Option<tokio::process::Command> {
+    let path = find_executable("docker")?;
+    let mut cmd = create_command(path);
+    cmd.env("PATH", get_extended_path());
+    Some(tokio::process::Command::from(cmd))
+}
+
+/// Parse the comma-joined `Labels` string ("k=v,k=v") into a map. A label
+/// *value* containing a comma will be truncated at it — such a container
+/// simply fails to match its project (fail closed, never misattribute).
+fn parse_labels(labels: &str) -> HashMap<&str, &str> {
+    labels
+        .split(',')
+        .filter_map(|pair| pair.split_once('='))
+        .map(|(k, v)| (k.trim(), v))
+        .collect()
+}
+
+/// True when `candidate` is `root` itself or a path underneath it.
+fn is_same_or_under(candidate: &str, root: &str) -> bool {
+    let root = root.trim_end_matches('/');
+    if root.is_empty() {
+        return false;
+    }
+    candidate == root
+        || candidate
+            .strip_prefix(root)
+            .is_some_and(|rest| rest.starts_with('/'))
+}
+
+/// Does this container provably belong to the project at one of `roots`?
+/// Only path-carrying labels count — name similarity is never enough.
+fn belongs_to_project(labels: &HashMap<&str, &str>, roots: &[&str]) -> bool {
+    [COMPOSE_WORKING_DIR_LABEL, DEVCONTAINER_FOLDER_LABEL]
+        .iter()
+        .filter_map(|key| labels.get(key))
+        .any(|value| roots.iter().any(|root| is_same_or_under(value, root)))
+}
+
+/// Parse the `Ports` column ("0.0.0.0:5432->5432/tcp, :::5432->5432/tcp,
+/// 6379/tcp") into published mappings. Unpublished ports (no `->`) and
+/// duplicate IPv4/IPv6 rows are dropped.
+fn parse_ports(ports: &str) -> Vec<PortMapping> {
+    let mut seen = Vec::new();
+    for entry in ports.split(',').map(str::trim) {
+        let Some((host, container)) = entry.split_once("->") else {
+            continue;
+        };
+        let Some(host_port) = host.rsplit(':').next().and_then(|p| p.parse::<u16>().ok()) else {
+            continue;
+        };
+        let (container_port_str, protocol) = container.split_once('/').unwrap_or((container, ""));
+        let Ok(container_port) = container_port_str.parse::<u16>() else {
+            continue;
+        };
+        let mapping = PortMapping {
+            host_port,
+            container_port,
+            protocol: protocol.to_string(),
+        };
+        if !seen.contains(&mapping) {
+            seen.push(mapping);
+        }
+    }
+    seen
+}
+
+/// Classify a failed `docker ps` into "daemon down" vs a real error.
+fn is_daemon_unreachable(stderr: &str) -> bool {
+    let lower = stderr.to_lowercase();
+    lower.contains("cannot connect to the docker daemon")
+        || lower.contains("docker daemon is not running")
+        || lower.contains("error during connect")
+        || lower.contains("is the docker daemon running")
+}
+
+/// Build the project's `ContainerInfo` list from raw `docker ps` JSON lines.
+/// Pure for testability.
+fn collect_project_containers(stdout: &str, roots: &[&str]) -> Vec<ContainerInfo> {
+    let mut containers: Vec<ContainerInfo> = stdout
+        .lines()
+        .filter_map(|line| serde_json::from_str::<DockerPsLine>(line).ok())
+        .filter_map(|line| {
+            let labels = parse_labels(&line.labels);
+            if !belongs_to_project(&labels, roots) {
+                return None;
+            }
+            Some(ContainerInfo {
+                id: line.id.clone(),
+                // Multi-name containers are comma-joined; the first is canonical.
+                name: line.names.split(',').next().unwrap_or(&line.id).to_string(),
+                image: line.image,
+                state: line.state,
+                status: line.status,
+                service: labels.get(COMPOSE_SERVICE_LABEL).map(|s| s.to_string()),
+                compose_project: labels.get(COMPOSE_PROJECT_LABEL).map(|s| s.to_string()),
+                ports: parse_ports(&line.ports),
+            })
+        })
+        .collect();
+    // Running containers first, then stable name order.
+    containers.sort_by(|a, b| {
+        let rank = |c: &ContainerInfo| if c.state == "running" { 0 } else { 1 };
+        rank(a).cmp(&rank(b)).then_with(|| a.name.cmp(&b.name))
+    });
+    containers
+}
+
+/// Container ids are hex; anything else is rejected before it reaches the CLI.
+fn validate_container_id(container_id: &str) -> Result<(), CommandError> {
+    let valid_len = (12..=64).contains(&container_id.len());
+    if !valid_len || !container_id.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(CommandError::Validation {
+            field: "container_id".into(),
+            reason: "not a valid container id".into(),
+        });
+    }
+    Ok(())
+}
+
+/// The raw path and its canonicalized form — compose may have recorded either
+/// (macOS `/tmp` vs `/private/tmp`), so membership checks accept both.
+fn project_roots(project_path: &str) -> Result<Vec<String>, CommandError> {
+    let canonical =
+        validate_project_path(project_path).map_err(|reason| CommandError::Validation {
+            field: "project_path".into(),
+            reason,
+        })?;
+    let mut roots = vec![project_path.trim_end_matches('/').to_string()];
+    let canonical = canonical.to_string_lossy().to_string();
+    if !roots.contains(&canonical) {
+        roots.push(canonical);
+    }
+    Ok(roots)
+}
+
+async fn scan_project_containers(project_path: &str) -> Result<ProjectContainers, CommandError> {
+    let roots = project_roots(project_path)?;
+
+    let Some(mut cmd) = docker_command() else {
+        return Ok(ProjectContainers {
+            engine: EngineStatus::NotInstalled,
+            containers: Vec::new(),
+        });
+    };
+    cmd.args(["ps", "--all", "--no-trunc", "--format", "{{json .}}"]);
+
+    let output = match run_with_timeout(cmd, "docker ps", LIST_TIMEOUT_SECS).await {
+        Ok(output) => output,
+        // The binary vanished between detection and spawn — treat as absent.
+        Err(CommandError::Io { .. }) => {
+            return Ok(ProjectContainers {
+                engine: EngineStatus::NotInstalled,
+                containers: Vec::new(),
+            });
+        }
+        Err(err) => return Err(err),
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        if is_daemon_unreachable(&stderr) {
+            return Ok(ProjectContainers {
+                engine: EngineStatus::NotRunning,
+                containers: Vec::new(),
+            });
+        }
+        return Err(CommandError::Process {
+            cmd: "docker ps".into(),
+            exit_code: output.status.code().unwrap_or(-1),
+            stderr,
+        });
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let root_refs: Vec<&str> = roots.iter().map(String::as_str).collect();
+    Ok(ProjectContainers {
+        engine: EngineStatus::Ok,
+        containers: collect_project_containers(&stdout, &root_refs),
+    })
+}
+
+/// List the Docker containers that belong to a project, plus engine
+/// availability. Containers are matched by compose/devcontainer path labels
+/// only — never by name similarity.
+///
+/// # Arguments
+/// * `project_path` - Absolute path to the project directory
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn list_project_containers(
+    project_path: String,
+) -> Result<ProjectContainers, CommandError> {
+    scan_project_containers(&project_path).await
+}
+
+/// Run a lifecycle action after re-verifying the container still belongs to
+/// the project — the id came from the frontend and could be stale or spoofed.
+async fn container_action(
+    project_path: &str,
+    container_id: &str,
+    action: &str,
+) -> Result<(), CommandError> {
+    validate_container_id(container_id)?;
+    let scan = scan_project_containers(project_path).await?;
+    if !scan.containers.iter().any(|c| c.id == container_id) {
+        return Err(CommandError::Validation {
+            field: "container_id".into(),
+            reason: "container does not belong to this project".into(),
+        });
+    }
+
+    let mut cmd = docker_command().ok_or(CommandError::Io {
+        message: "docker CLI not found".into(),
+    })?;
+    cmd.args([action, container_id]);
+    let label = format!("docker {action}");
+    let output = run_with_timeout(cmd, label.clone(), ACTION_TIMEOUT_SECS).await?;
+    if !output.status.success() {
+        return Err(CommandError::Process {
+            cmd: label,
+            exit_code: output.status.code().unwrap_or(-1),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Start a stopped container that belongs to the project.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn start_project_container(
+    project_path: String,
+    container_id: String,
+) -> Result<(), CommandError> {
+    container_action(&project_path, &container_id, "start").await
+}
+
+/// Stop a running container that belongs to the project.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn stop_project_container(
+    project_path: String,
+    container_id: String,
+) -> Result<(), CommandError> {
+    container_action(&project_path, &container_id, "stop").await
+}
+
+/// Restart a container that belongs to the project.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn restart_project_container(
+    project_path: String,
+    container_id: String,
+) -> Result<(), CommandError> {
+    container_action(&project_path, &container_id, "restart").await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ps_line(id: &str, name: &str, state: &str, labels: &str, ports: &str) -> String {
+        serde_json::json!({
+            "ID": id,
+            "Names": name,
+            "Image": "postgres:16",
+            "State": state,
+            "Status": "Up 2 hours",
+            "Ports": ports,
+            "Labels": labels,
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn parses_labels_into_map() {
+        let labels = parse_labels("a=1,com.docker.compose.service=db,b=x=y");
+        assert_eq!(labels.get("a"), Some(&"1"));
+        assert_eq!(labels.get("com.docker.compose.service"), Some(&"db"));
+        // split_once keeps everything after the first '=' as the value
+        assert_eq!(labels.get("b"), Some(&"x=y"));
+    }
+
+    #[test]
+    fn matches_compose_working_dir_exactly() {
+        let line = ps_line(
+            "a".repeat(64).as_str(),
+            "myapp-db-1",
+            "running",
+            "com.docker.compose.project.working_dir=/Users/me/ShipStudio/myapp,com.docker.compose.service=db,com.docker.compose.project=myapp",
+            "",
+        );
+        let found = collect_project_containers(&line, &["/Users/me/ShipStudio/myapp"]);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].service.as_deref(), Some("db"));
+        assert_eq!(found[0].compose_project.as_deref(), Some("myapp"));
+    }
+
+    #[test]
+    fn matches_compose_file_in_subdirectory() {
+        let line = ps_line(
+            "b".repeat(64).as_str(),
+            "myapp-db-1",
+            "running",
+            "com.docker.compose.project.working_dir=/Users/me/ShipStudio/myapp/infra",
+            "",
+        );
+        let found = collect_project_containers(&line, &["/Users/me/ShipStudio/myapp"]);
+        assert_eq!(found.len(), 1);
+    }
+
+    #[test]
+    fn does_not_match_sibling_project_with_shared_prefix() {
+        let line = ps_line(
+            "c".repeat(64).as_str(),
+            "myapp2-db-1",
+            "running",
+            "com.docker.compose.project.working_dir=/Users/me/ShipStudio/myapp2",
+            "",
+        );
+        assert!(collect_project_containers(&line, &["/Users/me/ShipStudio/myapp"]).is_empty());
+    }
+
+    #[test]
+    fn matches_devcontainer_label() {
+        let line = ps_line(
+            "d".repeat(64).as_str(),
+            "vsc-myapp-abc",
+            "running",
+            "devcontainer.local_folder=/Users/me/ShipStudio/myapp",
+            "",
+        );
+        assert_eq!(
+            collect_project_containers(&line, &["/Users/me/ShipStudio/myapp"]).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn ignores_unlabeled_containers() {
+        let line = ps_line("e".repeat(64).as_str(), "myapp", "running", "", "");
+        assert!(collect_project_containers(&line, &["/Users/me/ShipStudio/myapp"]).is_empty());
+    }
+
+    #[test]
+    fn sorts_running_before_stopped_then_by_name() {
+        let root = "com.docker.compose.project.working_dir=/p";
+        let lines = [
+            ps_line("f".repeat(64).as_str(), "b-stopped", "exited", root, ""),
+            ps_line("1".repeat(64).as_str(), "z-running", "running", root, ""),
+            ps_line("2".repeat(64).as_str(), "a-running", "running", root, ""),
+        ]
+        .join("\n");
+        let names: Vec<String> = collect_project_containers(&lines, &["/p"])
+            .into_iter()
+            .map(|c| c.name)
+            .collect();
+        assert_eq!(names, ["a-running", "z-running", "b-stopped"]);
+    }
+
+    #[test]
+    fn parses_ports_and_dedupes_ipv6_twin() {
+        let ports = parse_ports("0.0.0.0:5432->5432/tcp, :::5432->5432/tcp, 6379/tcp");
+        assert_eq!(
+            ports,
+            vec![PortMapping {
+                host_port: 5432,
+                container_port: 5432,
+                protocol: "tcp".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_remapped_host_port() {
+        let ports = parse_ports("127.0.0.1:15432->5432/tcp");
+        assert_eq!(ports[0].host_port, 15432);
+        assert_eq!(ports[0].container_port, 5432);
+    }
+
+    #[test]
+    fn empty_ports_string_parses_to_nothing() {
+        assert!(parse_ports("").is_empty());
+    }
+
+    #[test]
+    fn classifies_daemon_down_stderr() {
+        assert!(is_daemon_unreachable(
+            "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?"
+        ));
+        assert!(is_daemon_unreachable(
+            "error during connect: Get \"http://...\": open //./pipe/docker_engine"
+        ));
+        assert!(!is_daemon_unreachable("permission denied"));
+    }
+
+    #[test]
+    fn rejects_malformed_container_ids() {
+        assert!(validate_container_id("abc").is_err()); // too short
+        assert!(validate_container_id("g".repeat(12).as_str()).is_err()); // not hex
+        assert!(validate_container_id("deadbeef1234; rm -rf /").is_err());
+        assert!(validate_container_id("deadbeef1234").is_ok());
+        assert!(validate_container_id("a".repeat(64).as_str()).is_ok());
+    }
+
+    #[test]
+    fn is_same_or_under_handles_trailing_slash_and_empty() {
+        assert!(is_same_or_under("/a/b", "/a/b/"));
+        assert!(is_same_or_under("/a/b/c", "/a/b"));
+        assert!(!is_same_or_under("/a/bc", "/a/b"));
+        assert!(!is_same_or_under("/a/b", ""));
+    }
+
+    #[test]
+    fn skips_malformed_json_lines() {
+        let good = ps_line(
+            "3".repeat(64).as_str(),
+            "ok",
+            "running",
+            "com.docker.compose.project.working_dir=/p",
+            "",
+        );
+        let input = format!("not json\n{good}\n{{\"partial\":true}}");
+        assert_eq!(collect_project_containers(&input, &["/p"]).len(), 1);
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod claude;
 pub mod clipboard;
 pub mod code;
 pub mod conflicts;
+pub mod containers;
 pub mod custom_classes;
 pub mod edit;
 pub mod edit_css;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -605,6 +605,11 @@ pub fn run() {
             commands::conflicts::resolve_conflict,
             commands::conflicts::abort_merge,
             commands::conflicts::complete_merge,
+            // Project containers (Docker)
+            commands::containers::list_project_containers,
+            commands::containers::start_project_container,
+            commands::containers::stop_project_container,
+            commands::containers::restart_project_container,
             // Preview Proxy
             commands::proxy::start_preview_proxy,
             commands::proxy::stop_preview_proxy,

--- a/src/components/icons/utility.tsx
+++ b/src/components/icons/utility.tsx
@@ -27,6 +27,44 @@ export function PlusIcon({ size = 14 }: IconProps) {
   );
 }
 
+/** Triangle play glyph (lucide play) — start a stopped container. */
+export function PlayIcon({ size = 14, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <polygon points="6 3 20 12 6 21 6 3" />
+    </svg>
+  );
+}
+
+/** Square stop glyph (lucide square) — stop a running container. */
+export function StopIcon({ size = 14, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <rect x="5" y="5" width="14" height="14" rx="1.5" />
+    </svg>
+  );
+}
+
 /** Arrow down to a line (lucide arrow-down-to-line) — the git-pull metaphor:
  *  bring the remote's commits down into your working copy. */
 export function PullIcon({ size = 12, className }: IconProps) {

--- a/src/components/workspace/WorkspaceSidebar.tsx
+++ b/src/components/workspace/WorkspaceSidebar.tsx
@@ -10,7 +10,7 @@ import {
   type ReactNode,
 } from 'react';
 import { createPortal } from 'react-dom';
-import { SearchIcon, ChevronIcon, ResetIcon, LayersIcon } from '../icons';
+import { SearchIcon, ChevronIcon, ResetIcon, LayersIcon, PlayIcon, StopIcon } from '../icons';
 import { Button } from '../primitives/Button';
 import { BrowserDropdown } from '../preview/BrowserDropdown';
 import { useOpenPalette } from '../CommandPalette/paletteContext';
@@ -24,6 +24,15 @@ import {
 } from '../../lib/worktreeFamilies';
 import { formatRelativeTime } from '../../lib/branches';
 import type { TerminalTab } from '../../hooks/useTerminalManagement';
+import { useContainers } from '../../hooks/useContainers';
+import {
+  containerDotState,
+  containerLabel,
+  containerMeta,
+  isContainerRunning,
+} from '../../lib/containers';
+import { asCommandError, formatCommandError } from '../../lib/errors';
+import { useOptionalToast } from '../../contexts/ToastContext';
 import type { PinnedProjectRow } from '../../hooks/usePinnedProjects';
 import { useActiveAccount } from '../../hooks/useActiveAccount';
 import { useCommands } from '../../commands/useCommands';
@@ -37,7 +46,7 @@ import {
   type TabStatus,
 } from '../../lib/sessionRegistry';
 
-type SectionId = 'agents' | 'terminals' | 'worktrees' | 'commands';
+type SectionId = 'agents' | 'terminals' | 'worktrees' | 'commands' | 'containers';
 type GroupId = 'pinned' | 'projects';
 
 interface SidebarItem {
@@ -136,13 +145,22 @@ const SECTION_STORAGE_KEY = 'ship-studio:workspace-sidebar:collapsed';
 const PROJECT_EXPAND_STORAGE_KEY = 'ship-studio:workspace-sidebar:expanded-projects';
 
 function readCollapsed(): Record<SectionId, boolean> {
+  // Merge over defaults — stored state written before a section existed
+  // (e.g. 'containers') simply falls back to expanded.
+  const defaults: Record<SectionId, boolean> = {
+    agents: false,
+    terminals: false,
+    worktrees: false,
+    commands: false,
+    containers: false,
+  };
   try {
     const raw = localStorage.getItem(SECTION_STORAGE_KEY);
-    if (raw) return JSON.parse(raw) as Record<SectionId, boolean>;
+    if (raw) return { ...defaults, ...(JSON.parse(raw) as Partial<Record<SectionId, boolean>>) };
   } catch {
     // ignore
   }
-  return { agents: false, terminals: false, worktrees: false, commands: false };
+  return defaults;
 }
 
 function writeCollapsed(state: Record<SectionId, boolean>) {
@@ -270,6 +288,68 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
   onSwitchAccount,
 }: Props) {
   const { activeAccount, accounts } = useActiveAccount(currentProjectPath);
+  const { showToast } = useOptionalToast();
+  // Detected Docker containers for the current project (compose/devcontainer
+  // label matches only). Polls while a project is open; the section below
+  // stays hidden for the (majority of) projects with no containers.
+  const {
+    containers,
+    pendingIds: pendingContainerIds,
+    startProjectContainer,
+    stopProjectContainer,
+    restartProjectContainer,
+  } = useContainers(currentProjectPath);
+
+  // Palette contract: container actions are reachable via ⌘K, one entry per
+  // detected container. Failures surface as toasts (rule 3) — a rejected
+  // invoke is a CommandError object, not an Error.
+  useCommands(
+    () =>
+      containers.flatMap((c) => {
+        const label = containerLabel(c);
+        const guarded = (fn: (id: string) => Promise<void>) => async () => {
+          try {
+            await fn(c.id);
+          } catch (e) {
+            showToast(formatCommandError(asCommandError(e)), 'error');
+          }
+        };
+        const keywords = ['docker', 'container', c.name, c.image];
+        return isContainerRunning(c)
+          ? [
+              {
+                id: `containers.stop.${c.id}`,
+                title: `Stop container: ${label}`,
+                icon: <StopIcon size={14} />,
+                category: 'project' as const,
+                when: 'project' as const,
+                keywords,
+                run: guarded(stopProjectContainer),
+              },
+              {
+                id: `containers.restart.${c.id}`,
+                title: `Restart container: ${label}`,
+                icon: <ResetIcon size={14} />,
+                category: 'project' as const,
+                when: 'project' as const,
+                keywords,
+                run: guarded(restartProjectContainer),
+              },
+            ]
+          : [
+              {
+                id: `containers.start.${c.id}`,
+                title: `Start container: ${label}`,
+                icon: <PlayIcon size={14} />,
+                category: 'project' as const,
+                when: 'project' as const,
+                keywords,
+                run: guarded(startProjectContainer),
+              },
+            ];
+      }),
+    [containers, startProjectContainer, stopProjectContainer, restartProjectContainer, showToast]
+  );
   // The Workspaces feature is invisible until you actually have more than one.
   // For the ~80% single-workspace users the footer switcher stays hidden; the
   // picker is still reachable any time via the ⌘K command below.
@@ -489,6 +569,33 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
     });
   }, [worktrees, registryVersion, onSelectProject, onCloseProject]);
 
+  // Container rows: one action button toggling start/stop (restart lives in
+  // the palette). The dot speaks the same idle/active/attention vocabulary
+  // as agent rows; meta shows published ports for running containers.
+  const containerItems = useMemo<SidebarItem[]>(
+    () =>
+      containers.map((c) => {
+        const running = isContainerRunning(c);
+        const busy = pendingContainerIds.has(c.id);
+        const label = containerLabel(c);
+        return {
+          key: `container-${c.id}`,
+          label,
+          dotState: containerDotState(c.state),
+          meta: busy ? (running ? 'stopping' : 'starting') : containerMeta(c),
+          onAction: () => {
+            void (running ? stopProjectContainer(c.id) : startProjectContainer(c.id)).catch((e) =>
+              showToast(formatCommandError(asCommandError(e)), 'error')
+            );
+          },
+          actionIcon: running ? <StopIcon size={11} /> : <PlayIcon size={11} />,
+          actionLabel: running ? `Stop ${label}` : `Start ${label}`,
+          actionBusy: busy,
+        };
+      }),
+    [containers, pendingContainerIds, startProjectContainer, stopProjectContainer, showToast]
+  );
+
   const filterLower = filter.trim().toLowerCase();
   const matchesFilter = (label: string) =>
     !filterLower || label.toLowerCase().includes(filterLower);
@@ -496,6 +603,7 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
   const filteredAgents = agentItems.filter((i) => matchesFilter(i.label));
   const filteredTerminals = terminalItems.filter((i) => matchesFilter(i.label));
   const filteredCommands = commandItems.filter((i) => matchesFilter(i.label));
+  const filteredContainers = containerItems.filter((i) => matchesFilter(i.label));
 
   const atMaxTabs = terminalTabs.length >= maxTabs;
 
@@ -710,6 +818,17 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
                 items={filteredCommands}
                 emptyHint={filter ? 'No matches' : 'Not running'}
               />
+              {containerItems.length > 0 && (
+                <SidebarSection
+                  id="containers"
+                  label="Containers"
+                  total={containerItems.length}
+                  collapsed={collapsed.containers}
+                  onToggle={() => toggleSection('containers')}
+                  items={filteredContainers}
+                  emptyHint={filter ? 'No matches' : 'None detected'}
+                />
+              )}
             </div>
           ) : (
             <div key="inactive-body" className="sidebar-project-body-inner">

--- a/src/hooks/useContainers.ts
+++ b/src/hooks/useContainers.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  listProjectContainers,
+  restartContainer,
+  startContainer,
+  stopContainer,
+  type ContainerEngineStatus,
+  type ContainerInfo,
+} from '../lib/containers';
+import { usePolling } from './usePolling';
+import { logger } from '../lib/logger';
+
+const POLL_INTERVAL_MS = 5000;
+
+interface UseContainersReturn {
+  /** Containers attributed to the project (running first). */
+  containers: ContainerInfo[];
+  /** Engine availability from the last successful scan. */
+  engine: ContainerEngineStatus;
+  /** Ids with a start/stop/restart currently in flight. */
+  pendingIds: ReadonlySet<string>;
+  /** Lifecycle actions. They re-scan on completion and THROW on failure —
+   *  callers surface the error (toast) per the palette contract. */
+  startProjectContainer: (containerId: string) => Promise<void>;
+  stopProjectContainer: (containerId: string) => Promise<void>;
+  restartProjectContainer: (containerId: string) => Promise<void>;
+}
+
+/**
+ * Detect and track the Docker containers that belong to a project — the
+ * container-side sibling of the dev-server tracking. Polls `docker ps`
+ * (label-filtered in the backend) while a project is open; polling backs off
+ * exponentially on errors via `usePolling`.
+ */
+export function useContainers(projectPath: string | null): UseContainersReturn {
+  const [containers, setContainers] = useState<ContainerInfo[]>([]);
+  const [engine, setEngine] = useState<ContainerEngineStatus>('ok');
+  const [pendingIds, setPendingIds] = useState<ReadonlySet<string>>(new Set());
+  // Guards a stale poll response from a previous project overwriting the
+  // freshly-reset state after a project switch.
+  const pathRef = useRef(projectPath);
+  pathRef.current = projectPath;
+
+  useEffect(() => {
+    setContainers([]);
+    setEngine('ok');
+    setPendingIds(new Set());
+  }, [projectPath]);
+
+  const refresh = useCallback(async () => {
+    if (!projectPath) return;
+    const result = await listProjectContainers(projectPath);
+    if (pathRef.current !== projectPath) return;
+    setEngine(result.engine);
+    setContainers(result.containers);
+  }, [projectPath]);
+
+  usePolling(refresh, {
+    intervalMs: POLL_INTERVAL_MS,
+    enabled: projectPath !== null,
+    name: 'containers',
+  });
+
+  const runAction = useCallback(
+    async (containerId: string, action: (path: string, id: string) => Promise<void>) => {
+      if (!projectPath) return;
+      setPendingIds((prev) => new Set(prev).add(containerId));
+      try {
+        await action(projectPath, containerId);
+        // Fire-and-forget refresh failure: the 5s poll self-heals, and the
+        // action itself already succeeded.
+        await refresh().catch((err) => {
+          logger.debug('container refresh after action failed', { error: String(err) });
+        });
+      } finally {
+        setPendingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(containerId);
+          return next;
+        });
+      }
+    },
+    [projectPath, refresh]
+  );
+
+  const startProjectContainer = useCallback(
+    (containerId: string) => runAction(containerId, startContainer),
+    [runAction]
+  );
+  const stopProjectContainer = useCallback(
+    (containerId: string) => runAction(containerId, stopContainer),
+    [runAction]
+  );
+  const restartProjectContainer = useCallback(
+    (containerId: string) => runAction(containerId, restartContainer),
+    [runAction]
+  );
+
+  return {
+    containers,
+    engine,
+    pendingIds,
+    startProjectContainer,
+    stopProjectContainer,
+    restartProjectContainer,
+  };
+}

--- a/src/lib/containers.test.ts
+++ b/src/lib/containers.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { containerDotState, containerLabel, containerMeta, isContainerRunning } from './containers';
+
+describe('isContainerRunning', () => {
+  it('treats running and restarting as running', () => {
+    expect(isContainerRunning({ state: 'running' })).toBe(true);
+    expect(isContainerRunning({ state: 'restarting' })).toBe(true);
+    expect(isContainerRunning({ state: 'exited' })).toBe(false);
+    expect(isContainerRunning({ state: 'created' })).toBe(false);
+  });
+});
+
+describe('containerLabel', () => {
+  it('prefers the compose service name over the container name', () => {
+    expect(containerLabel({ name: 'myapp-db-1', service: 'db' })).toBe('db');
+  });
+
+  it('falls back to the container name without a service label', () => {
+    expect(containerLabel({ name: 'vsc-myapp-abc', service: null })).toBe('vsc-myapp-abc');
+  });
+});
+
+describe('containerDotState', () => {
+  it('maps engine states to sidebar dot vocabulary', () => {
+    expect(containerDotState('running')).toBe('active');
+    expect(containerDotState('restarting')).toBe('attention');
+    expect(containerDotState('paused')).toBe('idle');
+    expect(containerDotState('exited')).toBe('muted');
+    expect(containerDotState('created')).toBe('muted');
+    expect(containerDotState('dead')).toBe('muted');
+  });
+});
+
+describe('containerMeta', () => {
+  it('shows published host ports for running containers', () => {
+    expect(
+      containerMeta({
+        state: 'running',
+        ports: [
+          { hostPort: 5432, containerPort: 5432, protocol: 'tcp' },
+          { hostPort: 6379, containerPort: 6379, protocol: 'tcp' },
+        ],
+      })
+    ).toBe(':5432 :6379');
+  });
+
+  it('shows nothing for a running container without published ports', () => {
+    expect(containerMeta({ state: 'running', ports: [] })).toBeUndefined();
+  });
+
+  it('shows the engine state for non-running containers', () => {
+    expect(containerMeta({ state: 'exited', ports: [] })).toBe('exited');
+    expect(
+      containerMeta({
+        state: 'paused',
+        ports: [{ hostPort: 3000, containerPort: 3000, protocol: 'tcp' }],
+      })
+    ).toBe('paused');
+  });
+});

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -1,0 +1,147 @@
+/**
+ * Project container detection (Docker).
+ *
+ * Wraps the `*_project_container(s)` Tauri commands. A container belongs to a
+ * project only when a path-carrying label proves it (Docker Compose's
+ * `working_dir` label or a devcontainer's `local_folder` label) — the backend
+ * never guesses from name similarity, so everything surfaced here is reliably
+ * the project's own.
+ *
+ * @module lib/containers
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+
+/** Availability of the Docker engine on this machine. */
+export type ContainerEngineStatus = 'ok' | 'not-installed' | 'not-running';
+
+/** A single host→container published port. */
+export interface PortMapping {
+  hostPort: number;
+  containerPort: number;
+  protocol: string;
+}
+
+/** A container attributed to the project. */
+export interface ContainerInfo {
+  /** Full (untruncated) container id. */
+  id: string;
+  name: string;
+  image: string;
+  /** Engine state: `running`, `exited`, `paused`, `restarting`, `created`… */
+  state: string;
+  /** Human status line from `docker ps`, e.g. "Up 2 hours". */
+  status: string;
+  /** Compose service name, when the container came from a compose file. */
+  service: string | null;
+  /** Compose project name, when applicable. */
+  composeProject: string | null;
+  ports: PortMapping[];
+}
+
+/** Result of a project container scan. */
+export interface ProjectContainers {
+  engine: ContainerEngineStatus;
+  containers: ContainerInfo[];
+}
+
+/** Raw shape returned by the backend (snake_case fields). */
+interface RawContainerInfo {
+  id: string;
+  name: string;
+  image: string;
+  state: string;
+  status: string;
+  service: string | null;
+  compose_project: string | null;
+  ports: { host_port: number; container_port: number; protocol: string }[];
+}
+
+/**
+ * List the containers that belong to a project, plus engine availability
+ * (so callers can tell "no containers" apart from "Docker isn't running").
+ * @param projectPath - Absolute path to the project
+ */
+export async function listProjectContainers(projectPath: string): Promise<ProjectContainers> {
+  const raw = await invoke<{ engine: ContainerEngineStatus; containers: RawContainerInfo[] }>(
+    'list_project_containers',
+    { projectPath }
+  );
+  return {
+    engine: raw.engine,
+    containers: raw.containers.map((c) => ({
+      id: c.id,
+      name: c.name,
+      image: c.image,
+      state: c.state,
+      status: c.status,
+      service: c.service,
+      composeProject: c.compose_project,
+      ports: c.ports.map((p) => ({
+        hostPort: p.host_port,
+        containerPort: p.container_port,
+        protocol: p.protocol,
+      })),
+    })),
+  };
+}
+
+/** Start a stopped container that belongs to the project. */
+export async function startContainer(projectPath: string, containerId: string): Promise<void> {
+  return invoke('start_project_container', { projectPath, containerId });
+}
+
+/** Stop a running container that belongs to the project. */
+export async function stopContainer(projectPath: string, containerId: string): Promise<void> {
+  return invoke('stop_project_container', { projectPath, containerId });
+}
+
+/** Restart a container that belongs to the project. */
+export async function restartContainer(projectPath: string, containerId: string): Promise<void> {
+  return invoke('restart_project_container', { projectPath, containerId });
+}
+
+/** True while the container can be stopped (i.e. the action is "stop"). */
+export function isContainerRunning(container: Pick<ContainerInfo, 'state'>): boolean {
+  return container.state === 'running' || container.state === 'restarting';
+}
+
+/**
+ * Row label: the compose service name reads best ("db", "redis"); fall back
+ * to the container name for devcontainers and anything unnamed-by-compose.
+ */
+export function containerLabel(container: Pick<ContainerInfo, 'name' | 'service'>): string {
+  return container.service ?? container.name;
+}
+
+/**
+ * Sidebar dot state for a container's engine state — same vocabulary as the
+ * agent/terminal rows so the sidebar speaks one language.
+ */
+export function containerDotState(
+  state: string
+): 'idle' | 'active' | 'thinking' | 'attention' | 'muted' {
+  switch (state) {
+    case 'running':
+      return 'active';
+    case 'restarting':
+      return 'attention';
+    case 'paused':
+      return 'idle';
+    default: // created, exited, dead, removing
+      return 'muted';
+  }
+}
+
+/**
+ * Compact meta text for a container row. Running containers show their
+ * published host ports (":5432"); everything else shows the engine state.
+ * Only data reported by Docker is shown — a port is never assumed.
+ */
+export function containerMeta(
+  container: Pick<ContainerInfo, 'state' | 'ports'>
+): string | undefined {
+  if (!isContainerRunning(container)) return container.state;
+  if (container.ports.length === 0) return undefined;
+  return container.ports.map((p) => `:${p.hostPort}`).join(' ');
+}


### PR DESCRIPTION
## Summary

The sidebar previously only tracked the dev server. This adds a **Containers** section that detects the Docker containers belonging to the open project and lets you start/stop them from the sidebar (restart via ⌘K).

- **Backend** (`src-tauri/src/commands/containers.rs`): lists containers via `docker ps --format '{{json .}}'` and attributes them to the project by **path-carrying labels only** — Compose's `com.docker.compose.project.working_dir` (exact or subdirectory, so compose files in `infra/`/`docker/` work) and devcontainers' `devcontainer.local_folder`. Name similarity is never used, per the "Never Assume Data" principle — plain `docker run` containers with no provable association are deliberately not shown. The same scan reports engine availability (`ok` / `not-installed` / `not-running`) so the UI can tell "no containers" from "Docker isn't running". Lifecycle commands validate the container id (hex, 12–64 chars) and re-verify project ownership before shelling out.
- **Frontend**: `src/lib/containers.ts` (invoke wrappers + row-display helpers) and `src/hooks/useContainers.ts` (`usePolling`-based tracker, 5s interval while a project is open). The sidebar section hides itself when nothing is detected, shows compose service names with the existing status-dot vocabulary and published host ports as meta (`:5432`), and each container registers ⌘K commands (start/stop/restart) with toast-surfaced failures.
- Works with any engine fronting the `docker` CLI (Docker Desktop, OrbStack, Colima). Podman could be layered on later.

**Intended follow-up** (kept out of this PR to keep it reviewable): an explicit "Preview this port" affordance on container rows so a containerized frontend can drive the live preview. Auto-selecting a port would be guessing (we can't know `:8080` is HTTP vs gRPC), so it should be a user action — happy to take maintainer input on where that affordance belongs before building it.

## Test plan

- [x] Unit tests: 14 colocated Rust tests (label parsing, subdirectory/sibling-prefix matching, IPv4/IPv6 port dedup, daemon-down stderr classification, id validation, sorting) + 7 Vitest tests for display helpers
- [x] Manual: compose project (2 services, published ports) → section appears within one poll, service names + ports shown; stop/start from the row and restart from ⌘K flip states correctly
- [x] Manual: containers of *other* projects don't leak in; compose-file-in-subdirectory project still detected
- [x] Manual: Docker Desktop quit → section disappears (engine `not-running`), returns when Docker is back; projects with no containers show no section
- [x] Verified parsing assumptions against real `docker ps` output (full ids with `--no-trunc`, comma-joined labels, `[::]:port` twins)

## CI gates

- [x] `pnpm check:all && pnpm test:run && pnpm rust:test` passes locally

<details>
<summary><strong>Patterns checklist</strong> (only relevant if you changed code)</summary>

**Frontend**
- ~~New modals use `<ModalFrame>`~~ (no modals added)
- ~~New buttons use `<Button variant=…>`~~ (only sidebar row action buttons, using the existing `sidebar-row-action` pattern)
- [x] New async state uses `useAsyncState` / `useInvoke` (no hand-rolled `isLoading` + `error` triples)
- [x] New polling uses `usePolling` (no raw `setInterval`)
- ~~Modal state uses `useModal('id')`~~ (no modals added)

**CSS**
- ~~No raw hex colors…~~ (no CSS changes — reuses existing sidebar classes and icons)
- ~~New CSS files placed under `src/styles/…`~~ (none added)

**Rust**
- [x] New `#[tauri::command]`s return `Result<T, CommandError>` and have `#[tracing::instrument]`
- [x] User-supplied paths validated with `validate_project_path`
- [x] External CLI calls go through `run_with_timeout` (`src-tauri/src/external_command.rs`)

**Tests**
- [x] Added tests for non-trivial logic

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Containers** section to the project sidebar for viewing project-related Docker and Dev Container instances.
  * Displays container status, services, published ports, and engine availability.
  * Added controls to start, stop, and restart containers, with automatic status updates and progress feedback.
  * Container entries are searchable alongside other project items.
  * Added new play and stop icons for container actions.

* **Documentation**
  * Updated project documentation to describe container support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->