### PR TITLE
Mark missing-browser thumbnail error as Expected

### DIFF
--- a/src-tauri/src/commands/ide/screenshots/thumbnail.rs
+++ b/src-tauri/src/commands/ide/screenshots/thumbnail.rs
@@ -183,11 +183,11 @@ pub async fn capture_project_thumbnail(
 
         Ok(thumbnail_path_str)
     } else {
-        Err(
-            "No supported browser found for screenshots (a Chromium-based browser is required: Chrome, Chromium, Edge, Brave, or Arc)"
-                .to_string()
-                .into(),
-        )
+        // Expected: a machine without a Chromium-based browser is an
+        // environment gap, not a malfunction — not telemetry.
+        Err(CommandError::expected(
+            "No supported browser found for screenshots (a Chromium-based browser is required: Chrome, Chromium, Edge, Brave, or Arc)",
+        ))
     }
 }
 


### PR DESCRIPTION
Follow-up to #299 closing the last item on the admin-agent audit's environment-gap list: "no browser found" (thumbnail capture on a machine without any Chromium-based browser) is now `CommandError::Expected` — surfaced to the user unchanged, never a paid investigation.

With this, the audit's ask list maps as: Validation skip ✅ (#299), editor guardrails ✅ (Validation class), `validate_project_path` refusals ✅ (#299), missing CLIs ✅ (#299, `run_with_timeout` NotFound), missing browser ✅ (this PR). One deliberate divergence: **network timeouts still report** — timeout fingerprints surfaced real hangs (#271/#272 boot-gate work), and with the server-side refractory now recording repeats without re-analysis, a first-occurrence-per-shape investigation of timeouts is cheap enough to keep the signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)