### PR TITLE
Cut telemetry noise at the source: typed Expected errors, stop reporting Validation

### DIFF
--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -500,14 +500,11 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
         // A name collision is user input needing a different name, not a
         // malfunction — surface it in plain language instead of GitHub's raw
         // "GraphQL: Name already exists on this account (createRepository)"
-        // (issue #279). error_reporting skips this message so routine
-        // collisions don't generate telemetry noise.
+        // (issue #279). Expected: routine collisions aren't telemetry.
         if stderr.contains("Name already exists on this account") {
-            return Err(CommandError::Other {
-                message: format!(
-                    "A repository named \"{repo_name}\" already exists on this account. Choose a different name."
-                ),
-            });
+            return Err(CommandError::expected(format!(
+                "A repository named \"{repo_name}\" already exists on this account. Choose a different name."
+            )));
         }
         return Err(CommandError::Process {
             cmd: "gh repo create".to_string(),

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -56,9 +56,12 @@ fn strip_ansi(s: &str) -> String {
 /// version flag so a broken install (e.g. an npm package whose platform
 /// vendor binary is missing on disk) is skipped instead of being invoked and
 /// surfacing its internal ENOENT stack trace (issue #286).
-fn find_agent_binary(agent: &crate::agent::AgentConfig) -> Result<std::path::PathBuf, String> {
+fn find_agent_binary(
+    agent: &crate::agent::AgentConfig,
+) -> Result<std::path::PathBuf, CommandError> {
     crate::commands::claude::find_validated_binary(agent.binary_name, agent.version_flag)
-        .ok_or_else(|| format!("{} binary not found", agent.display_name))
+        // Expected: "agent not installed" is an environment gap, not a bug.
+        .ok_or_else(|| CommandError::expected(format!("{} binary not found", agent.display_name)))
 }
 
 /// Parse the output of `claude mcp list` which has the format:
@@ -346,7 +349,13 @@ pub async fn add_mcp_server(
         } else {
             stderr
         };
-        return Err((format!("Failed to add MCP server: {details}")).into());
+        let message = format!("Failed to add MCP server: {details}");
+        // "Already exists" is a benign race with a concurrent registration —
+        // the goal state is reached; callers treat it accordingly (#292).
+        if details.to_ascii_lowercase().contains("already exists") {
+            return Err(CommandError::expected(message));
+        }
+        return Err(message.into());
     }
 
     Ok(())

--- a/src-tauri/src/commands/plugins/plugin_lifecycle.rs
+++ b/src-tauri/src/commands/plugins/plugin_lifecycle.rs
@@ -559,7 +559,9 @@ pub fn toggle_plugin(
         write_registry(&project_path, &registry)?;
         Ok(())
     } else {
-        Err((format!("Plugin '{plugin_id}' not found")).into())
+        Err(CommandError::expected(format!(
+            "Plugin '{plugin_id}' not found"
+        )))
     }
 }
 

--- a/src-tauri/src/commands/plugins/plugin_storage.rs
+++ b/src-tauri/src/commands/plugins/plugin_storage.rs
@@ -111,7 +111,9 @@ pub async fn exec_plugin_shell(
         false
     };
     if !plugin_exists {
-        return Err((format!("Plugin '{plugin_id}' not found")).into());
+        return Err(CommandError::expected(format!(
+            "Plugin '{plugin_id}' not found"
+        )));
     }
 
     // Resolve the binary up front so a missing tool yields an actionable
@@ -119,10 +121,9 @@ pub async fn exec_plugin_shell(
     // directory (os error 2)" from Command::output() (issue #256). Mirrors
     // resolve_git() in plugin_lifecycle.rs / get_gh_command() in github.rs.
     if crate::utils::find_executable(&command).is_none() {
-        return Err((format!(
+        return Err(CommandError::expected(format!(
             "Plugin '{plugin_id}' tried to run '{command}', but it isn't installed or not on PATH."
-        ))
-        .into());
+        )));
     }
 
     // Build and execute command with timeout. The timeout is clamped: a
@@ -272,7 +273,9 @@ pub fn unlink_dev_plugin(project_path: String, plugin_id: String) -> Result<(), 
             return Err(("Plugin is not a dev plugin. Use uninstall instead.".to_string()).into());
         }
         None => {
-            return Err((format!("Plugin '{plugin_id}' not found")).into());
+            return Err(CommandError::expected(format!(
+                "Plugin '{plugin_id}' not found"
+            )));
         }
         _ => {}
     }

--- a/src-tauri/src/error_reporting.rs
+++ b/src-tauri/src/error_reporting.rs
@@ -362,48 +362,45 @@ fn command_error_fingerprint(err: &crate::errors::CommandError) -> Option<String
     match err {
         E::Timeout { cmd, .. } => Some(format!("cmderr-timeout-{cmd}")),
         E::Process { cmd, .. } => Some(format!("cmderr-process-{cmd}")),
-        E::Validation { field, .. } => Some(format!("cmderr-validation-{field}")),
         E::MergeConflict { .. } => Some("cmderr-merge-conflict".to_string()),
-        E::NotAuthenticated { .. } | E::Io { .. } | E::Other { .. } => None,
+        E::Validation { .. }
+        | E::NotAuthenticated { .. }
+        | E::Io { .. }
+        | E::Expected { .. }
+        | E::Other { .. } => None,
     }
 }
 
 /// Report a `CommandError` the moment it's serialized for the frontend —
