### PR TITLE
Add automatic bug reports to the admin agent

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -47,6 +47,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # Admin-agent bug reporting (docs/error-reporting.md). Compiled in via
+          # option_env! — if the secret is unset, reporting is a silent no-op.
+          BUG_REPORT_SECRET: ${{ secrets.BUG_REPORT_SECRET }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: 'Ship Studio ${{ github.ref_name }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,9 @@ jobs:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           CSTAR_IDENTITY_SECRET: ${{ secrets.CSTAR_IDENTITY_SECRET }}
+          # Admin-agent bug reporting (docs/error-reporting.md). Compiled in via
+          # option_env! — if the secret is unset, reporting is a silent no-op.
+          BUG_REPORT_SECRET: ${{ secrets.BUG_REPORT_SECRET }}
           APPLE_SIGNING_IDENTITY: "Developer ID Application"
           # Notarization intentionally disabled: it requires an in-effect Apple
           # Developer agreement (was returning HTTP 403 and blocking every

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -245,4 +245,4 @@ Create these in the PostHog UI and link them here when set up:
 - `error_message` is capped at 500 chars.
 - Search queries are capped at 100 chars by `trackSearch`; the original length lands in `query_length`.
 - Person properties on `$set_once` (first_seen, first_version) never overwrite — even on re-identify.
-- **Users can disable analytics via Settings → Usage analytics.** The Rust backend short-circuits all sends when the toggle is off; the setting persists across launches.
+- **Users can disable analytics via Settings → Usage analytics & error reports.** The Rust backend short-circuits all sends when the toggle is off; the setting persists across launches. The same toggle also disables automatic bug reports to the admin agent (see `docs/error-reporting.md`) — opted-out users share no data of any kind.

--- a/docs/error-reporting.md
+++ b/docs/error-reporting.md
@@ -1,0 +1,103 @@
+# Automatic Error Reporting (Admin Agent)
+
+Ship Studio automatically reports uncaught errors from production builds to the
+Ship Studio admin agent — an AI pipeline that investigates each report against
+the `ship-studio/ship-studio` codebase, files deduplicated GitHub issues, and
+can open draft fix PRs (it cannot merge). This is separate from Sentry, which
+handles aggregation/alerting; the admin agent is the act-on-it pipeline.
+
+## The endpoint
+
+```
+POST https://shipstudio-admin-agent.vercel.app/report
+Authorization: Bearer <BUG_REPORT_SECRET>
+Content-Type: application/json
+```
+
+Body fields: `message` (required), `stack`, `source`, `appVersion`,
+`fingerprint`, `context` (JSON object). Get `BUG_REPORT_SECRET` from Julian —
+never commit it.
+
+## How it's wired in the app
+
+All reporting funnels through **`src-tauri/src/error_reporting.rs`**:
+
+- `report_error(message, stack, source, fingerprint)` — the one Rust entry
+  point. Async fire-and-forget POST with a 5s timeout.
+- A panic hook (installed in `lib.rs::run()`, chained in front of Sentry's)
+  reports Rust panics with a `panic-<file>:<line>:<col>` fingerprint. The
+  panic path sends synchronously since the process may be about to die.
+- The `report_frontend_error` Tauri command relays frontend errors.
+
+Frontend errors reach it via **`src/lib/errorReporting.ts`** (`reportError`),
+hooked into:
+
+- the top-level React `ErrorBoundary` (skips plugin crashes — third-party code)
+- `window.onerror` and `unhandledrejection` in `main.tsx` (skips plugin errors
+  and the known Tauri `listeners[eventId]` noise)
+
+## The rules (enforced in code — keep them when extending)
+
+1. **Fire-and-forget.** Reporting can never throw, block, or fail the UX.
+2. **Production builds only.** Dev builds are a no-op. Overrides for testing:
+   `SHIPSTUDIO_BUG_REPORT_FORCE=1` (Rust side), `VITE_BUG_REPORT_FORCE=1`
+   (frontend gate).
+3. **Debounce.** One report per fingerprint per app session, with a session
+   hard cap, on both sides. The server dedups too (same fingerprint = same
+   agent session, no duplicate issues) — but don't hammer it.
+4. **No PII.** Messages and stacks are scrubbed of home-dir paths (usernames,
+   project folder names) in Rust via `logging::scrub_string` before leaving
+   the machine. Never include user project file contents, tokens, or env vars
+   in a report — reports can end up in public GitHub issues.
+
+## The secret
+
+`BUG_REPORT_SECRET` is compiled into the Rust binary at build time via
+`option_env!("BUG_REPORT_SECRET")` — it never appears in source or in the JS
+bundle. Builds without it (local builds, forks, CI without the secret) are a
+silent no-op. Release CI injects it from the `BUG_REPORT_SECRET` repo secret
+(both macOS and Windows workflows).
+
+Desktop binaries can be reverse-engineered, so treat the secret as
+rotate-friendly, not as a hard boundary: worst case is spam reports, and
+rotation takes a minute. If it leaks, tell Julian.
+
+## Fingerprints
+
+Every report is deduplicated by fingerprint; same fingerprint = the agent's
+existing session, no duplicate issue. When you add reporting at a known
+catch-site (e.g. an `Err` branch of a command), pass a stable slug:
+
+```rust
+crate::error_reporting::report_error(
+    &err.to_string(),
+    None,
+    "publishing",
+    Some("cmd-publish_to_staging"),
+);
+```
+
+Omit the fingerprint only in generic handlers — the server then hashes
+`message` + top stack frame, which fragments if the message contains variable
+data (paths, ports, IDs). Strip variable data from messages where you can.
+
+## Testing the pipeline
+
+Dev-build end-to-end test (requires the secret):
+
+```bash
+BUG_REPORT_SECRET=<secret> SHIPSTUDIO_BUG_REPORT_FORCE=1 VITE_BUG_REPORT_FORCE=1 pnpm tauri dev
+```
+
+Or send a raw test report:
+
+```bash
+curl -s -X POST https://shipstudio-admin-agent.vercel.app/report \
+  -H "Authorization: Bearer $BUG_REPORT_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"message":"Integration test","source":"integration-test","context":{"note":"testing the pipeline, do not file an issue"}}'
+```
+
+`{"ok":true,...}` means it landed. The agent posts its verdict (filed /
+duplicate / noise) to the community Slack; for a throwaway test the expected
+verdict is "noise — not filed", which is the pipeline working.

--- a/docs/error-reporting.md
+++ b/docs/error-reporting.md
@@ -26,6 +26,7 @@ per-site wiring. Coverage comes from choke points, not scattered calls:
 | Surface | Choke point | Fingerprint |
 |---|---|---|
 | Rust panics | panic hook in `error_reporting.rs` (chained in front of Sentry's) | `panic-<file>:<line>:<col>` |
+| **Every command failure sent to the UI** | `CommandError`'s `Serialize` impl (`errors.rs`) — fires exactly when the rejection crosses IPC, so it also catches structured Validation errors rendered inline with no toast or log | `cmderr-<variant>-<cmd/field>` |
 | Any backend `tracing::error!` | `AdminAgentLayer` tracing layer, attached in `logging::init_logging()` | `rs-<file>:<line>` (callsite) |
 | Frontend crashes (ErrorBoundary) | `logger.logError` → forwarding | message-based |
 | Any `logger.error` / `logger.logError` | forwarding inside `Logger.log()` | message-based |
@@ -34,7 +35,9 @@ per-site wiring. Coverage comes from choke points, not scattered calls:
 
 Excluded on purpose: plugin crashes (`blob:` stacks — third-party code), the
 known Tauri `listeners[eventId]` noise, error logs from dependencies (the
-tracing layer only forwards `ship_studio*` targets).
+tracing layer only forwards `ship_studio*` targets), and
+`CommandError::NotAuthenticated` (a not-yet-connected integration is an
+expected state, not a malfunction).
 
 **The rule for new code**: if something fails in a way that isn't the user's
 expected flow, call `tracing::error!` (Rust) or `logger.error` (frontend) or
@@ -52,14 +55,19 @@ All reporting funnels through **`src-tauri/src/error_reporting.rs`**
 Reports can trigger paid agent investigations, so spam protection is layered —
 all of it client-side before a single byte leaves the machine:
 
-1. **Session dedup** — one report per fingerprint per app session, on both the
+1. **Incident collapse** — one failure often fires several channels within
+   milliseconds (backend error log → `CommandError` over IPC → error toast).
+   The first channel to send wins; anything else within 5s is suppressed
+   without recording dedup state, so real recurrences still report. Panics
+   bypass the gap — a crash report is never swallowed by a lesser error.
+2. **Session dedup** — one report per fingerprint per app session, on both the
    frontend (cap 20) and Rust (cap 25) sides.
-2. **Cross-session refractory** — the same fingerprint reports at most once
+3. **Cross-session refractory** — the same fingerprint reports at most once
    per 24h, persisted in `bug-report-throttle.json` next to `app_state.json`.
    A crash-looping install that relaunches every few seconds still sends one
    report per day per bug.
-3. **Daily cap** — at most 30 reports per machine per day, whatever happens.
-4. **Server-side dedup** — same fingerprint = same agent session; repeats are
+4. **Daily cap** — at most 30 reports per machine per day, whatever happens.
+5. **Server-side dedup** — same fingerprint = same agent session; repeats are
    noted on the existing session, not new investigations.
 
 Throttle I/O fails open (a corrupt/unwritable file falls back to session dedup
@@ -78,6 +86,30 @@ only) — cost protection must never disable crash reporting entirely.
    project folder names) in Rust via `logging::scrub_string` before leaving
    the machine. Never include user project file contents, tokens, or env vars
    in a report — reports can end up in public GitHub issues.
+
+## User consent & what we collect
+
+Bug reporting is governed by the same Settings toggle as analytics — **"Usage
+analytics & error reports"**. When the user turns it off, this pipeline is
+fully disabled (the check lives in `error_reporting::enabled()`, the single
+gate every report passes through — frontend reports included, since they relay
+through the `report_frontend_error` command). No opt-out, no data, period.
+
+What a report contains, exhaustively:
+
+- the error message and stack trace (both scrubbed: `/Users/<name>`,
+  `/home/<name>`, `C:\Users\<name>` become `<redacted>` before leaving the
+  machine)
+- the subsystem/source name and a fingerprint slug (also scrubbed)
+- the app version, OS name (`macos`/`windows`/`linux`) and CPU architecture
+
+What is never collected: project file contents, code, env vars, tokens,
+usernames, machine identifiers, or anything else. Reports can end up in public
+GitHub issues, so the bar is "safe to publish."
+
+The ErrorBoundary crash screen shows "This crash was reported automatically"
+only when a report actually went out (production build, toggle on, not a
+plugin crash) — the disclosure is never shown to opted-out users.
 
 ## The secret
 
@@ -117,6 +149,10 @@ Dev-build end-to-end test (requires the secret):
 ```bash
 BUG_REPORT_SECRET=<secret> SHIPSTUDIO_BUG_REPORT_FORCE=1 VITE_BUG_REPORT_FORCE=1 pnpm tauri dev
 ```
+
+Two gotchas when testing: the Settings analytics toggle must be ON (the
+opt-out is absolute — it beats the force flags), and consecutive test triggers
+must be more than 5s apart or incident collapse will suppress the second one.
 
 Or send a raw test report:
 

--- a/docs/error-reporting.md
+++ b/docs/error-reporting.md
@@ -18,23 +18,52 @@ Body fields: `message` (required), `stack`, `source`, `appVersion`,
 `fingerprint`, `context` (JSON object). Get `BUG_REPORT_SECRET` from Julian —
 never commit it.
 
-## How it's wired in the app
+## What gets reported (coverage map)
 
-All reporting funnels through **`src-tauri/src/error_reporting.rs`**:
+The goal: **anything not working as intended reaches the agent**, without
+per-site wiring. Coverage comes from choke points, not scattered calls:
 
-- `report_error(message, stack, source, fingerprint)` — the one Rust entry
-  point. Async fire-and-forget POST with a 5s timeout.
-- A panic hook (installed in `lib.rs::run()`, chained in front of Sentry's)
-  reports Rust panics with a `panic-<file>:<line>:<col>` fingerprint. The
-  panic path sends synchronously since the process may be about to die.
-- The `report_frontend_error` Tauri command relays frontend errors.
+| Surface | Choke point | Fingerprint |
+|---|---|---|
+| Rust panics | panic hook in `error_reporting.rs` (chained in front of Sentry's) | `panic-<file>:<line>:<col>` |
+| Any backend `tracing::error!` | `AdminAgentLayer` tracing layer, attached in `logging::init_logging()` | `rs-<file>:<line>` (callsite) |
+| Frontend crashes (ErrorBoundary) | `logger.logError` → forwarding | message-based |
+| Any `logger.error` / `logger.logError` | forwarding inside `Logger.log()` | message-based |
+| Uncaught JS errors / unhandled rejections | `window` handlers in `main.tsx` | message-based |
+| Error toasts (user-visible failures) | `showToast(…, 'error')` in `useToasts` | message-based |
 
-Frontend errors reach it via **`src/lib/errorReporting.ts`** (`reportError`),
-hooked into:
+Excluded on purpose: plugin crashes (`blob:` stacks — third-party code), the
+known Tauri `listeners[eventId]` noise, error logs from dependencies (the
+tracing layer only forwards `ship_studio*` targets).
 
-- the top-level React `ErrorBoundary` (skips plugin crashes — third-party code)
-- `window.onerror` and `unhandledrejection` in `main.tsx` (skips plugin errors
-  and the known Tauri `listeners[eventId]` noise)
+**The rule for new code**: if something fails in a way that isn't the user's
+expected flow, call `tracing::error!` (Rust) or `logger.error` (frontend) or
+surface an error toast — any of those automatically notifies the agent. For
+high-value catch-sites, call `report_error` directly with a stable fingerprint
+slug (see below).
+
+All reporting funnels through **`src-tauri/src/error_reporting.rs`**
+(`report_error` — async fire-and-forget POST, 5s timeout; the
+`report_frontend_error` command relays frontend reports) and
+**`src/lib/errorReporting.ts`** (`reportError`) on the frontend.
+
+## Cost controls
+
+Reports can trigger paid agent investigations, so spam protection is layered —
+all of it client-side before a single byte leaves the machine:
+
+1. **Session dedup** — one report per fingerprint per app session, on both the
+   frontend (cap 20) and Rust (cap 25) sides.
+2. **Cross-session refractory** — the same fingerprint reports at most once
+   per 24h, persisted in `bug-report-throttle.json` next to `app_state.json`.
+   A crash-looping install that relaunches every few seconds still sends one
+   report per day per bug.
+3. **Daily cap** — at most 30 reports per machine per day, whatever happens.
+4. **Server-side dedup** — same fingerprint = same agent session; repeats are
+   noted on the existing session, not new investigations.
+
+Throttle I/O fails open (a corrupt/unwritable file falls back to session dedup
+only) — cost protection must never disable crash reporting entirely.
 
 ## The rules (enforced in code — keep them when extending)
 

--- a/src-tauri/src/error_reporting.rs
+++ b/src-tauri/src/error_reporting.rs
@@ -1,0 +1,242 @@
+//! # Automatic Error Reporting
+//!
+//! Sends error reports to the Ship Studio admin agent
+//! (<https://shipstudio-admin-agent.vercel.app>), which investigates them
+//! against the codebase, files deduplicated GitHub issues, and can open draft
+//! fix PRs. See `docs/error-reporting.md` for the full integration contract.
+//!
+//! This complements Sentry (aggregation/alerting); the admin agent is the
+//! act-on-it pipeline. Rules enforced here:
+//!
+//! - **Production builds only** — dev-loop noise never reaches the agent
+//!   (override with `SHIPSTUDIO_BUG_REPORT_FORCE=1` for integration testing).
+//! - **Secret stays in Rust** — injected at build time via
+//!   `option_env!("BUG_REPORT_SECRET")`; builds without it are a silent no-op.
+//! - **Fire-and-forget** — reporting can never block or fail the UX.
+//! - **One report per fingerprint per app session** — the server dedups too,
+//!   but we don't hammer it from tight error loops.
+//! - **No PII** — messages and stacks are scrubbed of home-dir paths
+//!   (usernames, project folder names) before leaving the machine, since
+//!   reports can end up in public GitHub issues.
+
+use crate::logging::scrub_string;
+use once_cell::sync::Lazy;
+use serde_json::json;
+use std::collections::HashSet;
+use std::sync::Mutex;
+use std::time::Duration;
+
+const ENDPOINT: &str = "https://shipstudio-admin-agent.vercel.app/report";
+const SEND_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Hard cap on reports per app session — a pathological error loop with
+/// varying messages (which defeat fingerprint dedup) stops here.
+const MAX_REPORTS_PER_SESSION: usize = 25;
+
+/// Dedup keys already reported this app session.
+static REPORTED: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+
+fn enabled() -> bool {
+    let force = std::env::var("SHIPSTUDIO_BUG_REPORT_FORCE").ok().as_deref() == Some("1");
+    !cfg!(debug_assertions) || force
+}
+
+fn secret() -> Option<&'static str> {
+    option_env!("BUG_REPORT_SECRET").filter(|s| !s.is_empty())
+}
+
+/// Stable per-session dedup key: the explicit fingerprint when the catch-site
+/// provides one, otherwise source + the first line of the message.
+fn dedupe_key(message: &str, source: &str, fingerprint: Option<&str>) -> String {
+    match fingerprint {
+        Some(f) => f.to_string(),
+        None => {
+            let first_line = message.lines().next().unwrap_or_default();
+            let truncated: String = first_line.chars().take(200).collect();
+            format!("{source}:{truncated}")
+        }
+    }
+}
+
+/// Returns true only the first time a key is seen this session.
+fn first_occurrence(key: &str) -> bool {
+    match REPORTED.lock() {
+        Ok(mut seen) => {
+            if seen.len() >= MAX_REPORTS_PER_SESSION {
+                return false;
+            }
+            seen.insert(key.to_string())
+        }
+        // Poisoned lock (a panic mid-insert): stop reporting rather than risk
+        // duplicate storms.
+        Err(_) => false,
+    }
+}
+
+fn build_body(
+    message: &str,
+    stack: Option<&str>,
+    source: &str,
+    fingerprint: Option<&str>,
+) -> serde_json::Value {
+    json!({
+        "message": scrub_string(message),
+        "stack": stack.map(scrub_string),
+        "source": source,
+        "appVersion": env!("CARGO_PKG_VERSION"),
+        "fingerprint": fingerprint,
+        "context": {
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+        },
+    })
+}
+
+async fn post(secret: &'static str, body: serde_json::Value) {
+    let _ = reqwest::Client::new()
+        .post(ENDPOINT)
+        .bearer_auth(secret)
+        .json(&body)
+        .timeout(SEND_TIMEOUT)
+        .send()
+        .await;
+}
+
+/// Report an error to the admin agent. Fire-and-forget: returns immediately,
+/// never blocks, never surfaces a failure.
+///
+/// Call this from `Err` branches at known catch-sites with a stable
+/// `fingerprint` slug (e.g. `"cmd-publish_to_staging"`) so repeat occurrences
+/// land on the agent's existing session instead of filing duplicate issues.
+pub fn report_error(message: &str, stack: Option<&str>, source: &str, fingerprint: Option<&str>) {
+    if !enabled() {
+        return;
+    }
+    let Some(secret) = secret() else { return };
+    if !first_occurrence(&dedupe_key(message, source, fingerprint)) {
+        return;
+    }
+    let body = build_body(message, stack, source, fingerprint);
+    tauri::async_runtime::spawn(async move {
+        post(secret, body).await;
+    });
+}
+
+/// Panic-path variant: sends synchronously (bounded by [`SEND_TIMEOUT`])
+/// because the process may be about to die and a spawned task would be lost.
+fn report_panic(message: &str, location: Option<&str>) {
+    if !enabled() {
+        return;
+    }
+    let Some(secret) = secret() else { return };
+    let fingerprint = location.map(|l| format!("panic-{}", scrub_string(l)));
+    if !first_occurrence(&dedupe_key(message, "panic", fingerprint.as_deref())) {
+        return;
+    }
+    let body = build_body(
+        &format!("panic: {message}"),
+        location,
+        "panic",
+        fingerprint.as_deref(),
+    );
+    // Dedicated thread + single-threaded runtime: the panic hook can fire on
+    // any thread, including inside an async context where block_on would panic.
+    let handle = std::thread::spawn(move || {
+        if let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            rt.block_on(post(secret, body));
+        }
+    });
+    let _ = handle.join();
+}
+
+/// Install a panic hook that reports to the admin agent, chaining the
+/// previously installed hook (Sentry's, when initialized) so both fire.
+/// Call after `logging::init_sentry()`.
+pub fn install_panic_hook() {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let payload = info.payload();
+        let message = payload
+            .downcast_ref::<&str>()
+            .map(|s| (*s).to_string())
+            .or_else(|| payload.downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "panic with non-string payload".to_string());
+        let location = info
+            .location()
+            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()));
+        report_panic(&message, location.as_deref());
+        prev(info);
+    }));
+}
+
+/// Forward an uncaught frontend error (ErrorBoundary, window.onerror,
+/// unhandledrejection) to the admin agent. The frontend gates on production
+/// and dedups per fingerprint too; this side re-checks both and scrubs paths.
+#[tauri::command]
+#[tracing::instrument(skip_all)]
+pub fn report_frontend_error(
+    message: String,
+    stack: Option<String>,
+    source: Option<String>,
+    fingerprint: Option<String>,
+) {
+    report_error(
+        &message,
+        stack.as_deref(),
+        source.as_deref().unwrap_or("frontend"),
+        fingerprint.as_deref(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dedupe_key_prefers_explicit_fingerprint() {
+        assert_eq!(
+            dedupe_key(
+                "anything at all",
+                "publishing",
+                Some("publish-staging-io-error")
+            ),
+            "publish-staging-io-error"
+        );
+    }
+
+    #[test]
+    fn dedupe_key_falls_back_to_source_and_first_line() {
+        let key = dedupe_key("boom happened\n    at some_frame:12", "frontend", None);
+        assert_eq!(key, "frontend:boom happened");
+    }
+
+    #[test]
+    fn dedupe_key_truncates_long_messages() {
+        let long = "x".repeat(500);
+        let key = dedupe_key(&long, "frontend", None);
+        assert_eq!(key.len(), "frontend:".len() + 200);
+    }
+
+    #[test]
+    fn first_occurrence_dedups_within_session() {
+        let key = "test-unique-fingerprint-for-dedup";
+        assert!(first_occurrence(key));
+        assert!(!first_occurrence(key));
+    }
+
+    #[test]
+    fn body_scrubs_home_dir_paths() {
+        let body = build_body(
+            "ENOENT: /Users/julian/ShipStudio/my-app/package.json",
+            Some("at load (/Users/julian/ShipStudio/my-app/src/index.ts:1:1)"),
+            "frontend",
+            None,
+        );
+        let text = body.to_string();
+        assert!(!text.contains("julian"), "username leaked: {text}");
+        assert!(text.contains("/Users/<redacted>"));
+    }
+}

--- a/src-tauri/src/error_reporting.rs
+++ b/src-tauri/src/error_reporting.rs
@@ -21,8 +21,10 @@
 
 use crate::logging::scrub_string;
 use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -73,6 +75,121 @@ fn first_occurrence(key: &str) -> bool {
     }
 }
 
+// --- Cross-session throttle ------------------------------------------------
+//
+// Each report can trigger a paid agent investigation, so the in-session dedup
+// alone isn't enough: a crash-looping install that relaunches every few
+// seconds would send one report per relaunch. Persist a small throttle file
+// next to app_state.json: the same fingerprint reports at most once per 24h,
+// and there's a global daily cap per machine. Any I/O failure fails open to
+// the in-session dedup — a broken disk must not disable crash reporting.
+
+/// Same fingerprint reports at most once per this window, across restarts.
+const REFRACTORY_SECS: i64 = 24 * 60 * 60;
+/// Global daily report cap per machine.
+const DAILY_CAP: usize = 30;
+/// Bound the throttle file: prune entries older than this…
+const PRUNE_AFTER_SECS: i64 = 7 * 24 * 60 * 60;
+/// …and never track more fingerprints than this (oldest dropped first).
+const MAX_TRACKED_FINGERPRINTS: usize = 300;
+
+#[derive(Default, Serialize, Deserialize)]
+struct Throttle {
+    #[serde(default)]
+    day: String,
+    #[serde(default)]
+    count: usize,
+    /// fingerprint -> unix timestamp of last report
+    #[serde(default)]
+    fingerprints: HashMap<String, i64>,
+}
+
+fn throttle_path() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        dirs::home_dir()
+            .map(|h| h.join("Library/Application Support/ShipStudio/bug-report-throttle.json"))
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        dirs::data_local_dir().map(|d| d.join("ShipStudio/bug-report-throttle.json"))
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        dirs::data_local_dir().map(|d| d.join("ship-studio/bug-report-throttle.json"))
+    }
+}
+
+/// Check + record `key` against the persistent throttle. Corrupt or missing
+/// files reset to an empty throttle (fail open); write failures are ignored.
+fn passes_persistent_throttle(path: &Path, key: &str, now: i64, today: &str) -> bool {
+    let mut throttle: Throttle = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default();
+
+    if throttle.day != today {
+        throttle.day = today.to_string();
+        throttle.count = 0;
+    }
+    if throttle.count >= DAILY_CAP {
+        return false;
+    }
+    if let Some(&last) = throttle.fingerprints.get(key) {
+        if now - last < REFRACTORY_SECS {
+            return false;
+        }
+    }
+
+    throttle.count += 1;
+    throttle.fingerprints.insert(key.to_string(), now);
+    throttle
+        .fingerprints
+        .retain(|_, ts| now - *ts < PRUNE_AFTER_SECS);
+    if throttle.fingerprints.len() > MAX_TRACKED_FINGERPRINTS {
+        let mut by_age: Vec<(String, i64)> = throttle
+            .fingerprints
+            .iter()
+            .map(|(k, ts)| (k.clone(), *ts))
+            .collect();
+        by_age.sort_by_key(|(_, ts)| *ts);
+        for (old_key, _) in by_age
+            .iter()
+            .take(throttle.fingerprints.len() - MAX_TRACKED_FINGERPRINTS)
+        {
+            throttle.fingerprints.remove(old_key);
+        }
+    }
+
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(serialized) = serde_json::to_string(&throttle) {
+        let _ = std::fs::write(path, serialized);
+    }
+    true
+}
+
+/// Full send gate: in-session dedup, then the persistent cross-session
+/// throttle. Returns true when this occurrence should be reported.
+fn allow_report(key: &str) -> bool {
+    if !first_occurrence(key) {
+        return false;
+    }
+    let Some(path) = throttle_path() else {
+        return true;
+    };
+    let now = chrono::Utc::now();
+    passes_persistent_throttle(
+        &path,
+        key,
+        now.timestamp(),
+        &now.format("%Y-%m-%d").to_string(),
+    )
+}
+
 fn build_body(
     message: &str,
     stack: Option<&str>,
@@ -113,7 +230,7 @@ pub fn report_error(message: &str, stack: Option<&str>, source: &str, fingerprin
         return;
     }
     let Some(secret) = secret() else { return };
-    if !first_occurrence(&dedupe_key(message, source, fingerprint)) {
+    if !allow_report(&dedupe_key(message, source, fingerprint)) {
         return;
     }
     let body = build_body(message, stack, source, fingerprint);
@@ -130,7 +247,7 @@ fn report_panic(message: &str, location: Option<&str>) {
     }
     let Some(secret) = secret() else { return };
     let fingerprint = location.map(|l| format!("panic-{}", scrub_string(l)));
-    if !first_occurrence(&dedupe_key(message, "panic", fingerprint.as_deref())) {
+    if !allow_report(&dedupe_key(message, "panic", fingerprint.as_deref())) {
         return;
     }
     let body = build_body(
@@ -170,6 +287,79 @@ pub fn install_panic_hook() {
         report_panic(&message, location.as_deref());
         prev(info);
     }));
+}
+
+// --- Tracing integration ---------------------------------------------------
+
+/// Forwards every `tracing::error!` from Ship Studio code to the admin agent,
+/// fingerprinted by callsite (`rs-<file>:<line>` — stable across occurrences
+/// and releases). Attached in `logging::init_logging()` alongside the Sentry
+/// layer, so any error-level log — existing or future — reports automatically
+/// without per-site wiring. When something isn't working as intended, log it
+/// with `tracing::error!` and the agent hears about it.
+pub struct AdminAgentLayer;
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for AdminAgentLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let meta = event.metadata();
+        if *meta.level() != tracing::Level::ERROR {
+            return;
+        }
+        let target = meta.target();
+        // Only our own code — error logs from dependencies aren't our bugs.
+        if !target.starts_with("ship_studio") {
+            return;
+        }
+        // Frontend logger errors arrive via `logging::log_frontend_event`; the
+        // frontend reports those itself with proper stacks (`errorReporting.ts`).
+        // Skipping here prevents double reports for the same incident.
+        if target.starts_with("ship_studio_lib::logging") {
+            return;
+        }
+
+        let mut visitor = EventVisitor::default();
+        event.record(&mut visitor);
+        if visitor.message.is_empty() {
+            return;
+        }
+        let fingerprint = match (meta.file(), meta.line()) {
+            (Some(file), Some(line)) => Some(format!("rs-{file}:{line}")),
+            _ => None,
+        };
+        let fields = if visitor.fields.is_empty() {
+            None
+        } else {
+            Some(visitor.fields.join("\n"))
+        };
+        report_error(
+            &visitor.message,
+            fields.as_deref(),
+            target,
+            fingerprint.as_deref(),
+        );
+    }
+}
+
+/// Collects the event's `message` field plus remaining fields as `key=value`
+/// lines (sent as the report's `stack` for extra context).
+#[derive(Default)]
+struct EventVisitor {
+    message: String,
+    fields: Vec<String>,
+}
+
+impl tracing::field::Visit for EventVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = format!("{value:?}");
+        } else {
+            self.fields.push(format!("{}={:?}", field.name(), value));
+        }
+    }
 }
 
 /// Forward an uncaught frontend error (ErrorBoundary, window.onerror,
