### PR TITLE
Bug bash round 3: fix the five newest auto-reported issues

### DIFF
--- a/src-tauri/src/commands/assets.rs
+++ b/src-tauri/src/commands/assets.rs
@@ -57,7 +57,7 @@ fn validate_asset_path(root_dir: &Path, asset_path: &str) -> Result<PathBuf, Str
     // Canonicalize to resolve any symlinks and ensure it's within the root.
     // For new files that don't exist yet, we need to check the parent
     let check_path = if full_path.exists() {
-        dunce::canonicalize(&full_path).map_err(|e| format!("Invalid path: {e}"))?
+        crate::utils::canonicalize_tagged(&full_path, "assets")?
     } else {
         // For non-existent paths, verify parent exists and is within the root
         let parent = full_path
@@ -66,10 +66,9 @@ fn validate_asset_path(root_dir: &Path, asset_path: &str) -> Result<PathBuf, Str
         if !parent.exists() {
             return Err("Parent directory does not exist".to_string());
         }
-        let canonical_parent =
-            dunce::canonicalize(parent).map_err(|e| format!("Invalid path: {e}"))?;
+        let canonical_parent = crate::utils::canonicalize_tagged(parent, "assets")?;
         let canonical_root = if root_dir.exists() {
-            dunce::canonicalize(root_dir).map_err(|e| format!("Invalid path: {e}"))?
+            crate::utils::canonicalize_tagged(root_dir, "assets")?
         } else {
             return Err("Assets folder does not exist".to_string());
         };
@@ -79,7 +78,7 @@ fn validate_asset_path(root_dir: &Path, asset_path: &str) -> Result<PathBuf, Str
         return Ok(full_path);
     };
 