-/// the one choke point that sees every backend failure a user experiences,
-/// including structured Validation errors rendered inline (no toast, no
-/// error log). Called from `CommandError`'s `Serialize` impl.
+/// the one choke point that sees every backend failure a user experiences.
+/// Called from `CommandError`'s `Serialize` impl.
 ///
-/// `NotAuthenticated` is skipped: a not-yet-connected integration is an
-/// expected state, not a malfunction. Same for "not a git repository" — a
-/// project that hasn't been `git init`ed is routine (the frontend already
-/// `.catch(() => null)`s it on a 10s poll), and reporting it spams telemetry
-/// with a non-bug on every poll tick (issue #254).
+/// Skipped variants are states where the app is working correctly:
+/// - `NotAuthenticated` — a not-yet-connected integration is expected.
+/// - `Validation` — user-input feedback rendered inline. These were
+///   deliberately reported at first (and did surface one real UX dead end,
+///   issue #287), but a cost audit showed the class is overwhelmingly
+///   "app refusing correctly" noise at investigation prices.
+/// - `Expected` — the typed marker for by-design refusals, environment gaps
+///   ("install X first"), and benign races, classified at the throw site.
+///   New skip cases belong THERE, not in message sniffing here.
+///
+/// One message-text exception remains: "not a git repository" arrives inside
+/// arbitrary git stderr passthrough (issue #254), so it can't be typed at a
+/// throw site.
 pub fn report_command_error(err: &crate::errors::CommandError) {
-    if matches!(err, crate::errors::CommandError::NotAuthenticated { .. }) {
+    use crate::errors::CommandError as E;
+    if matches!(
+        err,
+        E::NotAuthenticated { .. } | E::Validation { .. } | E::Expected { .. }
+    ) {
         return;
     }
-    if let crate::errors::CommandError::Other { message } = err {
-        let lower = message.to_ascii_lowercase();
-        if lower.contains("not a git repository") {
-            return;
-        }
-        // Repo-name collision on Create Repo — user input needing a different
-        // name, already surfaced as a friendly message (issue #279).
-        if lower.contains("already exists on this account") {
-            return;
-        }
-        // Stale plugin call racing an uninstall/project switch: an exec that
-        // was already in flight when its plugin was unloaded rejects with
-        // "Plugin 'x' not found" — an expected transient state, not a
-        // malfunction (issue #288). The "not found in registry" variants from
-        // update/check flows don't match this suffix and still report.
-        if lower.starts_with("plugin '") && lower.ends_with("' not found") {
-            return;
-        }
-        // Preview-bridge MCP registration racing a concurrent writer: the
-        // losing add fails "already exists" but the goal state (server
-        // registered) is reached; the frontend treats it as benign (#292).
-        if lower.contains("failed to add mcp server") && lower.contains("already exists") {
+    if let E::Other { message } = err {
+        if message
+            .to_ascii_lowercase()
+            .contains("not a git repository")
+        {
             return;
         }
     }
@@ -547,13 +544,14 @@ mod tests {
     #[test]
     fn command_error_fingerprints_are_stable_slugs() {
         use crate::errors::CommandError as E;
+        // Validation is no longer reported at all (user-input feedback, not
+        // a malfunction) — no fingerprint.
         assert_eq!(
             command_error_fingerprint(&E::Validation {
                 field: "branch".into(),
                 reason: "Invalid ref name".into()
-            })
-            .as_deref(),
-            Some("cmderr-validation-branch")
+            }),
+            None
         );
         assert_eq!(
             command_error_fingerprint(&E::Timeout {

--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -33,8 +33,27 @@ pub enum CommandError {
     #[error("Pull request {pr_number} cannot be merged cleanly: {stderr}")]
     MergeConflict { pr_number: i32, stderr: String },
 
+    /// An anticipated, by-design refusal or environment gap — the app
+    /// *working correctly*: editor guardrails, path-security refusals,
+    /// "install X first" states, benign races. Rendered to the frontend
+    /// identically to `Other` (it serializes as `Other`, so no TS change),
+    /// but never auto-reported to telemetry. This is the typed intent that
+    /// replaces the substring denylist in `report_command_error` — classify
+    /// at the throw site, don't sniff message text downstream.
+    #[error("{message}")]
+    Expected { message: String },
+
     #[error("{message}")]
     Other { message: String },
+}
+
+impl CommandError {
+    /// Shorthand for [`CommandError::Expected`].
+    pub fn expected(message: impl Into<String>) -> Self {
+        CommandError::Expected {
+            message: message.into(),
+        }
+    }
 }
 
 /// Serialization happens exactly once per command failure — when Tauri sends
@@ -96,6 +115,9 @@ impl Serialize for CommandError {
             CommandError::MergeConflict { pr_number, stderr } => {
                 Mirror::MergeConflict { pr_number, stderr }
             }
+            // Expected is a backend-only distinction (reporting intent);
+            // the frontend renders it exactly like Other.
+            CommandError::Expected { message } => Mirror::Other { message },
             CommandError::Other { message } => Mirror::Other { message },
         };
         mirror.serialize(serializer)
@@ -170,6 +192,17 @@ mod tests {
         };
         let json = serde_json::to_string(&err).unwrap();
         assert!(json.contains("\"field\":\"path\""));
+    }
+
+    #[test]
+    fn expected_serializes_as_other() {
+        // Expected is a backend-only reporting distinction — the frontend
+        // contract must not change (no new "type" value to handle).
+        let err = CommandError::expected("Git isn't installed");
+        let json = serde_json::to_string(&err).unwrap();
+        assert!(json.contains("\"type\":\"Other\""), "got: {json}");
+        assert!(json.contains("Git isn't installed"));
+        assert_eq!(err.to_string(), "Git isn't installed");
     }
 
     #[test]

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -50,9 +50,14 @@ pub async fn run_with_timeout(
             // Name the command: Windows renders a PATH miss as the bare
             // "program not found", which is useless without knowing WHICH
             // program (issue #296) — Timeout/Process already carry the label.
-            Err(CommandError::Io {
-                message: format!("`{label}`: {io_err}"),
-            })
+            let message = format!("`{label}`: {io_err}");
+            // A missing binary is an environment gap ("install X first"),
+            // not an app malfunction — Expected keeps it out of telemetry.
+            if io_err.kind() == std::io::ErrorKind::NotFound {
+                Err(CommandError::expected(message))
+            } else {
+                Err(CommandError::Io { message })
+            }
         }
         Err(_) => {
             warn!(cmd = %label, timeout_secs, "external command timed out");
@@ -98,14 +103,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_with_timeout_maps_missing_binary_to_io() {
+    async fn run_with_timeout_maps_missing_binary_to_expected_with_label() {
         let cmd = Command::new("definitely-not-a-real-binary-shipstudio");
         let err = run_with_timeout(cmd, "ghost", 5).await.unwrap_err();
+        // Missing binary = environment gap: labeled (#296) and typed
+        // Expected so it never reaches telemetry.
         match err {
-            CommandError::Io { message } => {
+            CommandError::Expected { message } => {
                 assert!(message.contains("`ghost`"), "got: {message}")
             }
-            other => panic!("expected Io, got {other:?}"),
+            other => panic!("expected Expected, got {other:?}"),
         }
     }
 

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -386,11 +386,12 @@ pub fn git_command() -> Result<Command, crate::errors::CommandError> {
             let _ = GIT_PATH.set(path);
             Ok(cmd)
         }
-        None => Err(crate::errors::CommandError::Other {
-            message: "Git isn't installed or couldn't be located. Install Git \
-                      (https://git-scm.com) and restart Ship Studio, then try again."
-                .into(),
-        }),
+        // Expected: a missing git is an environment gap the onboarding
+        // wizard handles, not an app malfunction.
+        None => Err(crate::errors::CommandError::expected(
+            "Git isn't installed or couldn't be located. Install Git \
+             (https://git-scm.com) and restart Ship Studio, then try again",
+        )),
     }
 }
 
@@ -753,10 +754,17 @@ pub fn canonicalize_tagged(
 /// Validates that a project path is inside an allowed projects root (the
 /// configured root or the default `~/ShipStudio`) or is a registered external
 /// project. Prevents path traversal where the frontend could pass arbitrary paths.
-pub fn validate_project_path(project_path: &str) -> Result<std::path::PathBuf, String> {
+///
+/// Refusals are `CommandError::Expected`: the sandbox rejecting a path is the
+/// app working correctly, not a malfunction to report.
+pub fn validate_project_path(
+    project_path: &str,
+) -> Result<std::path::PathBuf, crate::errors::CommandError> {
     let path = std::path::Path::new(project_path);
     if !path.is_absolute() {
-        return Err("Security error: project path must be absolute".to_string());
+        return Err(crate::errors::CommandError::expected(
+            "Security error: project path must be absolute",
+        ));
     }
     let canonical = canonicalize_tagged(path, "validate_project_path")?;
 
@@ -773,9 +781,9 @@ pub fn validate_project_path(project_path: &str) -> Result<std::path::PathBuf, S
         return Ok(canonical);
     }
 
-    Err(format!(
+    Err(crate::errors::CommandError::expected(format!(
         "Security error: path '{project_path}' is outside the projects directory"
-    ))
+    )))
 }
 
 /// Validates a path to a *file* that lives inside ~/ShipStudio (or a registered
@@ -790,7 +798,10 @@ pub fn validate_project_path(project_path: &str) -> Result<std::path::PathBuf, S
 /// absolute path.
 ///
 /// Returns the safe, canonical absolute path the caller should operate on.
-pub fn validate_project_file_path(file_path: &str) -> Result<std::path::PathBuf, String> {
+/// Refusals are `CommandError::Expected` (see [`validate_project_path`]).
+pub fn validate_project_file_path(
+    file_path: &str,
+) -> Result<std::path::PathBuf, crate::errors::CommandError> {
     let path = std::path::Path::new(file_path);
 
     let file_name = path
@@ -811,9 +822,9 @@ pub fn validate_project_file_path(file_path: &str) -> Result<std::path::PathBuf,
         || crate::commands::external_projects::is_registered_external_path(&canonical_parent)?;
 
     if !allowed {
-        return Err(format!(
+        return Err(crate::errors::CommandError::expected(format!(
             "Security error: path '{file_path}' is outside the projects directory"
-        ));
+        )));
     }
 
     let resolved = canonical_parent.join(file_name);
@@ -825,9 +836,9 @@ pub fn validate_project_file_path(file_path: &str) -> Result<std::path::PathBuf,
     // in assets.rs::upload_asset.)
     if let Ok(meta) = std::fs::symlink_metadata(&resolved) {
         if meta.file_type().is_symlink() {
-            return Err(format!(
+            return Err(crate::errors::CommandError::expected(format!(
                 "Security error: '{file_path}' is a symlink; refusing to follow it"
-            ));
+            )));
         }
     }
 
@@ -1310,7 +1321,9 @@ mod tests {
             // Current working directory in test runner is src-tauri, which is
             // outside ~/ShipStudio. `.` canonicalizes to cwd, so this should
             // fail the security check.
-            let err = validate_project_path(".").expect_err("should reject");
+            let err = validate_project_path(".")
+                .expect_err("should reject")
+                .to_string();
             assert!(
                 err.contains("Security error") || err.contains("outside ShipStudio"),
                 "unexpected error: {err}"
@@ -1320,7 +1333,8 @@ mod tests {
         #[test]
         fn rejects_nonexistent_path() {
             let err = validate_project_path("/this/path/definitely/does/not/exist/shipstudio-test")
-                .expect_err("should reject nonexistent");
+                .expect_err("should reject nonexistent")
+                .to_string();
             // Either "Invalid path" (from canonicalize) or the security error —
             // both are acceptable rejection modes.
             assert!(!err.is_empty(), "empty error for nonexistent path");
@@ -1440,7 +1454,8 @@ mod tests {
             let home = dirs::home_dir().expect("home dir");
             let target = home.join(".zshenv-shipstudio-audit-test");
             let err = validate_project_file_path(&target.to_string_lossy())
-                .expect_err("file in $HOME (outside ShipStudio) must be rejected");
+                .expect_err("file in $HOME (outside ShipStudio) must be rejected")
+                .to_string();
             assert!(
                 err.contains("Security error") || err.contains("outside ShipStudio"),
                 "unexpected error: {err}"


### PR DESCRIPTION
Implements the in-app half of the error-telemetry cost audit (fixes 2 and 3): 81% of paid agent investigations were triggered by the app *refusing correctly* — validation feedback, security refusals, missing-CLI states, benign races.

## 1. `Validation` errors are no longer reported
`report_command_error` skips `CommandError::Validation` entirely (97 sites of user-input feedback like "Class names can't be empty…"). The original deliberate choice to include them is reversed with eyes open — this class did surface one real UX dead end (#287) — because at investigation prices the class is overwhelmingly noise, and the planned server-side per-fingerprint refractory is the right tool for the residual signal.

## 2. Typed `Expected` intent replaces the substring denylist
New `CommandError::Expected { message }` + `CommandError::expected()` constructor: the by-design refusal / environment-gap classification, made at the throw site instead of sniffed from message text downstream (#295 was precisely a denylist regex missing a wording variant).

- **Serializes as `Other`** — zero frontend changes, locked by a test. The distinction exists only for the reporting hook.
- `report_command_error` now skips `NotAuthenticated | Validation | Expected`; the denylist shrinks from four entries to one — "not a git repository", which arrives inside arbitrary git stderr passthrough and can't be typed at a throw site.

Throw sites converted to `Expected`:
- Repo-name collision on Create Repo (#279)
- `Plugin 'x' not found` (stale-call race, #288) and plugin-tool-missing (#256)
- MCP agent-binary-not-found and the "already exists" add race (#292)
- `git_command()`'s "Git isn't installed" (#297)
- `validate_project_path` / `validate_project_file_path` security refusals — these now return `CommandError` directly instead of `Err(String) → Other → reported` (the audit's `utils.rs` finding). The `From<CommandError> for String` bridge keeps every call site compiling unchanged.
- `run_with_timeout` spawn `NotFound` — "Vercel CLI not installed" is an environment gap, not a crash (4+ reports today). Still labeled per #296; other I/O kinds still report.

## Verification
- `cargo test`: 748 passed (new: Expected→Other serialization lock; updated: missing-binary maps to Expected, Validation fingerprint removed)
- `pnpm test:run`: 1375 passed; `tsc --noEmit`, `eslint`, `pnpm check:patterns` clean

Pairs with the server-side global refractory being built in the admin-agent repo — that one kills cross-machine repeats; this one stops non-bugs from ever leaving the machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expected conditions, such as missing tools, unavailable plugins, duplicate repositories, and invalid project paths.
  * Clarified error messages for missing executables and unregistered plugins.
  * Reduced error reporting for expected, validation, authentication, and environment-related conditions.
  * Preserved existing frontend error display behavior while improving internal error classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->