### PR TITLE
Bug bash round 2: fix 26 auto-reported issues + plugin docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,281 @@
+# Building Ship Studio Plugins
+
+Ship Studio plugins are small ES modules that render React components into
+well-defined slots of the app (workspace toolbar, preview, terminal dropdown,
+dashboard sidebar) and talk to the app through a sandboxed context: toasts,
+project info, plugin-scoped storage, shell commands in the project directory,
+and an allow-listed set of Tauri commands.
+
+A plugin is just a git repo (or local folder) with two required files:
+
+```
+my-plugin/
+├── plugin.json      # manifest (repo root)
+└── dist/index.js    # prebuilt ES module bundle
+```
+
+No build happens at install time — `dist/index.js` must be committed prebuilt.
+
+The fastest way to see a working plugin is the in-repo example at
+[`test-plugins/hello-world/`](../test-plugins/hello-world/): a hand-written
+manifest + bundle with no build step at all.
+
+## The manifest: `plugin.json`
+
+```json
+{
+  "id": "hello-world",
+  "name": "Hello World",
+  "version": "1.0.0",
+  "description": "A test plugin that validates the Ship Studio plugin pipeline.",
+  "slots": ["toolbar"],
+  "author": "Ship Studio",
+  "repository": "",
+  "setup": [],
+  "min_app_version": "0.1.0",
+  "icon": "",
+  "api_version": 1
+}
+```
+
+| Field | Required | Meaning |
+|---|---|---|
+| `id` | ✅ | Unique id; becomes the on-disk directory name. No `/`, `\`, `..`, or leading `.` |
+| `name` | ✅ | Display name shown in the Plugin Manager |
+| `version` | ✅ | Your plugin's semver, shown as `v{version}` |
+| `description` | ✅ | One-line description |
+| `slots` | | Slot names this plugin renders into (see [Slots](#slots)) |
+| `author` | | Shown next to the version |
+| `repository` | | Informational |
+| `min_app_version` | | Strict semver (`"0.18.0"`, not `"v0.18"`). Install/link fails if the app is older; empty = no gate |
+| `api_version` | | Plugin API version. Current: `1` (`0` = legacy). Unsupported versions install but are skipped at load with an explanatory error |
+| `required_commands` | | Tauri commands your plugin may call through `invoke.call()` (see [Invoke proxy](#invoke-allow-listed-tauri-commands)). Install fails if you request one outside the allow-list |
+| `setup` | | Reserved for future use — accepted but ignored (logs a warning) |
+| `icon` | | Reserved — not currently rendered; the toolbar slot component doubles as the icon |
+
+## The entry point: `dist/index.js`
+
+The bundle is loaded as a Blob-URL ES module (10s import timeout) and must be
+fully self-contained — no bare imports left at runtime. The module contract:
+
+```js
+export const name = 'My Plugin';            // optional, falls back to id
+export const slots = {                      // slot name -> React component
+  toolbar: MyToolbarButton,
+};
+export function onActivate() {}             // optional, after successful load
+export function onDeactivate() {}           // optional, on unload
+```
+
+**Do not bundle React.** The app exposes its own copy on
+`window.__SHIPSTUDIO_REACT__` / `window.__SHIPSTUDIO_REACT_DOM__`; mark
+`react` and `react-dom` as externals that resolve to those globals. Bundling a
+second React is the #1 cause of plugin crashes.
+
+Example esbuild setup:
+
+```bash
+esbuild src/index.tsx --bundle --format=esm --outfile=dist/index.js \
+  --external:react --external:react-dom \
+  --banner:js="const React = window.__SHIPSTUDIO_REACT__;"
+```
+
+(With the SDK you rarely need `react-dom`; hooks and `React.createElement`
+come through the same global.)
+
+## Slots
+
+`slots` keys are matched against `<PluginSlot name="…">` mount points in the
+app. Available today:
+
+| Slot | Where it renders |
+|---|---|
+| `toolbar` | Workspace header (hosting plugins: `vercel`, `cloudflare`, `netlify`) or the Plugins dropdown (everything else); also used as the plugin's icon in the manager grid |
+| `publish` | Workspace header, left of the Publish button |
+| `preview` | Preview pane chrome |
+| `terminal` | The terminal toolbar dropdown |
+| `sidebar` | Dashboard (projects view) sidebar |
+
+Slot components receive **no props** — all data comes from the plugin context
+(below). Each plugin renders inside its own error boundary: a crash shows an
+error chip and disables the plugin for the session (never uninstalls it), so
+a broken plugin can't take the workspace down.
+
+## The SDK: `@shipstudio/plugin-sdk`
+
+The SDK lives in this repo at [`packages/plugin-sdk/`](../packages/plugin-sdk/)
+(source-only package, React 19 peer dep). It wraps the runtime context in typed
+hooks and ships themed UI components so plugins match the app without any CSS.
+
+```tsx
+import {
+  useProject, useShell, useToast, usePluginStorage,
+  useAppActions, useTheme, useInvoke,
+  Button, Input, Select, Modal, Spinner, Badge, Stack, Text,
+} from '@shipstudio/plugin-sdk';
+
+function MyToolbarButton() {
+  const project = useProject();       // { name, path, currentBranch, hasUncommittedChanges, devServerUrl? } | null
+  const toast = useToast();           // (message, type?: 'success' | 'error') => void
+  const shell = useShell();           // { exec(command, args, { timeout? }) }
+  const storage = usePluginStorage(); // { read(), write(data) }
+  const actions = useAppActions();    // showToast, refreshGitStatus, refreshBranches, focusTerminal, openUrl
+  const invoke = useInvoke();         // { call(command, args?) } — gated by required_commands
+
+  return (
+    <Button
+      variant="secondary"
+      size="sm"
+      onClick={async () => {
+        const res = await shell.exec('npx', ['--version'], { timeout: 30 });
+        toast(`npx ${res.stdout.trim()}`, 'success');
+      }}
+    >
+      Check npx
+    </Button>
+  );
+}
+
+export const slots = { toolbar: MyToolbarButton };
+```
+
+### Runtime capabilities
+
+- **`storage.read()` / `storage.write(data)`** — a plugin-scoped JSON blob at
+  `{project}/.shipstudio/plugins/{id}/storage.json`. Whole-object semantics:
+  read, merge, write. Writes are mutex-guarded per plugin.
+- **`shell.exec(command, args, { timeout? })`** — runs a binary in the project
+  directory with the app's extended PATH. Default timeout 120s. Returns
+  `{ stdout, stderr, exit_code }`. A missing binary fails with a clear error
+  naming your plugin and the command.
+- **`actions`** — `showToast(msg, type?)`, `refreshGitStatus()`,
+  `refreshBranches()`, `focusTerminal()`, `openUrl(url)`.
+- **`theme`** — 14 color values as `var(--…)` strings (`bgPrimary`,
+  `textPrimary`, `accent`, `action`, `error`, …) safe to use in inline styles;
+  they track the app theme automatically.
+- Every async capability toasts the error before re-throwing, so failures are
+  never silent.
+
+All backend calls use the current project's path — capabilities that touch the
+project fail when no project is open (`useProject()` returns `null` on the
+dashboard, so gate on it).
+
+### `invoke`: allow-listed Tauri commands
+
+`invoke.call(command, args?)` may only call commands you declared in
+`required_commands`, which themselves must be within the app's plugin
+allow-list:
+
+```
+check_git_has_changes, get_changed_files, get_file_diff, get_branch_status,
+list_branches, get_current_branch, get_stash_info,
+list_projects, list_pages, read_project_metadata,
+get_branch_prefix_preference, get_auto_accept_mode,
+commit_changes, create_branch, switch_branch, fetch_all_branches, git_pull,
+check_ide_availability, open_in_ide, open_url_in_browser,
+create_preview_webview, resize_preview_webview, destroy_preview_webview,
+navigate_preview_webview,
+read_plugin_storage, write_plugin_storage, read_plugin_manifest
+```
+
+Declaring anything outside this list fails the install; calling anything you
+didn't declare rejects at runtime.
+
+### Without the SDK
+
+Raw-JS plugins (like hello-world) can use the window globals directly:
+`window.__SHIPSTUDIO_REACT__` for React and
+`window.__SHIPSTUDIO_PLUGINS__[pluginId]` for the context value.
+
+## Styling
+
+Prefer the SDK components — they're themed via inline styles and need no CSS.
+If you render your own elements, these classes and variables are **plugin-stable
+API** (defined in `src/styles/global/base.css`, see
+[docs/design-system.md](design-system.md)):
+
+- `toolbar-icon-btn` — icon button matching the workspace toolbar chrome
+- `btn-primary`, `btn-secondary` — standard action buttons
+- CSS variables: `--bg-primary/secondary/tertiary`, `--text-primary/secondary/muted`,
+  `--border`, `--accent`, `--action`, `--success`, `--warning`, `--error`,
+  `--font-mono`, `--radius`, …
+
+## Developing a plugin locally
+
+1. Create a folder with `plugin.json` and a built `dist/index.js`.
+2. In Ship Studio: **Plugins → Link Dev Plugin** and pick the folder. Linking
+   validates the manifest and requires `dist/index.js` to exist ("Did you run
+   the build?").
+3. Iterate: rebuild your bundle, then hit **Reload** on the plugin row — the
+   bundle is re-read from your folder (dev plugins load live from the linked
+   path, nothing is copied).
+4. **Unlink** removes it from the project's registry without touching your
+   files.
+
+Dev plugins are per-project; the plugin registry and installed files live at
+`{project}/.shipstudio/plugins/` (shared across git worktrees of the same
+repo).
+
+## Distributing a plugin
+
+**Install from URL** (Plugins → Install from URL) accepts a git URL
+(`https://`, `git://`, `ssh://`, or `git@…`) and does a `--depth 1` clone.
+Requirements:
+
+- `plugin.json` at the **repo root**
+- committed `dist/index.js`
+- the clone is used as-is: nothing is built, `.git` is stripped, the HEAD
+  commit is recorded for update checks
+
+**Updates**: the manager compares your repo's remote HEAD against the
+installed commit (`git ls-remote`) and offers a re-clone.
+
+**Plugin library**: the in-app library is driven by
+[`ship-studio/plugin-registry`](https://github.com/ship-studio/plugin-registry)
+(`registry.json` with `{ id, name, description, repo, author, category }`
+entries). Open a PR there to list your plugin. The
+[Vercel plugin](https://github.com/ship-studio/plugin-vercel) is a full
+real-world reference.
+
+## Walkthrough: hello-world
+
+[`test-plugins/hello-world/`](../test-plugins/hello-world/) is the minimal
+end-to-end example — a manifest (shown above) plus this bundle, written by
+hand with no build step:
+
+```js
+const React = window.__SHIPSTUDIO_REACT__;
+
+function HelloWorldButton() {
+  const ctx = window.__SHIPSTUDIO_PLUGIN_CONTEXT__;
+  return React.createElement(
+    'button',
+    {
+      className: 'toolbar-icon-btn',
+      title: 'Hello World Plugin',
+      onClick: () => ctx.actions.showToast('Hello from plugin!', 'success'),
+    },
+    'HW'
+  );
+}
+
+export const name = 'Hello World';
+export const slots = { toolbar: HelloWorldButton };
+export function onActivate() { console.log('[hello-world] activated'); }
+export function onDeactivate() { console.log('[hello-world] deactivated'); }
+```
+
+Link it via **Plugins → Link Dev Plugin**, and a "HW" button appears in the
+Plugins dropdown; clicking it fires a toast through the plugin context.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `No plugin.json found` on install | Manifest isn't at the repo root |
+| `Plugin bundle not found at …/dist/index.js` | You didn't commit/build the bundle |
+| `Requires plugin API v…` at load | `api_version` outside the app's supported set (`0`, `1`) |
+| `Plugin '{name}' requires Ship Studio v…` | `min_app_version` newer than the running app |
+| `…requests commands that are not available to plugins` | `required_commands` includes something outside the allow-list |
+| Plugin crashes instantly / hooks error | You bundled your own React — externalize it |
+| `"…" crashed — disabled for this session` chip | Your component threw; fix and re-enable from Plugins |

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -143,8 +143,22 @@ async fn run_agent_headless(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        error!("{} CLI failed: {}", agent.display_name, stderr);
-        return Err(format!("{} CLI failed: {}", agent.display_name, stderr).into());
+        // A silent non-zero exit (empty stderr) used to surface as the
+        // undiagnosable "Claude Code CLI failed: " — fall back to the exit code
+        // and a stdout snippet so there's something to act on (issue #269).
+        let detail = if stderr.trim().is_empty() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let snippet: String = stdout.trim().chars().take(300).collect();
+            if snippet.is_empty() {
+                format!("exit code {:?}, no output", output.status.code())
+            } else {
+                format!("exit code {:?}: {snippet}", output.status.code())
+            }
+        } else {
+            stderr.trim().to_string()
+        };
+        error!("{} CLI failed: {}", agent.display_name, detail);
+        return Err(format!("{} CLI failed: {}", agent.display_name, detail).into());
     }
 
     match final_message {

--- a/src-tauri/src/commands/external_projects.rs
+++ b/src-tauri/src/commands/external_projects.rs
@@ -164,7 +164,7 @@ pub async fn register_external_project(app: AppHandle) -> Result<Option<String>,
         }
 
         return Err(
-            "Selected folder doesn't appear to be a project — no package.json or .html files found."
+            "Selected folder doesn't appear to be a project — no project files found (package.json, .html, .git, or a language manifest like Cargo.toml, go.mod, pyproject.toml…)."
                 .to_string()
                 .into(),
         );

--- a/src-tauri/src/commands/git/branches.rs
+++ b/src-tauri/src/commands/git/branches.rs
@@ -66,7 +66,10 @@ pub async fn list_branches(project_path: String) -> Result<Vec<BranchInfo>, Comm
         .map_err(|e| e.to_string())?;
 
     if !output.status.success() {
-        return Err(("Failed to list branches".to_string()).into());
+        // Include git's stderr — a bare "Failed to list branches" is
+        // undiagnosable from telemetry (issue #252).
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err((format!("Failed to list branches: {}", stderr.trim())).into());
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -65,8 +65,12 @@ pub(crate) async fn run_git_net(
     // precede the subcommand in `args`.
     if let Some(gh) = find_executable("gh") {
         cmd.arg("-c").arg("credential.helper=");
+        // Git hands a `!`-prefixed helper to `sh -c`, which word-splits on
+        // spaces — so the path must be quoted or a default Windows install
+        // (`C:\Program Files\GitHub CLI\gh.exe`) becomes the command `C:\Program`
+        // (issue #265). Single quotes keep backslashes literal under POSIX sh.
         cmd.arg("-c").arg(format!(
-            "credential.helper=!{} auth git-credential",
+            "credential.helper=!'{}' auth git-credential",
             gh.display()
         ));
     }
@@ -118,7 +122,24 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
         .map_err(|e| e.to_string())?;
 
     if !add_output.status.success() {
-        return Err(String::from_utf8_lossy(&add_output.stderr).to_string());
+        let add_stderr = String::from_utf8_lossy(&add_output.stderr).to_string();
+        // In a sparse-checkout repo, `git add -A` exits 1 when untracked files
+        // exist outside the sparse cone (e.g. a CMS sync writing into an
+        // excluded dir) — blocking every commit/publish even though the in-cone
+        // changes are fine (issue #275). Retry with --sparse, which stages
+        // out-of-cone paths instead of refusing.
+        if add_stderr.contains("outside of your sparse-checkout definition") {
+            let sparse_output = create_command("git")
+                .args(["add", "-A", "--sparse"])
+                .current_dir(path)
+                .output()
+                .map_err(|e| e.to_string())?;
+            if !sparse_output.status.success() {
+                return Err(String::from_utf8_lossy(&sparse_output.stderr).to_string());
+            }
+        } else {
+            return Err(add_stderr);
+        }
     }
 
     // Check if there are staged changes to commit
@@ -136,7 +157,21 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
         .map_err(|e| e.to_string())?;
 
     if !commit_output.status.success() {
-        return Err(String::from_utf8_lossy(&commit_output.stderr).to_string());
+        // `status --porcelain` can report entries `add -A` couldn't stage (e.g.
+        // a nested git repo), so the commit can still come up empty. Git prints
+        // "nothing to commit" to *stdout* and leaves stderr blank — treat it as
+        // the no-op it is instead of surfacing an empty error (issue #274).
+        let stdout = String::from_utf8_lossy(&commit_output.stdout);
+        if stdout.contains("nothing to commit") || stdout.contains("working tree clean") {
+            return Ok(false);
+        }
+        let stderr = String::from_utf8_lossy(&commit_output.stderr);
+        let detail = if stderr.trim().is_empty() {
+            stdout.to_string()
+        } else {
+            stderr.to_string()
+        };
+        return Err(detail);
     }
 
     Ok(true)
@@ -297,13 +332,21 @@ pub async fn check_prerequisites() -> Vec<PrerequisiteCheck> {
 }
 
 /// Returns the configured projects root directory (custom or default `~/ShipStudio`).
+///
+/// Normalized to forward slashes: the frontend builds project paths by
+/// concatenating `/` onto this value, so a native Windows backslash path here
+/// produces mixed-separator paths (`C:\Users\x\ShipStudio/proj`) that break
+/// `@tauri-apps/plugin-fs` scope resolution (issue #257).
 #[tauri::command]
 #[tracing::instrument]
 pub async fn get_shipstudio_dir() -> Result<String, CommandError> {
-    Ok(crate::utils::projects_root()?.to_string_lossy().to_string())
+    Ok(crate::utils::normalize_separators(
+        &crate::utils::projects_root()?.to_string_lossy(),
+    ))
 }
 
 /// Creates the configured projects root directory if it doesn't exist.
+/// Forward-slash normalized for the same reason as [`get_shipstudio_dir`].
 #[tauri::command]
 #[tracing::instrument]
 pub async fn ensure_shipstudio_dir() -> Result<String, CommandError> {
@@ -318,7 +361,9 @@ pub async fn ensure_shipstudio_dir() -> Result<String, CommandError> {
         })?;
     }
 
-    Ok(projects_dir.to_string_lossy().to_string())
+    Ok(crate::utils::normalize_separators(
+        &projects_dir.to_string_lossy(),
+    ))
 }
 
 #[tauri::command]
@@ -467,6 +512,35 @@ mod tests {
         // No changes since last commit
         let committed = git_stage_and_commit(tmp.path(), "should be noop").unwrap();
         assert!(!committed, "no changes should return false");
+    }
+
+    /// Issue #275: with sparse-checkout enabled, untracked files outside the
+    /// cone make `git add -A` exit 1 — staging must retry with `--sparse`
+    /// instead of aborting every commit/publish for the whole repo.
+    #[test]
+    fn stage_and_commit_survives_files_outside_sparse_cone() {
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        std::fs::create_dir_all(tmp.path().join("src/app")).unwrap();
+        std::fs::write(tmp.path().join("src/app/a.txt"), "in cone").unwrap();
+        std::fs::create_dir_all(tmp.path().join("src/images")).unwrap();
+        std::fs::write(tmp.path().join("src/images/b.txt"), "out of cone").unwrap();
+        commit_all(tmp.path(), "initial");
+        assert!(Command::new("git")
+            .args(["sparse-checkout", "set", "src/app"])
+            .current_dir(tmp.path())
+            .status()
+            .expect("git sparse-checkout")
+            .success());
+        // A build/CMS step writes into the excluded directory.
+        std::fs::create_dir_all(tmp.path().join("src/images/airtable")).unwrap();
+        std::fs::write(tmp.path().join("src/images/airtable/x.webp"), "img").unwrap();
+
+        let result = git_stage_and_commit(tmp.path(), "sync assets");
+        assert!(
+            result.is_ok(),
+            "sparse-checkout stray files must not abort commit: {result:?}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/git/sync.rs
+++ b/src-tauri/src/commands/git/sync.rs
@@ -138,6 +138,10 @@ pub async fn discard_changes(project_path: String) -> Result<(), CommandError> {
 #[tracing::instrument(skip(project_path, message), fields(project = %project_path))]
 pub async fn commit_changes(project_path: String, message: String) -> Result<bool, CommandError> {
     let validated_path = validate_project_path(&project_path)?;
+    // Self-heal a missing user.name/user.email from the gh CLI identity before
+    // committing, mirroring push_to_github — without it, Submit for Review's
+    // auto-commit dies on git's "Please tell me who you are" (issue #276).
+    let _ = crate::commands::github::ensure_git_identity(&validated_path);
     let committed = git_stage_and_commit(&validated_path, &message)?;
     if committed {
         GIT_CACHE.invalidate_status(&project_path);

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -58,6 +58,11 @@ pub fn get_gh_command() -> Command {
     };
     cmd.env("PATH", get_extended_path());
     cmd.envs(crate::commands::accounts::get_env_vars_for_active_account());
+    // No caller feeds gh stdin, and a GUI-spawned gh has no tty — if gh ever
+    // decides to prompt (stale credential, ambiguous host) it must fail fast
+    // instead of blocking on input that can never arrive until the 60s network
+    // timeout kills it with a bare "timed out" (issue #259).
+    cmd.stdin(std::process::Stdio::null());
     cmd
 }
 
@@ -76,6 +81,8 @@ pub fn get_gh_command_for_project(project_path: &std::path::Path) -> Command {
     cmd.envs(crate::commands::accounts::get_env_vars_for_project(
         project_path,
     ));
+    // Fail fast instead of blocking on a prompt — see get_gh_command().
+    cmd.stdin(std::process::Stdio::null());
     cmd
 }
 

--- a/src-tauri/src/commands/ide/mod.rs
+++ b/src-tauri/src/commands/ide/mod.rs
@@ -71,12 +71,25 @@ fn find_windows_browser(relative_path: &str) -> Option<PathBuf> {
 pub(crate) fn find_chromium_browser() -> Option<PathBuf> {
     #[cfg(target_os = "macos")]
     {
+        // Brave and Arc are Chromium-based and drive the same --headless=new
+        // screenshot flags; the Windows list below already includes Brave. A
+        // user with only Brave/Arc installed had no working thumbnail fallback
+        // (issues #262/#263). Per-user ~/Applications installs count too.
         let mac_paths = [
-            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-            "/Applications/Chromium.app/Contents/MacOS/Chromium",
-            "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+            "Google Chrome.app/Contents/MacOS/Google Chrome",
+            "Chromium.app/Contents/MacOS/Chromium",
+            "Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+            "Brave Browser.app/Contents/MacOS/Brave Browser",
+            "Arc.app/Contents/MacOS/Arc",
         ];
-        mac_paths.iter().map(PathBuf::from).find(|p| p.exists())
+        let mut roots = vec![PathBuf::from("/Applications")];
+        if let Some(home) = dirs::home_dir() {
+            roots.push(home.join("Applications"));
+        }
+        roots
+            .iter()
+            .flat_map(|root| mac_paths.iter().map(move |p| root.join(p)))
+            .find(|p| p.exists())
     }
 
     #[cfg(target_os = "windows")]

--- a/src-tauri/src/commands/ide/screenshots/thumbnail.rs
+++ b/src-tauri/src/commands/ide/screenshots/thumbnail.rs
@@ -163,7 +163,7 @@ pub async fn capture_project_thumbnail(
         Ok(thumbnail_path_str)
     } else {
         Err(
-            "No supported browser found for screenshots (Chrome, Chromium, or Edge required)"
+            "No supported browser found for screenshots (a Chromium-based browser is required: Chrome, Chromium, Edge, Brave, or Arc)"
                 .to_string()
                 .into(),
         )

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -9,7 +9,7 @@
 //! - Claude: `claude mcp list`, `claude mcp add`, `claude mcp remove`
 //! - Codex: `codex mcp list`, `codex mcp add`, `codex mcp remove`
 use crate::errors::CommandError;
-use crate::utils::{create_command, find_executable, get_extended_path, validate_project_path};
+use crate::utils::{create_command, get_extended_path, validate_project_path};
 use serde::Serialize;
 
 /// Represents an MCP server configured for an agent.
@@ -47,8 +47,14 @@ fn strip_ansi(s: &str) -> String {
 }
 
 /// Find the agent binary path.
+///
+/// Uses the same thorough resolver as the rest of the app
+/// (`claude::find_binary_by_name`: every NVM version's bin, `~/.<agent>/bin`,
+/// pnpm/volta/fnm dirs…) — the narrower `find_executable` missed installs like
+/// `~/.codex/bin/codex`, so the MCP modal said "Codex binary not found" while
+/// the Agents panel showed it installed (issue #250).
 fn find_agent_binary(agent: &crate::agent::AgentConfig) -> Result<std::path::PathBuf, String> {
-    find_executable(agent.binary_name)
+    crate::commands::claude::find_binary_by_name(agent.binary_name)
         .ok_or_else(|| format!("{} binary not found", agent.display_name))
 }
 

--- a/src-tauri/src/commands/plugins/plugin_storage.rs
+++ b/src-tauri/src/commands/plugins/plugin_storage.rs
@@ -109,6 +109,17 @@ pub async fn exec_plugin_shell(
         return Err((format!("Plugin '{plugin_id}' not found")).into());
     }
 
+    // Resolve the binary up front so a missing tool yields an actionable
+    // message naming the plugin and command, not a raw "No such file or
+    // directory (os error 2)" from Command::output() (issue #256). Mirrors
+    // resolve_git() in plugin_lifecycle.rs / get_gh_command() in github.rs.
+    if crate::utils::find_executable(&command).is_none() {
+        return Err((format!(
+            "Plugin '{plugin_id}' tried to run '{command}', but it isn't installed or not on PATH."
+        ))
+        .into());
+    }
+
     // Build and execute command with timeout
     let timeout = timeout_secs.unwrap_or(120);
     let output = tokio::time::timeout(

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -188,13 +188,29 @@ fn ensure_gitignore_has_shipstudio_sync(project: &std::path::Path) -> Result<(),
 /// Check if a directory is a valid project.
 /// Accepts any directory inside ~/ShipStudio that has project files,
 /// a .gitignore (blank projects), or a .shipstudio metadata folder.
+///
+/// The language-ecosystem markers match `looks_like_project_root` in
+/// external_projects.rs — the manual "Select Project Folder" picker used to
+/// reject a Rust/Go/Python/Ruby/Java/PHP project that the automatic
+/// registration path would happily accept (issue #251).
 pub(crate) fn is_valid_project(path: &std::path::Path) -> bool {
+    const ECOSYSTEM_MARKERS: &[&str] = &[
+        "Cargo.toml",
+        "go.mod",
+        "pyproject.toml",
+        "requirements.txt",
+        "Gemfile",
+        "pom.xml",
+        "build.gradle",
+        "composer.json",
+    ];
     path.is_dir()
         && (path.join("package.json").exists()
             || detection::has_html_files(path)
             || path.join(".gitignore").exists()
             || path.join(".shipstudio").exists()
-            || path.join(".git").exists())
+            || path.join(".git").exists()
+            || ECOSYSTEM_MARKERS.iter().any(|m| path.join(m).exists()))
 }
 
 /// Counts app-managed git worktrees for a project: subdirectories of
@@ -982,13 +998,20 @@ fn remove_dir_all_robust(path: &Path) -> std::io::Result<()> {
         );
     }
 
+    // Backoff schedule totalling ~8s: field reports show antivirus / Search
+    // indexer locks routinely outlasting the previous flat ~1s budget (10 ×
+    // 100ms), still surfacing "os error 32" to the user (issue #253). Growing
+    // sleeps keep the common quick-release case fast while giving a slow
+    // scanner time to let go.
+    let mut delay = std::time::Duration::from_millis(100);
     let mut retries = 10;
     loop {
         match std::fs::remove_dir_all(path) {
             Ok(()) => return Ok(()),
             Err(e) if retries > 0 && is_retryable_delete_error(&e) => {
                 retries -= 1;
-                std::thread::sleep(std::time::Duration::from_millis(100));
+                std::thread::sleep(delay);
+                delay = (delay * 2).min(std::time::Duration::from_secs(1));
             }
             Err(e) => return Err(e),
         }
@@ -1519,6 +1542,22 @@ mod tests {
                 .lock()
                 .unwrap_or_else(|e| e.into_inner()) = None;
         }
+    }
+
+    /// Issue #251: the manual "Select Project Folder" picker must accept the
+    /// same language-ecosystem projects the automatic registration path does.
+    #[test]
+    fn is_valid_project_accepts_ecosystem_manifests() {
+        for marker in ["Cargo.toml", "go.mod", "pyproject.toml", "Gemfile"] {
+            let tmp = tempfile::tempdir().unwrap();
+            std::fs::write(tmp.path().join(marker), "").unwrap();
+            assert!(
+                is_valid_project(tmp.path()),
+                "{marker} alone should mark a valid project"
+            );
+        }
+        let empty = tempfile::tempdir().unwrap();
+        assert!(!is_valid_project(empty.path()));
     }
 
     #[test]

--- a/src-tauri/src/commands/pty_session.rs
+++ b/src-tauri/src/commands/pty_session.rs
@@ -430,11 +430,23 @@ pub fn pty_session_write(session_id: String, data: Vec<u8>) -> Result<(), Comman
     let Some(session) = session else {
         return Err("unknown session".to_string().into());
     };
+    // A write racing the child's exit hits EIO on the closed PTY master —
+    // surface it as the expected "session ended" state, not a raw
+    // "Input/output error (os error 5)" (issue #260).
+    if !session.alive.load(std::sync::atomic::Ordering::Relaxed) {
+        return Err("terminal session has ended".to_string().into());
+    }
     let mut w = session
         .writer
         .lock()
         .map_err(|e| format!("writer lock poisoned: {e}"))?;
-    w.write_all(&data).map_err(|e| format!("write: {e}"))?;
+    w.write_all(&data).map_err(|e| {
+        if e.raw_os_error() == Some(5) {
+            "terminal session has ended".to_string()
+        } else {
+            format!("write: {e}")
+        }
+    })?;
     Ok(())
 }
 

--- a/src-tauri/src/commands/publishing.rs
+++ b/src-tauri/src/commands/publishing.rs
@@ -73,46 +73,10 @@ pub async fn publish_to_github(
     // Ensure git identity matches GitHub account before committing
     let _ = ensure_git_identity(&validated_path);
 
-    // Stage all changes
-    let output = create_command("git")
-        .args(["add", "-A"])
-        .current_dir(&validated_path)
-        .output()
-        .map_err(CommandError::from)?;
-
-    if !output.status.success() {
-        return Err(CommandError::Process {
-            cmd: "git add -A".to_string(),
-            exit_code: output.status.code().unwrap_or(-1),
-            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-        });
-    }
-
-    // Check if there are changes to commit
-    let status = create_command("git")
-        .args(["status", "--porcelain"])
-        .current_dir(&validated_path)
-        .output()
-        .map_err(CommandError::from)?;
-
-    let has_changes = !String::from_utf8_lossy(&status.stdout).trim().is_empty();
-
-    if has_changes {
-        // Commit changes
-        let output = create_command("git")
-            .args(["commit", "-m", &message])
-            .current_dir(&validated_path)
-            .output()
-            .map_err(CommandError::from)?;
-
-        if !output.status.success() {
-            return Err(CommandError::Process {
-                cmd: "git commit".to_string(),
-                exit_code: output.status.code().unwrap_or(-1),
-                stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-            });
-        }
-    }
+    // Stage and commit through the shared helper: it retries sparse-checkout
+    // refusals (issue #275) and treats an empty commit as a no-op instead of a
+    // hard failure (issue #274), unlike the hand-rolled sequence it replaces.
+    git_stage_and_commit(&validated_path, &message).map_err(CommandError::from)?;
 
     // Push to origin
     let output = run_git_net(&["push", "-u", "origin", &branch], &validated_path, "push").await?;
@@ -146,8 +110,10 @@ pub async fn publish_to_staging(
     // Ensure git identity matches GitHub account before committing
     let _ = ensure_git_identity(&validated_path);
 
-    // Stage and commit any changes
-    let _ = git_stage_and_commit(&validated_path, &message);
+    // Stage and commit any changes. A real staging/commit failure must not be
+    // swallowed — the push below would silently deploy stale code (benign cases
+    // like "nothing to commit" and sparse-checkout are handled in the helper).
+    git_stage_and_commit(&validated_path, &message).map_err(CommandError::from)?;
 
     // Push to staging branch - Vercel auto-deploys via GitHub integration
     // Note: Using regular push instead of force push to avoid overwriting others' work
@@ -198,8 +164,8 @@ pub async fn publish_to_production(
     // Ensure git identity matches GitHub account before committing
     let _ = ensure_git_identity(&validated_path);
 
-    // Stage and commit any changes
-    let _ = git_stage_and_commit(&validated_path, &message);
+    // Stage and commit any changes (real failures propagate — see staging).
+    git_stage_and_commit(&validated_path, &message).map_err(CommandError::from)?;
 
     // Push to main branch - Vercel auto-deploys to production via GitHub integration
     let push_output = run_git_net(
@@ -253,38 +219,11 @@ pub async fn publish_branch(
     // Ensure git identity matches GitHub account before committing
     let _ = ensure_git_identity(&validated_path);
 
-    // Stage all changes
-    let _ = create_command("git")
-        .args(["add", "-A"])
-        .current_dir(&validated_path)
-        .output();
-
-    // Check if there are changes to commit
-    let status = create_command("git")
-        .args(["status", "--porcelain"])
-        .current_dir(&validated_path)
-        .output()
-        .map_err(CommandError::from)?;
-
-    let has_changes = !String::from_utf8_lossy(&status.stdout).trim().is_empty();
-
-    if has_changes {
-        // Commit changes
-        let commit_output = create_command("git")
-            .args(["commit", "-m", &message])
-            .current_dir(&validated_path)
-            .output()
-            .map_err(CommandError::from)?;
-
-        if !commit_output.status.success() {
-            let stderr = String::from_utf8_lossy(&commit_output.stderr);
-            return Err(CommandError::Process {
-                cmd: "git commit".to_string(),
-                exit_code: commit_output.status.code().unwrap_or(-1),
-                stderr: stderr.to_string(),
-            });
-        }
-    }
+    // Stage and commit through the shared helper. The old hand-rolled sequence
+    // discarded `git add -A`'s result entirely, so a staging failure surfaced
+    // later as an inexplicable "Uncommitted changes" on switch (issue #273);
+    // the helper also handles sparse-checkout (#275) and empty commits (#274).
+    git_stage_and_commit(&validated_path, &message).map_err(CommandError::from)?;
 
     // Push to origin
     let push_output =

--- a/src-tauri/src/commands/pull_requests.rs
+++ b/src-tauri/src/commands/pull_requests.rs
@@ -48,7 +48,13 @@ pub async fn list_pull_requests(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        if stderr.contains("no pull requests") || stderr.contains("Could not") {
+        // "no git remotes found" is gh's message for a local-only repo that was
+        // never connected to GitHub — an expected state (github.rs models it as
+        // the "no-remote" status), not an error worth toasting (issue #268).
+        if stderr.contains("no pull requests")
+            || stderr.contains("Could not")
+            || stderr.contains("no git remotes found")
+        {
             return Ok(Vec::new());
         }
         return Err((stderr.to_string()).into());

--- a/src-tauri/src/commands/setup/status.rs
+++ b/src-tauri/src/commands/setup/status.rs
@@ -362,6 +362,44 @@ pub async fn get_full_setup_status() -> FullSetupStatus {
         (version, whoami)
     };
 
+    // Claude auth goes through the ONE shared truth (CLI-first, file
+    // fallback) — the same answer the wizard pre-checks and dashboard get.
+    // File indicators alone lied in both directions: they survive a sign-out
+    // (issue #159) and don't exist yet mid-first-login on a fresh machine,
+    // which deadlocked the Connect button against this checklist. Computed
+    // once here (not per item) because the guided phase polls this command
+    // every 3s and the CLI probe spawns a subprocess.
+    //
+    // Joined with the other probes rather than awaited after them: run
+    // sequentially, its up-to-10s CLI probe stacked on the ~8s probe phase
+    // and could blow past the frontend's boot-gate timeout, dumping a fully
+    // set-up user into onboarding (issue #272).
+    let claude_binary_ready = agent_paths
+        .get(
+            ALL_AGENTS
+                .iter()
+                .position(|a| a.id == "claude-code")
+                .unwrap_or(0),
+        )
+        .map(|p| p.is_some())
+        .unwrap_or(false);
+    let claude_auth_fut = async {
+        if !claude_binary_ready {
+            return (false, false);
+        }
+        if active_account_id == crate::commands::accounts::DEFAULT_ACCOUNT_ID {
+            let active = crate::commands::setup::auth::claude_auth_truth(&active_account_id).await;
+            (active, active)
+        } else {
+            tokio::join!(
+                crate::commands::setup::auth::claude_auth_truth(&active_account_id),
+                crate::commands::setup::auth::claude_auth_truth(
+                    crate::commands::accounts::DEFAULT_ACCOUNT_ID,
+                )
+            )
+        }
+    };
+
     let (
         pkg_mgr_version,
         node_version,
@@ -369,13 +407,15 @@ pub async fn get_full_setup_status() -> FullSetupStatus {
         (gh_version, gh_auth, gh_username),
         agent_probes,
         (vercel_version, vercel_whoami_result),
+        (claude_auth_active, claude_auth_global),
     ) = tokio::join!(
         pkg_mgr_fut,
         node_fut,
         git_fut,
         gh_fut,
         agents_fut,
-        vercel_fut
+        vercel_fut,
+        claude_auth_fut
     );
 
     let mut items = Vec::new();
@@ -492,40 +532,10 @@ pub async fn get_full_setup_status() -> FullSetupStatus {
         error_message: None,
     });
 
-    // 6-7. Agent CLIs and Auth — check ALL agents (probed above with timeouts)
+    // 6-7. Agent CLIs and Auth — check ALL agents (probed above with timeouts).
+    // claude_auth_active / claude_auth_global come from the joined
+    // claude_auth_fut above.
     let mut detected_agents = Vec::new();
-
-    // Claude auth goes through the ONE shared truth (CLI-first, file
-    // fallback) — the same answer the wizard pre-checks and dashboard get.
-    // File indicators alone lied in both directions: they survive a sign-out
-    // (issue #159) and don't exist yet mid-first-login on a fresh machine,
-    // which deadlocked the Connect button against this checklist. Computed
-    // once here (not per item) because the guided phase polls this command
-    // every 3s and the CLI probe spawns a subprocess.
-    let claude_binary_ready = agent_paths
-        .get(
-            ALL_AGENTS
-                .iter()
-                .position(|a| a.id == "claude-code")
-                .unwrap_or(0),
-        )
-        .map(|p| p.is_some())
-        .unwrap_or(false);
-    let claude_auth_active = if claude_binary_ready {
-        crate::commands::setup::auth::claude_auth_truth(&active_account_id).await
-    } else {
-        false
-    };
-    let claude_auth_global = if !claude_binary_ready {
-        false
-    } else if active_account_id == crate::commands::accounts::DEFAULT_ACCOUNT_ID {
-        claude_auth_active
-    } else {
-        crate::commands::setup::auth::claude_auth_truth(
-            crate::commands::accounts::DEFAULT_ACCOUNT_ID,
-        )
-        .await
-    };
 
     for ((agent, agent_path), (agent_version, command_auth)) in
         ALL_AGENTS.iter().zip(&agent_paths).zip(agent_probes)

--- a/src-tauri/src/commands/templates.rs
+++ b/src-tauri/src/commands/templates.rs
@@ -6,6 +6,20 @@ use crate::errors::CommandError;
 
 const TEMPLATES_API_URL: &str = "https://www.ship.studio/api/v1/templates";
 
+/// Render a reqwest error with its full source chain. reqwest's `Display` only
+/// prints the top-level context ("error sending request for url (...)"), while
+/// the actionable detail — DNS failure, connection refused, timed out, TLS —
+/// lives in the `source()` chain (issue #255).
+fn describe_reqwest_error(e: &reqwest::Error) -> String {
+    let mut msg = e.to_string();
+    let mut source = std::error::Error::source(e);
+    while let Some(s) = source {
+        msg.push_str(&format!(": {s}"));
+        source = s.source();
+    }
+    msg
+}
+
 /// Fetch community templates from the Ship Studio API.
 /// Accepts optional query parameters that map to the API spec.
 /// Returns the raw JSON string so the frontend can parse it.
@@ -55,7 +69,7 @@ pub async fn fetch_community_templates(
         .get(url)
         .send()
         .await
-        .map_err(|e| format!("Failed to fetch templates: {e}"))?;
+        .map_err(|e| format!("Failed to fetch templates: {}", describe_reqwest_error(&e)))?;
 
     if !response.status().is_success() {
         return Err((format!("API returned status {}", response.status())).into());
@@ -76,11 +90,12 @@ pub async fn download_template_zip(url: String) -> Result<String, CommandError> 
         .build()
         .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
 
-    let response = client
-        .get(&url)
-        .send()
-        .await
-        .map_err(|e| format!("Failed to download template: {e}"))?;
+    let response = client.get(&url).send().await.map_err(|e| {
+        format!(
+            "Failed to download template: {}",
+            describe_reqwest_error(&e)
+        )
+    })?;
 
     if !response.status().is_success() {
         return Err((format!("Download failed with status {}", response.status())).into());

--- a/src-tauri/src/error_reporting.rs
+++ b/src-tauri/src/error_reporting.rs
@@ -374,10 +374,21 @@ fn command_error_fingerprint(err: &crate::errors::CommandError) -> Option<String
 /// error log). Called from `CommandError`'s `Serialize` impl.
 ///
 /// `NotAuthenticated` is skipped: a not-yet-connected integration is an
-/// expected state, not a malfunction.
+/// expected state, not a malfunction. Same for "not a git repository" — a
+/// project that hasn't been `git init`ed is routine (the frontend already
+/// `.catch(() => null)`s it on a 10s poll), and reporting it spams telemetry
+/// with a non-bug on every poll tick (issue #254).
 pub fn report_command_error(err: &crate::errors::CommandError) {
     if matches!(err, crate::errors::CommandError::NotAuthenticated { .. }) {
         return;
+    }
+    if let crate::errors::CommandError::Other { message } = err {
+        if message
+            .to_ascii_lowercase()
+            .contains("not a git repository")
+        {
+            return;
+        }
     }
     let fingerprint = command_error_fingerprint(err);
     report_error(

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -591,11 +591,17 @@ async fn proxy_http_request(
     // Connect to target via hostname so both IPv4 and IPv6 are tried.
     // Vite-based dev servers (Astro, SvelteKit, Nuxt) bind to `localhost` which
     // resolves to `::1` (IPv6) on macOS -- hardcoding 127.0.0.1 fails for those.
+    // Each timeout site names its phase: all three produce the same bare
+    // "deadline has elapsed" otherwise, making a 5s connect stall
+    // indistinguishable from a 5-minute hung response (issue #271).
     let stream = tokio::time::timeout(
         UPSTREAM_CONNECT_TIMEOUT,
         TcpStream::connect(format!("localhost:{target_port}")),
     )
-    .await??;
+    .await
+    .map_err(|_| {
+        format!("connect to localhost:{target_port} timed out after {UPSTREAM_CONNECT_TIMEOUT:?}")
+    })??;
     let io = TokioIo::new(stream);
 
     let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
@@ -658,7 +664,12 @@ async fn proxy_http_request(
         UPSTREAM_RESPONSE_TIMEOUT,
         sender.send_request(forwarded_req),
     )
-    .await??;
+    .await
+    .map_err(|_| {
+        format!(
+            "dev server on localhost:{target_port} didn't answer within {UPSTREAM_RESPONSE_TIMEOUT:?}"
+        )
+    })??;
 
     // Intercept auth-handshake redirect loops before they leave the proxy.
     // Forwarding the redirect would bounce the iframe through a third-party
@@ -714,7 +725,12 @@ async fn proxy_http_request(
                 status.as_u16()
             );
             let body_bytes = tokio::time::timeout(HTML_BODY_TIMEOUT, resp.collect())
-                .await??
+                .await
+                .map_err(|_| {
+                    format!(
+                        "reading error page body from localhost:{target_port} timed out after {HTML_BODY_TIMEOUT:?}"
+                    )
+                })??
                 .to_bytes();
             if body_bytes.len() < MAX_BODY_SIZE {
                 full_body(Bytes::from(inject_error_into_html(
@@ -800,22 +816,36 @@ async fn handle_websocket_upgrade(
     req: Request<Incoming>,
     target_port: u16,
 ) -> Result<Response<ProxyBody>, hyper::Error> {
-    // Connect via hostname for IPv4/IPv6 compatibility (see proxy_http_request)
-    let target_stream = match tokio::time::timeout(
-        UPSTREAM_CONNECT_TIMEOUT,
-        TcpStream::connect(format!("localhost:{target_port}")),
-    )
-    .await
-    .map_err(std::io::Error::from)
-    .and_then(|r| r)
-    {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::error!("[Proxy] WebSocket target connection failed: {}", e);
-            return Ok(Response::builder()
-                .status(StatusCode::BAD_GATEWAY)
-                .body(full_body(Bytes::from("WebSocket proxy error")))
-                .unwrap());
+    // Connect via hostname for IPv4/IPv6 compatibility (see proxy_http_request).
+    // Retry briefly on connection-refused: an HMR socket's upgrade often lands
+    // mid dev-server restart, and a single missed connect used to hard-fail the
+    // upgrade with BAD_GATEWAY instead of riding out the gap (issue #258). The
+    // retry loop stays bounded by UPSTREAM_CONNECT_TIMEOUT overall.
+    let connect_deadline = tokio::time::Instant::now() + UPSTREAM_CONNECT_TIMEOUT;
+    let target_stream = loop {
+        let attempt = tokio::time::timeout_at(
+            connect_deadline,
+            TcpStream::connect(format!("localhost:{target_port}")),
+        )
+        .await
+        .map_err(std::io::Error::from)
+        .and_then(|r| r);
+        match attempt {
+            Ok(s) => break s,
+            Err(e) => {
+                let retryable = e.kind() == std::io::ErrorKind::ConnectionRefused
+                    && tokio::time::Instant::now() + std::time::Duration::from_millis(250)
+                        < connect_deadline;
+                if retryable {
+                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                    continue;
+                }
+                tracing::error!("[Proxy] WebSocket target connection failed: {}", e);
+                return Ok(Response::builder()
+                    .status(StatusCode::BAD_GATEWAY)
+                    .body(full_body(Bytes::from("WebSocket proxy error")))
+                    .unwrap());
+            }
         }
     };
 

--- a/src-tauri/src/proxy/select_script.html
+++ b/src-tauri/src/proxy/select_script.html
@@ -575,6 +575,12 @@ document.addEventListener('beforeinput',function(e){if(txtEditing&&e.data&&/[<{]
 /* Paste as plain text, stripping the two chars that would break JSX/Astro markup
    (rather than dropping the whole paste). */
 document.addEventListener('paste',function(e){if(!txtEditing)return;e.preventDefault();var t=((e.clipboardData||window.clipboardData).getData('text/plain')||'').replace(/[<{]/g,'');if(t)document.execCommand('insertText',false,t);},true);
+/* Dropped text takes the browser's default rich-HTML insertion path, bypassing the
+   beforeinput/paste guards above — the illegal markup then survives until save, where
+   the backend rejects it and the whole edit is lost (issue #267). Mirror the paste
+   handler: plain text only, same char stripping. */
+document.addEventListener('drop',function(e){if(!txtEditing)return;e.preventDefault();var t=((e.dataTransfer&&e.dataTransfer.getData('text/plain'))||'').replace(/[<{]/g,'');if(t)document.execCommand('insertText',false,t);},true);
+document.addEventListener('dragover',function(e){if(txtEditing)e.preventDefault();},true);
 /* Keep the blue editing box sized to the element, and reposition the format bubble. */
 document.addEventListener('input',function(){if(txtEditing){place(hoverBox,txtEl);updateFmtBar();}},true);
 document.addEventListener('selectionchange',function(){if(txtEditing)updateFmtBar();});

--- a/src/components/branches/PullRequestsTab.tsx
+++ b/src/components/branches/PullRequestsTab.tsx
@@ -24,7 +24,7 @@ import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { Spinner } from '../primitives/Spinner';
 import { useOptionalToast } from '../../contexts/ToastContext';
-import { asCommandError, formatCommandError } from '../../lib/errors';
+import { asCommandError, formatCommandError, isMergeConflictError } from '../../lib/errors';
 
 interface PullRequestsTabProps {
   /** Project path for PR operations */
@@ -127,7 +127,16 @@ export function PullRequestsTab({
       setPostMergeInfo({ branchName: headRef, baseBranch: baseRef });
     } catch (e) {
       trackError('pr_merge', e, 'Workspace');
-      onToast?.(`Failed to merge: ${formatCommandError(asCommandError(e))}`, 'error');
+      // A PR can turn unmergeable between list fetch and click (stale/UNKNOWN
+      // `mergeable`). Route to the conflict-resolution flow like the Resolve
+      // button does, instead of dumping gh's raw multi-line stderr into a
+      // toast (issue #278).
+      if (isMergeConflictError(e) && onResolveConflicts) {
+        onToast?.('This pull request has merge conflicts', 'error');
+        onResolveConflicts(headRef, baseRef);
+      } else {
+        onToast?.(`Failed to merge: ${formatCommandError(asCommandError(e))}`, 'error');
+      }
     } finally {
       setMergingPr(null);
     }

--- a/src/components/branches/UnsavedChangesModal.tsx
+++ b/src/components/branches/UnsavedChangesModal.tsx
@@ -42,12 +42,25 @@ export function UnsavedChangesModal({
   const [isPublishing, setIsPublishing] = useState(false);
   const [isDiscarding, setIsDiscarding] = useState(false);
 
+  // The working tree can pick up new changes between this modal's action and
+  // the switch (dev-server config writes, background tooling), in which case
+  // the switch fails again with "Uncommitted changes" — a dead end inside the
+  // very modal meant to resolve it (issue #273). Retry once with auto-stash so
+  // stragglers can't strand the user.
+  const switchWithStashRetry = async () => {
+    const result = await switchBranch(projectPath, targetBranch, false);
+    if (!result.success && result.error?.includes('Uncommitted changes')) {
+      return switchBranch(projectPath, targetBranch, true);
+    }
+    return result;
+  };
+
   const handlePublishAndSwitch = async () => {
     setIsPublishing(true);
     try {
       await publishBranch(projectPath);
       onToast?.(`Published ${currentBranch}`, 'success');
-      const result = await switchBranch(projectPath, targetBranch, false);
+      const result = await switchWithStashRetry();
       if (result.success) {
         onSwitchComplete(targetBranch);
         onClose();
@@ -65,7 +78,7 @@ export function UnsavedChangesModal({
     setIsDiscarding(true);
     try {
       await discardChanges(projectPath);
-      const result = await switchBranch(projectPath, targetBranch, false);
+      const result = await switchWithStashRetry();
       if (result.success) {
         onToast?.(`Switched to ${targetBranch}`, 'success');
         onSwitchComplete(targetBranch);

--- a/src/components/terminal/BuildTerminal.tsx
+++ b/src/components/terminal/BuildTerminal.tsx
@@ -91,6 +91,9 @@ export function BuildTerminal({
     const container = containerRef.current;
     if (!container) return;
     let cancelled = false;
+    // Set once openPtySession resolves — resize calls before that would hit
+    // the backend's "unknown session" guard (issue #261).
+    let sessionOpened = false;
     const disposers: Array<() => void> = [];
 
     const term = new XTerm({
@@ -184,7 +187,11 @@ export function BuildTerminal({
           rows: Math.max(term.rows, 2),
           projectPath: cwd,
         });
+        sessionOpened = true;
         if (cancelled) return;
+        // Layout may have settled while the open was in flight (those resize
+        // callbacks were skipped) — sync the PTY to the current size once.
+        void resizePtySession(sessionId, Math.max(term.cols, 2), Math.max(term.rows, 2));
 
         const gate = createAttachGate((bytes) => {
           term.write(bytes);
@@ -238,10 +245,16 @@ export function BuildTerminal({
       }
     })();
 
+    // ResizeObserver fires an initial callback within a frame of observe(),
+    // while openPtySession is a real IPC round-trip — an unguarded resize can
+    // reach the backend before the session exists in its registry, producing
+    // "unknown session" (issue #261). Mirror Terminal.tsx's opened-guard.
     const resizeObserver = new ResizeObserver(() => {
       if (cancelled) return;
       safeFit();
-      void resizePtySession(sessionId, term.cols, term.rows);
+      if (sessionOpened) {
+        void resizePtySession(sessionId, term.cols, term.rows);
+      }
     });
     resizeObserver.observe(container);
 

--- a/src/hooks/useAppSetup.ts
+++ b/src/hooks/useAppSetup.ts
@@ -31,8 +31,13 @@ import type { AppView } from '../lib/types';
  * Tauri invoke (e.g. a CLI probe wedged on a broken PATH or network mount)
  * becomes a rejection that routes to onboarding instead of an eternal
  * spinner (#173). Timeouts are generous — these normally settle in <1s.
+ *
+ * Must comfortably exceed the backend's own worst case (~10s of internally
+ * bounded probes in get_full_setup_status, plus Windows' cmd.exe hop per
+ * subprocess) — a frontend gate tighter than the backend's own budget dumps
+ * fully-set-up users into onboarding (issue #272).
  */
-const BOOT_GATE_TIMEOUT_MS = 15_000;
+const BOOT_GATE_TIMEOUT_MS = 20_000;
 /** CLI status refresh spawns gh/agent subprocesses — give it a bit longer. */
 const CLI_REFRESH_TIMEOUT_MS = 20_000;
 

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -318,6 +318,34 @@ export function useProjectLifecycle({
     }
     openingProjectPathRef.current = project.path;
 
+    // Ensure external projects are registered BEFORE the workspace opens.
+    // Projects outside ~/ShipStudio can enter the app via session restore, URL
+    // params, or direct path — without this, all validate_project_path() calls
+    // would fail. Checked up front (not mid-open) because a refusal is fatal:
+    // proceeding used to land the user in a broken workspace where every
+    // backend call toasted "Security error: path ... is outside the projects
+    // directory" with no way out (issue #266). Local config read/write, ~ms.
+    try {
+      const wasRegistered = await invoke<boolean>('ensure_external_project_registered', {
+        path: project.path,
+      });
+      if (wasRegistered) {
+        logger.info(`[OpenProject] Auto-registered external project: ${project.path}`);
+      }
+    } catch (e) {
+      logger.warn('[OpenProject] Failed to ensure external project registration', { error: e });
+      openingProjectPathRef.current = null;
+      showToast(
+        `Can't open "${project.name}" — its folder isn't a recognized project location. Re-add it via "Select Project Folder".`,
+        'error'
+      );
+      return;
+    }
+    if (navVersion !== navigationVersionRef.current) {
+      openingProjectPathRef.current = null;
+      return; // Superseded while awaiting registration
+    }
+
     // Set the active project so every subsequent event in this session
     // auto-tags project context. The hash is sync (FNV-1a) so this never
     // blocks the render path. We intentionally do NOT emit the raw
@@ -522,20 +550,6 @@ export function useProjectLifecycle({
       // duplicate-window detection already ran above and would have
       // focused the existing window. Logged for diagnostics.
       logger.warn('[OpenProject] Failed to register project session', { error: e });
-    }
-
-    // Ensure external projects are registered before any backend commands run.
-    // Projects outside ~/ShipStudio can enter the app via session restore, URL params,
-    // or direct path — without this, all validate_project_path() calls would fail.
-    try {
-      const wasRegistered = await invoke<boolean>('ensure_external_project_registered', {
-        path: project.path,
-      });
-      if (wasRegistered) {
-        logger.info(`[OpenProject] Auto-registered external project: ${project.path}`);
-      }
-    } catch (e) {
-      logger.warn('[OpenProject] Failed to ensure external project registration', { error: e });
     }
 
     // We never stop the outgoing project's dev server on switch — that's

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -13,8 +13,8 @@ import { invoke } from '@tauri-apps/api/core';
 import { spawn, IPty } from 'tauri-pty';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
 import { homeDir } from '@tauri-apps/api/path';
-import { readTextFile } from '@tauri-apps/plugin-fs';
 import { logger } from './logger';
+import { readProjectFile } from './code';
 import { trackError } from './analytics';
 import { isWindows } from './setup';
 
@@ -349,10 +349,14 @@ export async function startDevServer(
     // Try to read package.json to get the dev script and parse it to use correct port
     // We use npx to run the command so that local node_modules/.bin executables are found
     try {
-      const packageJsonPath = `${projectPath}/package.json`;
-      logger.info('[DevServer] Reading package.json', { path: packageJsonPath, desiredPort: port });
-      const packageJson = await readTextFile(packageJsonPath);
-      const pkg = JSON.parse(packageJson) as { scripts?: { dev?: string } };
+      logger.info('[DevServer] Reading package.json', { projectPath, desiredPort: port });
+      // Read through the backend rather than plugin-fs: validate_project_path
+      // accepts registered external projects anywhere on disk, while the
+      // static fs scope only covers $HOME and /Volumes — so projects in e.g.
+      // /Applications/XAMPP lost dev-script parsing (issue #264). It also
+      // sidesteps Windows mixed-separator concatenation (issue #257).
+      const file = await readProjectFile(projectPath, 'package.json');
+      const pkg = JSON.parse(file.content) as { scripts?: { dev?: string } };
       const devScript = pkg.scripts?.dev;
 
       if (devScript) {
@@ -381,7 +385,7 @@ export async function startDevServer(
       }
     } catch (e) {
       // Fall back to npm run dev with port forwarded via -- --port
-      // This handles external projects where readTextFile is blocked by Tauri scope
+      // (e.g. package.json genuinely missing, or not valid JSON)
       trackError('devserver_package_json', e, 'Workspace');
       const errorMessage = e instanceof Error ? e.message : String(e);
       logger.error('[DevServer] Failed to read/parse package.json, falling back to npm run dev', {


### PR DESCRIPTION
# Bug bash round 2: 27 overnight auto-reported issues

The automatic bug reporting shipped in v0.18.0 filed 29 issues overnight (#250–#278). This PR fixes 26 of them; #270 lives in the private Vercel flow (commented), and #262/#263 are duplicates fixed together.

## Git & publishing

- **#265** — quote the `gh` path in the `credential.helper` shell command; the default Windows install path (`C:\Program Files\GitHub CLI\gh.exe`) word-split into `C:\Program: command not found`, breaking every fetch/pull/merge.
- **#275** — sparse-checkout repos couldn't commit/publish at all: `git add -A` exits 1 when untracked files exist outside the cone. Staging now retries with `--sparse`. (+ regression test reproducing shippy's repro)
- **#274** — `git commit` that comes up empty ("nothing to commit" on stdout, empty stderr) is now a benign no-op instead of an opaque ``` `git commit` exited with status 1: ``` error.
- **#273** — `publish_branch` discarded `git add -A`'s result entirely; all publish paths now go through the shared `git_stage_and_commit` (which also means staging/production can no longer silently push stale code after a failed commit). UnsavedChangesModal also retries the switch with auto-stash when stragglers appear between publish/discard and the switch, instead of dead-ending with "stash or commit" inside the modal meant to resolve exactly that.
- **#276** — `commit_changes` (Submit for Review's auto-commit) now runs `ensure_git_identity` first, mirroring Push to GitHub, so a missing `user.name`/`user.email` self-heals from the gh identity.
- **#252** — `list_branches` failures now include git's stderr instead of a bare "Failed to list branches".
- **#268** — `gh pr list`'s "no git remotes found" (local-only repo) is treated as an empty PR list, not a raw error.
- **#278** — merging from the Pull Requests tab now routes conflict errors into the existing conflict-resolution flow instead of dumping gh's multi-line stderr into a toast.
- **#254** — "Not a git repository" is no longer reported to telemetry: it's an expected state the frontend already handles, polled every 10s on non-git projects.

## CLI & process handling

- **#250** — the MCP modal's commands now use the shared thorough binary resolver (`claude::find_binary_by_name`), so it agrees with the Agents panel about what's installed (e.g. `~/.codex/bin/codex`).
- **#259** — gh commands get `stdin(null)` so an unexpected credential prompt fails fast instead of silently eating the 60s network timeout.
- **#269** — agent CLI failures with empty stderr now report the exit code + a stdout snippet instead of "Claude Code CLI failed: ".
- **#256** — `exec_plugin_shell` resolves the binary up front and names the plugin + command when it's missing, instead of surfacing "No such file or directory (os error 2)".

## Preview, proxy & PTY

- **#258** — WebSocket (HMR) upgrades retry on connection-refused within the 5s connect budget, so a mid-restart dev server doesn't hard-fail the socket with BAD_GATEWAY.
- **#271** — the proxy's three timeout sites each name their phase and port ("connect to localhost:3000 timed out after 5s" vs. a bare "deadline has elapsed").
- **#260** — writing to a PTY whose process just exited reports "terminal session has ended" instead of raw EIO.
- **#261** — BuildTerminal no longer fires `pty_session_resize` before `pty_session_open` resolves (the "unknown session" reports); size is synced once after open.

## Dev server & paths

- **#257** — `get_shipstudio_dir`/`ensure_shipstudio_dir` return forward-slash-normalized paths, so frontend `${dir}/${name}` concatenation can't produce mixed-separator Windows paths.
- **#264** — the dev server's package.json read goes through the backend's `read_project_file` (which honors registered external projects) instead of plugin-fs scope globs, so projects outside `$HOME`//`Volumes` keep custom dev-script/port parsing.

## Projects & platform

- **#251** — "Select Project Folder" accepts the same language-ecosystem manifests (Cargo.toml, go.mod, pyproject.toml, requirements.txt, Gemfile, pom.xml, build.gradle, composer.json) as the automatic registration path, and the rejection message reflects the real checks. (+ test)
- **#253** — Windows locked-file deletes back off exponentially (~8s budget, was a flat ~1s) for antivirus/indexer locks.
- **#266** — opening a project whose path the backend refuses to trust now aborts before the workspace renders, with one clear toast — instead of a broken workspace where every call toasts "Security error: path is outside the projects directory".
- **#262 / #263** (dupes) — headless-screenshot fallback probes Brave, Arc, and per-user `~/Applications` installs on macOS.
- **#272** — the Claude auth probes in `get_full_setup_status` join the concurrent probe phase instead of running after it (worst case ~18s → ~10s), and the frontend boot gate is 20s, so a slow Windows machine can't get dumped into onboarding while fully set up.
- **#255** — template fetch/download errors include reqwest's full source chain (DNS vs. refused vs. timeout vs. TLS), not just "error sending request for url".
- **#267** — the visual text editor sanitizes drag-and-drop like paste (plain text, `<`/`{` stripped), closing the path where dropped rich HTML survived to save time and got the whole edit rejected and discarded.

## Docs

- **#277** — new `docs/plugins.md`: plugin.json manifest reference, slots, SDK API, storage/shell runtime, dev-link and install flows, hello-world walkthrough.

## Verification

- `cargo test` — all pass (plus 2 new regression tests)
- `cargo check` / `clippy` — clean (pre-existing warning classes only)
- `pnpm test:run` — 1370 passed
- `tsc --noEmit`, `eslint`, `pnpm check:patterns` — clean

Fixes #250, fixes #251, fixes #252, fixes #253, fixes #254, fixes #255, fixes #256, fixes #257, fixes #258, fixes #259, fixes #260, fixes #261, fixes #262, fixes #263, fixes #264, fixes #265, fixes #266, fixes #267, fixes #268, fixes #269, fixes #271, fixes #272, fixes #273, fixes #274, fixes #275, fixes #276, fixes #277, fixes #278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing projects using common language ecosystem files.
  * macOS browser detection now includes Brave and Arc, including user-installed browsers.
  * Added comprehensive documentation for creating, developing, installing, and distributing plugins.

* **Bug Fixes**
  * Improved Git operations, branch switching, publishing, sparse checkouts, and identity setup.
  * Merge conflicts now route directly to conflict resolution.
  * Improved terminal session handling, proxy retries, drag-and-drop editing, and project loading.
  * Error messages now provide more actionable details across setup, templates, Git, and agent commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->