-    let canonical_root = dunce::canonicalize(root_dir).map_err(|e| format!("Invalid path: {e}"))?;
+    let canonical_root = crate::utils::canonicalize_tagged(root_dir, "assets")?;
 
     if !check_path.starts_with(&canonical_root) {
         return Err("Security error: path is outside the assets folder".to_string());
@@ -194,9 +193,8 @@ pub async fn set_assets_root(project_path: String, root: String) -> Result<Strin
 
     // Canonical containment check — the sanitizer blocks traversal lexically,
     // but symlinked folders could still escape the project.
-    let canonical_dir = dunce::canonicalize(&dir).map_err(|e| format!("Invalid path: {e}"))?;
-    let canonical_workspace =
-        dunce::canonicalize(&workspace).map_err(|e| format!("Invalid path: {e}"))?;
+    let canonical_dir = crate::utils::canonicalize_tagged(&dir, "assets")?;
+    let canonical_workspace = crate::utils::canonicalize_tagged(&workspace, "assets")?;
     if !canonical_dir.starts_with(&canonical_workspace) {
         return Err(("Security error: folder is outside the project".to_string()).into());
     }
@@ -278,10 +276,8 @@ pub async fn upload_asset(
     let file_path = dest_dir.join(&file_name);
 
     // Ensure final path is within the assets folder
-    let canonical_root =
-        dunce::canonicalize(&root_dir).map_err(|e| format!("Invalid path: {e}"))?;
-    let canonical_dest =
-        dunce::canonicalize(&dest_dir).map_err(|e| format!("Invalid path: {e}"))?;
+    let canonical_root = crate::utils::canonicalize_tagged(&root_dir, "assets")?;
+    let canonical_dest = crate::utils::canonicalize_tagged(&dest_dir, "assets")?;
     if !canonical_dest.starts_with(&canonical_root) {
         return Err(
             ("Security error: destination is outside the assets folder".to_string()).into(),
@@ -316,10 +312,8 @@ pub async fn delete_asset(project_path: String, asset_path: String) -> Result<()
     let full_path = validate_asset_path(&root_dir, &asset_path)?;
 
     // Double-check it's within the assets folder
-    let canonical_root =
-        dunce::canonicalize(&root_dir).map_err(|e| format!("Invalid path: {e}"))?;
-    let canonical_path =
-        dunce::canonicalize(&full_path).map_err(|e| format!("Invalid path: {e}"))?;
+    let canonical_root = crate::utils::canonicalize_tagged(&root_dir, "assets")?;
+    let canonical_path = crate::utils::canonicalize_tagged(&full_path, "assets")?;
     if !canonical_path.starts_with(&canonical_root) {
         return Err(("Security error: path is outside the assets folder".to_string()).into());
     }
@@ -362,9 +356,8 @@ pub async fn rename_asset(
     let new_path = parent.join(&new_name);
 
     // Check new path is still within the assets folder
-    let canonical_root =
-        dunce::canonicalize(&root_dir).map_err(|e| format!("Invalid path: {e}"))?;
-    let canonical_parent = dunce::canonicalize(parent).map_err(|e| format!("Invalid path: {e}"))?;
+    let canonical_root = crate::utils::canonicalize_tagged(&root_dir, "assets")?;
+    let canonical_parent = crate::utils::canonicalize_tagged(parent, "assets")?;
     if !canonical_parent.starts_with(&canonical_root) {
         return Err(("Security error: path is outside the assets folder".to_string()).into());
     }
@@ -410,14 +403,12 @@ pub async fn create_asset_folder(
     let full_path = root_dir.join(folder_name);
 
     // Ensure it's within the assets folder
-    let canonical_root =
-        dunce::canonicalize(&root_dir).map_err(|e| format!("Invalid path: {e}"))?;
+    let canonical_root = crate::utils::canonicalize_tagged(&root_dir, "assets")?;
 
     // For the new folder, check parent is within the assets folder
     if let Some(parent) = full_path.parent() {
         if parent.exists() {
-            let canonical_parent =
-                dunce::canonicalize(parent).map_err(|e| format!("Invalid path: {e}"))?;
+            let canonical_parent = crate::utils::canonicalize_tagged(parent, "assets")?;
             if !canonical_parent.starts_with(&canonical_root) {
                 return Err(
                     ("Security error: path is outside the assets folder".to_string()).into(),

--- a/src-tauri/src/commands/attached_libraries.rs
+++ b/src-tauri/src/commands/attached_libraries.rs
@@ -184,7 +184,7 @@ pub async fn add_attached_library(app: AppHandle) -> Result<Option<String>, Comm
         None => return Ok(None), // User cancelled
     };
 
-    let canonical = dunce::canonicalize(&folder_path).map_err(|e| format!("Invalid path: {e}"))?;
+    let canonical = crate::utils::canonicalize_tagged(&folder_path, "attached_libraries")?;
     if !canonical.is_dir() {
         return Err("Selected path is not a folder.".to_string().into());
     }

--- a/src-tauri/src/commands/external_projects.rs
+++ b/src-tauri/src/commands/external_projects.rs
@@ -171,7 +171,7 @@ pub async fn register_external_project(app: AppHandle) -> Result<Option<String>,
     }
 
     // Canonicalize the path
-    let canonical = dunce::canonicalize(&folder_path).map_err(|e| format!("Invalid path: {e}"))?;
+    let canonical = crate::utils::canonicalize_tagged(&folder_path, "register_external_project")?;
     let canonical_str = canonical.to_string_lossy().to_string();
 
     // Reject folders that already live under a projects root (configured or
@@ -326,7 +326,7 @@ pub async fn ensure_external_project_registered(
     path: String,
 ) -> Result<bool, CommandError> {
     let canonical =
-        dunce::canonicalize(Path::new(&path)).map_err(|e| format!("Invalid path: {e}"))?;
+        crate::utils::canonicalize_tagged(Path::new(&path), "ensure_external_project_registered")?;
 
     // Skip if already inside a projects root (configured or default) — those are
     // already trusted by validate_project_path and listed automatically.
@@ -380,8 +380,7 @@ pub async fn ensure_external_project_registered(
 #[tauri::command]
 #[tracing::instrument]
 pub async fn is_project_external(path: String) -> Result<bool, CommandError> {
-    let canonical =
-        dunce::canonicalize(Path::new(&path)).map_err(|e| format!("Invalid path: {e}"))?;
+    let canonical = crate::utils::canonicalize_tagged(Path::new(&path), "is_project_external")?;
 
     let config = load_config()?;
     for project in &config.projects {

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -495,6 +495,18 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        // A name collision is user input needing a different name, not a
+        // malfunction — surface it in plain language instead of GitHub's raw
+        // "GraphQL: Name already exists on this account (createRepository)"
+        // (issue #279). error_reporting skips this message so routine
+        // collisions don't generate telemetry noise.
+        if stderr.contains("Name already exists on this account") {
+            return Err(CommandError::Other {
+                message: format!(
+                    "A repository named \"{repo_name}\" already exists on this account. Choose a different name."
+                ),
+            });
+        }
         return Err(CommandError::Process {
             cmd: "gh repo create".to_string(),
             exit_code: output.status.code().unwrap_or(-1),

--- a/src-tauri/src/commands/ide/screenshots/playwright.rs
+++ b/src-tauri/src/commands/ide/screenshots/playwright.rs
@@ -269,8 +269,11 @@ const {{ chromium }} = require('playwright');
         screenshot_path_str.replace('\\', "\\\\")
     );
 
-    // Write script to the playwright env directory (where node_modules is)
-    let script_path = playwright_env.join("capture-script.js");
+    // Write script to the playwright env directory (where node_modules is).
+    // Unique name per invocation: a fixed filename let concurrent captures
+    // delete/overwrite each other's script mid-run — Node then died with
+    // MODULE_NOT_FOUND on the shared path (issue #282).
+    let script_path = playwright_env.join(format!("capture-script-{}.js", uuid::Uuid::new_v4()));
     std::fs::write(&script_path, &script)
         .map_err(|e| format!("Failed to write capture script: {e}"))?;
 
@@ -376,8 +379,12 @@ const {{ chromium }} = require('playwright');
         screenshot_path_str.replace('\\', "\\\\")
     );
 
-    // Write script to the playwright env directory
-    let script_path = playwright_env.join("capture-viewport-script.js");
+    // Write script to the playwright env directory. Unique per invocation —
+    // see the same fix in capture_fullpage_playwright (issue #282).
+    let script_path = playwright_env.join(format!(
+        "capture-viewport-script-{}.js",
+        uuid::Uuid::new_v4()
+    ));
     std::fs::write(&script_path, &script)
         .map_err(|e| format!("Failed to write capture script: {e}"))?;
 

--- a/src-tauri/src/error_reporting.rs
+++ b/src-tauri/src/error_reporting.rs
@@ -383,10 +383,13 @@ pub fn report_command_error(err: &crate::errors::CommandError) {
         return;
     }
     if let crate::errors::CommandError::Other { message } = err {
-        if message
-            .to_ascii_lowercase()
-            .contains("not a git repository")
-        {
+        let lower = message.to_ascii_lowercase();
+        if lower.contains("not a git repository") {
+            return;
+        }
+        // Repo-name collision on Create Repo — user input needing a different
+        // name, already surfaced as a friendly message (issue #279).
+        if lower.contains("already exists on this account") {
             return;
         }
     }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -706,6 +706,21 @@ pub fn normalize_separators(path: &str) -> String {
     path.to_string()
 }
 
+/// Canonicalize with a diagnosable error naming the call site and the path.
+///
+/// A bare "Invalid path: No such file or directory (os error 2)" is emitted
+/// from ~20 canonicalize sites and is untraceable from telemetry (issue #284).
+/// Including the path is safe: error reports scrub home directories before
+/// anything leaves the machine.
+pub fn canonicalize_tagged(
+    path: impl AsRef<std::path::Path>,
+    site: &str,
+) -> Result<std::path::PathBuf, String> {
+    let path = path.as_ref();
+    dunce::canonicalize(path)
+        .map_err(|e| format!("Invalid path in {site} ('{}'): {e}", path.display()))
+}
+
 /// Validates that a project path is inside an allowed projects root (the
 /// configured root or the default `~/ShipStudio`) or is a registered external
 /// project. Prevents path traversal where the frontend could pass arbitrary paths.
@@ -714,7 +729,7 @@ pub fn validate_project_path(project_path: &str) -> Result<std::path::PathBuf, S
     if !path.is_absolute() {
         return Err("Security error: project path must be absolute".to_string());
     }
-    let canonical = dunce::canonicalize(path).map_err(|e| format!("Invalid path: {e}"))?;
+    let canonical = canonicalize_tagged(path, "validate_project_path")?;
 
     // Allow paths inside any allowed projects root
     if allowed_project_roots()
@@ -759,7 +774,7 @@ pub fn validate_project_file_path(file_path: &str) -> Result<std::path::PathBuf,
 
     // Canonicalize the parent (must exist) — resolves symlinks and `..` so the
     // containment check below can't be defeated lexically.
-    let canonical_parent = dunce::canonicalize(parent).map_err(|e| format!("Invalid path: {e}"))?;
+    let canonical_parent = canonicalize_tagged(parent, "validate_project_file_path")?;
 
     let allowed = allowed_project_roots()
         .iter()

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -46,7 +46,7 @@ import { listen } from '@tauri-apps/api/event';
 import { homeDir } from '@tauri-apps/api/path';
 import { getShellPath, getSystemEnv } from '../../lib/project';
 import { loadNerdFonts } from '../../lib/fonts';
-import { isWindows } from '../../lib/setup';
+import { isWindows, resolveCliPath } from '../../lib/setup';
 import { isPasteChord, readClipboardText, stageClipboardImage } from '../../lib/clipboard';
 import { logger } from '../../lib/logger';
 import { asCommandError, formatCommandError } from '../../lib/errors';
@@ -718,8 +718,35 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         }
 
         // On Windows, agent may be a .cmd script - must run through cmd.exe
-        const spawnCmd = isWin ? 'cmd.exe' : agent.binaryName;
+        let spawnCmd = isWin ? 'cmd.exe' : agent.binaryName;
         const spawnArgs = isWin ? ['/C', agent.binaryName, ...agentArgs] : agentArgs;
+
+        // Resolve the bare binary name through the backend's thorough
+        // discovery (every NVM version, ~/.<agent>/bin, npm prefix -g …) the
+        // way OnboardingTerminal already does. The hand-built PATH above is a
+        // subset of what the status checks search, so "installed ✓ but Unable
+        // to spawn claude" was possible (issue #280). Resolution errors fail
+        // OPEN — the spawn proceeds with the bare name as before.
+        try {
+          const resolved = await resolveCliPath(agent.binaryName);
+          if (resolved) {
+            const pathSep = isWin ? ';' : ':';
+            if (!env.PATH.split(pathSep).includes(resolved.dir)) {
+              env.PATH = `${env.PATH}${pathSep}${resolved.dir}`;
+            }
+            if (!isWin) {
+              // Spawn the resolved absolute path — deterministic, no PATH
+              // shadowing. (Windows keeps the cmd.exe wrapper; the appended
+              // PATH dir makes the shim resolvable there.)
+              spawnCmd = resolved.path;
+            }
+          }
+        } catch (err) {
+          logger.warn('[Terminal] resolveCliPath failed — spawning bare name', {
+            binary: agent.binaryName,
+            error: String(err),
+          });
+        }
 
         // The backend session id is the tab's sessionName UUID — it survives
         // component unmount/remount and project switches, so attach is

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -258,7 +258,9 @@ export function useProjectLifecycle({
       // and a log so we notice. Don't toast: this is internal.
       trackError('workspace_gate_subpath_check', err, 'Dashboard');
       logger.error('[OpenProject] getWorkspaceSubpath failed; opening as-is', {
-        error: err instanceof Error ? err.message : String(err),
+        // Tauri rejections are plain objects — String(err) renders them as
+        // "[object Object]" (issue #283); asCommandError handles both shapes.
+        error: formatCommandError(asCommandError(err)),
       });
       return false;
     }
@@ -270,7 +272,7 @@ export function useProjectLifecycle({
     } catch (err) {
       trackError('workspace_gate_detect', err, 'Dashboard');
       logger.error('[OpenProject] detectWorkspaces failed; opening as-is', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
       return false;
     }
@@ -746,7 +748,7 @@ export function useProjectLifecycle({
     } catch (err) {
       trackError('monorepo_pick_save', err, 'Dashboard');
       logger.error('[OpenProject] Failed to save workspace subpath', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
       showToast(
         `Couldn't save workspace pick: ${formatCommandError(asCommandError(err))}`,
@@ -835,7 +837,7 @@ export function useProjectLifecycle({
       }
     } catch (err) {
       logger.warn('[OpenProject] Cancel rollback failed', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
     }
   };


### PR DESCRIPTION
The auto-reporter filed five more issues while round 2 was in flight. This fixes all five:

- **#279** — Create Repo name collisions now show "A repository named \"x\" already exists on this account. Choose a different name." instead of GitHub's raw GraphQL error, and no longer fire telemetry (it's user input, not a malfunction).
- **#280** — the agent terminal resolves the agent binary through the backend's thorough `resolve_cli_path` discovery before spawning (mirroring OnboardingTerminal's existing fix), so installs in older-NVM/`~/.claude/bin`/`npm prefix -g` locations can't hit "Unable to spawn claude" while the status checks say installed ✓. Resolution failures fail open to the previous bare-name spawn.
- **#282** — viewport/full-page Playwright captures each write a UUID-suffixed script file, so concurrent captures can't delete/overwrite each other's script mid-run (the Windows MODULE_NOT_FOUND race).
- **#283** — `runMonorepoGate`'s catch blocks (and two sibling sites in the same hook) render Tauri command rejections via `asCommandError`/`formatCommandError` instead of `String(err)`'s `[object Object]`.
- **#284** — new `utils::canonicalize_tagged(path, site)` helper replaces every bare `Invalid path: {e}` (~20 sites across `validate_project_path`, `validate_project_file_path`, external_projects, attached_libraries, assets), so future reports name the call site and the offending path (telemetry scrubs home dirs, so including the path is safe).

## Verification
- `cargo test` — 740 passed; `cargo check` clean
- `pnpm test:run` — 1374 passed
- `tsc --noEmit`, `eslint`, `pnpm check:patterns` — clean

Fixes #279, fixes #280, fixes #282, fixes #283, fixes #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved asset, project, and attached-library path validation with clearer error details and safer path handling.
  - GitHub repository creation now explains when a repository name is already taken.
  - Fixed concurrent Playwright screenshots that could fail during capture.
  - Improved terminal startup when command-line tools are installed in non-standard locations.
  - Standardized error messages shown when project or workspace operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->