### PR TITLE
Bug bash: 10 open issues — fixes and hardening

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -304,6 +304,16 @@ mod tests {
     }
 
     #[test]
+    fn opencode_auth_indicator_matches_cli_credentials_path() {
+        // Verified against the CLI itself (issue #47): `opencode auth list`
+        // prints "Credentials ~/.local/share/opencode/auth.json". If detection
+        // ever shows "Not signed in" after a successful login, re-verify with
+        // that command before touching these values.
+        assert_eq!(OPENCODE.auth_config_dir, ".local/share/opencode");
+        assert_eq!(OPENCODE.auth_indicators, &["auth.json"]);
+    }
+
+    #[test]
     fn claude_code_setup_item_ids() {
         assert_eq!(CLAUDE_CODE.setup_item_ids, ("claude", "claude_auth"));
     }

--- a/src-tauri/src/commands/claude.rs
+++ b/src-tauri/src/commands/claude.rs
@@ -171,8 +171,34 @@ fn candidate_paths_for(binary_name: &str) -> Vec<std::path::PathBuf> {
                     exe_name
                 )),
                 home.join(format!(r".local\bin\{}", exe_name)),
+                // Node version managers / alt package managers not on the GUI
+                // PATH (issue #242: "installed but shows as not installed").
+                home.join(format!(r".volta\bin\{}", exe_name)),
+                home.join(format!(r"scoop\shims\{}", exe_name)),
+                home.join(format!(r"scoop\shims\{}", cmd_name)),
             ] {
                 push_candidate(&mut paths, &mut seen, path);
+            }
+        }
+
+        if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
+            for path in [
+                std::path::PathBuf::from(&local_app_data).join(format!("pnpm\\{}", cmd_name)),
+                std::path::PathBuf::from(&local_app_data).join(format!("pnpm\\{}", exe_name)),
+                std::path::PathBuf::from(&local_app_data).join(format!("Volta\\bin\\{}", exe_name)),
+            ] {
+                push_candidate(&mut paths, &mut seen, path);
+            }
+        }
+
+        // pnpm's global bin dir is configurable — trust $PNPM_HOME when set.
+        if let Ok(pnpm_home) = std::env::var("PNPM_HOME") {
+            for name in [&cmd_name, &exe_name] {
+                push_candidate(
+                    &mut paths,
+                    &mut seen,
+                    std::path::PathBuf::from(&pnpm_home).join(name),
+                );
             }
         }
 
@@ -218,10 +244,45 @@ fn candidate_paths_for(binary_name: &str) -> Vec<std::path::PathBuf> {
                 home.join(format!("n/bin/{binary_name}")),
                 home.join(format!(".{binary_name}/bin/{binary_name}")),
                 home.join(format!(".bun/bin/{binary_name}")),
+                // Node version managers / alt package managers not on the GUI
+                // PATH (issue #242: "installed but shows as not installed").
+                home.join(format!(".volta/bin/{binary_name}")),
+                home.join(format!(".yarn/bin/{binary_name}")),
+                home.join(format!(".asdf/shims/{binary_name}")),
+                home.join(format!(".nodenv/shims/{binary_name}")),
+                home.join(format!("Library/pnpm/{binary_name}")),
+                home.join(format!(".local/share/pnpm/{binary_name}")),
                 std::path::PathBuf::from(format!("/usr/local/bin/{binary_name}")),
                 std::path::PathBuf::from(format!("/opt/homebrew/bin/{binary_name}")),
             ] {
                 push_candidate(&mut paths, &mut seen, path);
+            }
+
+            // pnpm's global bin dir is configurable — trust $PNPM_HOME when set.
+            if let Ok(pnpm_home) = std::env::var("PNPM_HOME") {
+                push_candidate(
+                    &mut paths,
+                    &mut seen,
+                    std::path::PathBuf::from(pnpm_home).join(binary_name),
+                );
+            }
+
+            // fnm keeps each Node version's global installs under its own dir,
+            // like NVM below. Default FNM_DIR differs per platform.
+            for fnm_base in [
+                home.join(".local/share/fnm/node-versions"),
+                home.join("Library/Application Support/fnm/node-versions"),
+                home.join(".fnm/node-versions"),
+            ] {
+                if let Ok(entries) = std::fs::read_dir(&fnm_base) {
+                    for entry in entries.flatten().filter(|e| e.path().is_dir()) {
+                        push_candidate(
+                            &mut paths,
+                            &mut seen,
+                            entry.path().join("installation/bin").join(binary_name),
+                        );
+                    }
+                }
             }
 
             // Enumerate *every* installed Node version's bin dir (newest first),
