### PR TITLE
Fix v0.18.0 auto-reported bugs: validated MCP binary, stale plugin calls, multi-instance markup editing

### DIFF
--- a/src-tauri/src/commands/edit.rs
+++ b/src-tauri/src/commands/edit.rs
@@ -2769,49 +2769,37 @@ pub struct ElementHtml {
     pub file: String,
     pub line: usize,
     pub html: String,
+    /// Present when the element's class string resolves to several identical
+    /// source spots whose markup is byte-identical: every candidate location.
+    /// Edits write to all of them by default; a `location` argument targets one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locations: Option<Vec<Location>>,
 }
 
-/// Resolve an element to the source markup span, file, and contents, plus the
-/// byte span — shared by resolve/apply (and `edit_structure`'s insert/
-/// duplicate/delete) so every caller derives the span identically.
-pub(crate) fn locate_element(
-    project_path: &str,
-    signature: ElementSignature,
-) -> Result<(String, std::path::PathBuf, String, usize, usize, usize), CommandError> {
-    let resolution = resolve_classname_source(project_path.to_string(), signature)?;
-    let (file, line, class_name) = match resolution {
-        Resolution::Resolved {
-            file,
-            line,
-            class_name,
-            ..
-        } => (file, line, class_name),
-        Resolution::Multi { .. } => {
-            return Err(CommandError::Validation {
-                field: "element".into(),
-                reason: "This element appears in several identical places, so editing its markup here could change the wrong one. Ask your agent to edit it instead.".into(),
-            })
-        }
-        Resolution::NoClass => {
-            return Err(CommandError::Validation {
-                field: "element".into(),
-                reason: "This element has no class in source to anchor its markup on. Add a class to it first (the Add class action), then its markup becomes editable.".into(),
-            })
-        }
-        // The class resolver couldn't anchor this element to source (its classes
-        // are dynamic/generated). The markup editor is class-anchored, so phrase
-        // it for *markup*, not the class-string reason.
-        Resolution::ReadOnly { .. } => {
-            return Err(CommandError::Validation {
-                field: "element".into(),
-                reason: "This element can't be matched to its source markup (it has no static class to anchor on). Edit it with your agent instead.".into(),
-            })
-        }
-    };
-    let root = validate_project_path(project_path)?;
-    let abs = root.join(&file);
+/// One located instance of an element: its file, that file's source, and the
+/// byte span of the element's markup (opening tag → matching close tag).
+#[derive(Debug)]
+pub(crate) struct LocatedInstance {
+    pub(crate) file: String,
+    pub(crate) abs: std::path::PathBuf,
+    pub(crate) src: String,
+    pub(crate) line: usize,
+    pub(crate) start: usize,
+    pub(crate) end: usize,
+}
+
+/// Locate the element anchored by the className literal at `file:line` and
+/// derive its markup span — the shared tail of every element-markup path, so
+/// single- and multi-instance callers derive spans identically.
+fn locate_instance(
+    root: &Path,
+    file: &str,
+    line: usize,
+    class_name: &str,
+) -> Result<LocatedInstance, CommandError> {
+    let abs = root.join(file);
     let src = std::fs::read_to_string(&abs).map_err(CommandError::from)?;
-    let span = find_attr_spans(&src, attrs_for_path(&file))
+    let span = find_attr_spans(&src, attrs_for_path(file))
         .into_iter()
         .find(|s| s.line == line && s.value == class_name)
         .ok_or_else(|| CommandError::Validation {
@@ -2823,26 +2811,149 @@ pub(crate) fn locate_element(
             field: "element".into(),
             reason: "couldn't map this element to its source markup".into(),
         })?;
-    Ok((file, abs, src, line, start, end))
+    Ok(LocatedInstance {
+        file: file.to_string(),
+        abs,
+        src,
+        line,
+        start,
+        end,
+    })
+}
+
+/// Locate every editable instance of an element under `root`.
+///
+/// `Resolved` yields one instance. `Multi` (one class string at several
+/// identical source spots) yields all of them when their markup is
+/// byte-identical — the markup editor then offers edit-all/pick-one, exactly
+/// like the class editor (issue #287) — or the picked one when `target` names
+/// a location from the set. Instances whose markup has diverged can't be
+/// group-edited safely and fail closed.
+fn locate_instances_at(
+    root: &Path,
+    resolution: Resolution,
+    target: Option<&Location>,
+) -> Result<(Vec<LocatedInstance>, Option<Vec<Location>>), CommandError> {
+    match resolution {
+        Resolution::Resolved {
+            file,
+            line,
+            class_name,
+            ..
+        } => Ok((vec![locate_instance(root, &file, line, &class_name)?], None)),
+        Resolution::Multi {
+            locations,
+            class_name,
+        } => {
+            if let Some(t) = target {
+                if !locations
+                    .iter()
+                    .any(|l| l.file == t.file && l.line == t.line)
+                {
+                    return Err(CommandError::Validation {
+                        field: "location".into(),
+                        reason: "that source location no longer matches — reselect the element"
+                            .into(),
+                    });
+                }
+                let inst = locate_instance(root, &t.file, t.line, &class_name)?;
+                return Ok((vec![inst], Some(locations)));
+            }
+            let instances = locations
+                .iter()
+                .map(|l| locate_instance(root, &l.file, l.line, &class_name))
+                .collect::<Result<Vec<_>, _>>()?;
+            let first_html = &instances[0].src[instances[0].start..instances[0].end];
+            if instances
+                .iter()
+                .any(|i| &i.src[i.start..i.end] != first_html)
+            {
+                return Err(CommandError::Validation {
+                    field: "element".into(),
+                    reason: "This element appears in several places whose markup differs, so editing it here could change the wrong one. Ask your agent to edit it instead.".into(),
+                });
+            }
+            Ok((instances, Some(locations)))
+        }
+        Resolution::NoClass => Err(CommandError::Validation {
+            field: "element".into(),
+            reason: "This element has no class in source to anchor its markup on. Add a class to it first (the Add class action), then its markup becomes editable.".into(),
+        }),
+        // The class resolver couldn't anchor this element to source (its classes
+        // are dynamic/generated). The markup editor is class-anchored, so phrase
+        // it for *markup*, not the class-string reason.
+        Resolution::ReadOnly { .. } => Err(CommandError::Validation {
+            field: "element".into(),
+            reason: "This element can't be matched to its source markup (it has no static class to anchor on). Edit it with your agent instead.".into(),
+        }),
+    }
+}
+
+/// Validate the project path, resolve the signature, and locate instances —
+/// the command-facing wrapper around [`locate_instances_at`].
+fn locate_element_instances(
+    project_path: &str,
+    signature: ElementSignature,
+    target: Option<&Location>,
+) -> Result<(Vec<LocatedInstance>, Option<Vec<Location>>), CommandError> {
+    let resolution = resolve_classname_source(project_path.to_string(), signature)?;
+    let root = validate_project_path(project_path)?;
+    locate_instances_at(&root, resolution, target)
+}
+
+/// Resolve an element to the source markup span, file, and contents, plus the
+/// byte span — used by `edit_structure`'s insert/duplicate/delete, which need
+/// exactly one unambiguous instance (structural ops on one of several
+/// identical elements can't default to "all").
+pub(crate) fn locate_element(
+    project_path: &str,
+    signature: ElementSignature,
+) -> Result<(String, std::path::PathBuf, String, usize, usize, usize), CommandError> {
+    let resolution = resolve_classname_source(project_path.to_string(), signature)?;
+    if let Resolution::Multi { .. } = resolution {
+        return Err(CommandError::Validation {
+            field: "element".into(),
+            reason: "This element appears in several identical places, so editing its markup here could change the wrong one. Ask your agent to edit it instead.".into(),
+        });
+    }
+    let root = validate_project_path(project_path)?;
+    let (instances, _) = locate_instances_at(&root, resolution, None)?;
+    let inst = instances.into_iter().next().expect("resolved yields one");
+    Ok((
+        inst.file, inst.abs, inst.src, inst.line, inst.start, inst.end,
+    ))
 }
 
 /// Resolve a clicked element to its source HTML (opening tag → closing tag).
+///
+/// `location` (optional) targets one instance of a multi-sourced element —
+/// the "just one" path; omitted, a `Multi` element resolves to its shared
+/// markup with `locations` listing every spot.
 #[tauri::command]
 #[tracing::instrument(skip(signature), fields(project = %project_path))]
 pub fn resolve_element_html(
     project_path: String,
     signature: ElementSignature,
+    location: Option<Location>,
 ) -> Result<ElementHtml, CommandError> {
-    let (file, _abs, src, line, start, end) = locate_element(&project_path, signature)?;
+    let (instances, locations) =
+        locate_element_instances(&project_path, signature, location.as_ref())?;
+    let first = &instances[0];
     Ok(ElementHtml {
-        file,
-        line,
-        html: src[start..end].to_string(),
+        file: first.file.clone(),
+        line: first.line,
+        html: first.src[first.start..first.end].to_string(),
+        locations,
     })
 }
 
 /// Replace an element's source markup, after verifying it still equals
 /// `old_html` (drift guard — the file may have changed since selection).
+///
+/// A multi-sourced element writes to every instance (or just `location`, if
+/// given), skipping spots whose markup has drifted — mirroring
+/// `apply_classname_edit_multi`. Returns how many instances were updated;
+/// zero (everything drifted) is an error.
 #[tauri::command]
 #[tracing::instrument(skip(signature, old_html, new_html), fields(project = %project_path))]
 pub fn apply_element_html(
@@ -2850,22 +2961,57 @@ pub fn apply_element_html(
     signature: ElementSignature,
     old_html: String,
     new_html: String,
-) -> Result<(), CommandError> {
-    let (_file, abs, src, _line, start, end) = locate_element(&project_path, signature)?;
-    if src[start..end] != old_html {
+    location: Option<Location>,
+) -> Result<usize, CommandError> {
+    let (instances, _) = locate_element_instances(&project_path, signature, location.as_ref())?;
+    let applied = apply_html_to_instances(&instances, &old_html, &new_html)?;
+    if applied == 0 {
         return Err(CommandError::Validation {
             field: "old_html".into(),
             reason: "source no longer matches — reselect the element".into(),
         });
     }
-    let mut updated = String::with_capacity(src.len() + new_html.len());
-    updated.push_str(&src[..start]);
-    updated.push_str(&new_html);
-    updated.push_str(&src[end..]);
-    std::fs::write(&abs, updated).map_err(CommandError::from)?;
     let root = validate_project_path(&project_path)?;
     invalidate_index_cache(&root);
-    Ok(())
+    Ok(applied)
+}
+
+/// Write `new_html` over every instance whose span still equals `old_html`.
+/// Instances are grouped per file and rewritten in one pass in descending
+/// span order, so several spots in the same file don't invalidate each
+/// other's offsets; each file is written at most once.
+fn apply_html_to_instances(
+    instances: &[LocatedInstance],
+    old_html: &str,
+    new_html: &str,
+) -> Result<usize, CommandError> {
+    let mut by_file: std::collections::BTreeMap<&std::path::Path, (&str, Vec<(usize, usize)>)> =
+        std::collections::BTreeMap::new();
+    for inst in instances {
+        by_file
+            .entry(inst.abs.as_path())
+            .or_insert((&inst.src, Vec::new()))
+            .1
+            .push((inst.start, inst.end));
+    }
+    let mut applied = 0usize;
+    for (abs, (src, mut spans)) in by_file {
+        spans.sort_by(|a, b| b.0.cmp(&a.0));
+        let mut updated = src.to_string();
+        let mut changed = false;
+        for (start, end) in spans {
+            if &src[start..end] != old_html {
+                continue; // drifted since selection — skip this spot
+            }
+            updated.replace_range(start..end, new_html);
+            changed = true;
+            applied += 1;
+        }
+        if changed {
+            std::fs::write(abs, updated).map_err(CommandError::from)?;
+        }
+    }
+    Ok(applied)
 }
 
 #[cfg(test)]
@@ -2927,6 +3073,168 @@ mod tests {
         // must not be read as markup — the outer div's real close wins.
         let src = r#"<div class="cls"><script>if (a < b) { x("</div>") }</script>done</div>"#;
         assert_eq!(span_str(src), src);
+    }
+
+    // ── Multi-instance markup editing (issue #287) ───────────────────────────
+
+    fn multi_res(locs: &[(&str, usize)], class: &str) -> Resolution {
+        Resolution::Multi {
+            locations: locs
+                .iter()
+                .map(|(f, l)| Location {
+                    file: f.to_string(),
+                    line: *l,
+                    column: 1,
+                })
+                .collect(),
+            class_name: class.to_string(),
+        }
+    }
+
+    #[test]
+    fn multi_identical_markup_resolves_and_applies_to_all() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        let card = r#"export const C = () => <div className="card">Buy now</div>;"#;
+        std::fs::write(root.join("A.tsx"), card).unwrap();
+        std::fs::write(root.join("B.tsx"), card).unwrap();
+
+        let res = multi_res(&[("A.tsx", 1), ("B.tsx", 1)], "card");
+        let (instances, locations) = locate_instances_at(root, res, None).unwrap();
+        assert_eq!(instances.len(), 2);
+        assert_eq!(locations.as_ref().map(Vec::len), Some(2));
+        let html = &instances[0].src[instances[0].start..instances[0].end];
+        assert_eq!(html, r#"<div className="card">Buy now</div>"#);
+
+        let applied =
+            apply_html_to_instances(&instances, html, r#"<div className="card">Buy later</div>"#)
+                .unwrap();
+        assert_eq!(applied, 2);
+        for f in ["A.tsx", "B.tsx"] {
+            assert!(std::fs::read_to_string(root.join(f))
+                .unwrap()
+                .contains("Buy later"));
+        }
+    }
+
+    #[test]
+    fn multi_differing_markup_fails_closed() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("A.tsx"),
+            r#"export const A = () => <div className="card">Alpha</div>;"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("B.tsx"),
+            r#"export const B = () => <div className="card">Beta</div>;"#,
+        )
+        .unwrap();
+
+        let res = multi_res(&[("A.tsx", 1), ("B.tsx", 1)], "card");
+        let err = locate_instances_at(root, res, None).unwrap_err();
+        match err {
+            CommandError::Validation { reason, .. } => {
+                assert!(reason.contains("markup differs"), "got: {reason}")
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_target_location_edits_only_that_instance() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        let card = r#"export const C = () => <div className="card">Buy now</div>;"#;
+        std::fs::write(root.join("A.tsx"), card).unwrap();
+        std::fs::write(root.join("B.tsx"), card).unwrap();
+
+        let target = Location {
+            file: "B.tsx".into(),
+            line: 1,
+            column: 1,
+        };
+        let res = multi_res(&[("A.tsx", 1), ("B.tsx", 1)], "card");
+        let (instances, _) = locate_instances_at(root, res, Some(&target)).unwrap();
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0].file, "B.tsx");
+
+        let applied = apply_html_to_instances(
+            &instances,
+            r#"<div className="card">Buy now</div>"#,
+            r#"<div className="card">Buy later</div>"#,
+        )
+        .unwrap();
+        assert_eq!(applied, 1);
+        assert!(std::fs::read_to_string(root.join("B.tsx"))
+            .unwrap()
+            .contains("Buy later"));
+        assert!(std::fs::read_to_string(root.join("A.tsx"))
+            .unwrap()
+            .contains("Buy now"));
+    }
+
+    #[test]
+    fn multi_same_file_instances_apply_without_offset_drift() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("List.tsx"),
+            "export const L = () => (\n  <ul>\n    <li className=\"item\">One thing</li>\n    <li className=\"item\">One thing</li>\n  </ul>\n);\n",
+        )
+        .unwrap();
+
+        let res = multi_res(&[("List.tsx", 3), ("List.tsx", 4)], "item");
+        let (instances, _) = locate_instances_at(root, res, None).unwrap();
+        assert_eq!(instances.len(), 2);
+        let applied = apply_html_to_instances(
+            &instances,
+            r#"<li className="item">One thing</li>"#,
+            r#"<li className="item">Another thing entirely</li>"#,
+        )
+        .unwrap();
+        assert_eq!(applied, 2);
+        let updated = std::fs::read_to_string(root.join("List.tsx")).unwrap();
+        assert_eq!(updated.matches("Another thing entirely").count(), 2);
+        assert!(!updated.contains("One thing"));
+    }
+
+    #[test]
+    fn multi_apply_skips_drifted_spot() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        let card = r#"export const C = () => <div className="card">Buy now</div>;"#;
+        std::fs::write(root.join("A.tsx"), card).unwrap();
+        std::fs::write(root.join("B.tsx"), card).unwrap();
+
+        let res = multi_res(&[("A.tsx", 1), ("B.tsx", 1)], "card");
+        let (instances, _) = locate_instances_at(root, res, None).unwrap();
+        // B drifts after locating (user edited the file directly).
+        std::fs::write(
+            root.join("B.tsx"),
+            r#"export const C = () => <div className="card">Changed</div>;"#,
+        )
+        .unwrap();
+        // Spans were captured pre-drift; only spans still matching old_html write.
+        let fresh_a = locate_instance(root, "A.tsx", 1, "card").unwrap();
+        let drifted_b = LocatedInstance {
+            src: std::fs::read_to_string(root.join("B.tsx")).unwrap(),
+            ..instances.into_iter().find(|i| i.file == "B.tsx").unwrap()
+        };
+        let applied = apply_html_to_instances(
+            &[fresh_a, drifted_b],
+            r#"<div className="card">Buy now</div>"#,
+            r#"<div className="card">Buy later</div>"#,
+        )
+        .unwrap();
+        assert_eq!(applied, 1);
+        assert!(std::fs::read_to_string(root.join("A.tsx"))
+            .unwrap()
+            .contains("Buy later"));
+        assert!(std::fs::read_to_string(root.join("B.tsx"))
+            .unwrap()
+            .contains("Changed"));
     }
 
     fn sig(class: &str, tag: &str, ancestors: &[&str]) -> ElementSignature {

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -49,12 +49,15 @@ fn strip_ansi(s: &str) -> String {
 /// Find the agent binary path.
 ///
 /// Uses the same thorough resolver as the rest of the app
-/// (`claude::find_binary_by_name`: every NVM version's bin, `~/.<agent>/bin`,
-/// pnpm/volta/fnm dirs…) — the narrower `find_executable` missed installs like
-/// `~/.codex/bin/codex`, so the MCP modal said "Codex binary not found" while
-/// the Agents panel showed it installed (issue #250).
+/// (every NVM version's bin, `~/.<agent>/bin`, pnpm/volta/fnm dirs…) — the
+/// narrower `find_executable` missed installs like `~/.codex/bin/codex`, so
+/// the MCP modal said "Codex binary not found" while the Agents panel showed
+/// it installed (issue #250). Candidates are validated with the agent's
+/// version flag so a broken install (e.g. an npm package whose platform
+/// vendor binary is missing on disk) is skipped instead of being invoked and
+/// surfacing its internal ENOENT stack trace (issue #286).
 fn find_agent_binary(agent: &crate::agent::AgentConfig) -> Result<std::path::PathBuf, String> {
-    crate::commands::claude::find_binary_by_name(agent.binary_name)
+    crate::commands::claude::find_validated_binary(agent.binary_name, agent.version_flag)
         .ok_or_else(|| format!("{} binary not found", agent.display_name))
 }
 

--- a/src-tauri/src/error_reporting.rs
+++ b/src-tauri/src/error_reporting.rs
@@ -392,6 +392,14 @@ pub fn report_command_error(err: &crate::errors::CommandError) {
         if lower.contains("already exists on this account") {
             return;
         }
+        // Stale plugin call racing an uninstall/project switch: an exec that
+        // was already in flight when its plugin was unloaded rejects with
+        // "Plugin 'x' not found" — an expected transient state, not a
+        // malfunction (issue #288). The "not found in registry" variants from
+        // update/check flows don't match this suffix and still report.
+        if lower.starts_with("plugin '") && lower.ends_with("' not found") {
+            return;
+        }
     }
     let fingerprint = command_error_fingerprint(err);
     report_error(

--- a/src/components/edit/ElementHtmlEditor.tsx
+++ b/src/components/edit/ElementHtmlEditor.tsx
@@ -18,10 +18,11 @@
 import { useEffect, useRef, useState } from 'react';
 import { Button } from '../primitives/Button';
 import { CodeOverlayEditor } from './CodeOverlayEditor';
+import { MultiSourceControl } from './MultiSourceControl';
 import { useOptionalToast } from '../../contexts/ToastContext';
 import { resolveElementHtml, applyElementHtml } from '../../lib/edit-html';
 import { asCommandError, formatCommandError } from '../../lib/errors';
-import type { ElementSignature } from '../../lib/edit';
+import type { ElementSignature, SourceLocation } from '../../lib/edit';
 
 /** Friendly, prefix-free message for the panel — the backend's Validation
  *  reasons are already complete sentences, so show them verbatim. */
@@ -41,6 +42,11 @@ export function ElementHtmlEditor({ projectPath, signature }: Props) {
   const [error, setError] = useState('');
   const [text, setText] = useState('');
   const [saving, setSaving] = useState(false);
+  // Set when the markup lives at several identical source spots: Save writes
+  // to all of them (default) or the one the user picked — same edit-all /
+  // pick-one affordance as the class editor (issue #287).
+  const [locations, setLocations] = useState<SourceLocation[] | null>(null);
+  const [multiTarget, setMultiTarget] = useState<'all' | number>('all');
   const baselineRef = useRef('');
   const sigRef = useRef(signature);
   sigRef.current = signature;
@@ -54,6 +60,8 @@ export function ElementHtmlEditor({ projectPath, signature }: Props) {
         if (cancelled) return;
         baselineRef.current = res.html;
         setText(res.html);
+        setLocations(res.locations && res.locations.length > 1 ? res.locations : null);
+        setMultiTarget('all');
         setStatus('ready');
       })
       .catch((e) => {
@@ -71,9 +79,16 @@ export function ElementHtmlEditor({ projectPath, signature }: Props) {
     if (!dirty) return;
     setSaving(true);
     try {
-      await applyElementHtml(projectPath, sigRef.current, baselineRef.current, text);
+      const target = locations && multiTarget !== 'all' ? locations[multiTarget] : undefined;
+      const applied = await applyElementHtml(
+        projectPath,
+        sigRef.current,
+        baselineRef.current,
+        text,
+        target
+      );
       baselineRef.current = text;
-      showToast('Markup saved', 'success');
+      showToast(applied > 1 ? `Markup saved in ${applied} places` : 'Markup saved', 'success');
     } catch (e) {
       showToast(editorErrorText(e), 'error');
     } finally {
@@ -90,6 +105,10 @@ export function ElementHtmlEditor({ projectPath, signature }: Props) {
         <code className="ss-htmltab__tag">&lt;{signature.tagName || 'element'}&gt;</code>
         {firstClass && <span className="ss-htmltab__cls">.{firstClass}</span>}
       </div>
+
+      {status === 'ready' && locations && (
+        <MultiSourceControl locations={locations} target={multiTarget} onChange={setMultiTarget} />
+      )}
 
       <div className="ss-htmltab__main">
         {status === 'loading' && <div className="ss-htmltab__msg">Loading markup…</div>}

--- a/src/components/plugins/PluginSlot.test.tsx
+++ b/src/components/plugins/PluginSlot.test.tsx
@@ -7,6 +7,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockIPC } from '@tauri-apps/api/mocks';
 import { buildContext } from './PluginSlot';
+import { unloadPluginModule } from '../../lib/plugin-loader';
 import type { PluginAppActions, PluginThemeData } from '../../contexts/PluginContext';
 
 const theme: PluginThemeData = {
@@ -94,6 +95,19 @@ describe('buildContext failure reporting', () => {
     await expect(ctx.invoke.call('allowed_cmd')).rejects.toThrow('boom from backend');
     expect(showToast).toHaveBeenCalledTimes(1);
     expect(showToast.mock.calls[0][0]).toContain('Plugin "Sanity"');
+  });
+
+  it('suppresses the toast for a call that raced a plugin unload (#288)', async () => {
+    const { actions, showToast } = makeActions();
+    const stale = { ...project, path: '/p/stale' };
+    const ctx = buildContext('vercel', 'Vercel', stale, actions, theme, []);
+
+    // Call goes out, then the plugin is unloaded (project switch/uninstall)
+    // before the rejection lands — no user-facing toast, but still re-throws.
+    const pending = ctx.shell.exec('vercel', ['whoami']);
+    unloadPluginModule(stale.path, 'vercel');
+    await expect(pending).rejects.toThrow('boom from backend');
+    expect(showToast).not.toHaveBeenCalled();
   });
 
   it('does not toast when the call succeeds', async () => {

--- a/src/components/plugins/PluginSlot.tsx
+++ b/src/components/plugins/PluginSlot.tsx
@@ -19,8 +19,9 @@ import {
   type PluginThemeData,
 } from '../../contexts/PluginContext';
 import { execPluginShell, readPluginStorage, writePluginStorage } from '../../lib/plugins';
-import { markPluginCrashed, isPluginCrashed } from '../../lib/plugin-loader';
+import { markPluginCrashed, isPluginCrashed, wasPluginUnloaded } from '../../lib/plugin-loader';
 import { asCommandError, formatCommandError } from '../../lib/errors';
+import { logger } from '../../lib/logger';
 import { invoke } from '@tauri-apps/api/core';
 import { WarningIcon } from '../icons';
 import type { LoadedPlugin } from '../../hooks/usePlugins';
@@ -169,6 +170,15 @@ export function buildContext(
 
   /** Toast the rejection (naming the plugin), then re-throw for the caller. */
   const report = (e: unknown): never => {
+    // A call that was already in flight when its plugin was unloaded
+    // (project switch, uninstall) rejects after the plugin is gone —
+    // an expected transient state, not an actionable error (issue #288).
+    if (wasPluginUnloaded(projectPath, pluginId)) {
+      logger.warn(`Plugin "${pluginId}" call rejected after unload — suppressing toast`, {
+        error: formatCommandError(asCommandError(e)),
+      });
+      throw e;
+    }
     actions.showToast(`Plugin "${pluginName}": ${formatCommandError(asCommandError(e))}`, 'error');
     throw e;
   };

--- a/src/lib/edit-html.ts
+++ b/src/lib/edit-html.ts
@@ -5,7 +5,7 @@
  */
 
 import { invoke } from '@tauri-apps/api/core';
-import type { ElementSignature } from './edit';
+import type { ElementSignature, SourceLocation } from './edit';
 
 /** The selected element's source markup and where it lives. */
 export interface ElementHtml {
@@ -13,22 +13,37 @@ export interface ElementHtml {
   line: number;
   /** The element's source HTML: opening tag through its matching close tag. */
   html: string;
+  /** Present when the element's class string resolves to several identical
+   *  source spots with byte-identical markup: every candidate location.
+   *  Edits apply to all of them by default; pass a `location` to target one. */
+  locations?: SourceLocation[];
 }
 
-/** Resolve a clicked element to its source HTML. */
+/** Resolve a clicked element to its source HTML. Pass `location` (one of the
+ *  resolved `locations`) to target a single instance of a multi-sourced element. */
 export function resolveElementHtml(
   projectPath: string,
-  signature: ElementSignature
+  signature: ElementSignature,
+  location?: SourceLocation
 ): Promise<ElementHtml> {
-  return invoke<ElementHtml>('resolve_element_html', { projectPath, signature });
+  return invoke<ElementHtml>('resolve_element_html', { projectPath, signature, location });
 }
 
-/** Replace an element's source markup, verifying it still equals `oldHtml`. */
+/** Replace an element's source markup, verifying it still equals `oldHtml`.
+ *  A multi-sourced element writes to every instance — or just `location`, if
+ *  given. Resolves with how many instances were updated. */
 export function applyElementHtml(
   projectPath: string,
   signature: ElementSignature,
   oldHtml: string,
-  newHtml: string
-): Promise<void> {
-  return invoke<void>('apply_element_html', { projectPath, signature, oldHtml, newHtml });
+  newHtml: string,
+  location?: SourceLocation
+): Promise<number> {
+  return invoke<number>('apply_element_html', {
+    projectPath,
+    signature,
+    oldHtml,
+    newHtml,
+    location,
+  });
 }

--- a/src/lib/plugin-loader.ts
+++ b/src/lib/plugin-loader.ts
@@ -43,6 +43,18 @@ const moduleCache = new Map<string, PluginModule>();
 /** Cache of blob URLs for cleanup */
 const blobUrlCache = new Map<string, string>();
 
+/**
+ * Tombstones for unloaded plugin modules, keyed like `moduleCache`.
+ *
+ * `onDeactivate` can't cancel work that's already in flight (a timer tick
+ * that fired just before deactivation, a promise awaiting a backend round
+ * trip), so those calls reject after the plugin is gone — e.g. with
+ * "Plugin 'x' not found" on project switch or uninstall (issue #288).
+ * Callers check `wasPluginUnloaded` to treat such late rejections as an
+ * expected transient state instead of a user-facing error.
+ */
+const unloadedKeys = new Set<string>();
+
 function cacheKey(projectPath: string, pluginId: string): string {
   return `${projectPath}:${pluginId}`;
 }
@@ -99,6 +111,7 @@ export async function loadPluginModule(
     };
 
     moduleCache.set(key, pluginModule);
+    unloadedKeys.delete(key);
 
     // Call onActivate lifecycle hook
     if (pluginModule.onActivate) {
@@ -146,12 +159,22 @@ export function unloadPluginModule(
   }
 
   moduleCache.delete(key);
+  unloadedKeys.add(key);
 
   const blobUrl = blobUrlCache.get(key);
   if (blobUrl) {
     URL.revokeObjectURL(blobUrl);
     blobUrlCache.delete(key);
   }
+}
+
+/**
+ * Whether a plugin module was unloaded (and not since re-loaded) for this
+ * project. Used to recognize backend rejections from calls that were already
+ * in flight when the plugin was deactivated (issue #288).
+ */
+export function wasPluginUnloaded(projectPath: string, pluginId: string): boolean {
+  return unloadedKeys.has(cacheKey(projectPath, pluginId));
 }
 
 /** Plugins that crashed at render time. Checked synchronously by PluginSlot to skip them. */


### PR DESCRIPTION
Round 4 of the auto-reported bug bash — the three issues filed from v0.18.0 telemetry since the 0.18.1 release.

fixes #286
fixes #287
fixes #288

## #286 — MCP registration used an unvalidated binary resolver
`find_agent_binary` in `mcp.rs` now uses `find_validated_binary` (probes each candidate with the agent's version flag) instead of the exists-on-disk-only `find_binary_by_name`. A broken install — like the reported Homebrew-npm Codex whose platform vendor binary was missing — is skipped in favor of a working install elsewhere, or fails with the clear "Codex binary not found" message instead of a raw Node.js ENOENT stack trace. This is the follow-through on #250, which introduced the thorough-but-unvalidated resolver.

## #288 — "Plugin 'vercel' not found" from calls racing an unload
`onDeactivate` can't cancel in-flight work, so a timer tick or pending backend round trip from a just-unloaded plugin (project switch, uninstall) rejected after the fact and toasted "Plugin 'x' not found."
- `plugin-loader.ts` now tombstones unloaded module keys (`wasPluginUnloaded`); re-loading clears the tombstone.
- `buildContext`'s failure reporter checks the tombstone and logs instead of toasting for late rejections — genuine errors from live plugins still toast, covered by a new test.
- `report_command_error` skips the exact `Plugin '…' not found` message from telemetry (expected transient race); the "not found in registry" variants still report.

## #287 — markup editor dead-ended on duplicated elements
The raw-HTML editor hard-failed with "appears in several identical places… ask your agent" on `Resolution::Multi` — reported 4× across macOS (both arches) and Windows. It now gets the class editor's exact affordance:
- `resolve_element_html` locates every instance of a Multi element; when their markup is byte-identical it returns the shared HTML plus all `locations`.
- `apply_element_html` writes to every instance by default (per-spot drift guard, stale spots skipped, same-file spans rewritten in one descending-offset pass, each file written once) and returns the applied count; an optional `location` param targets a single instance.
- `ElementHtmlEditor` reuses `MultiSourceControl` ("Editing N places… Just one?") and toasts "Markup saved in N places."
- Instances whose markup has diverged still fail closed with a message that says *why* ("markup differs").
- Structural ops (duplicate/delete/insert) intentionally keep requiring a single unambiguous instance.
- Bonus: attribute editing in the settings panel now works on multi-sourced elements too (it shares these commands), applying to all instances like class edits already did.

## Verification
- `cargo test`: 745 passed (5 new: multi resolve/apply, differing-markup fail-closed, pick-one targeting, same-file offset safety, drift skip)
- `pnpm test:run`: 1375 passed (1 new: stale-plugin toast suppression)
- `tsc --noEmit`, `eslint`, `pnpm check:patterns`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Edit identical HTML elements across multiple source locations at once.
  * Choose a specific location when editing repeated elements.
  * Save confirmations now report how many locations were updated.

* **Bug Fixes**
  * Prevented edits from overwriting changed or inconsistent markup.
  * Improved detection of valid agent installations.
  * Suppressed unnecessary error notifications for unloaded plugins and expected missing-plugin errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->