@@ -225,6 +415,76 @@ mod tests {
         let key = "test-unique-fingerprint-for-dedup";
         assert!(first_occurrence(key));
         assert!(!first_occurrence(key));
+    }
+
+    #[test]
+    fn throttle_allows_first_and_blocks_repeat_within_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("throttle.json");
+        let now = 1_000_000;
+        assert!(passes_persistent_throttle(&path, "fp-a", now, "2026-07-28"));
+        // Same key, next session, one hour later: blocked.
+        assert!(!passes_persistent_throttle(
+            &path,
+            "fp-a",
+            now + 3_600,
+            "2026-07-28"
+        ));
+        // Different key still allowed.
+        assert!(passes_persistent_throttle(
+            &path,
+            "fp-b",
+            now + 3_600,
+            "2026-07-28"
+        ));
+        // Same key after the 24h window: allowed again.
+        assert!(passes_persistent_throttle(
+            &path,
+            "fp-a",
+            now + REFRACTORY_SECS + 1,
+            "2026-07-29"
+        ));
+    }
+
+    #[test]
+    fn throttle_enforces_daily_cap_and_resets_next_day() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("throttle.json");
+        let now = 1_000_000;
+        for i in 0..DAILY_CAP {
+            assert!(passes_persistent_throttle(
+                &path,
+                &format!("fp-{i}"),
+                now,
+                "2026-07-28"
+            ));
+        }
+        assert!(!passes_persistent_throttle(
+            &path,
+            "fp-over-cap",
+            now,
+            "2026-07-28"
+        ));
+        // New day: cap resets.
+        assert!(passes_persistent_throttle(
+            &path,
+            "fp-over-cap",
+            now + REFRACTORY_SECS + 1,
+            "2026-07-29"
+        ));
+    }
+
+    #[test]
+    fn throttle_fails_open_on_corrupt_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("throttle.json");
+        std::fs::write(&path, "not json{{{").unwrap();
+        assert!(passes_persistent_throttle(
+            &path,
+            "fp-a",
+            1_000_000,
+            "2026-07-28"
+        ));
     }
 
     #[test]