@@ -452,6 +513,29 @@ mod tests {
         // Should include at least one entry — at minimum the built-in fallbacks
         // even on a machine without a `claude` install.
         assert!(!paths.is_empty());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn candidate_paths_for_covers_node_version_managers() {
+        // Issue #242: installs via volta / pnpm / asdf / nodenv were invisible
+        // to detection. Guard the fixed candidate list against regressing.
+        let home = dirs::home_dir().expect("home dir");
+        let paths = candidate_paths_for("codex");
+        for expected in [
+            home.join(".volta/bin/codex"),
+            home.join(".yarn/bin/codex"),
+            home.join(".asdf/shims/codex"),
+            home.join(".nodenv/shims/codex"),
+            home.join("Library/pnpm/codex"),
+            home.join(".local/share/pnpm/codex"),
+        ] {
+            assert!(
+                paths.contains(&expected),
+                "candidate list is missing {}",
+                expected.display()
+            );
+        }
     }
 
     #[cfg(not(windows))]

--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -26,3 +26,29 @@ pub fn stop_preview_proxy(window_label: String) -> Result<(), CommandError> {
     crate::proxy::stop_preview_proxy(&window_label);
     Ok(())
 }
+
+/// Probe the dev server's root and return its real HTTP status code.
+///
+/// The webview can't do this itself: a cross-origin fetch to localhost needs
+/// `mode: 'no-cors'`, whose opaque response hides the status — so a wedged
+/// server that answers 404 for every route still looks "ready" (issue #243).
+/// Returns `None` when the server is unreachable or times out, `Some(status)`
+/// otherwise. Uses `localhost` (not 127.0.0.1) so servers bound to either
+/// stack are reached, and GET (not HEAD, which dev servers often reject).
+#[tauri::command]
+#[tracing::instrument]
+pub async fn probe_preview_status(port: u16, timeout_ms: u64) -> Result<Option<u16>, CommandError> {
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(std::time::Duration::from_millis(timeout_ms))
+        .build()
+        .map_err(|e| CommandError::Other {
+            message: format!("probe client: {e}"),
+        })?;
+
+    match client.get(format!("http://localhost:{port}/")).send().await {
+        Ok(resp) => Ok(Some(resp.status().as_u16())),
+        Err(_) => Ok(None),
+    }
+}

--- a/src-tauri/src/commands/pty/stream.rs
+++ b/src-tauri/src/commands/pty/stream.rs
@@ -205,6 +205,43 @@ pub async fn get_project_pty_pids(project_path: String) -> Result<Vec<u32>, Comm
     Ok(get_project_pty_pids_internal(&project_path))
 }
 
+/// Kill all tracked PTY processes (sync version, all windows).
+///
+/// App-exit-only: the `RunEvent::Exit` hook can't await, and the quit path
+/// (`exit(0)` after a prevented close request) never fires the per-window
+/// `Destroyed` cleanup — without this sweep dev servers survive the app and
+/// keep their ports (issue #229).
+pub fn kill_all_pty_sync() -> u32 {
+    let pids: Vec<(u32, u32)> = {
+        let Ok(registry) = PTY_REGISTRY.lock() else {
+            return 0;
+        };
+        registry.iter().map(|(&id, info)| (id, info.pid)).collect()
+    };
+
+    for (_id, pid) in &pids {
+        #[cfg(unix)]
+        {
+            let _ = create_command("kill")
+                .args(["-9", &pid.to_string()])
+                .output();
+        }
+
+        #[cfg(windows)]
+        {
+            let _ = create_command("taskkill")
+                .args(["/F", "/T", "/PID", &pid.to_string()])
+                .output();
+        }
+    }
+
+    if let Ok(mut registry) = PTY_REGISTRY.lock() {
+        registry.clear();
+    }
+
+    pids.len() as u32
+}
+
 /// Kill all tracked PTY processes (all windows).
 ///
 /// WARNING: This kills PTYs across ALL windows. Use `kill_window_pty` instead
@@ -316,10 +353,7 @@ pub async fn kill_port(port: u32) -> Result<(), CommandError> {
                 let pids = String::from_utf8_lossy(&output.stdout);
                 for pid in pids.lines() {
                     if let Ok(pid_num) = pid.trim().parse::<i32>() {
-                        // Kill the process and its children
-                        let _ = create_command("kill")
-                            .args(["-9", &pid_num.to_string()])
-                            .output();
+                        kill_listener_and_group(pid_num);
                     }
                 }
             }
@@ -329,14 +363,71 @@ pub async fn kill_port(port: u32) -> Result<(), CommandError> {
 
     #[cfg(not(unix))]
     {
-        // Windows: use netstat and taskkill
+        // Windows: use netstat and taskkill. /T kills the listener's whole
+        // process tree — dev servers fork workers that would otherwise survive
+        // and hold state (issues #229, #243).
         let _ = create_command("cmd")
-            .args(["/C", &format!("for /f \"tokens=5\" %a in ('netstat -aon ^| findstr :{} ^| findstr LISTENING') do taskkill /F /PID %a", port)])
+            .args(["/C", &format!("for /f \"tokens=5\" %a in ('netstat -aon ^| findstr :{} ^| findstr LISTENING') do taskkill /F /T /PID %a", port)])
             .output();
     }
 
-    // Give processes time to die
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    // Wait until the port is actually free (bounded) instead of hoping 100ms
+    // is enough. A dev server's worker tree can take longer to tear down, and
+    // respawning against a half-dead predecessor corrupts its on-disk state —
+    // the "every route 404s until manual restart" failure (issue #243).
+    for _ in 0..20 {
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        if !port_is_listening(port) {
+            break;
+        }
+    }
 
     Ok(())
+}
+
+/// True while something still accepts TCP connections on `port`. Resolves
+/// `localhost` (not a hardcoded 127.0.0.1) so dev servers bound to either
+/// stack are seen — same lesson as the preview proxy's upstream connect.
+fn port_is_listening(port: u32) -> bool {
+    use std::net::{TcpStream, ToSocketAddrs};
+    let Ok(addrs) = format!("localhost:{port}").to_socket_addrs() else {
+        return false;
+    };
+    addrs.into_iter().any(|addr| {
+        TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(250)).is_ok()
+    })
+}
+
+/// Kill the process listening on a port — and its whole process group.
+///
+/// `kill -9 <pid>` alone leaves the dev server's forked workers (Turbopack
+/// compilers, npm→node wrappers) alive; a survivor can hold or re-bind the
+/// port and serve a stale route table where every request 404s (issue #243).
+/// Escalates TERM→KILL on the group, guarded so we can never signal our own
+/// process group or the init group. Falls back to the old single-PID SIGKILL
+/// when the group can't be resolved or is shared with us.
+#[cfg(unix)]
+fn kill_listener_and_group(pid: i32) {
+    let pgid_of = |p: i32| -> Option<i32> {
+        let out = create_command("ps")
+            .args(["-o", "pgid=", "-p", &p.to_string()])
+            .output()
+            .ok()?;
+        String::from_utf8_lossy(&out.stdout).trim().parse().ok()
+    };
+
+    let own_pgid = pgid_of(std::process::id() as i32);
+    match pgid_of(pid) {
+        Some(pgid) if pgid > 1 && own_pgid.is_some_and(|own| own != pgid) => {
+            let group = format!("-{pgid}");
+            let _ = create_command("kill").args(["-TERM", &group]).output();
+            std::thread::sleep(std::time::Duration::from_millis(300));
+            let _ = create_command("kill").args(["-9", &group]).output();
+        }
+        _ => {
+            let _ = create_command("kill")
+                .args(["-9", &pid.to_string()])
+                .output();
+        }
+    }
 }

