### PR TITLE
Fix round-5 auto-reported bugs: git resolution, MCP races, plugin timeout cap, diagnostic context

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -237,7 +237,7 @@ pub async fn generate_pr_description(
 }
 
 async fn get_branch_name(path: &std::path::Path) -> Result<String, CommandError> {
-    let mut cmd = create_command("git");
+    let mut cmd = crate::utils::git_command()?;
     cmd.args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(path);
     let output = run_with_timeout(
@@ -255,7 +255,7 @@ async fn get_branch_name(path: &std::path::Path) -> Result<String, CommandError>
 }
 
 async fn get_commit_messages(path: &std::path::Path, base: &str) -> Result<String, CommandError> {
-    let mut cmd = create_command("git");
+    let mut cmd = crate::utils::git_command()?;
     cmd.args([
         "--no-pager",
         "log",
@@ -276,7 +276,7 @@ async fn get_commit_messages(path: &std::path::Path, base: &str) -> Result<Strin
 }
 
 async fn get_diff_stat(path: &std::path::Path, base: &str) -> Result<String, CommandError> {
-    let mut cmd = create_command("git");
+    let mut cmd = crate::utils::git_command()?;
     cmd.args(["--no-pager", "diff", &format!("{base}...HEAD"), "--stat"])
         .current_dir(path);
     let output = run_with_timeout(
@@ -290,7 +290,7 @@ async fn get_diff_stat(path: &std::path::Path, base: &str) -> Result<String, Com
 }
 
 async fn get_diff(path: &std::path::Path, base: &str) -> Result<String, CommandError> {
-    let mut cmd = create_command("git");
+    let mut cmd = crate::utils::git_command()?;
     cmd.args(["--no-pager", "diff", &format!("{base}...HEAD")])
         .current_dir(path);
     let output = run_with_timeout(
@@ -497,7 +497,7 @@ pub async fn generate_commit_message_for_path(
 }
 
 fn git_status_porcelain(path: &std::path::Path) -> Result<String, CommandError> {
-    let output = create_command("git")
+    let output = crate::utils::git_command()?
         .args(["status", "--porcelain"])
         .current_dir(path)
         .output()
@@ -512,8 +512,10 @@ fn git_status_porcelain(path: &std::path::Path) -> Result<String, CommandError> 
 /// unborn branch (no commits) `git diff HEAD` fails; we return whatever stdout
 /// it produced (empty) and let the porcelain file list carry the context.
 fn git_working_diff(path: &std::path::Path) -> String {
-    create_command("git")
-        .args(["--no-pager", "diff", "HEAD"])
+    let Ok(mut cmd) = crate::utils::git_command() else {
+        return String::new();
+    };
+    cmd.args(["--no-pager", "diff", "HEAD"])
         .current_dir(path)
         .output()
         .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
@@ -748,7 +750,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let git = |args: &[&str]| {
-            create_command("git")
+            crate::utils::git_command()
+                .unwrap()
                 .args(args)
                 .current_dir(dir)
                 .output()
@@ -778,7 +781,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let git = |args: &[&str]| {
-            create_command("git")
+            crate::utils::git_command()
+                .unwrap()
                 .args(args)
                 .current_dir(dir)
                 .output()

--- a/src-tauri/src/commands/conflicts.rs
+++ b/src-tauri/src/commands/conflicts.rs
@@ -5,7 +5,7 @@
 use crate::commands::github::ensure_git_identity;
 use crate::errors::CommandError;
 use crate::types::{ConflictBlock, ConflictedFile};
-use crate::utils::{create_command, validate_project_path};
+use crate::utils::validate_project_path;
 
 /// Parse git merge conflict markers from file content.
 pub fn parse_conflicts(content: &str, all_lines: &[&str]) -> (Vec<ConflictBlock>, String, String) {
@@ -113,7 +113,7 @@ pub async fn get_conflict_info(project_path: String) -> Result<Vec<ConflictedFil
     let validated_path = validate_project_path(&project_path)?;
 
     // Get list of files with unmerged changes
-    let output = create_command("git")
+    let output = crate::utils::git_command()?
         .args(["diff", "--name-only", "--diff-filter=U"])
         .current_dir(&validated_path)
         .output()
@@ -133,7 +133,7 @@ pub async fn get_conflict_info(project_path: String) -> Result<Vec<ConflictedFil
         let file_path = validated_path.join(file);
 
         // Check if file is binary
-        let is_binary = create_command("git")
+        let is_binary = crate::utils::git_command()?
             .args(["diff", "--numstat", file])
             .current_dir(&validated_path)
             .output()
@@ -266,7 +266,7 @@ pub async fn resolve_conflict(
 
     // If no more conflicts, stage the file
     if !has_more_conflicts {
-        let add_output = create_command("git")
+        let add_output = crate::utils::git_command()?
             .args(["add", &file_path])
             .current_dir(&validated_path)
             .output()
@@ -287,7 +287,7 @@ pub async fn resolve_conflict(
 pub async fn abort_merge(project_path: String) -> Result<(), CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let output = create_command("git")
+    let output = crate::utils::git_command()?
         .args(["merge", "--abort"])
         .current_dir(&validated_path)
         .output()
@@ -308,7 +308,7 @@ pub async fn complete_merge(project_path: String) -> Result<(), CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
     // Stage all changes
-    let add_output = create_command("git")
+    let add_output = crate::utils::git_command()?
         .args(["add", "."])
         .current_dir(&validated_path)
         .output()
@@ -323,7 +323,7 @@ pub async fn complete_merge(project_path: String) -> Result<(), CommandError> {
     let _ = ensure_git_identity(&validated_path);
 
     // Create the merge commit
-    let commit_output = create_command("git")
+    let commit_output = crate::utils::git_command()?
         .args(["commit", "-m", "Resolved merge conflicts via Ship Studio"])
         .current_dir(&validated_path)
         .output()

--- a/src-tauri/src/commands/git/branches.rs
+++ b/src-tauri/src/commands/git/branches.rs
@@ -59,7 +59,7 @@ pub async fn list_branches(project_path: String) -> Result<Vec<BranchInfo>, Comm
     }
 
     // Get all branches (local and remote)
-    let output = create_command("git")
+    let output = crate::utils::git_command()?
         .args(["branch", "-a", "--format=%(refname:short)|%(objectname:short)|%(committerdate:unix)|%(authorname)|%(HEAD)"])
         .current_dir(&validated_path)
         .output()
@@ -189,7 +189,7 @@ pub async fn get_current_branch(project_path: String) -> Result<String, CommandE
 
     let validated_path = validate_project_path(&project_path)?;
 
-    let output = create_command("git")
+    let output = crate::utils::git_command()?
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(&validated_path)
         .output()
@@ -239,7 +239,7 @@ pub async fn switch_branch(
     let has_changes = git_has_any_changes(&validated_path)?;
 
     if has_changes && auto_stash {
-        let stash_output = create_command("git")
+        let stash_output = crate::utils::git_command()?
             .args([
                 "stash",
                 "push",
@@ -281,7 +281,7 @@ pub async fn switch_branch(
     }
 
     // Try to checkout the branch
-    let checkout_output = create_command("git")
+    let checkout_output = crate::utils::git_command()?
         .args(["checkout", "--end-of-options", &branch_name])
         .current_dir(&validated_path)
         .output()
@@ -290,7 +290,7 @@ pub async fn switch_branch(
     if !checkout_output.status.success() {
         // Checkout failed - restore the stash if we made one
         if stashed {
-            if let Err(e) = create_command("git")
+            if let Err(e) = crate::utils::git_command()?
                 .args(["stash", "pop"])
                 .current_dir(&validated_path)
                 .output()
@@ -323,7 +323,7 @@ pub async fn switch_branch(
         // If we're switching back to the branch where we stashed from, offer to apply
         if stash_info.from_branch == branch_name {
             // Try to auto-apply the stash
-            let pop_output = create_command("git")
+            let pop_output = crate::utils::git_command()?
                 .args(["stash", "pop"])
                 .current_dir(&validated_path)
                 .output();
@@ -348,7 +348,7 @@ pub async fn switch_branch(
     }
 
     // Pull latest changes from remote
-    if let Err(e) = create_command("git")
+    if let Err(e) = crate::utils::git_command()?
         .args(["pull", "--ff-only"])
         .current_dir(&validated_path)
         .output()
@@ -406,7 +406,7 @@ pub async fn create_branch(
     }
 
     // Get the current branch name
-    let current_branch_output = create_command("git")
+    let current_branch_output = crate::utils::git_command()?
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(&validated_path)
         .output()
@@ -428,7 +428,7 @@ pub async fn create_branch(
 
     if is_from_current {
         // Create branch from current HEAD (preserves local changes)
-        let output = create_command("git")
+        let output = crate::utils::git_command()?
             .args(["checkout", "-b", &branch_name])
             .current_dir(&validated_path)
             .output()
@@ -452,7 +452,7 @@ pub async fn create_branch(
         let explicit_remote = from_branch.starts_with("origin/");
 
         let local_exists = !explicit_remote
-            && create_command("git")
+            && crate::utils::git_command()?
                 .args(["show-ref", "--verify", "--quiet"])
                 .arg(format!("refs/heads/{plain}"))
                 .current_dir(&validated_path)
@@ -469,7 +469,7 @@ pub async fn create_branch(
             format!("origin/{plain}")
         };
 
-        let output = create_command("git")
+        let output = crate::utils::git_command()?
             .args(["checkout", "-b", &branch_name, &base_ref])
             .current_dir(&validated_path)
             .output()
@@ -570,7 +570,7 @@ pub async fn delete_branch(
     }
 
     // Get current branch to make sure we're not on it
-    let current = create_command("git")
+    let current = crate::utils::git_command()?
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(&validated_path)
         .output()
@@ -586,7 +586,7 @@ pub async fn delete_branch(
     }
 
     // Delete local branch
-    let local_output = create_command("git")
+    let local_output = crate::utils::git_command()?
         .args(["branch", "-D", "--", &branch_name])
         .current_dir(&validated_path)
         .output()
@@ -623,7 +623,7 @@ pub async fn delete_branch(
         // surfaces remote-tracking refs as branches, that stale ref makes the branch
         // look undeleted (the reported "auto clean doesn't delete the branch anymore").
         // `-rD` is a harmless no-op when the ref is already gone or there's no remote.
-        let _ = create_command("git")
+        let _ = crate::utils::git_command()?
             .args(["branch", "-rD", &format!("origin/{branch_name}")])
             .current_dir(&validated_path)
             .output();

--- a/src-tauri/src/commands/git/graph.rs
+++ b/src-tauri/src/commands/git/graph.rs
@@ -8,7 +8,7 @@
 
 use crate::errors::CommandError;
 use crate::types::{BranchGraphNode, BranchGraphResult};
-use crate::utils::{create_command, validate_project_path};
+use crate::utils::validate_project_path;
 use std::collections::HashSet;
 use tracing::debug;
 
@@ -41,7 +41,10 @@ impl RawBranch {
 /// Mirrors `list_branches` but does no background fetch — the graph reflects
 /// whatever refs are already present.
 fn list_raw_branches(path: &std::path::Path) -> Vec<RawBranch> {
-    let output = create_command("git")
+    let Ok(mut cmd) = crate::utils::git_command() else {
+        return Vec::new();
+    };
+    let output = cmd
         .args([
             "branch",
             "-a",
@@ -121,7 +124,8 @@ fn detect_default_branch(names: &HashSet<String>) -> Option<String> {
 
 /// Commit hash a ref points at.
 fn rev_parse(path: &std::path::Path, git_ref: &str) -> Option<String> {
-    let out = create_command("git")
+    let out = crate::utils::git_command()
+        .ok()?
         .args([
             "rev-parse",
             "--verify",
@@ -145,7 +149,8 @@ fn rev_parse(path: &std::path::Path, git_ref: &str) -> Option<String> {
 
 /// The merge-base commit of two refs, plus its committer timestamp.
 fn merge_base(path: &std::path::Path, a: &str, b: &str) -> Option<(String, i64)> {
-    let out = create_command("git")
+    let out = crate::utils::git_command()
+        .ok()?
         .args(["merge-base", a, b])
         .current_dir(path)
         .output()
@@ -157,7 +162,8 @@ fn merge_base(path: &std::path::Path, a: &str, b: &str) -> Option<(String, i64)>
     if hash.is_empty() {
         return None;
     }
-    let date_out = create_command("git")
+    let date_out = crate::utils::git_command()
+        .ok()?
         .args(["show", "-s", "--format=%ct", &hash])
         .current_dir(path)
         .output()

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -25,7 +25,7 @@ pub use worktree::*;
 use crate::errors::CommandError;
 use crate::external_command::run_with_timeout;
 use crate::types::PrerequisiteCheck;
-use crate::utils::{create_command, find_executable, get_extended_path, validate_project_path};
+use crate::utils::{find_executable, get_extended_path, validate_project_path};
 use tracing::{debug, error, info, instrument};
 
 /// Default timeout for git network operations (fetch / pull / push). 60s is
@@ -56,7 +56,7 @@ pub(crate) async fn run_git_net(
 ) -> Result<std::process::Output, CommandError> {
     let workspace_env = crate::commands::accounts::get_env_vars_for_project(cwd);
 
-    let mut cmd = create_command("git");
+    let mut cmd = crate::utils::git_command()?;
 
     // Force HTTPS credential resolution through gh (which reads the GH_CONFIG_DIR
     // injected below) for every workspace. The empty `credential.helper=` first
@@ -91,7 +91,7 @@ pub(crate) async fn run_git_net(
 
 /// Checks if there are uncommitted changes (staged or unstaged tracked files).
 pub fn git_has_uncommitted_changes(path: &std::path::Path) -> Result<bool, String> {
-    let status = create_command("git")
+    let status = crate::utils::git_command()?
         .args(["status", "--porcelain", "-uno"])
         .current_dir(path)
         .output()
@@ -102,7 +102,7 @@ pub fn git_has_uncommitted_changes(path: &std::path::Path) -> Result<bool, Strin
 
 /// Checks if there are any changes (including untracked) in the working directory.
 pub fn git_has_any_changes(path: &std::path::Path) -> Result<bool, String> {
-    let status = create_command("git")
+    let status = crate::utils::git_command()?
         .args(["status", "--porcelain"])
         .current_dir(path)
         .output()
@@ -115,7 +115,7 @@ pub fn git_has_any_changes(path: &std::path::Path) -> Result<bool, String> {
 /// Returns true if a commit was made, false if nothing to commit.
 pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<bool, String> {
     // Stage all changes
-    let add_output = create_command("git")
+    let add_output = crate::utils::git_command()?
         .args(["add", "-A"])
         .current_dir(path)
         .output()
@@ -129,7 +129,7 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
         // changes are fine (issue #275). Retry with --sparse, which stages
         // out-of-cone paths instead of refusing.
         if add_stderr.contains("outside of your sparse-checkout definition") {
-            let sparse_output = create_command("git")
+            let sparse_output = crate::utils::git_command()?
                 .args(["add", "-A", "--sparse"])
                 .current_dir(path)
                 .output()
@@ -150,7 +150,7 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
     }
 
     // Commit
-    let commit_output = create_command("git")
+    let commit_output = crate::utils::git_command()?
         .args(["commit", "-m", message])
         .current_dir(path)
         .output()
@@ -179,7 +179,8 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
 
 /// Get the current branch name synchronously (for internal use)
 pub fn get_current_branch_sync(path: &std::path::Path) -> Option<String> {
-    let output = create_command("git")
+    let output = crate::utils::git_command()
+        .ok()?
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(path)
         .output()
@@ -199,7 +200,10 @@ pub fn get_current_branch_sync(path: &std::path::Path) -> Option<String> {
 
 /// Calculates how many commits `branch` is ahead/behind compared to `compare_to`.
 pub fn get_ahead_behind(path: &std::path::Path, branch: &str, compare_to: &str) -> (i32, i32) {
-    let output = create_command("git")
+    let Ok(mut cmd) = crate::utils::git_command() else {
+        return (0, 0);
+    };
+    let output = cmd
         .args([
             "rev-list",
             "--left-right",
@@ -244,7 +248,10 @@ pub fn get_ahead_behind_batch(
     // being parsed as a flag.
     for name in branch_names {
         let range = format!("{name}...{compare_to}");
-        let output = create_command("git")
+        let Ok(mut cmd) = crate::utils::git_command() else {
+            break;
+        };
+        let output = cmd
             .args(["rev-list", "--left-right", "--count", "--end-of-options"])
             .arg(&range)
             .current_dir(path)
@@ -374,7 +381,7 @@ pub async fn init_git_repo(project_path: String) -> Result<(), CommandError> {
     info!("Initializing git repository");
 
     // Initialize git repo
-    let output = create_command("git")
+    let output = crate::utils::git_command()?
         .args(["init"])
         .current_dir(&validated_path)
         .output()

--- a/src-tauri/src/commands/git/stash.rs
+++ b/src-tauri/src/commands/git/stash.rs
@@ -3,7 +3,7 @@
 use crate::cache::GIT_CACHE;
 use crate::errors::CommandError;
 use crate::types::RestoreResult;
-use crate::utils::{create_command, validate_project_path};
+use crate::utils::validate_project_path;
 use tracing::{info, instrument, warn};
 
 use super::{
@@ -34,7 +34,7 @@ pub async fn get_stash_info(
 pub async fn stash_changes(project_path: String) -> Result<bool, CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let output = create_command("git")
+    let output = crate::utils::git_command()?
         .args([
             "stash",
             "push",
@@ -63,7 +63,7 @@ pub async fn stash_changes(project_path: String) -> Result<bool, CommandError> {
 pub async fn apply_stash(project_path: String) -> Result<bool, CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let pop_output = create_command("git")
+    let pop_output = crate::utils::git_command()?
         .args(["stash", "pop"])
         .current_dir(&validated_path)
         .output()
@@ -91,7 +91,7 @@ pub async fn apply_stash(project_path: String) -> Result<bool, CommandError> {
 pub async fn drop_stash(project_path: String) -> Result<bool, CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let drop_output = create_command("git")
+    let drop_output = crate::utils::git_command()?
         .args(["stash", "drop"])
         .current_dir(&validated_path)
         .output()
@@ -127,7 +127,7 @@ pub async fn get_backups(
     info!(limit, "Getting backups");
 
     // Format: hash|full_hash|message|timestamp|relative_time
-    let output = create_command("git")
+    let output = crate::utils::git_command()?
         .args([
             "--no-pager",
             "log",
@@ -187,7 +187,7 @@ pub async fn restore_backup(
     };
 
     // Get the commit message of the target backup
-    let msg_output = create_command("git")
+    let msg_output = crate::utils::git_command()?
         .args(["--no-pager", "log", "-1", "--format=%s", &commit_hash])
         .current_dir(&validated_path)
         .output()
@@ -205,7 +205,7 @@ pub async fn restore_backup(
     let has_changes = git_has_any_changes(&validated_path)?;
     if has_changes {
         info!("Stashing current changes");
-        let stash_output = create_command("git")
+        let stash_output = crate::utils::git_command()?
             .args(["stash", "push", "-m", "Auto-stash before restore"])
             .current_dir(&validated_path)
             .output()
@@ -221,7 +221,7 @@ pub async fn restore_backup(
     let branch_name = format!("restore-{short_hash}");
 
     // Check if branch already exists and delete it if so
-    let branch_exists = create_command("git")
+    let branch_exists = crate::utils::git_command()?
         .args(["rev-parse", "--verify", &branch_name])
         .current_dir(&validated_path)
         .output()
@@ -230,13 +230,13 @@ pub async fn restore_backup(
 
     if branch_exists {
         // Delete the existing branch
-        let _ = create_command("git")
+        let _ = crate::utils::git_command()?
             .args(["branch", "-D", &branch_name])
             .current_dir(&validated_path)
             .output();
     }
 
-    let create_output = create_command("git")
+    let create_output = crate::utils::git_command()?
         .args(["checkout", "-b", &branch_name])
         .current_dir(&validated_path)
         .output()
@@ -245,7 +245,7 @@ pub async fn restore_backup(
     if !create_output.status.success() {
         // Restore stash if we created one
         if has_changes {
-            if let Err(e) = create_command("git")
+            if let Err(e) = crate::utils::git_command()?
                 .args(["stash", "pop"])
                 .current_dir(&validated_path)
                 .output()
@@ -261,7 +261,7 @@ pub async fn restore_backup(
     }
 
     // 3. Checkout all files from the target commit
-    let checkout_output = create_command("git")
+    let checkout_output = crate::utils::git_command()?
         .args(["checkout", &commit_hash, "--", "."])
         .current_dir(&validated_path)
         .output()
@@ -269,7 +269,7 @@ pub async fn restore_backup(
 
     if !checkout_output.status.success() {
         // Switch back to original branch and restore stash
-        if let Err(e) = create_command("git")
+        if let Err(e) = crate::utils::git_command()?
             .args(["checkout", &current_branch])
             .current_dir(&validated_path)
             .output()
@@ -279,7 +279,7 @@ pub async fn restore_backup(
                 e
             );
         }
-        if let Err(e) = create_command("git")
+        if let Err(e) = crate::utils::git_command()?
             .args(["branch", "-D", &branch_name])
             .current_dir(&validated_path)
             .output()
@@ -287,7 +287,7 @@ pub async fn restore_backup(
             warn!("Failed to delete restore branch during recovery: {}", e);
         }
         if has_changes {
-            if let Err(e) = create_command("git")
+            if let Err(e) = crate::utils::git_command()?
                 .args(["stash", "pop"])
                 .current_dir(&validated_path)
                 .output()
@@ -306,7 +306,7 @@ pub async fn restore_backup(
     if !committed {
         // No changes means we're already at this state
         // Switch back to original branch and clean up
-        if let Err(e) = create_command("git")
+        if let Err(e) = crate::utils::git_command()?
             .args(["checkout", &current_branch])
             .current_dir(&validated_path)
             .output()
@@ -316,7 +316,7 @@ pub async fn restore_backup(
                 e
             );
         }
-        if let Err(e) = create_command("git")
+        if let Err(e) = crate::utils::git_command()?
             .args(["branch", "-D", &branch_name])
             .current_dir(&validated_path)
             .output()
@@ -324,7 +324,7 @@ pub async fn restore_backup(
             warn!("Failed to delete restore branch after no-op restore: {}", e);
         }
         if has_changes {
-            if let Err(e) = create_command("git")
+            if let Err(e) = crate::utils::git_command()?
                 .args(["stash", "pop"])
                 .current_dir(&validated_path)
                 .output()
@@ -337,7 +337,7 @@ pub async fn restore_backup(
 
     // 5. Push the new branch to remote
     info!("Pushing restore branch");
-    let push_output = create_command("git")
+    let push_output = crate::utils::git_command()?
         .args(["push", "-u", "origin", &branch_name])
         .current_dir(&validated_path)
         .output()

--- a/src-tauri/src/commands/git/status.rs
+++ b/src-tauri/src/commands/git/status.rs
@@ -3,7 +3,7 @@
 use crate::cache::GIT_CACHE;
 use crate::errors::CommandError;
 use crate::types::{BranchStatus, ChangedFile};
-use crate::utils::{create_command, validate_project_path};
+use crate::utils::validate_project_path;
 use tracing::warn;
 
 // Network git ops (fetch) go through the workspace-scoped helper in the parent
@@ -35,7 +35,7 @@ pub async fn check_git_has_changes(project_path: String) -> Result<bool, Command
     }
 
     // Check for unpushed commits
-    let unpushed = create_command("git")
+    let unpushed = crate::utils::git_command()?
         .args(["--no-pager", "log", "@{u}..", "--oneline"])
         .current_dir(&project)
         .output();
@@ -47,7 +47,7 @@ pub async fn check_git_has_changes(project_path: String) -> Result<bool, Command
         }
         Err(_) => {
             // No upstream set, check if we have commits
-            let commits = create_command("git")
+            let commits = crate::utils::git_command()?
                 .args(["--no-pager", "log", "--oneline", "-1"])
                 .current_dir(&project)
                 .output()
@@ -83,7 +83,7 @@ pub async fn get_changed_files(project_path: String) -> Result<Vec<ChangedFile>,
     }
 
     // Run git status --porcelain (include untracked files)
-    let output = create_command("git")
+    let output = crate::utils::git_command()?
         .args(["status", "--porcelain"])
         .current_dir(&project)
         .output()
@@ -142,7 +142,7 @@ pub async fn get_file_diff(
     let validated_path = validate_project_path(&project_path)?;
 
     // Run git diff HEAD -- <filepath> to get all uncommitted changes
-    let output = create_command("git")
+    let output = crate::utils::git_command()?
         .args(["diff", "HEAD", "--", &file_path])
         .current_dir(&validated_path)
         .output()
@@ -153,7 +153,7 @@ pub async fn get_file_diff(
     // If diff is empty, the file might be untracked (new file)
     if diff_content.trim().is_empty() {
         // Check if file is untracked
-        let status_output = create_command("git")
+        let status_output = crate::utils::git_command()?
             .args(["status", "--porcelain", "--", &file_path])
             .current_dir(&validated_path)
             .output()
@@ -235,7 +235,7 @@ pub async fn get_branch_status(project_path: String) -> Result<BranchStatus, Com
     }
 
     // Check if staging branch exists on remote
-    let staging_check = create_command("git")
+    let staging_check = crate::utils::git_command()?
         .args(["ls-remote", "--heads", "origin", "staging"])
         .current_dir(&validated_path)
         .output()
@@ -247,7 +247,7 @@ pub async fn get_branch_status(project_path: String) -> Result<BranchStatus, Com
 
     // Get commits ahead/behind for staging
     let (staging_ahead, staging_behind) = if staging_exists {
-        let output = create_command("git")
+        let output = crate::utils::git_command()?
             .args([
                 "rev-list",
                 "--left-right",
@@ -270,7 +270,7 @@ pub async fn get_branch_status(project_path: String) -> Result<BranchStatus, Com
     };
 
     // Get commits ahead/behind for main
-    let output = create_command("git")
+    let output = crate::utils::git_command()?
         .args(["rev-list", "--left-right", "--count", "HEAD...origin/main"])
         .current_dir(&validated_path)
         .output();
@@ -317,7 +317,7 @@ pub async fn reset_to_branch(project_path: String, branch: String) -> Result<(),
     }
 
     // Reset hard to the remote branch
-    let reset = create_command("git")
+    let reset = crate::utils::git_command()?
         .args(["reset", "--hard", remote_branch])
         .current_dir(&validated_path)
         .output()
@@ -329,7 +329,7 @@ pub async fn reset_to_branch(project_path: String, branch: String) -> Result<(),
     }
 
     // Clean untracked files
-    let clean = create_command("git")
+    let clean = crate::utils::git_command()?
         .args(["clean", "-fd"])
         .current_dir(&validated_path)
         .output()

--- a/src-tauri/src/commands/git/sync.rs
+++ b/src-tauri/src/commands/git/sync.rs
@@ -2,7 +2,7 @@
 
 use crate::cache::GIT_CACHE;
 use crate::errors::CommandError;
-use crate::utils::{create_command, validate_project_path};
+use crate::utils::validate_project_path;
 
 use super::git_stage_and_commit;
 // Network git ops (fetch, pull, merge) go through the workspace-scoped helper in
@@ -103,7 +103,7 @@ pub async fn discard_changes(project_path: String) -> Result<(), CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
     // Discard changes to tracked files
-    let checkout_output = create_command("git")
+    let checkout_output = crate::utils::git_command()?
         .args(["checkout", "."])
         .current_dir(&validated_path)
         .output()
@@ -115,7 +115,7 @@ pub async fn discard_changes(project_path: String) -> Result<(), CommandError> {
     }
 
     // Remove untracked files
-    let clean_output = create_command("git")
+    let clean_output = crate::utils::git_command()?
         .args(["clean", "-fd"])
         .current_dir(&validated_path)
         .output()

--- a/src-tauri/src/commands/git/worktree.rs
+++ b/src-tauri/src/commands/git/worktree.rs
@@ -14,7 +14,7 @@
 
 use crate::cache::GIT_CACHE;
 use crate::errors::CommandError;
-use crate::utils::{create_command, projects_root, validate_project_path};
+use crate::utils::{projects_root, validate_project_path};
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 use tracing::{info, instrument, warn};
@@ -174,7 +174,7 @@ fn pick_free_port(start: u16) -> Option<u16> {
 }
 
 fn run_worktree_git(cwd: &Path, args: &[&str]) -> Result<std::process::Output, CommandError> {
-    create_command("git")
+    crate::utils::git_command()?
         .args(args)
         .current_dir(cwd)
         .output()

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -250,7 +250,9 @@ pub async fn get_project_github_status(project_path: String) -> ProjectGitHubSta
 
     // Get remote URL (with timeout)
     let step_start = std::time::Instant::now();
-    let mut remote_cmd = create_command("git");
+    let Ok(mut remote_cmd) = crate::utils::git_command() else {
+        return not_a_repo;
+    };
     remote_cmd
         .args(["remote", "get-url", "origin"])
         .current_dir(&project)
@@ -351,14 +353,14 @@ pub async fn get_project_github_status(project_path: String) -> ProjectGitHubSta
 /// Ensures git user.name and user.email are configured for the repo.
 /// If not set, fetches the user's identity from GitHub CLI and sets it locally.
 pub fn ensure_git_identity(repo_path: &std::path::Path) -> Result<(), CommandError> {
-    let has_name = create_command("git")
+    let has_name = crate::utils::git_command()?
         .args(["config", "user.name"])
         .current_dir(repo_path)
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);
 
-    let has_email = create_command("git")
+    let has_email = crate::utils::git_command()?
         .args(["config", "user.email"])
         .current_dir(repo_path)
         .output()
@@ -389,7 +391,7 @@ pub fn ensure_git_identity(repo_path: &std::path::Path) -> Result<(), CommandErr
 
     if !has_name {
         let display_name = name.unwrap_or(login);
-        create_command("git")
+        crate::utils::git_command()?
             .args(["config", "user.name", display_name])
             .current_dir(repo_path)
             .output()
@@ -406,7 +408,7 @@ pub fn ensure_git_identity(repo_path: &std::path::Path) -> Result<(), CommandErr
         } else {
             user_email.to_string()
         };
-        create_command("git")
+        crate::utils::git_command()?
             .args(["config", "user.email", &final_email])
             .current_dir(repo_path)
             .output()
@@ -431,7 +433,7 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
     // Check if it's already a git repo, if not initialize
     let git_dir = validated_path.join(".git");
     if !git_dir.exists() {
-        create_command("git")
+        crate::utils::git_command()?
             .args(["init"])
             .current_dir(&validated_path)
             .output()
@@ -452,7 +454,7 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
     );
 
     // Ensure at least one commit exists (gh repo create --push requires it)
-    let has_commits = create_command("git")
+    let has_commits = crate::utils::git_command()?
         .args(["rev-parse", "HEAD"])
         .current_dir(&validated_path)
         .output()
@@ -460,7 +462,7 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
         .unwrap_or(false);
 
     if !has_commits {
-        let output = create_command("git")
+        let output = crate::utils::git_command()?
             .args([
                 "commit",
                 "--allow-empty",

--- a/src-tauri/src/commands/ide/screenshots/thumbnail.rs
+++ b/src-tauri/src/commands/ide/screenshots/thumbnail.rs
@@ -134,7 +134,28 @@ pub async fn capture_project_thumbnail(
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err((format!("Browser screenshot failed: {stderr}")).into());
+            let stderr = stderr.trim();
+            // Headless Chromium can die with EMPTY stderr (crash, killed by
+            // AV/security software) — fall back to the exit code plus a
+            // stdout snippet so the report says something (issue #291).
+            let detail = if stderr.is_empty() {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let stdout = stdout.trim();
+                let code = output
+                    .status
+                    .code()
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "killed by signal".to_string());
+                if stdout.is_empty() {
+                    format!("exit code {code}, no output")
+                } else {
+                    let snippet: String = stdout.chars().take(300).collect();
+                    format!("exit code {code}: {snippet}")
+                }
+            } else {
+                stderr.to_string()
+            };
+            return Err((format!("Browser screenshot failed: {detail}")).into());
         }
 
         // Read the captured image and resize using the image crate (cross-platform)

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -352,6 +352,21 @@ pub async fn add_mcp_server(
     Ok(())
 }
 
+/// Does this CLI error text mean "no server with that name exists"?
+///
+/// Wording varies by agent CLI and version: "No MCP server named x",
+/// "No project-local MCP server found with name: x", "x not found",
+/// "no such server". An allowlist of exact phrases kept missing variants
+/// (issue #295), so match on the shape instead.
+fn mcp_server_not_found(details: &str) -> bool {
+    let lower = details.to_ascii_lowercase();
+    lower.contains("not found")
+        || lower.contains("no such")
+        || (lower.contains("no ")
+            && lower.contains("server")
+            && (lower.contains("found") || lower.contains("named")))
+}
+
 /// Remove an MCP server by name using the agent's CLI.
 #[tauri::command]
 #[tracing::instrument(skip_all, fields(agent = ?agent_id))]
@@ -401,6 +416,16 @@ pub async fn remove_mcp_server(
         } else {
             stderr
         };
+        // Removing a server that's already gone is the goal state, not an
+        // error — the preview bridge's remove-then-add cycle races manual
+        // removes and re-registrations, and CLI wording for "not found"
+        // varies by agent/version ("No MCP server named …", "No
+        // project-local MCP server found with name: …"), so match broadly
+        // (issues #248, #295).
+        if mcp_server_not_found(&details) {
+            tracing::info!(server = %name, "mcp remove: server already absent — treating as success");
+            return Ok(());
+        }
         return Err((format!("Failed to remove MCP server: {details}")).into());
     }
 
@@ -572,5 +597,28 @@ mod tests {
     fn test_shell_split_extra_whitespace() {
         let args = shell_split("  my-server   --   npx  ");
         assert_eq!(args, vec!["my-server", "--", "npx"]);
+    }
+
+    #[test]
+    fn not_found_matches_known_cli_wordings() {
+        // Claude Code
+        assert!(mcp_server_not_found(
+            "No MCP server named \"shipstudio-preview\" in local scope"
+        ));
+        // The #295 variant that slipped past the old exact-phrase check
+        assert!(mcp_server_not_found(
+            "No project-local MCP server found with name: shipstudio-preview"
+        ));
+        assert!(mcp_server_not_found("server 'x' not found"));
+        assert!(mcp_server_not_found("no such server: x"));
+    }
+
+    #[test]
+    fn not_found_rejects_real_failures() {
+        assert!(!mcp_server_not_found(
+            "MCP server shipstudio-preview already exists in local config"
+        ));
+        assert!(!mcp_server_not_found("permission denied writing config"));
+        assert!(!mcp_server_not_found(""));
     }
 }

--- a/src-tauri/src/commands/plugins/mod.rs
+++ b/src-tauri/src/commands/plugins/mod.rs
@@ -291,7 +291,8 @@ fn plugins_owner_root(validated: &Path) -> PathBuf {
         }
     }
     let resolved = (|| {
-        let output = create_command("git")
+        let output = crate::utils::git_command()
+            .ok()?
             .args(["rev-parse", "--git-common-dir"])
             .current_dir(validated)
             .output()

--- a/src-tauri/src/commands/plugins/plugin_storage.rs
+++ b/src-tauri/src/commands/plugins/plugin_storage.rs
@@ -18,6 +18,11 @@ use super::{
     PluginInfo, RegistryEntry, ShellResult,
 };
 
+/// Hard ceiling on a plugin's requested shell timeout. Plugins pass
+/// `timeout_secs` straight through, so an accidental millisecond value
+/// (15000 as "15s") used to become a ~4-hour hang (issue #294).
+const MAX_PLUGIN_SHELL_TIMEOUT_SECS: u64 = 600;
+
 /// Read plugin storage data
 ///
 /// Storage is at {project}/.shipstudio/plugins/{plugin-id}/storage.json
@@ -120,28 +125,32 @@ pub async fn exec_plugin_shell(
         .into());
     }
 
-    // Build and execute command with timeout
-    let timeout = timeout_secs.unwrap_or(120);
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(timeout),
-        tokio::task::spawn_blocking(move || {
-            create_command(&command)
-                .args(&args)
-                .current_dir(&validated_path)
-                .env("PATH", get_extended_path())
-                .env(
-                    "HOME",
-                    dirs::home_dir()
-                        .map(|h| h.to_string_lossy().to_string())
-                        .unwrap_or_default(),
-                )
-                .output()
-        }),
-    )
-    .await
-    .map_err(|_| format!("Plugin shell command timed out ({timeout}s)"))?
-    .map_err(|e| format!("Failed to spawn command: {e}"))?
-    .map_err(|e| format!("Failed to execute command: {e}"))?;
+    // Build and execute command with timeout. The timeout is clamped: a
+    // plugin passing e.g. a millisecond value as seconds (15000 → ~4 hours)
+    // must not hang the user for hours (issue #294).
+    let timeout = timeout_secs
+        .unwrap_or(120)
+        .min(MAX_PLUGIN_SHELL_TIMEOUT_SECS);
+    let mut std_cmd = create_command(&command);
+    std_cmd
+        .args(&args)
+        .current_dir(&validated_path)
+        .env("PATH", get_extended_path())
+        .env(
+            "HOME",
+            dirs::home_dir()
+                .map(|h| h.to_string_lossy().to_string())
+                .unwrap_or_default(),
+        );
+    // tokio Command with kill_on_drop: when the timeout fires, dropping the
+    // output future kills the child instead of leaking it to run invisibly
+    // to completion in the background (issue #294).
+    let mut cmd = tokio::process::Command::from(std_cmd);
+    cmd.kill_on_drop(true);
+    let output = tokio::time::timeout(std::time::Duration::from_secs(timeout), cmd.output())
+        .await
+        .map_err(|_| format!("Plugin shell command timed out ({timeout}s)"))?
+        .map_err(|e| format!("Failed to execute command: {e}"))?;
 
     Ok(ShellResult {
         stdout: String::from_utf8_lossy(&output.stdout).to_string(),

--- a/src-tauri/src/commands/publishing.rs
+++ b/src-tauri/src/commands/publishing.rs
@@ -11,7 +11,7 @@ use crate::commands::git::run_git_net;
 use crate::commands::github::ensure_git_identity;
 use crate::errors::CommandError;
 use crate::types::PublishResult;
-use crate::utils::{create_command, validate_project_path};
+use crate::utils::validate_project_path;
 use tracing::{debug, error, info, instrument, warn};
 
 #[tauri::command]
@@ -25,7 +25,7 @@ pub async fn publish_to_github(
     info!(message = %message, "Publishing to GitHub");
 
     // Get current branch name
-    let branch_output = create_command("git")
+    let branch_output = crate::utils::git_command()?
         .args(["branch", "--show-current"])
         .current_dir(&validated_path)
         .output()
@@ -205,7 +205,7 @@ pub async fn publish_branch(
     let message = resolve_commit_message(&validated_path, commit_message).await;
 
     // Get current branch name
-    let branch_output = create_command("git")
+    let branch_output = crate::utils::git_command()?
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(&validated_path)
         .output()

--- a/src-tauri/src/commands/pull_requests.rs
+++ b/src-tauri/src/commands/pull_requests.rs
@@ -6,7 +6,7 @@ use crate::commands::github::get_gh_command_for_project;
 use crate::errors::CommandError;
 use crate::external_command::run_with_timeout;
 use crate::types::PullRequestInfo;
-use crate::utils::{create_command, validate_project_path};
+use crate::utils::validate_project_path;
 
 /// Timeout for network-facing CLI ops (gh/git) so a hung remote can't freeze a
 /// PR command. Matches git/branches.rs.
@@ -100,7 +100,7 @@ pub async fn create_pull_request(
     let validated_path = validate_project_path(&project_path)?;
 
     // Push the branch to the remote first (gh pr create requires this)
-    let mut push_cmd = create_command("git");
+    let mut push_cmd = crate::utils::git_command()?;
     push_cmd
         .args(["push", "-u", "origin", "HEAD"])
         .envs(crate::commands::accounts::get_env_vars_for_project(
@@ -189,7 +189,7 @@ pub async fn checkout_pull_request(
     }
 
     // Return the branch name that was checked out
-    let branch_output = create_command("git")
+    let branch_output = crate::utils::git_command()?
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(&validated_path)
         .output()
@@ -229,7 +229,7 @@ mod tests {
     /// commands). `git --version` is deterministic and needs no repo or remote.
     #[tokio::test]
     async fn run_net_executes_command_through_timeout() {
-        let mut cmd = create_command("git");
+        let mut cmd = crate::utils::git_command().unwrap();
         cmd.args(["--version"]);
         let out = run_net(cmd, "git --version")
             .await

--- a/src-tauri/src/commands/snapshots.rs
+++ b/src-tauri/src/commands/snapshots.rs
@@ -24,7 +24,7 @@
 //!   restoring files doesn't itself create a new snapshot.
 
 use crate::errors::CommandError;
-use crate::utils::{create_command, validate_project_path};
+use crate::utils::validate_project_path;
 use notify::{EventKind, RecursiveMode, Watcher};
 use serde::Serialize;
 use std::collections::{HashMap, VecDeque};
@@ -143,7 +143,7 @@ fn is_relevant_path(p: &Path, project_root: &Path) -> bool {
 /// Capture the current working tree as a stash commit. Returns the SHA, or
 /// empty string if the tree is clean (nothing to snapshot).
 fn capture_snapshot(project_path: &Path) -> Result<String, CommandError> {
-    let output = create_command("git")
+    let output = crate::utils::git_command()?
         .args(["stash", "create"])
         .current_dir(project_path)
         .output()
@@ -177,7 +177,10 @@ fn diff_files(project_path: &Path, from_sha: &str, to_sha: &str) -> Vec<String> 
     if from_ref == to_ref {
         return Vec::new();
     }
-    let output = match create_command("git")
+    let Ok(mut diff_cmd) = crate::utils::git_command() else {
+        return Vec::new();
+    };
+    let output = match diff_cmd
         .args(["diff", "--name-only", from_ref, to_ref])
         .current_dir(project_path)
         .output()
@@ -199,7 +202,7 @@ fn diff_files(project_path: &Path, from_sha: &str, to_sha: &str) -> Vec<String> 
 fn apply_snapshot(project_path: &Path, sha: &str) -> Result<(), CommandError> {
     if sha.is_empty() {
         // Clean working tree: reset tracked files to HEAD.
-        let out = create_command("git")
+        let out = crate::utils::git_command()?
             .args(["checkout-index", "-a", "-f"])
             .current_dir(project_path)
             .output()
@@ -219,7 +222,7 @@ fn apply_snapshot(project_path: &Path, sha: &str) -> Result<(), CommandError> {
     // `stash create` produces a merge commit whose first parent is HEAD and
     // whose tree is the working tree. Apply that tree to both the index and
     // the working directory.
-    let read_tree = create_command("git")
+    let read_tree = crate::utils::git_command()?
         .args(["read-tree", "-u", "--reset", sha])
         .current_dir(project_path)
         .output()

--- a/src-tauri/src/error_reporting.rs
+++ b/src-tauri/src/error_reporting.rs
@@ -400,6 +400,12 @@ pub fn report_command_error(err: &crate::errors::CommandError) {
         if lower.starts_with("plugin '") && lower.ends_with("' not found") {
             return;
         }
+        // Preview-bridge MCP registration racing a concurrent writer: the
+        // losing add fails "already exists" but the goal state (server
+        // registered) is reached; the frontend treats it as benign (#292).
+        if lower.contains("failed to add mcp server") && lower.contains("already exists") {
+            return;
+        }
     }
     let fingerprint = command_error_fingerprint(err);
     report_error(

--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -124,6 +124,16 @@ impl From<&str> for CommandError {
     }
 }
 
+/// Lets `?` propagate a `CommandError` (e.g. from `utils::git_command`)
+/// inside the legacy helpers that still return `Result<_, String>`. New
+/// commands should return `CommandError` directly — this exists so shared
+/// fallible helpers work in both worlds without per-site `.map_err`.
+impl From<CommandError> for String {
+    fn from(err: CommandError) -> Self {
+        err.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -47,8 +47,11 @@ pub async fn run_with_timeout(
         }
         Ok(Err(io_err)) => {
             warn!(cmd = %label, error = %io_err, "external command spawn failed");
+            // Name the command: Windows renders a PATH miss as the bare
+            // "program not found", which is useless without knowing WHICH
+            // program (issue #296) — Timeout/Process already carry the label.
             Err(CommandError::Io {
-                message: io_err.to_string(),
+                message: format!("`{label}`: {io_err}"),
             })
         }
         Err(_) => {
@@ -99,7 +102,9 @@ mod tests {
         let cmd = Command::new("definitely-not-a-real-binary-shipstudio");
         let err = run_with_timeout(cmd, "ghost", 5).await.unwrap_err();
         match err {
-            CommandError::Io { .. } => {}
+            CommandError::Io { message } => {
+                assert!(message.contains("`ghost`"), "got: {message}")
+            }
             other => panic!("expected Io, got {other:?}"),
         }
     }

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -921,7 +921,15 @@ async fn handle_websocket_upgrade(
     let target_resp = match sender.send_request(forwarded_req).await {
         Ok(r) => r,
         Err(e) => {
-            tracing::error!("[Proxy] WebSocket forward failed: {}", e);
+            // Include the upstream port: "invalid HTTP version parsed" here
+            // means the socket connected but returned non-HTTP bytes (wrong
+            // process on the port, dev server mid-restart, AV interference) —
+            // without the port the report is uncorrelatable (issue #293).
+            tracing::error!(
+                "[Proxy] WebSocket forward to 127.0.0.1:{} failed: {}",
+                target_port,
+                e
+            );
             return Ok(Response::builder()
                 .status(StatusCode::BAD_GATEWAY)
                 .body(full_body(Bytes::from("WebSocket proxy error")))

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -365,6 +365,35 @@ fn build_extended_path() -> String {
     paths.join(get_path_separator())
 }
 
+/// Build a `Command` for git, resolving the full binary path first.
+///
+/// Spawning bare `"git"` can fail to resolve on Windows even when git is
+/// installed — and the resulting `io::Error` renders as the context-free
+/// "program not found" (issue #297). Resolving via [`find_executable`] fixes
+/// resolution and yields a clear, actionable error when git truly is missing.
+///
+/// The resolved path is cached after the first success; a miss is re-probed
+/// on every call, so installing git mid-session (the onboarding wizard does
+/// exactly this) starts working without an app restart.
+pub fn git_command() -> Result<Command, crate::errors::CommandError> {
+    static GIT_PATH: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+    if let Some(path) = GIT_PATH.get() {
+        return Ok(create_command(path));
+    }
+    match find_executable("git") {
+        Some(path) => {
+            let cmd = create_command(&path);
+            let _ = GIT_PATH.set(path);
+            Ok(cmd)
+        }
+        None => Err(crate::errors::CommandError::Other {
+            message: "Git isn't installed or couldn't be located. Install Git \
+                      (https://git-scm.com) and restart Ship Studio, then try again."
+                .into(),
+        }),
+    }
+}
+
 /// Finds an executable by checking common installation paths.
 /// This is needed because bundled macOS apps don't inherit the user's shell PATH.
 /// On Windows, checks standard Program Files and AppData locations.

--- a/src/components/plugins/McpModal.tsx
+++ b/src/components/plugins/McpModal.tsx
@@ -136,7 +136,11 @@ export function McpModal({
       await fetchServers();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      if (/no mcp server named|not found/i.test(message)) {
+      // CLI wording varies ("No MCP server named …", "No project-local MCP
+      // server found with name: …") — match the shape, not exact phrases
+      // (#295). The backend now also treats these as success (mcp.rs), so
+      // this is defense for wordings that slip through.
+      if (/no .*mcp server|not found|no such/i.test(message)) {
         // Already gone (e.g. the preview bridge's remove-then-re-add cycle
         // raced this click) — that's the outcome the user wanted, not an error.
         await fetchServers();

--- a/src/lib/agentBridge.ts
+++ b/src/lib/agentBridge.ts
@@ -133,7 +133,23 @@ function writeRegistrationCache(key: string, url: string): void {
  * Local scope: the config stays in the user's own agent settings and never
  * lands in the repo (the URL embeds a secret and must not be committed).
  */
-export async function registerPreviewMcpServer(url: string, projectPath: string): Promise<void> {
+export function registerPreviewMcpServer(url: string, projectPath: string): Promise<void> {
+  // Serialize per project: the remove-then-add cycle is not atomic, so two
+  // concurrent registrations (e.g. a re-attach racing the first attach) could
+  // interleave and fail with "already exists" on the losing add (issue #292).
+  const existing = inFlightRegistrations.get(projectPath);
+  if (existing) return existing;
+  const run = doRegisterPreviewMcpServer(url, projectPath).finally(() => {
+    inFlightRegistrations.delete(projectPath);
+  });
+  inFlightRegistrations.set(projectPath, run);
+  return run;
+}
+
+/** In-flight preview registrations keyed by project path (see above). */
+const inFlightRegistrations = new Map<string, Promise<void>>();
+
+async function doRegisterPreviewMcpServer(url: string, projectPath: string): Promise<void> {
   const agentId = 'claude-code';
   const cache = readRegistrationCache();
   if (cache[projectPath] === url) return;
@@ -143,12 +159,20 @@ export async function registerPreviewMcpServer(url: string, projectPath: string)
   } catch {
     // Not registered yet — the normal case on first registration.
   }
-  await addMcpServer(
-    `--transport http ${PREVIEW_MCP_SERVER_NAME} ${url}`,
-    'local',
-    projectPath,
-    agentId
-  );
+  try {
+    await addMcpServer(
+      `--transport http ${PREVIEW_MCP_SERVER_NAME} ${url}`,
+      'local',
+      projectPath,
+      agentId
+    );
+  } catch (err) {
+    // "Already exists" means a concurrent writer (another window, a manual
+    // add) recreated the entry between our remove and add — the goal state
+    // (server registered, same stable URL) is reached, so don't fail (#292).
+    if (!/already exists/i.test(formatCommandError(asCommandError(err)))) throw err;
+    logger.info('[AgentBridge] MCP entry already present — treating as registered');
+  }
   writeRegistrationCache(projectPath, url);
 }
 


### PR DESCRIPTION
Round 5 of the auto-reported bug bash — all seven issues filed from v0.18.0/0.18.1 telemetry today.

fixes #291
fixes #292
fixes #293
fixes #294
fixes #295
fixes #296
fixes #297

## #297 — core git commands surfaced bare "program not found" on Windows
New `utils::git_command()` resolves the git binary via `find_executable` before spawning (fixing the Windows bare-`Command::new` resolution quirk) and returns a clear "Git isn't installed…" error when it's truly missing. The resolved path is positive-cached; a miss is re-probed every call, so the onboarding wizard installing git mid-session starts working without a restart. All 91 `create_command("git")` sites across 14 files now route through it; infallible helpers (Option/Vec/tuple returns) degrade gracefully. Adds `impl From<CommandError> for String` so the helper propagates through legacy `Result<_, String>` helpers.

## #296 — `CommandError::Io` dropped the command label
`run_with_timeout` now formats the Io message as `` `{label}`: {io_err} ``, matching Timeout/Process. A Windows "program not found" through the shared helper now names the missing CLI. Test updated to assert the label.

## #295 + #292 — MCP remove/add races (both sides of #248)
- `remove_mcp_server` is now idempotent: CLI "no server found" wording variants ("No MCP server named …", "No project-local MCP server found with name: …", "not found", "no such") are treated as the goal state, with a shape-based matcher + unit tests. Kills the telemetry noise at the root; `McpModal`'s frontend regex is broadened as defense.
- `registerPreviewMcpServer` is serialized per project via an in-flight promise map, and a racing "already exists" on the add side is treated as benign (the end state — server registered with the same stable URL — is reached). Telemetry skips that message too.

## #294 — unbounded plugin shell timeout + leaked child
`exec_plugin_shell` clamps plugin-supplied `timeout_secs` to 600s (a reported 15000s ≈ 4.2-hour hang came from a likely ms-as-seconds mistake), and now runs the child via `tokio::process::Command` with `kill_on_drop(true)` — a timed-out command is killed instead of running invisibly to completion in the background.

## #293 / #291 — diagnostic context for two Windows-only reports
- WebSocket proxy forward errors now include the upstream port ("forward to 127.0.0.1:{port} failed"), so "invalid HTTP version parsed" occurrences can be correlated with a framework/setup.
- The headless-Chromium thumbnail fallback reports the exit code and a stdout snippet when stderr is empty (crash/AV-kill cases), instead of the dead-end "Browser screenshot failed: ".

## Verification
- `cargo test`: 747 passed (2 new for the MCP not-found matcher; existing Io test extended)
- `pnpm test:run`: 1375 passed; `tsc --noEmit`, `eslint`, `pnpm check:patterns` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git operations now provide clearer setup guidance when Git cannot be found.
  * Plugin shell commands are limited to a safe maximum runtime and terminate cleanly when timed out.
  * Concurrent MCP server registrations are handled more reliably.

* **Bug Fixes**
  * Removing an already-missing MCP server now completes successfully.
  * Improved diagnostics for failed project thumbnail captures.
  * Git-related operations handle command failures more consistently.
  * External command and proxy errors now include more useful details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->