--- a/src-tauri/src/error_reporting.rs
+++ b/src-tauri/src/error_reporting.rs
@@ -18,6 +18,8 @@
 //! - **No PII** — messages and stacks are scrubbed of home-dir paths
 //!   (usernames, project folder names) before leaving the machine, since
 //!   reports can end up in public GitHub issues.
+//! - **Opt-out respected** — turning off "Usage analytics & error reports" in
+//!   Settings disables this pipeline entirely, alongside PostHog analytics.
 
 use crate::logging::scrub_string;
 use once_cell::sync::Lazy;
@@ -26,7 +28,7 @@ use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const ENDPOINT: &str = "https://shipstudio-admin-agent.vercel.app/report";
 const SEND_TIMEOUT: Duration = Duration::from_secs(5);
@@ -40,7 +42,16 @@ static REPORTED: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet:
 
 fn enabled() -> bool {
     let force = std::env::var("SHIPSTUDIO_BUG_REPORT_FORCE").ok().as_deref() == Some("1");
-    !cfg!(debug_assertions) || force
+    if cfg!(debug_assertions) && !force {
+        return false;
+    }
+    // Privacy: the Settings → "Usage analytics & error reports" toggle governs
+    // this pipeline too. Opted-out users share nothing — not even scrubbed
+    // crash reports. This is the single authoritative check; every report
+    // (frontend or backend) funnels through here.
+    crate::commands::setup::read_app_state()
+        .analytics_enabled
+        .unwrap_or(true)
 }
 
 fn secret() -> Option<&'static str> {