--- a/src-tauri/src/commands/pty_session.rs
+++ b/src-tauri/src/commands/pty_session.rs
@@ -491,6 +491,43 @@ pub fn pty_session_kill(session_id: String) -> Result<(), CommandError> {
     Ok(())
 }
 
+/// Kill every live session's process (sync). App-exit-only sweep for the
+/// `RunEvent::Exit` hook (issue #229). Kills by PID (tree kill on Windows)
+/// instead of the stored `ChildKiller`, which terminates only the direct
+/// child — on Windows that leaves grandchildren (and their listening ports)
+/// alive. Immediate kills, no grace period: the app is quitting and a wait
+/// here would visibly lag it.
+pub fn kill_all_sessions_sync() -> u32 {
+    let sessions: Vec<Arc<Session>> = {
+        let Ok(mut map) = REGISTRY.lock() else {
+            return 0;
+        };
+        map.drain().map(|(_, s)| s).collect()
+    };
+
+    let mut count = 0;
+    for session in sessions {
+        if !session.alive.load(Ordering::Relaxed) {
+            continue;
+        }
+        let pid = session.pid.to_string();
+
+        #[cfg(unix)]
+        let _ = crate::utils::create_command("kill")
+            .args(["-9", &pid])
+            .output();
+
+        #[cfg(windows)]
+        let _ = crate::utils::create_command("taskkill")
+            .args(["/F", "/T", "/PID", &pid])
+            .output();
+
+        session.alive.store(false, Ordering::Relaxed);
+        count += 1;
+    }
+    count
+}
+
 #[tauri::command]
 #[tracing::instrument]
 pub fn pty_session_attach(session_id: String) -> Result<AttachResult, CommandError> {

--- a/src-tauri/src/commands/setup/auth.rs
+++ b/src-tauri/src/commands/setup/auth.rs
@@ -93,9 +93,16 @@ pub async fn start_claude_auth(
     let agent_path = find_binary_by_name(agent.binary_name)
         .ok_or(format!("{} not installed", agent.display_name))?;
 
+    // Strip any previously injected token before an interactive login: a
+    // revoked-but-not-expired vault token in the env shadows the fresh login
+    // and re-auth can never succeed (issue #159, same pattern as
+    // connect_claude_account).
+    let mut env = get_env_vars_for_active_account();
+    env.remove("CLAUDE_CODE_OAUTH_TOKEN");
+
     let child = create_command(&agent_path)
         .args(agent.auth_trigger_args)
-        .envs(get_env_vars_for_active_account())
+        .envs(env)
         .spawn()
         .map_err(|e| format!("Failed to start {} auth: {}", agent.display_name, e))?;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -613,6 +613,7 @@ pub fn run() {
             // Preview Proxy
             commands::proxy::start_preview_proxy,
             commands::proxy::stop_preview_proxy,
+            commands::proxy::probe_preview_status,
             // Static File Server
             commands::static_server::start_static_server,
             commands::static_server::stop_static_server,
@@ -767,6 +768,18 @@ pub fn run() {
             commands::clipboard::read_clipboard_text,
             commands::clipboard::stage_clipboard_image,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|_app, event| {
+            if let tauri::RunEvent::Exit = event {
+                // The quit path calls exit(0) after preventDefault() on the
+                // close request, so WindowEvent::Destroyed cleanup never runs.
+                // This is the only hook that fires for every shutdown — dev
+                // servers and agent PTYs must die here or they outlive the app
+                // and keep their ports (issue #229: EADDRINUSE on relaunch).
+                let ptys = commands::pty::kill_all_pty_sync();
+                let sessions = commands::pty_session::kill_all_sessions_sync();
+                tracing::info!(ptys, sessions, "App exit: killed tracked PTY processes");
+            }
+        });
 }

--- a/src/components/dashboard/ClaudeConnectTerminal.tsx
+++ b/src/components/dashboard/ClaudeConnectTerminal.tsx
@@ -83,6 +83,8 @@ export function ClaudeConnectTerminal({
         cursorStyle: 'block',
         scrollback: 1000,
         allowProposedApi: true,
+        // Keep agent TUI text readable on the dark background (#232).
+        minimumContrastRatio: 4.5,
         theme: {
           background: '#1e1e1e',
           foreground: '#cccccc',

--- a/src/components/dashboard/WorkspaceConnectTerminal.tsx
+++ b/src/components/dashboard/WorkspaceConnectTerminal.tsx
@@ -77,6 +77,8 @@ export function WorkspaceConnectTerminal({
         cursorStyle: 'block',
         scrollback: 1000,
         allowProposedApi: true,
+        // Keep agent TUI text readable on the dark background (#232).
+        minimumContrastRatio: 4.5,
         theme: {
           background: '#1e1e1e',
           foreground: '#cccccc',

--- a/src/components/plugins/McpModal.tsx
+++ b/src/components/plugins/McpModal.tsx
@@ -135,9 +135,14 @@ export function McpModal({
       void trackEvent('mcp_server_removed', { scope: server.scope, $screen_name: 'MCP Modal' });
       await fetchServers();
     } catch (err) {
-      logger.error('Failed to remove MCP server', {
-        error: err instanceof Error ? err.message : String(err),
-      });
+      const message = err instanceof Error ? err.message : String(err);
+      if (/no mcp server named|not found/i.test(message)) {
+        // Already gone (e.g. the preview bridge's remove-then-re-add cycle
+        // raced this click) — that's the outcome the user wanted, not an error.
+        await fetchServers();
+      } else {
+        logger.error('Failed to remove MCP server', { error: message });
+      }
     } finally {
       setRemovingServer(null);
     }

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -1071,7 +1071,7 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
         devServerOutput={devServerOutput}
         onStop={conn.stopConnecting}
         onRetry={conn.handleRetry}
-        processExited={serverProcessGone}
+        processExited={serverProcessGone || conn.serverStale}
         exitCode={devServerUnexpectedExit?.exitCode ?? null}
         onRestartServer={onRestartDevServer}
         onFixWithAgent={handleFixWithAgent && (() => handleFixWithAgent('server-down'))}

--- a/src/components/setup/OnboardingTerminal.tsx
+++ b/src/components/setup/OnboardingTerminal.tsx
@@ -113,6 +113,8 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
       // a TUI agent's redraws, which makes the scrollbar jump around.
       scrollback: 5000,
       allowProposedApi: true,
+      // Keep agent TUI text readable on the dark background (#232).
+      minimumContrastRatio: 4.5,
       theme: {
         background: '#1e1e1e',
         foreground: '#cccccc',

--- a/src/components/setup/OnboardingTerminal.tsx
+++ b/src/components/setup/OnboardingTerminal.tsx
@@ -479,10 +479,15 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
             return;
           }
           logger.error('[OnboardingTerminal] Still no output after respawn', { command });
+          const failure = `${command} did not respond.`;
           terminalRef.current?.write(
-            `\r\n\x1b[31m${command} did not respond.\x1b[0m\r\n` +
+            `\r\n\x1b[31m${failure}\x1b[0m\r\n` +
               `\x1b[33mMake sure "${command}" is installed and on your PATH, then close this window and try again.\x1b[0m\r\n`
           );
+          // Tell the parent the flow failed so the checklist offers a retry —
+          // without this the terminal showed the message but the wizard sat
+          // in "connecting" forever (issue #245).
+          onExitRef.current(1, failure);
         }, 10_000);
 
         // Focus the terminal

--- a/src/components/terminal/BuildTerminal.tsx
+++ b/src/components/terminal/BuildTerminal.tsx
@@ -101,6 +101,8 @@ export function BuildTerminal({
       cursorStyle: 'bar',
       scrollback: 5000,
       allowProposedApi: true,
+      // Keep CLI text readable on the dark background (#232).
+      minimumContrastRatio: 4.5,
       theme: {
         background: '#1e1e1e',
         foreground: '#cccccc',

--- a/src/components/terminal/DevServerLogs.tsx
+++ b/src/components/terminal/DevServerLogs.tsx
@@ -137,6 +137,8 @@ export function DevServerLogs({
       // Stdin stays enabled so interactive CLI prompts (Shopify password,
       // y/n confirms) can be answered here; keys flow to the PTY via onInput.
       disableStdin: false,
+      // Keep CLI text readable on the dark background (#232).
+      minimumContrastRatio: 4.5,
       theme: {
         background: '#1a1a1a',
         foreground: '#cccccc',

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -406,6 +406,10 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       cursorStyle: 'block',
       scrollback: 5000,
       allowProposedApi: true,
+      // Lift low-contrast text (e.g. ANSI black / dim greys on our dark
+      // background) to WCAG AA against the actual cell background, so black
+      // text on colored chips stays dark. Same default as VS Code (#232).
+      minimumContrastRatio: 4.5,
       theme: {
         background: '#1e1e1e',
         foreground: '#cccccc',

--- a/src/hooks/useDismissOnOutsidePointer.ts
+++ b/src/hooks/useDismissOnOutsidePointer.ts
@@ -2,13 +2,14 @@
  * Dismiss-on-outside-pointer for hand-rolled popovers (visual editor).
  *
  * Registers a CAPTURE-phase document listener while `open` is true, and calls
- * `onDismiss` when the event lands outside the popover. Registration is
- * deferred by one animation frame: on some engines (WKWebView on macOS
- * Sequoia, issue #172) the opening gesture's pointerdown can be dispatched
- * AFTER the effect that registers the listener runs, so a listener attached
- * synchronously sees the very gesture that opened the popover and closes it
- * instantly. Deferring one frame guarantees the opening gesture's events can
- * never reach the listener, regardless of engine event/effect ordering.
+ * `onDismiss` when the event lands outside the popover. On some engines
+ * (WKWebView on macOS Sequoia, issue #172; Ventura/Intel, issue #236) the
+ * opening gesture's pointerdown can be dispatched AFTER the effect that
+ * registers the listener runs, so a listener attached synchronously sees the
+ * very gesture that opened the popover and closes it instantly. Two guards
+ * prevent that: registration is deferred by one animation frame, and events
+ * whose timeStamp predates the open are ignored (timeStamps are creation-time,
+ * so a late-dispatched opening gesture is still recognizable).
  *
  * This deliberately does NOT replace `useClickOutside` (bubble-phase `click`
  * semantics) — it's the shared home for the capture-phase
@@ -56,7 +57,17 @@ export function useDismissOnOutsidePointer(
   useEffect(() => {
     if (!open) return;
 
+    // The rAF defer alone lost the race on slow machines (issue #236, Intel
+    // Ventura): the engine can dispatch the opening gesture's pointerdown even
+    // later than the next frame. Event timeStamps are creation-time (when the
+    // user acted), so any event minted before the popover opened is part of
+    // the opening gesture no matter how late it's dispatched — drop it.
+    // Engines with epoch-based timeStamps make this check always-false, which
+    // degrades to the previous behavior instead of breaking dismissal.
+    const openedAt = performance.now();
+
     const onDown = (e: Event) => {
+      if (e.timeStamp <= openedAt) return;
       const target = e.target as Node;
       const outside = isOutsideRef.current
         ? isOutsideRef.current(target)

--- a/src/hooks/usePreviewConnection.test.ts
+++ b/src/hooks/usePreviewConnection.test.ts
@@ -307,3 +307,115 @@ describe('usePreviewConnection blank-iframe watchdog', () => {
     await teardown(unmount);
   });
 });
+
+describe('usePreviewConnection stale-404 detection (issue #243)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  /** Route probe_preview_status through a status script; other commands keep
+   *  their defaults. `statuses` is consumed one per health check; the last
+   *  value repeats once exhausted. */
+  async function installProbeStatuses(statuses: Array<number | null>) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === 'start_preview_proxy') return Promise.resolve(8080);
+      if (cmd === 'list_pages') return Promise.resolve([]);
+      if (cmd === 'probe_preview_status') {
+        const next = statuses.length > 1 ? statuses.shift() : statuses[0];
+        return Promise.resolve(next);
+      }
+      return Promise.resolve(undefined);
+    });
+  }
+
+  /** Drive the hook to serverReady via the readiness probe. */
+  async function reachReady(server: ReturnType<typeof installSlowServerFetch>) {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    await act(async () => {
+      server.finishCompile();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+  }
+
+  it('flags the server stale after three consecutive 404s on a previously-healthy root', async () => {
+    const server = installSlowServerFetch();
+    await installProbeStatuses([200, 404, 404, 404]);
+    const { result, unmount } = renderHook(() => usePreviewConnection(baseParams));
+    await reachReady(server);
+    expect(result.current.serverReady).toBe(true);
+
+    // Check 1 (200): records the healthy root. Checks 2–3 (404): strikes, not
+    // yet a verdict.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30000);
+    });
+    expect(result.current.serverStale).toBe(false);
+    expect(result.current.serverReady).toBe(true);
+
+    // Check 4: third consecutive 404 — wedged, surface the error + restart.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+    });
+    expect(result.current.serverStale).toBe(true);
+    expect(result.current.hasError).toBe(true);
+    expect(result.current.serverReady).toBe(false);
+
+    await act(async () => {
+      unmount();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+  });
+
+  it('never flags a root that was never healthy (projects with no "/" route)', async () => {
+    const server = installSlowServerFetch();
+    await installProbeStatuses([404]);
+    const { result, unmount } = renderHook(() => usePreviewConnection(baseParams));
+    await reachReady(server);
+    expect(result.current.serverReady).toBe(true);
+
+    // Many 404 checks in a row — without a prior healthy root this is the
+    // project's normal shape, not a wedged server.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60000);
+    });
+    expect(result.current.serverStale).toBe(false);
+    expect(result.current.serverReady).toBe(true);
+    expect(result.current.hasError).toBe(false);
+
+    await act(async () => {
+      unmount();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+  });
+
+  it('treats an unreachable server as crashed after three failed checks', async () => {
+    const server = installSlowServerFetch();
+    await installProbeStatuses([200, null, null, null]);
+    const { result, unmount } = renderHook(() => usePreviewConnection(baseParams));
+    await reachReady(server);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(40000);
+    });
+    expect(result.current.hasError).toBe(true);
+    expect(result.current.serverReady).toBe(false);
+    // Crashed, not stale — the restart affordance for stale is separate.
+    expect(result.current.serverStale).toBe(false);
+
+    await act(async () => {
+      unmount();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+  });
+});

--- a/src/hooks/usePreviewConnection.ts
+++ b/src/hooks/usePreviewConnection.ts
@@ -40,6 +40,12 @@ const SERVER_READY_TIMEOUT_MS = 30000;
 export const SERVER_MAX_RETRIES = 60;
 /** Consecutive health check failures before marking server as down */
 const HEALTH_CHECK_MAX_FAILURES = 3;
+/** Consecutive 404s on the root (after it was once healthy) before treating
+ *  the dev server as wedged. A restart race can leave a dev server accepting
+ *  connections but 404ing every route — including ones it served moments
+ *  earlier (issue #243). Requiring a previously-healthy root means projects
+ *  that legitimately have no `/` route are never flagged. */
+const STALE_404_MAX_STRIKES = 3;
 
 /** Information about a page/route */
 export interface PageInfo {
@@ -104,8 +110,14 @@ export function usePreviewConnection({
   // land on the dev server directly.
   const externalUrl = `${devServerUrl}${iframePath === '/' ? '' : iframePath}`;
 
+  // The dev server answers TCP but 404s every route — wedged by a restart
+  // race, only a process restart recovers it (issue #243).
+  const [serverStale, setServerStale] = useState(false);
+
   const wasRestartingRef = useRef(false);
   const healthCheckFailuresRef = useRef(0);
+  const notFoundStreakRef = useRef(0);
+  const sawHealthyRootRef = useRef(false);
   // Last time the HMR watchdog auto-reloaded the preview — throttles recovery
   // so a flapping HMR socket can't put the iframe in a reload loop.
   const lastHmrRecoveryRef = useRef(0);
@@ -166,7 +178,10 @@ export function usePreviewConnection({
     setPageSearch('');
     setReloadToken(0);
     setIframeBlank(false);
+    setServerStale(false);
     iframeAliveRef.current = false;
+    notFoundStreakRef.current = 0;
+    sawHealthyRootRef.current = false;
 
     const timer = setTimeout(() => setRetryCount(0), 1500);
     return () => clearTimeout(timer);
@@ -178,9 +193,12 @@ export function usePreviewConnection({
       setServerReady(false);
       setIsLoading(true);
       setHasError(false);
+      setServerStale(false);
       setRetryCount(-1);
       setIsStopped(false);
       wasRestartingRef.current = true;
+      notFoundStreakRef.current = 0;
+      sawHealthyRootRef.current = false;
     } else if (wasRestartingRef.current) {
       wasRestartingRef.current = false;
       const timer = setTimeout(() => setRetryCount(0), 1000);
@@ -528,29 +546,59 @@ export function usePreviewConnection({
       return;
     }
 
+    const markDown = (reason: string) => {
+      logger.warn(`[Preview] ${reason}`);
+      setServerReady(false);
+      setHasError(true);
+      setIsLoading(false);
+    };
+
+    // Probes from Rust so the real status code is visible — a webview fetch to
+    // the (cross-origin) dev server must use `no-cors`, whose opaque response
+    // resolves for ANY completed response, so "up but 404ing every route"
+    // (issue #243) was structurally undetectable here.
     const healthCheck = async () => {
+      let status: number | null;
       try {
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), HEALTH_CHECK_TIMEOUT_MS);
-
-        await fetch(devServerUrl, { mode: 'no-cors', signal: controller.signal });
-
-        clearTimeout(timeoutId);
-        healthCheckFailuresRef.current = 0;
+        status = await invoke<number | null>('probe_preview_status', {
+          port,
+          timeoutMs: HEALTH_CHECK_TIMEOUT_MS,
+        });
       } catch {
+        // Probe command itself failed — treat as inconclusive, not as a
+        // server failure.
+        return;
+      }
+
+      if (status === null) {
+        notFoundStreakRef.current = 0;
         healthCheckFailuresRef.current += 1;
         logger.warn(
           `[Preview] Dev server health check failed (${healthCheckFailuresRef.current}/${HEALTH_CHECK_MAX_FAILURES})`
         );
-
         if (healthCheckFailuresRef.current >= HEALTH_CHECK_MAX_FAILURES) {
-          logger.warn(
-            '[Preview] Dev server appears to have crashed after multiple failed health checks'
-          );
-          setServerReady(false);
-          setHasError(true);
-          setIsLoading(false);
+          markDown('Dev server appears to have crashed after multiple failed health checks');
         }
+        return;
+      }
+
+      healthCheckFailuresRef.current = 0;
+
+      if (status === 404 && sawHealthyRootRef.current) {
+        notFoundStreakRef.current += 1;
+        logger.warn(
+          `[Preview] Dev server root 404'd after being healthy (${notFoundStreakRef.current}/${STALE_404_MAX_STRIKES})`
+        );
+        if (notFoundStreakRef.current >= STALE_404_MAX_STRIKES) {
+          markDown('Dev server is up but 404s every route — needs a restart');
+          setServerStale(true);
+        }
+        return;
+      }
+
+      notFoundStreakRef.current = 0;
+      if (status < 400) {
+        sawHealthyRootRef.current = true;
       }
     };
 
@@ -585,7 +633,7 @@ export function usePreviewConnection({
       stopPolling();
       document.removeEventListener('visibilitychange', handleVisibility);
     };
-  }, [serverReady, devServerUrl]);
+  }, [serverReady, port]);
 
   // Handlers
   const handleRefresh = useCallback(() => {
@@ -660,6 +708,7 @@ export function usePreviewConnection({
     hasError,
     retryCount,
     serverReady,
+    serverStale,
     isStopped,
     iframeBlank,
 

--- a/src/lib/branches.test.ts
+++ b/src/lib/branches.test.ts
@@ -47,6 +47,13 @@ describe('sanitizeBranchName', () => {
     expect(sanitizeBranchName('//a/b//')).toBe('a/b');
   });
 
+  it('strips leading dashes (issue #247 repro — git rejects refs starting with "-")', () => {
+    expect(sanitizeBranchName('-test')).toBe('test');
+    expect(sanitizeBranchName('--force')).toBe('force');
+    expect(sanitizeBranchName('-./fix')).toBe('fix');
+    expect(sanitizeBranchName('---')).toBe('');
+  });
+
   it('strips a trailing ".lock"', () => {
     expect(sanitizeBranchName('mybranch.lock')).toBe('mybranch');
     // exposed after collapsing ".." → "."

--- a/src/lib/branches.ts
+++ b/src/lib/branches.ts
@@ -147,7 +147,7 @@ export async function discardChanges(projectPath: string): Promise<void> {
  * - strips characters invalid in git refs (`~ ^ : ? * [ ] \` and `@{`)
  * - collapses `..` runs into a single `.`
  * - collapses repeated `-` / `/`
- * - strips leading/trailing `/` and `.`, and a trailing `.lock`
+ * - strips leading `-`, `/` and `.`, trailing `/` and `.`, and a trailing `.lock`
  *
  * An input with nothing salvageable returns an empty string — callers must
  * treat that the same as an empty input.
@@ -170,7 +170,7 @@ export function sanitizeBranchName(name: string): string {
   // → "name"), so repeat until stable.
   for (;;) {
     const next = sanitized
-      .replace(/^[/.]+/, '') // leading slashes/dots
+      .replace(/^[-/.]+/, '') // leading dashes/slashes/dots (git rejects leading "-")
       .replace(/[/.]+$/, '') // trailing slashes/dots
       .replace(/\.lock$/, ''); // git refuses refs ending in ".lock"
     if (next === sanitized) break;

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -709,6 +709,20 @@ export interface TerminalCommand {
   args: string[];
 }
 
+/**
+ * Network flags for every `npm install -g` we spawn during setup. npm's
+ * defaults let a stalled registry connection idle indefinitely with no output,
+ * which the onboarding terminal can't distinguish from a slow install — the
+ * flow just hangs (issue #245, Codex install stuck after one warn line).
+ * Bounding fetches makes a dead connection exit non-zero, which surfaces the
+ * error and the retry UI.
+ */
+const NPM_NETWORK_FLAGS = [
+  '--fetch-timeout=120000',
+  '--fetch-retries=3',
+  '--fetch-retry-maxtimeout=30000',
+];
+
 /** Get terminal commands based on current platform */
 export function getTerminalCommands(): Record<string, TerminalCommand> {
   const isWin = isWindows();
@@ -757,9 +771,11 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
       },
       codex: {
         // --force clears EEXIST failures from stale/partial global installs,
-        // which npm otherwise reports opaquely (issue #164).
+        // which npm otherwise reports opaquely (issue #164). The fetch flags
+        // bound registry stalls so a hung download fails (and offers retry)
+        // instead of sitting silent forever (issue #245).
         command: 'npm',
-        args: ['install', '-g', '@openai/codex', '--force'],
+        args: ['install', '-g', '@openai/codex', '--force', ...NPM_NETWORK_FLAGS],
       },
       codex_auth: {
         // Dedicated login subcommand (`codex login` — "Manage login") instead
@@ -773,7 +789,7 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
         // via npm (Node is set up in step 1, same as Codex below).
         // --force clears EEXIST failures from stale/partial global installs.
         command: 'npm',
-        args: ['install', '-g', 'opencode-ai', '--force'],
+        args: ['install', '-g', 'opencode-ai', '--force', ...NPM_NETWORK_FLAGS],
       },
       opencode_auth: {
         command: 'opencode',
@@ -792,7 +808,7 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
       vercel: {
         // --force clears EEXIST failures from stale/partial global installs.
         command: 'npm',
-        args: ['install', '-g', 'vercel', '--force'],
+        args: ['install', '-g', 'vercel', '--force', ...NPM_NETWORK_FLAGS],
       },
       vercel_auth: {
         command: 'vercel',
@@ -856,9 +872,11 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
       },
       codex: {
         // --force clears EEXIST failures from stale/partial global installs,
-        // which npm otherwise reports opaquely (issue #164).
+        // which npm otherwise reports opaquely (issue #164). The fetch flags
+        // bound registry stalls so a hung download fails (and offers retry)
+        // instead of sitting silent forever (issue #245).
         command: '/bin/bash',
-        args: ['-c', 'npm install -g @openai/codex --force'],
+        args: ['-c', `npm install -g @openai/codex --force ${NPM_NETWORK_FLAGS.join(' ')}`],
       },
       codex_auth: {
         // Dedicated login subcommand (`codex login`) — see the Windows entry
@@ -885,7 +903,7 @@ export function getTerminalCommands(): Record<string, TerminalCommand> {
       vercel: {
         // --force clears EEXIST failures from stale/partial global installs.
         command: '/bin/bash',
-        args: ['-c', 'npm install -g vercel --force'],
+        args: ['-c', `npm install -g vercel --force ${NPM_NETWORK_FLAGS.join(' ')}`],
       },
       vercel_auth: {
         command: 'vercel',

--- a/src/styles/features/workspace/main.css
+++ b/src/styles/features/workspace/main.css
@@ -76,6 +76,11 @@
   padding: 8px 10px;
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
+  /* Stack the header above the preview pane so popovers opened from it
+     (including toolbar plugin popovers, which get no z-index scaffolding)
+     aren't painted under the preview's error/status overlays (issue 246). */
+  position: relative;
+  z-index: var(--z-workspace-header);
 }
 
 /* Collapse the header's text labels to icon-only so every control stays

--- a/src/styles/global/base.css
+++ b/src/styles/global/base.css
@@ -169,6 +169,10 @@
    *               used 10000+ here; the tokens preserve that layering.
    */
   --z-dropdown: 100;
+  /* Workspace header — above the preview pane's overlays (which use
+     --z-dropdown) so anything floated from the header (core dropdowns,
+     toolbar plugin popovers) wins without needing its own z-index. */
+  --z-workspace-header: 200;
   /* Fullscreen preview overlay — above workspace chrome, below modals. */
   --z-preview-fullscreen: 900;
   /* Visual editor panel width — shared by the panel itself (visual-editor.css)


### PR DESCRIPTION
Sweep of the open issue backlog: three auto-filed reports, plus long-standing community bugs. Two rounds of commits.

## Round 1

**#247 — New Worktree modal lets leading-dash branch names through**
`sanitizeBranchName()` now strips leading `-` (mirroring `BranchesTab`'s separate sanitizer). Tests added.

**#248 — MCP "Remove" fails with "No MCP server named ..."**
"Not found" CLI responses are treated as the success they effectively are (the preview bridge's remove-then-re-add cycle can race a manual click): refresh the list, no error log.

**#232 — Agent follow-up questions render near-unreadable dark text**
All xterm instances set `minimumContrastRatio: 4.5` (VS Code's default) — lifts ANSI black/dim text against the actual cell background, so black-on-colored-chip stays dark.

**#246 — Toolbar plugin popovers render behind preview overlays**
`.workspace-header` forms a stacking context at new `--z-workspace-header: 200` — everything floated from the header beats the preview's overlays (100) without plugin authors needing our z-index scale. Still under fullscreen preview (900) and modals (1000).

## Round 2

**#243 — Preview 404s every route after dev-server restart race**
Two-part fix:
- `kill_port` now kills the listener's whole **process group** (TERM→KILL, guarded against signalling our own group) and waits up to 2s for the port to actually free. Windows `taskkill` gains `/T`. Surviving Turbopack/npm workers were corrupting the next server generation's state.
- New `probe_preview_status` Rust command returns the dev server's **real HTTP status** (the webview's `no-cors` health fetch structurally can't see one). The periodic health check now detects "up but 404s every route" — 3 consecutive 404s on a previously-healthy root → error card + Restart button. Hook tests added. The one-line `Preview.tsx` wiring is an isolated commit (that file is being modified on `fix/dev-server-port-identity`).

**#229 — Dev server survives app close, port stuck (EADDRINUSE on relaunch)**
Root cause: the quit path calls `exit(0)` after `preventDefault()` on the close request, so `WindowEvent::Destroyed` cleanup never fires — and there was no `RunEvent` handler at all. Added a `RunEvent::Exit` hook that sweeps **both** PTY registries (`PTY_REGISTRY` + `pty_session::REGISTRY`) with tree kills on Windows.

**#236 — Visual editor dropdowns close instantly (Ventura/Intel)**
The #172 fix raced: one-rAF-deferred listener registration can still lose to a late-dispatched opening `pointerdown` on slow machines. `useDismissOnOutsidePointer` now also ignores any event whose `timeStamp` predates the open — creation-time stamps identify the opening gesture no matter how late it's dispatched. Degrades safely on epoch-timestamp engines.

**#242 — Codex installed but shown as "not installed"**
Detection now probes volta, pnpm (incl. `$PNPM_HOME`), fnm, asdf, nodenv, yarn, and scoop locations on both platforms. Regression test locks the list.

**#245 / #164 — Onboarding installs hang silently**
- All `npm install -g` setup commands pass `--fetch-timeout/--fetch-retries/--fetch-retry-maxtimeout`, so a dead registry connection errors (→ retry UI) instead of stalling forever after one `npm warn` line.
- When the onboarding terminal's respawn is also silent, it now notifies the wizard (`onExit`) so the checklist offers retry, instead of printing a message while the wizard spins forever.

**#159 — Cannot sign back into Claude after signing out**
The bulk merged earlier in #192; this closes the residual gap: interactive `claude auth login` (setup flow) no longer inherits a possibly-revoked `CLAUDE_CODE_OAUTH_TOKEN` that shadows the fresh sign-in — same strip `connect_claude_account` already does.

**#47 — Opencode auth indicator path**
Verified against the CLI itself (`opencode auth list` → `Credentials ~/.local/share/opencode/auth.json`); locked with a test.

Fixes #247
Fixes #248
Fixes #232
Fixes #246
Fixes #243
Fixes #229
Fixes #236
Fixes #242
Fixes #47

## Verification
- `cargo test` — all pass (new tests: candidate paths, opencode indicator)
- `pnpm test:run` — 1374 passed (new: sanitizer leading-dash, stale-404 detection ×3)
- `tsc --noEmit`, `eslint --max-warnings 0`, `pnpm check:patterns` — clean

(#245, #164, #159 intentionally NOT auto-closed: those fixes are partial hardening — reporters should confirm.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved terminal text readability by enforcing stronger contrast across multiple terminal views.

* **New Features**
  * Added detection for “stale” preview servers (e.g., repeated root 404s) to drive a clearer “restart needed” state.

* **Bug Fixes**
  * MCP server removal now treats “already gone/not found” as successful.
  * Workspace header popovers now render above preview overlays.
  * Branch names no longer retain leading dashes.
  * Improved onboarding terminal failure reporting when the startup watchdog triggers.

* **Tests**
  * Added coverage for leading-dash branch sanitization and stale preview connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->