@@ -172,22 +183,74 @@ fn passes_persistent_throttle(path: &Path, key: &str, now: i64, today: &str) -> 
     true
 }
 
-/// Full send gate: in-session dedup, then the persistent cross-session
-/// throttle. Returns true when this occurrence should be reported.
-fn allow_report(key: &str) -> bool {
+// --- Incident collapse ------------------------------------------------------
+//
+// One failure often fires several reporting channels within milliseconds:
+// the backend logs `tracing::error!`, the `CommandError` crosses IPC (its
+// Serialize hook), and the frontend shows an error toast. Each carries a
+// different fingerprint, so dedup alone won't merge them — and each unique
+// report can trigger a paid investigation. The first channel to fire wins;
+// anything else inside the gap is suppressed *before* any dedup state is
+// recorded, so a genuine recurrence later can still report.
+
+const MIN_GAP: Duration = Duration::from_secs(5);
+static LAST_REPORT_AT: Lazy<Mutex<Option<Instant>>> = Lazy::new(|| Mutex::new(None));
+
+fn within_min_gap() -> bool {
+    match LAST_REPORT_AT.lock() {
+        Ok(guard) => matches!(*guard, Some(t) if t.elapsed() < MIN_GAP),
+        Err(_) => true, // poisoned: suppress rather than risk a storm
+    }
+}
+
+fn mark_report_sent() {
+    if let Ok(mut guard) = LAST_REPORT_AT.lock() {
+        *guard = Some(Instant::now());
+    }
+}
+
+/// Session dedup read-only check — no state is recorded.
+fn session_already_seen(key: &str) -> bool {
+    match REPORTED.lock() {
+        Ok(seen) => seen.len() >= MAX_REPORTS_PER_SESSION || seen.contains(key),
+        Err(_) => true,
+    }
+}
+
+/// Full send gate: session dedup, incident collapse, then the persistent
+/// cross-session throttle. Returns true when this occurrence should be sent.
+/// `respect_gap: false` is for panics — a crash report must never be
+/// swallowed because some lesser error fired just before it.
+fn allow_report_with_gap(key: &str, respect_gap: bool) -> bool {
+    if session_already_seen(key) {
+        return false;
+    }
+    if respect_gap && within_min_gap() {
+        return false;
+    }
     if !first_occurrence(key) {
         return false;
     }
-    let Some(path) = throttle_path() else {
-        return true;
+    let allowed = match throttle_path() {
+        None => true,
+        Some(path) => {
+            let now = chrono::Utc::now();
+            passes_persistent_throttle(
+                &path,
+                key,
+                now.timestamp(),
+                &now.format("%Y-%m-%d").to_string(),
+            )
+        }
     };
-    let now = chrono::Utc::now();
-    passes_persistent_throttle(
-        &path,
-        key,
-        now.timestamp(),
-        &now.format("%Y-%m-%d").to_string(),
-    )
+    if allowed {
+        mark_report_sent();
+    }
+    allowed
+}
+
+fn allow_report(key: &str) -> bool {
+    allow_report_with_gap(key, true)
 }
 
 fn build_body(
@@ -201,7 +264,9 @@ fn build_body(
         "stack": stack.map(scrub_string),
         "source": source,
         "appVersion": env!("CARGO_PKG_VERSION"),
-        "fingerprint": fingerprint,
+        // Scrubbed defensively like message/stack — fingerprints are meant to
+        // be static slugs, but nothing should leave unscrubbed.
+        "fingerprint": fingerprint.map(scrub_string),
         "context": {
             "os": std::env::consts::OS,
             "arch": std::env::consts::ARCH,
@@ -247,7 +312,7 @@ fn report_panic(message: &str, location: Option<&str>) {
     }
     let Some(secret) = secret() else { return };
     let fingerprint = location.map(|l| format!("panic-{}", scrub_string(l)));
-    if !allow_report(&dedupe_key(message, "panic", fingerprint.as_deref())) {
+    if !allow_report_with_gap(&dedupe_key(message, "panic", fingerprint.as_deref()), false) {
         return;
     }
     let body = build_body(
@@ -287,6 +352,40 @@ pub fn install_panic_hook() {
         report_panic(&message, location.as_deref());
         prev(info);
     }));
+}
+
+/// Derive a stable fingerprint for a `CommandError` crossing the IPC
+/// boundary. `None` for both the skip-entirely case and variants whose
+/// messages carry the only useful identity (dedup falls back to content).
+fn command_error_fingerprint(err: &crate::errors::CommandError) -> Option<String> {
+    use crate::errors::CommandError as E;
+    match err {
+        E::Timeout { cmd, .. } => Some(format!("cmderr-timeout-{cmd}")),
+        E::Process { cmd, .. } => Some(format!("cmderr-process-{cmd}")),
+        E::Validation { field, .. } => Some(format!("cmderr-validation-{field}")),
+        E::MergeConflict { .. } => Some("cmderr-merge-conflict".to_string()),
+        E::NotAuthenticated { .. } | E::Io { .. } | E::Other { .. } => None,
+    }
+}
+
+/// Report a `CommandError` the moment it's serialized for the frontend —
+/// the one choke point that sees every backend failure a user experiences,
+/// including structured Validation errors rendered inline (no toast, no
+/// error log). Called from `CommandError`'s `Serialize` impl.
+///
+/// `NotAuthenticated` is skipped: a not-yet-connected integration is an
+/// expected state, not a malfunction.
+pub fn report_command_error(err: &crate::errors::CommandError) {
+    if matches!(err, crate::errors::CommandError::NotAuthenticated { .. }) {
+        return;
+    }
+    let fingerprint = command_error_fingerprint(err);
+    report_error(
+        &err.to_string(),
+        None,
+        "command-error",
+        fingerprint.as_deref(),
+    );
 }
 
 // --- Tracing integration ---------------------------------------------------
@@ -415,6 +514,38 @@ mod tests {
         let key = "test-unique-fingerprint-for-dedup";
         assert!(first_occurrence(key));
         assert!(!first_occurrence(key));
+    }
+
+    #[test]
+    fn command_error_fingerprints_are_stable_slugs() {
+        use crate::errors::CommandError as E;
+        assert_eq!(
+            command_error_fingerprint(&E::Validation {
+                field: "branch".into(),
+                reason: "Invalid ref name".into()
+            })
+            .as_deref(),
+            Some("cmderr-validation-branch")
+        );
+        assert_eq!(
+            command_error_fingerprint(&E::Timeout {
+                cmd: "git fetch".into(),
+                secs: 30
+            })
+            .as_deref(),
+            Some("cmderr-timeout-git fetch")
+        );
+        // Variable-message variants dedupe on content instead.
+        assert!(command_error_fingerprint(&E::Other {
+            message: "x".into()
+        })
+        .is_none());
+    }
+
+    #[test]
+    fn incident_gap_suppresses_rapid_followups() {
+        mark_report_sent();
+        assert!(within_min_gap());
     }
 
     #[test]

--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -6,11 +6,10 @@
 //!
 //! When adding a new variant, also update the TS mirror in `src/lib/errors.ts`.
 
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 use thiserror::Error;
 
-#[derive(Debug, Error, Serialize, Clone)]
-#[serde(tag = "type")]
+#[derive(Debug, Error, Clone)]
 pub enum CommandError {
     #[error("`{cmd}` timed out after {secs}s")]
     Timeout { cmd: String, secs: u64 },
@@ -36,6 +35,71 @@ pub enum CommandError {
 
     #[error("{message}")]
     Other { message: String },
+}
+
+/// Serialization happens exactly once per command failure — when Tauri sends
+/// the rejection across the IPC boundary to the frontend. That makes it the
+/// one choke point that sees every backend failure a user experiences, so it
+/// doubles as the admin-agent report hook (docs/error-reporting.md). The
+/// mirror enum reproduces the old `#[serde(tag = "type")]` derive exactly
+/// (locked by the tests below); the exhaustive match forces this impl to be
+/// updated when a variant is added.
+impl Serialize for CommandError {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        crate::error_reporting::report_command_error(self);
+
+        #[derive(Serialize)]
+        #[serde(tag = "type")]
+        enum Mirror<'a> {
+            Timeout {
+                cmd: &'a str,
+                secs: &'a u64,
+            },
+            Process {
+                cmd: &'a str,
+                exit_code: &'a i32,
+                stderr: &'a str,
+            },
+            Validation {
+                field: &'a str,
+                reason: &'a str,
+            },
+            NotAuthenticated {
+                service: &'a str,
+            },
+            Io {
+                message: &'a str,
+            },
+            MergeConflict {
+                pr_number: &'a i32,
+                stderr: &'a str,
+            },
+            Other {
+                message: &'a str,
+            },
+        }
+
+        let mirror = match self {
+            CommandError::Timeout { cmd, secs } => Mirror::Timeout { cmd, secs },
+            CommandError::Process {
+                cmd,
+                exit_code,
+                stderr,
+            } => Mirror::Process {
+                cmd,
+                exit_code,
+                stderr,
+            },
+            CommandError::Validation { field, reason } => Mirror::Validation { field, reason },
+            CommandError::NotAuthenticated { service } => Mirror::NotAuthenticated { service },
+            CommandError::Io { message } => Mirror::Io { message },
+            CommandError::MergeConflict { pr_number, stderr } => {
+                Mirror::MergeConflict { pr_number, stderr }
+            }
+            CommandError::Other { message } => Mirror::Other { message },
+        };
+        mirror.serialize(serializer)
+    }
 }
 
 impl From<std::io::Error> for CommandError {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub mod agent;
 pub mod agent_bridge;
 pub mod cache;
 pub mod commands;
+pub mod error_reporting;
 pub mod errors;
 pub mod external_command;
 pub mod logging;
@@ -81,6 +82,10 @@ fn cleanup_agent_processes() {
 pub fn run() {
     // Sentry must init before the tracing subscriber so its layer can attach.
     logging::init_sentry();
+
+    // Admin-agent panic reporting chains Sentry's panic hook, so it must come
+    // after init_sentry().
+    error_reporting::install_panic_hook();
 
     // Initialize logging first
     if let Err(e) = logging::init_logging() {
@@ -738,6 +743,8 @@ pub fn run() {
             // Logging
             logging::get_log_path,
             logging::log_frontend_event,
+            // Error reporting (admin agent)
+            error_reporting::report_frontend_error,
             // Snapshots / Undo-Redo
             commands::snapshots::snapshot_start_watching,
             commands::snapshots::snapshot_stop_watching,

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -60,7 +60,7 @@ pub fn init_sentry() {
     let _ = SENTRY_GUARD.set(guard);
 }
 
-fn scrub_string(s: &str) -> String {
+pub(crate) fn scrub_string(s: &str) -> String {
     // Strip local paths so Sentry doesn't see usernames or project folder names.
     let re_unix = regex_lite_replace(s, "/Users/", "/Users/<redacted>");
     let re_home = regex_lite_replace(&re_unix, "/home/", "/home/<redacted>");

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -176,6 +176,10 @@ pub fn init_logging() -> Result<(), String> {
     // attach unconditionally.
     let subscriber = subscriber.with(sentry_tracing::layer());
 
+    // Forward error-level events to the admin agent (docs/error-reporting.md).
+    // Also a no-op outside production builds and gated/throttled internally.
+    let subscriber = subscriber.with(crate::error_reporting::AdminAgentLayer);
+
     subscriber.init();
 
     tracing::info!(

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,7 +1,6 @@
 import { Component, ReactNode } from 'react';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { logger } from '../lib/logger';
-import { reportError } from '../lib/errorReporting';
 import { lookupBlobOwner, markPluginCrashed } from '../lib/plugin-loader';
 import { uninstallPlugin } from '../lib/plugins';
 
@@ -27,20 +26,12 @@ export class ErrorBoundary extends Component<Props, State> {
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     logger.logError(error, { componentStack: errorInfo.componentStack ?? undefined });
 
+    // The logError above also reports the crash to the admin agent
+    // (logger forwards error-level logs — see docs/error-reporting.md).
+
     // Auto-remove crashing plugins so they don't crash again on Continue
     const stack = error.stack ?? '';
     const blobMatch = /blob:[^\s:)]+/.exec(stack);
-
-    // Report app crashes to the admin agent — but not plugin crashes, which
-    // are third-party code and get auto-removed below.
-    if (!blobMatch) {
-      reportError({
-        message: error.message,
-        stack: `${stack}\n\nComponent stack:${errorInfo.componentStack ?? ''}`,
-        source: 'react-error-boundary',
-      });
-    }
-
     if (blobMatch) {
       const owner = lookupBlobOwner(blobMatch[0]);
       if (owner) {
@@ -121,6 +112,11 @@ export class ErrorBoundary extends Component<Props, State> {
               ? 'A plugin crashed. You can continue without it or restart the app.'
               : this.state.error?.message || 'An unexpected error occurred'}
           </p>
+          {import.meta.env.PROD && !this.isPluginError() && (
+            <p style={{ fontSize: '12px', color: '#666', margin: '-12px 0 24px 0' }}>
+              This crash was reported automatically so it can be fixed.
+            </p>
+          )}
           <div style={{ display: 'flex', gap: '12px' }}>
             {this.isPluginError() && (
               <button

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, ReactNode } from 'react';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { logger } from '../lib/logger';
+import { reportError } from '../lib/errorReporting';
 import { lookupBlobOwner, markPluginCrashed } from '../lib/plugin-loader';
 import { uninstallPlugin } from '../lib/plugins';
 
@@ -29,6 +30,17 @@ export class ErrorBoundary extends Component<Props, State> {
     // Auto-remove crashing plugins so they don't crash again on Continue
     const stack = error.stack ?? '';
     const blobMatch = /blob:[^\s:)]+/.exec(stack);
+
+    // Report app crashes to the admin agent — but not plugin crashes, which
+    // are third-party code and get auto-removed below.
+    if (!blobMatch) {
+      reportError({
+        message: error.message,
+        stack: `${stack}\n\nComponent stack:${errorInfo.componentStack ?? ''}`,
+        source: 'react-error-boundary',
+      });
+    }
+
     if (blobMatch) {
       const owner = lookupBlobOwner(blobMatch[0]);
       if (owner) {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, ReactNode } from 'react';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { logger } from '../lib/logger';
+import { getAnalyticsEnabled } from '../lib/analytics';
 import { lookupBlobOwner, markPluginCrashed } from '../lib/plugin-loader';
 import { uninstallPlugin } from '../lib/plugins';
 
@@ -11,15 +12,18 @@ interface Props {
 interface State {
   hasError: boolean;
   error: Error | null;
+  /** True when the crash was actually reported (production build, user has
+   *  analytics & error reports enabled, not a plugin crash). */
+  reportedAutomatically: boolean;
 }
 
 export class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false, error: null };
+    this.state = { hasError: false, error: null, reportedAutomatically: false };
   }
 
-  static getDerivedStateFromError(error: Error): State {
+  static getDerivedStateFromError(error: Error): Partial<State> {
     return { hasError: true, error };
   }
 
@@ -32,6 +36,18 @@ export class ErrorBoundary extends Component<Props, State> {
     // Auto-remove crashing plugins so they don't crash again on Continue
     const stack = error.stack ?? '';
     const blobMatch = /blob:[^\s:)]+/.exec(stack);
+
+    // Show the "reported automatically" disclosure only when a report really
+    // went out: production build, analytics & error reports enabled, and not
+    // a plugin crash (those are excluded from reporting).
+    if (import.meta.env.PROD && !blobMatch) {
+      getAnalyticsEnabled()
+        .then((enabled) => {
+          if (enabled) this.setState({ reportedAutomatically: true });
+        })
+        .catch(() => {});
+    }
+
     if (blobMatch) {
       const owner = lookupBlobOwner(blobMatch[0]);
       if (owner) {
@@ -56,7 +72,7 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   handleContinue = () => {
-    this.setState({ hasError: false, error: null });
+    this.setState({ hasError: false, error: null, reportedAutomatically: false });
   };
 
   handleRestart = async () => {
@@ -112,7 +128,7 @@ export class ErrorBoundary extends Component<Props, State> {
               ? 'A plugin crashed. You can continue without it or restart the app.'
               : this.state.error?.message || 'An unexpected error occurred'}
           </p>
-          {import.meta.env.PROD && !this.isPluginError() && (
+          {this.state.reportedAutomatically && (
             <p style={{ fontSize: '12px', color: '#666', margin: '-12px 0 24px 0' }}>
               This crash was reported automatically so it can be fixed.
             </p>

--- a/src/components/dashboard/SettingsModal.tsx
+++ b/src/components/dashboard/SettingsModal.tsx
@@ -391,9 +391,11 @@ export function SettingsModal({
             </div>
             <div className="settings-row">
               <div className="settings-row-info">
-                <span className="settings-row-label">Usage analytics</span>
+                <span className="settings-row-label">Usage analytics &amp; error reports</span>
                 <span className="settings-row-description">
-                  Help improve Ship Studio by sharing usage data like feature usage, and errors.
+                  Help improve Ship Studio by sharing anonymous usage data and automatic error
+                  reports (error messages and stack traces only — never your code or file contents,
+                  and paths are anonymized). Turning this off stops all data sharing.
                 </span>
               </div>
               <button

--- a/src/hooks/useToasts.test.ts
+++ b/src/hooks/useToasts.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+
+vi.mock('../lib/errorReporting', () => ({
+  reportError: vi.fn(),
+}));
+
 import { useToasts } from './useToasts';
+import { reportError } from '../lib/errorReporting';
 
 describe('useToasts', () => {
   beforeEach(() => {
@@ -201,5 +207,30 @@ describe('useToasts', () => {
       vi.advanceTimersByTime(2000);
     });
     expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it('reports error toasts to the admin agent', () => {
+    const { result } = renderHook(() => useToasts());
+
+    act(() => {
+      result.current.showToast('Failed to create branch', 'error');
+    });
+
+    expect(vi.mocked(reportError)).toHaveBeenCalledWith({
+      message: 'Failed to create branch',
+      source: 'toast',
+    });
+  });
+
+  it('does not report success or info toasts', () => {
+    vi.mocked(reportError).mockClear();
+    const { result } = renderHook(() => useToasts());
+
+    act(() => {
+      result.current.showToast('Saved', 'success');
+      result.current.showToast('FYI', 'info');
+    });
+
+    expect(vi.mocked(reportError)).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useToasts.ts
+++ b/src/hooks/useToasts.ts
@@ -12,6 +12,7 @@
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
+import { reportError } from '../lib/errorReporting';
 
 /** Toast notification type */
 export type ToastType = 'success' | 'error' | 'info';
@@ -74,6 +75,12 @@ export function useToasts(): UseToastsReturn {
   }, []);
 
   const showToast = useCallback((message: string, type: ToastType = 'success') => {
+    // An error toast is, by definition, the user seeing something not work as
+    // intended — report it to the admin agent (deduped + throttled; see
+    // docs/error-reporting.md).
+    if (type === 'error') {
+      reportError({ message, source: 'toast' });
+    }
     const id = ++toastIdRef.current;
     setToasts((prev) => {
       // Keep max toasts, remove oldest if needed

--- a/src/lib/errorReporting.test.ts
+++ b/src/lib/errorReporting.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mockIPC, clearMocks } from '@tauri-apps/api/mocks';
+import { dedupeKey, shouldReport, reportError } from './errorReporting';
+
+afterEach(() => {
+  clearMocks();
+});
+
+describe('dedupeKey', () => {
+  it('prefers the explicit fingerprint', () => {
+    expect(
+      dedupeKey({ message: 'anything', source: 'publishing', fingerprint: 'publish-io-error' })
+    ).toBe('publish-io-error');
+  });
+
+  it('falls back to source + message', () => {
+    expect(dedupeKey({ message: 'boom', source: 'window-error' })).toBe('window-error:boom');
+  });
+
+  it('defaults source to frontend and truncates long messages', () => {
+    const key = dedupeKey({ message: 'x'.repeat(500) });
+    expect(key).toBe(`frontend:${'x'.repeat(200)}`);
+  });
+});
+
+describe('shouldReport', () => {
+  it('allows the first occurrence and blocks repeats', () => {
+    const report = { message: 'unique-dedup-test-error', fingerprint: 'unique-dedup-test' };
+    expect(shouldReport(report)).toBe(true);
+    expect(shouldReport(report)).toBe(false);
+  });
+
+  it('treats different fingerprints independently', () => {
+    expect(shouldReport({ message: 'a', fingerprint: 'independent-test-a' })).toBe(true);
+    expect(shouldReport({ message: 'a', fingerprint: 'independent-test-b' })).toBe(true);
+  });
+});
+
+describe('reportError', () => {
+  it('does not invoke the backend in dev/test builds', () => {
+    let invoked = false;
+    mockIPC(() => {
+      invoked = true;
+    });
+    reportError({ message: 'dev-build error', fingerprint: 'dev-build-gate-test' });
+    expect(invoked).toBe(false);
+  });
+
+  it('never throws, even with no IPC mock installed', () => {
+    expect(() => reportError({ message: 'no-ipc error' })).not.toThrow();
+  });
+});

--- a/src/lib/errorReporting.ts
+++ b/src/lib/errorReporting.ts
@@ -1,0 +1,77 @@
+/**
+ * Automatic error reporting to the Ship Studio admin agent.
+ *
+ * Uncaught frontend errors (ErrorBoundary, window.onerror, unhandledrejection)
+ * are forwarded to the Rust backend (`report_frontend_error`), which scrubs
+ * home-dir paths and relays them to the admin agent. The agent investigates
+ * against the codebase, files deduplicated GitHub issues, and can open draft
+ * fix PRs. See docs/error-reporting.md for the full contract.
+ *
+ * Rules enforced here (the Rust side re-checks them all):
+ * - Fire-and-forget — never throws, never blocks the UX.
+ * - Production builds only (VITE_BUG_REPORT_FORCE=1 overrides for testing).
+ * - One report per fingerprint per app session, with a session hard cap.
+ *
+ * @module lib/errorReporting
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+
+export interface ErrorReport {
+  message: string;
+  stack?: string;
+  /** Subsystem/feature name, e.g. 'react-error-boundary', 'window-error'. */
+  source?: string;
+  /**
+   * Stable slug for known catch-sites (e.g. 'publish-staging-io-error').
+   * Repeat occurrences of the same fingerprint land on the agent's existing
+   * session instead of filing duplicate issues. Omit for generic handlers —
+   * the backend/server derive one from the message + top stack frame.
+   */
+  fingerprint?: string;
+}
+
+/** Varying messages defeat fingerprint dedup — stop after this many reports. */
+const MAX_REPORTS_PER_SESSION = 20;
+
+const reportedKeys = new Set<string>();
+
+/** Session dedup key: explicit fingerprint, else source + truncated message. */
+export function dedupeKey(report: ErrorReport): string {
+  return report.fingerprint ?? `${report.source ?? 'frontend'}:${report.message.slice(0, 200)}`;
+}
+
+/**
+ * Records the report's dedup key and returns whether it should be sent.
+ * True only for the first occurrence per session, under the session cap.
+ */
+export function shouldReport(report: ErrorReport): boolean {
+  if (reportedKeys.size >= MAX_REPORTS_PER_SESSION) return false;
+  const key = dedupeKey(report);
+  if (reportedKeys.has(key)) return false;
+  reportedKeys.add(key);
+  return true;
+}
+
+function reportingEnabled(): boolean {
+  return import.meta.env.PROD || import.meta.env.VITE_BUG_REPORT_FORCE === '1';
+}
+
+/**
+ * Report an uncaught error to the admin agent. Safe to call from anywhere,
+ * including error paths — it can never throw or reject.
+ */
+export function reportError(report: ErrorReport): void {
+  try {
+    if (!reportingEnabled()) return;
+    if (!shouldReport(report)) return;
+    void invoke('report_frontend_error', {
+      message: report.message,
+      stack: report.stack,
+      source: report.source ?? 'frontend',
+      fingerprint: report.fingerprint,
+    }).catch(() => {});
+  } catch {
+    // Error reporting must never be the thing that crashes the app.
+  }
+}

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -9,12 +9,18 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('./errorReporting', () => ({
+  reportError: vi.fn(),
+}));
+
 // Import after mocking
 import { logger } from './logger';
 import { invoke } from '@tauri-apps/api/core';
+import { reportError } from './errorReporting';
 
 describe('Logger', () => {
   const mockInvoke = vi.mocked(invoke);
+  const mockReportError = vi.mocked(reportError);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -179,6 +185,30 @@ describe('Logger', () => {
         message: 'Message 2',
         context: null,
       });
+    });
+  });
+
+  describe('admin agent forwarding', () => {
+    it('forwards error logs to reportError with stack and context', () => {
+      const err = new Error('forward me');
+      logger.logError(err, { projectPath: '/tmp/x' });
+
+      expect(mockReportError).toHaveBeenCalledTimes(1);
+      const arg = mockReportError.mock.calls[0][0];
+      expect(arg.message).toBe('forward me');
+      expect(arg.source).toBe('frontend-log');
+      expect(arg.stack).toContain('context:');
+    });
+
+    it('does not forward non-error levels', () => {
+      logger.warn('just a warning');
+      logger.info('just info');
+      expect(mockReportError).not.toHaveBeenCalled();
+    });
+
+    it('does not forward plugin (blob:) errors', () => {
+      logger.error('plugin exploded', { stack: 'at blob:app://x/y:1:1' });
+      expect(mockReportError).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -8,6 +8,7 @@
  */
 
 import { invoke } from '@tauri-apps/api/core';
+import { reportError } from './errorReporting';
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
@@ -109,10 +110,33 @@ class Logger {
       this.buffer.shift();
     }
 
-    // Immediately send errors to backend
+    // Immediately send errors to backend, and report them to the admin agent
     if (level === 'error') {
       void this.sendToBackend(entry);
+      this.forwardToAdminAgent(entry);
     }
+  }
+
+  /**
+   * Forward an error-level log to the admin agent (docs/error-reporting.md).
+   * Every `logger.error`/`logger.logError` call marks something not working
+   * as intended, so each one becomes a report — deduped per session and
+   * throttled cross-session on the Rust side. Plugin errors (blob: URLs) are
+   * third-party code and excluded.
+   */
+  private forwardToAdminAgent(entry: LogEntry) {
+    const contextText = entry.context ? JSON.stringify(entry.context) : '';
+    if (entry.message.includes('blob:') || contextText.includes('blob:')) return;
+
+    const { stack, ...rest } = entry.context ?? {};
+    const parts: string[] = [];
+    if (typeof stack === 'string') parts.push(stack);
+    if (Object.keys(rest).length > 0) parts.push(`context: ${JSON.stringify(rest)}`);
+    reportError({
+      message: entry.message,
+      stack: parts.length > 0 ? parts.join('\n\n') : undefined,
+      source: 'frontend-log',
+    });
   }
 
   private async sendToBackend(entry: LogEntry) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,6 +20,7 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { exposeReactGlobals, lookupBlobOwner, markPluginCrashed } from './lib/plugin-loader';
 import { uninstallPlugin } from './lib/plugins';
 import { exposePluginContextRef } from './contexts/PluginContext';
+import { reportError } from './lib/errorReporting';
 import { OverlayScrollbars } from 'overlayscrollbars';
 import 'overlayscrollbars/overlayscrollbars.css';
 
@@ -37,7 +38,15 @@ window.addEventListener('error', (event) => {
     event.filename?.startsWith('blob:') ||
     msg.includes('Plugin context') ||
     msg.includes('plugin-sdk');
-  if (!isPluginError) return;
+  if (!isPluginError) {
+    // App bug (not third-party plugin code) — report to the admin agent.
+    reportError({
+      message: msg,
+      stack: event.error instanceof Error ? event.error.stack : undefined,
+      source: 'window-error',
+    });
+    return;
+  }
 
   event.preventDefault();
   console.error('[Ship Studio] Plugin error caught by global handler:', msg);
@@ -76,7 +85,15 @@ window.addEventListener('unhandledrejection', (event) => {
     (message.includes('handlerId') && stack.includes('user-script'))
   ) {
     event.preventDefault();
+    return;
   }
+
+  // Genuine unhandled rejection from app code — report to the admin agent.
+  reportError({
+    message,
+    stack: reason instanceof Error ? reason.stack : undefined,
+    source: 'unhandled-rejection',
+  });
 });
 
 // Patch removeChild to handle nodes relocated by OverlayScrollbars.


### PR DESCRIPTION
## What

Uncaught errors in production builds now report automatically to the Ship Studio admin agent (`shipstudio-admin-agent.vercel.app/report`), which investigates against the codebase, files deduplicated GitHub issues, and can open draft fix PRs.

## How it's wired

**Rust (`src-tauri/src/error_reporting.rs`)** — single entry point `report_error()`:
- Fire-and-forget POST with a 5s timeout; reporting can never block or fail the UX
- Panic hook chained in front of Sentry's, with a stable `panic-<file>:<line>:<col>` fingerprint; the panic path sends synchronously since the process may be dying
- `report_frontend_error` Tauri command relays frontend errors
- Prod-only (`SHIPSTUDIO_BUG_REPORT_FORCE=1` overrides for testing), per-fingerprint session dedup with a hard cap of 25, home-dir paths scrubbed via the existing `logging::scrub_string` before anything leaves the machine

**Frontend (`src/lib/errorReporting.ts`)** — same gates client-side, hooked into:
- the top-level React ErrorBoundary (plugin crashes excluded — third-party code)
- `window.onerror` / `unhandledrejection` in `main.tsx` (plugin errors and the known Tauri `listeners[eventId]` noise excluded)

**Secret handling** — `BUG_REPORT_SECRET` is compiled in via `option_env!` (never in source or the JS bundle); builds without it are a silent no-op. Both release workflows now inject it from the repo secret.

## To activate

1. Add the `BUG_REPORT_SECRET` repository secret (Settings → Secrets → Actions)
2. Next release picks it up — no other steps

## Docs

`docs/error-reporting.md` covers the contract, fingerprint guidance for future catch-sites, and how to test the pipeline end-to-end.

## Testing

- 5 new Rust unit tests (dedup key, session dedup, PII scrubbing) — pass
- 7 new Vitest tests (dedup, prod gating, never-throws) — pass
- `cargo clippy` clean, full frontend suite green via pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled automatic admin-agent error reporting for production frontend errors (window errors, unhandled rejections, toast errors) and backend traced errors/panics.
  * Added privacy-safe payload scrubbing plus per-session and cross-restart throttling with fire-and-forget sending; reporting is disabled when the bug-report secret is missing (unless forced).
  * ErrorBoundary now discloses when a non-plugin crash was auto-reported (when error reporting is enabled).
* **Documentation**
  * Added detailed guidance for the admin-agent pipeline, fingerprinting, throttling rules, and testing.
  * Updated analytics/privacy settings text to include automatic error reports.
* **Tests**
  * Added coverage for deduplication, throttling, scrubbing, and disabled behavior.
* **Chores**
  * Updated release workflows to pass the bug-report secret into release steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->