### PR TITLE
Fix round-6 auto-reported bugs: resolver guard, plugin logging, thumbnail retry loop, git safe.directory

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -237,9 +237,8 @@ pub async fn generate_pr_description(
 }
 
 async fn get_branch_name(path: &std::path::Path) -> Result<String, CommandError> {
-    let mut cmd = crate::utils::git_command()?;
-    cmd.args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(path);
+    let mut cmd = crate::utils::git_command_in(path)?;
+    cmd.args(["rev-parse", "--abbrev-ref", "HEAD"]);
     let output = run_with_timeout(
         tokio::process::Command::from(cmd),
         "git rev-parse",
@@ -255,15 +254,14 @@ async fn get_branch_name(path: &std::path::Path) -> Result<String, CommandError>
 }
 
 async fn get_commit_messages(path: &std::path::Path, base: &str) -> Result<String, CommandError> {
-    let mut cmd = crate::utils::git_command()?;
+    let mut cmd = crate::utils::git_command_in(path)?;
     cmd.args([
         "--no-pager",
         "log",
         &format!("{base}..HEAD"),
         "--pretty=format:%s",
         "--no-merges",
-    ])
-    .current_dir(path);
+    ]);
     let output = run_with_timeout(
         tokio::process::Command::from(cmd),
         "git log",
@@ -276,9 +274,8 @@ async fn get_commit_messages(path: &std::path::Path, base: &str) -> Result<Strin
 }
 
 async fn get_diff_stat(path: &std::path::Path, base: &str) -> Result<String, CommandError> {
-    let mut cmd = crate::utils::git_command()?;
-    cmd.args(["--no-pager", "diff", &format!("{base}...HEAD"), "--stat"])
-        .current_dir(path);
+    let mut cmd = crate::utils::git_command_in(path)?;
+    cmd.args(["--no-pager", "diff", &format!("{base}...HEAD"), "--stat"]);
     let output = run_with_timeout(
         tokio::process::Command::from(cmd),
         "git diff --stat",
@@ -290,9 +287,8 @@ async fn get_diff_stat(path: &std::path::Path, base: &str) -> Result<String, Com
 }
 
 async fn get_diff(path: &std::path::Path, base: &str) -> Result<String, CommandError> {
-    let mut cmd = crate::utils::git_command()?;
-    cmd.args(["--no-pager", "diff", &format!("{base}...HEAD")])
-        .current_dir(path);
+    let mut cmd = crate::utils::git_command_in(path)?;
+    cmd.args(["--no-pager", "diff", &format!("{base}...HEAD")]);
     let output = run_with_timeout(
         tokio::process::Command::from(cmd),
         "git diff",
@@ -497,9 +493,8 @@ pub async fn generate_commit_message_for_path(
 }
 
 fn git_status_porcelain(path: &std::path::Path) -> Result<String, CommandError> {
-    let output = crate::utils::git_command()?
+    let output = crate::utils::git_command_in(path)?
         .args(["status", "--porcelain"])
-        .current_dir(path)
         .output()
         .map_err(CommandError::from)?;
     if !output.status.success() {
@@ -512,11 +507,10 @@ fn git_status_porcelain(path: &std::path::Path) -> Result<String, CommandError> 
 /// unborn branch (no commits) `git diff HEAD` fails; we return whatever stdout
 /// it produced (empty) and let the porcelain file list carry the context.
 fn git_working_diff(path: &std::path::Path) -> String {
-    let Ok(mut cmd) = crate::utils::git_command() else {
+    let Ok(mut cmd) = crate::utils::git_command_in(path) else {
         return String::new();
     };
     cmd.args(["--no-pager", "diff", "HEAD"])
-        .current_dir(path)
         .output()
         .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
         .unwrap_or_default()
@@ -750,10 +744,9 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let git = |args: &[&str]| {
-            crate::utils::git_command()
+            crate::utils::git_command_in(dir)
                 .unwrap()
                 .args(args)
-                .current_dir(dir)
                 .output()
                 .unwrap()
         };
@@ -781,10 +774,9 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let git = |args: &[&str]| {
-            crate::utils::git_command()
+            crate::utils::git_command_in(dir)
                 .unwrap()
                 .args(args)
-                .current_dir(dir)
                 .output()
                 .unwrap()
         };

--- a/src-tauri/src/commands/conflicts.rs
+++ b/src-tauri/src/commands/conflicts.rs
@@ -113,9 +113,8 @@ pub async fn get_conflict_info(project_path: String) -> Result<Vec<ConflictedFil
     let validated_path = validate_project_path(&project_path)?;
 
     // Get list of files with unmerged changes
-    let output = crate::utils::git_command()?
+    let output = crate::utils::git_command_in(&validated_path)?
         .args(["diff", "--name-only", "--diff-filter=U"])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -133,9 +132,8 @@ pub async fn get_conflict_info(project_path: String) -> Result<Vec<ConflictedFil
         let file_path = validated_path.join(file);
 
         // Check if file is binary
-        let is_binary = crate::utils::git_command()?
+        let is_binary = crate::utils::git_command_in(&validated_path)?
             .args(["diff", "--numstat", file])
-            .current_dir(&validated_path)
             .output()
             .map(|out| {
                 let stdout = String::from_utf8_lossy(&out.stdout);
@@ -266,9 +264,8 @@ pub async fn resolve_conflict(
 
     // If no more conflicts, stage the file
     if !has_more_conflicts {
-        let add_output = crate::utils::git_command()?
+        let add_output = crate::utils::git_command_in(&validated_path)?
             .args(["add", &file_path])
-            .current_dir(&validated_path)
             .output()
             .map_err(|e| e.to_string())?;
 
@@ -287,9 +284,8 @@ pub async fn resolve_conflict(
 pub async fn abort_merge(project_path: String) -> Result<(), CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let output = crate::utils::git_command()?
+    let output = crate::utils::git_command_in(&validated_path)?
         .args(["merge", "--abort"])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -308,9 +304,8 @@ pub async fn complete_merge(project_path: String) -> Result<(), CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
     // Stage all changes
-    let add_output = crate::utils::git_command()?
+    let add_output = crate::utils::git_command_in(&validated_path)?
         .args(["add", "."])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -323,9 +318,8 @@ pub async fn complete_merge(project_path: String) -> Result<(), CommandError> {
     let _ = ensure_git_identity(&validated_path);
 
     // Create the merge commit
-    let commit_output = crate::utils::git_command()?
+    let commit_output = crate::utils::git_command_in(&validated_path)?
         .args(["commit", "-m", "Resolved merge conflicts via Ship Studio"])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/commands/git/branches.rs
+++ b/src-tauri/src/commands/git/branches.rs
@@ -59,9 +59,8 @@ pub async fn list_branches(project_path: String) -> Result<Vec<BranchInfo>, Comm
     }
 
     // Get all branches (local and remote)
-    let output = crate::utils::git_command()?
+    let output = crate::utils::git_command_in(&validated_path)?
         .args(["branch", "-a", "--format=%(refname:short)|%(objectname:short)|%(committerdate:unix)|%(authorname)|%(HEAD)"])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -189,9 +188,8 @@ pub async fn get_current_branch(project_path: String) -> Result<String, CommandE
 
     let validated_path = validate_project_path(&project_path)?;
 
-    let output = crate::utils::git_command()?
+    let output = crate::utils::git_command_in(&validated_path)?
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -239,14 +237,13 @@ pub async fn switch_branch(
     let has_changes = git_has_any_changes(&validated_path)?;
 
     if has_changes && auto_stash {
-        let stash_output = crate::utils::git_command()?
+        let stash_output = crate::utils::git_command_in(&validated_path)?
             .args([
                 "stash",
                 "push",
                 "-m",
                 &format!("Auto-stash by Ship Studio (from {current_branch})"),
             ])
-            .current_dir(&validated_path)
             .output()
             .map_err(|e| e.to_string())?;
 
@@ -281,18 +278,16 @@ pub async fn switch_branch(
     }
 
     // Try to checkout the branch
-    let checkout_output = crate::utils::git_command()?
+    let checkout_output = crate::utils::git_command_in(&validated_path)?
         .args(["checkout", "--end-of-options", &branch_name])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
     if !checkout_output.status.success() {
         // Checkout failed - restore the stash if we made one
         if stashed {
-            if let Err(e) = crate::utils::git_command()?
+            if let Err(e) = crate::utils::git_command_in(&validated_path)?
                 .args(["stash", "pop"])
-                .current_dir(&validated_path)
                 .output()
             {
                 warn!("Failed to restore stash after checkout failure: {}", e);
@@ -323,9 +318,8 @@ pub async fn switch_branch(
         // If we're switching back to the branch where we stashed from, offer to apply
         if stash_info.from_branch == branch_name {
             // Try to auto-apply the stash
-            let pop_output = crate::utils::git_command()?
+            let pop_output = crate::utils::git_command_in(&validated_path)?
                 .args(["stash", "pop"])
-                .current_dir(&validated_path)
                 .output();
 
             if let Ok(output) = pop_output {
@@ -348,9 +342,8 @@ pub async fn switch_branch(
     }
 
     // Pull latest changes from remote
-    if let Err(e) = crate::utils::git_command()?
+    if let Err(e) = crate::utils::git_command_in(&validated_path)?
         .args(["pull", "--ff-only"])
-        .current_dir(&validated_path)
         .output()
     {
         warn!("Failed to pull latest changes after branch switch: {}", e);
@@ -406,9 +399,8 @@ pub async fn create_branch(
     }
 
     // Get the current branch name
-    let current_branch_output = crate::utils::git_command()?
+    let current_branch_output = crate::utils::git_command_in(&validated_path)?
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -428,9 +420,8 @@ pub async fn create_branch(
 
     if is_from_current {
         // Create branch from current HEAD (preserves local changes)
-        let output = crate::utils::git_command()?
+        let output = crate::utils::git_command_in(&validated_path)?
             .args(["checkout", "-b", &branch_name])
-            .current_dir(&validated_path)
             .output()
             .map_err(|e| e.to_string())?;
 
@@ -452,10 +443,9 @@ pub async fn create_branch(
         let explicit_remote = from_branch.starts_with("origin/");
 
         let local_exists = !explicit_remote
-            && crate::utils::git_command()?
+            && crate::utils::git_command_in(&validated_path)?
                 .args(["show-ref", "--verify", "--quiet"])
                 .arg(format!("refs/heads/{plain}"))
-                .current_dir(&validated_path)
                 .output()
                 .map(|o| o.status.success())
                 .unwrap_or(false);
@@ -469,9 +459,8 @@ pub async fn create_branch(
             format!("origin/{plain}")
         };
 
-        let output = crate::utils::git_command()?
+        let output = crate::utils::git_command_in(&validated_path)?
             .args(["checkout", "-b", &branch_name, &base_ref])
-            .current_dir(&validated_path)
             .output()
             .map_err(|e| e.to_string())?;
 
@@ -570,9 +559,8 @@ pub async fn delete_branch(
     }
 
     // Get current branch to make sure we're not on it
-    let current = crate::utils::git_command()?
+    let current = crate::utils::git_command_in(&validated_path)?
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -586,9 +574,8 @@ pub async fn delete_branch(
     }
 
     // Delete local branch
-    let local_output = crate::utils::git_command()?
+    let local_output = crate::utils::git_command_in(&validated_path)?
         .args(["branch", "-D", "--", &branch_name])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -623,9 +610,8 @@ pub async fn delete_branch(
         // surfaces remote-tracking refs as branches, that stale ref makes the branch
         // look undeleted (the reported "auto clean doesn't delete the branch anymore").
         // `-rD` is a harmless no-op when the ref is already gone or there's no remote.
-        let _ = crate::utils::git_command()?
+        let _ = crate::utils::git_command_in(&validated_path)?
             .args(["branch", "-rD", &format!("origin/{branch_name}")])
-            .current_dir(&validated_path)
             .output();
     }
 

--- a/src-tauri/src/commands/git/graph.rs
+++ b/src-tauri/src/commands/git/graph.rs
@@ -41,7 +41,7 @@ impl RawBranch {
 /// Mirrors `list_branches` but does no background fetch — the graph reflects
 /// whatever refs are already present.
 fn list_raw_branches(path: &std::path::Path) -> Vec<RawBranch> {
-    let Ok(mut cmd) = crate::utils::git_command() else {
+    let Ok(mut cmd) = crate::utils::git_command_in(path) else {
         return Vec::new();
     };
     let output = cmd
@@ -50,7 +50,6 @@ fn list_raw_branches(path: &std::path::Path) -> Vec<RawBranch> {
             "-a",
             "--format=%(refname:short)|%(committerdate:unix)|%(HEAD)",
         ])
-        .current_dir(path)
         .output();
 
     let stdout = match output {
@@ -124,7 +123,7 @@ fn detect_default_branch(names: &HashSet<String>) -> Option<String> {
 
 /// Commit hash a ref points at.
 fn rev_parse(path: &std::path::Path, git_ref: &str) -> Option<String> {
-    let out = crate::utils::git_command()
+    let out = crate::utils::git_command_in(path)
         .ok()?
         .args([
             "rev-parse",
@@ -133,7 +132,6 @@ fn rev_parse(path: &std::path::Path, git_ref: &str) -> Option<String> {
             "--end-of-options",
             git_ref,
         ])
-        .current_dir(path)
         .output()
         .ok()?;
     if !out.status.success() {
@@ -149,10 +147,9 @@ fn rev_parse(path: &std::path::Path, git_ref: &str) -> Option<String> {
 
 /// The merge-base commit of two refs, plus its committer timestamp.
 fn merge_base(path: &std::path::Path, a: &str, b: &str) -> Option<(String, i64)> {
-    let out = crate::utils::git_command()
+    let out = crate::utils::git_command_in(path)
         .ok()?
         .args(["merge-base", a, b])
-        .current_dir(path)
         .output()
         .ok()?;
     if !out.status.success() {
@@ -162,10 +159,9 @@ fn merge_base(path: &std::path::Path, a: &str, b: &str) -> Option<(String, i64)>
     if hash.is_empty() {
         return None;
     }
-    let date_out = crate::utils::git_command()
+    let date_out = crate::utils::git_command_in(path)
         .ok()?
         .args(["show", "-s", "--format=%ct", &hash])
-        .current_dir(path)
         .output()
         .ok()?;
     let date = String::from_utf8_lossy(&date_out.stdout)

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -56,7 +56,9 @@ pub(crate) async fn run_git_net(
 ) -> Result<std::process::Output, CommandError> {
     let workspace_env = crate::commands::accounts::get_env_vars_for_project(cwd);
 
-    let mut cmd = crate::utils::git_command()?;
+    // git_command_in also passes `-c safe.directory=<cwd>` (issue #305) and
+    // sets the working directory.
+    let mut cmd = crate::utils::git_command_in(cwd)?;
 
     // Force HTTPS credential resolution through gh (which reads the GH_CONFIG_DIR
     // injected below) for every workspace. The empty `credential.helper=` first
@@ -76,7 +78,6 @@ pub(crate) async fn run_git_net(
     }
 
     cmd.args(args)
-        .current_dir(cwd)
         .env("PATH", get_extended_path())
         // Never block on an interactive credential prompt: a GUI-spawned git has
         // no usable tty, so a prompt would hang the worker. Fail fast instead.
@@ -91,9 +92,8 @@ pub(crate) async fn run_git_net(
 
 /// Checks if there are uncommitted changes (staged or unstaged tracked files).
 pub fn git_has_uncommitted_changes(path: &std::path::Path) -> Result<bool, String> {
-    let status = crate::utils::git_command()?
+    let status = crate::utils::git_command_in(path)?
         .args(["status", "--porcelain", "-uno"])
-        .current_dir(path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -102,9 +102,8 @@ pub fn git_has_uncommitted_changes(path: &std::path::Path) -> Result<bool, Strin
 
 /// Checks if there are any changes (including untracked) in the working directory.
 pub fn git_has_any_changes(path: &std::path::Path) -> Result<bool, String> {
-    let status = crate::utils::git_command()?
+    let status = crate::utils::git_command_in(path)?
         .args(["status", "--porcelain"])
-        .current_dir(path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -115,9 +114,8 @@ pub fn git_has_any_changes(path: &std::path::Path) -> Result<bool, String> {
 /// Returns true if a commit was made, false if nothing to commit.
 pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<bool, String> {
     // Stage all changes
-    let add_output = crate::utils::git_command()?
+    let add_output = crate::utils::git_command_in(path)?
         .args(["add", "-A"])
-        .current_dir(path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -129,9 +127,8 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
         // changes are fine (issue #275). Retry with --sparse, which stages
         // out-of-cone paths instead of refusing.
         if add_stderr.contains("outside of your sparse-checkout definition") {
-            let sparse_output = crate::utils::git_command()?
+            let sparse_output = crate::utils::git_command_in(path)?
                 .args(["add", "-A", "--sparse"])
-                .current_dir(path)
                 .output()
                 .map_err(|e| e.to_string())?;
             if !sparse_output.status.success() {
@@ -150,9 +147,8 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
     }
 
     // Commit
-    let commit_output = crate::utils::git_command()?
+    let commit_output = crate::utils::git_command_in(path)?
         .args(["commit", "-m", message])
-        .current_dir(path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -179,10 +175,9 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
 
 /// Get the current branch name synchronously (for internal use)
 pub fn get_current_branch_sync(path: &std::path::Path) -> Option<String> {
-    let output = crate::utils::git_command()
+    let output = crate::utils::git_command_in(path)
         .ok()?
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(path)
         .output()
         .ok()?;
 
@@ -200,7 +195,7 @@ pub fn get_current_branch_sync(path: &std::path::Path) -> Option<String> {
 
 /// Calculates how many commits `branch` is ahead/behind compared to `compare_to`.
 pub fn get_ahead_behind(path: &std::path::Path, branch: &str, compare_to: &str) -> (i32, i32) {
-    let Ok(mut cmd) = crate::utils::git_command() else {
+    let Ok(mut cmd) = crate::utils::git_command_in(path) else {
         return (0, 0);
     };
     let output = cmd
@@ -210,7 +205,6 @@ pub fn get_ahead_behind(path: &std::path::Path, branch: &str, compare_to: &str) 
             "--count",
             &format!("{branch}...{compare_to}"),
         ])
-        .current_dir(path)
         .output();
 
     match output {
@@ -248,13 +242,12 @@ pub fn get_ahead_behind_batch(
     // being parsed as a flag.
     for name in branch_names {
         let range = format!("{name}...{compare_to}");
-        let Ok(mut cmd) = crate::utils::git_command() else {
+        let Ok(mut cmd) = crate::utils::git_command_in(path) else {
             break;
         };
         let output = cmd
             .args(["rev-list", "--left-right", "--count", "--end-of-options"])
             .arg(&range)
-            .current_dir(path)
             .output();
 
         let (ahead, behind) = match output {
@@ -381,9 +374,8 @@ pub async fn init_git_repo(project_path: String) -> Result<(), CommandError> {
     info!("Initializing git repository");
 
     // Initialize git repo
-    let output = crate::utils::git_command()?
+    let output = crate::utils::git_command_in(&validated_path)?
         .args(["init"])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| {
             error!(error = %e, "Failed to execute git init");

--- a/src-tauri/src/commands/git/stash.rs
+++ b/src-tauri/src/commands/git/stash.rs
@@ -34,7 +34,7 @@ pub async fn get_stash_info(
 pub async fn stash_changes(project_path: String) -> Result<bool, CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let output = crate::utils::git_command()?
+    let output = crate::utils::git_command_in(&validated_path)?
         .args([
             "stash",
             "push",
@@ -42,7 +42,6 @@ pub async fn stash_changes(project_path: String) -> Result<bool, CommandError> {
             "-m",
             "Ship Studio: set aside before creating a branch",
         ])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -63,9 +62,8 @@ pub async fn stash_changes(project_path: String) -> Result<bool, CommandError> {
 pub async fn apply_stash(project_path: String) -> Result<bool, CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let pop_output = crate::utils::git_command()?
+    let pop_output = crate::utils::git_command_in(&validated_path)?
         .args(["stash", "pop"])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -91,9 +89,8 @@ pub async fn apply_stash(project_path: String) -> Result<bool, CommandError> {
 pub async fn drop_stash(project_path: String) -> Result<bool, CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let drop_output = crate::utils::git_command()?
+    let drop_output = crate::utils::git_command_in(&validated_path)?
         .args(["stash", "drop"])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -127,14 +124,13 @@ pub async fn get_backups(
     info!(limit, "Getting backups");
 
     // Format: hash|full_hash|message|timestamp|relative_time
-    let output = crate::utils::git_command()?
+    let output = crate::utils::git_command_in(&validated_path)?
         .args([
             "--no-pager",
             "log",
             &format!("-{limit}"),
             "--format=%h|%H|%s|%ct|%cr",
         ])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -187,9 +183,8 @@ pub async fn restore_backup(
     };
 
     // Get the commit message of the target backup
-    let msg_output = crate::utils::git_command()?
+    let msg_output = crate::utils::git_command_in(&validated_path)?
         .args(["--no-pager", "log", "-1", "--format=%s", &commit_hash])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -205,9 +200,8 @@ pub async fn restore_backup(
     let has_changes = git_has_any_changes(&validated_path)?;
     if has_changes {
         info!("Stashing current changes");
-        let stash_output = crate::utils::git_command()?
+        let stash_output = crate::utils::git_command_in(&validated_path)?
             .args(["stash", "push", "-m", "Auto-stash before restore"])
-            .current_dir(&validated_path)
             .output()
             .map_err(|e| e.to_string())?;
 
@@ -221,33 +215,29 @@ pub async fn restore_backup(
     let branch_name = format!("restore-{short_hash}");
 
     // Check if branch already exists and delete it if so
-    let branch_exists = crate::utils::git_command()?
+    let branch_exists = crate::utils::git_command_in(&validated_path)?
         .args(["rev-parse", "--verify", &branch_name])
-        .current_dir(&validated_path)
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);
 
     if branch_exists {
         // Delete the existing branch
-        let _ = crate::utils::git_command()?
+        let _ = crate::utils::git_command_in(&validated_path)?
             .args(["branch", "-D", &branch_name])
-            .current_dir(&validated_path)
             .output();
     }
 
-    let create_output = crate::utils::git_command()?
+    let create_output = crate::utils::git_command_in(&validated_path)?
         .args(["checkout", "-b", &branch_name])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
     if !create_output.status.success() {
         // Restore stash if we created one
         if has_changes {
-            if let Err(e) = crate::utils::git_command()?
+            if let Err(e) = crate::utils::git_command_in(&validated_path)?
                 .args(["stash", "pop"])
-                .current_dir(&validated_path)
                 .output()
             {
                 warn!(
@@ -261,17 +251,15 @@ pub async fn restore_backup(
     }
 
     // 3. Checkout all files from the target commit
-    let checkout_output = crate::utils::git_command()?
+    let checkout_output = crate::utils::git_command_in(&validated_path)?
         .args(["checkout", &commit_hash, "--", "."])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
     if !checkout_output.status.success() {
         // Switch back to original branch and restore stash
-        if let Err(e) = crate::utils::git_command()?
+        if let Err(e) = crate::utils::git_command_in(&validated_path)?
             .args(["checkout", &current_branch])
-            .current_dir(&validated_path)
             .output()
         {
             warn!(
@@ -279,17 +267,15 @@ pub async fn restore_backup(
                 e
             );
         }
-        if let Err(e) = crate::utils::git_command()?
+        if let Err(e) = crate::utils::git_command_in(&validated_path)?
             .args(["branch", "-D", &branch_name])
-            .current_dir(&validated_path)
             .output()
         {
             warn!("Failed to delete restore branch during recovery: {}", e);
         }
         if has_changes {
-            if let Err(e) = crate::utils::git_command()?
+            if let Err(e) = crate::utils::git_command_in(&validated_path)?
                 .args(["stash", "pop"])
-                .current_dir(&validated_path)
                 .output()
             {
                 warn!("Failed to restore stash during recovery: {}", e);
@@ -306,9 +292,8 @@ pub async fn restore_backup(
     if !committed {
         // No changes means we're already at this state
         // Switch back to original branch and clean up
-        if let Err(e) = crate::utils::git_command()?
+        if let Err(e) = crate::utils::git_command_in(&validated_path)?
             .args(["checkout", &current_branch])
-            .current_dir(&validated_path)
             .output()
         {
             warn!(
@@ -316,17 +301,15 @@ pub async fn restore_backup(
                 e
             );
         }
-        if let Err(e) = crate::utils::git_command()?
+        if let Err(e) = crate::utils::git_command_in(&validated_path)?
             .args(["branch", "-D", &branch_name])
-            .current_dir(&validated_path)
             .output()
         {
             warn!("Failed to delete restore branch after no-op restore: {}", e);
         }
         if has_changes {
-            if let Err(e) = crate::utils::git_command()?
+            if let Err(e) = crate::utils::git_command_in(&validated_path)?
                 .args(["stash", "pop"])
-                .current_dir(&validated_path)
                 .output()
             {
                 warn!("Failed to restore stash after no-op restore: {}", e);
@@ -337,9 +320,8 @@ pub async fn restore_backup(
 
     // 5. Push the new branch to remote
     info!("Pushing restore branch");
-    let push_output = crate::utils::git_command()?
+    let push_output = crate::utils::git_command_in(&validated_path)?
         .args(["push", "-u", "origin", &branch_name])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/commands/git/status.rs
+++ b/src-tauri/src/commands/git/status.rs
@@ -35,9 +35,8 @@ pub async fn check_git_has_changes(project_path: String) -> Result<bool, Command
     }
 
     // Check for unpushed commits
-    let unpushed = crate::utils::git_command()?
+    let unpushed = crate::utils::git_command_in(&project)?
         .args(["--no-pager", "log", "@{u}..", "--oneline"])
-        .current_dir(&project)
         .output();
 
     let result = match unpushed {
@@ -47,9 +46,8 @@ pub async fn check_git_has_changes(project_path: String) -> Result<bool, Command
         }
         Err(_) => {
             // No upstream set, check if we have commits
-            let commits = crate::utils::git_command()?
+            let commits = crate::utils::git_command_in(&project)?
                 .args(["--no-pager", "log", "--oneline", "-1"])
-                .current_dir(&project)
                 .output()
                 .map_err(|e| e.to_string())?;
 
@@ -83,9 +81,8 @@ pub async fn get_changed_files(project_path: String) -> Result<Vec<ChangedFile>,
     }
 
     // Run git status --porcelain (include untracked files)
-    let output = crate::utils::git_command()?
+    let output = crate::utils::git_command_in(&project)?
         .args(["status", "--porcelain"])
-        .current_dir(&project)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -142,9 +139,8 @@ pub async fn get_file_diff(
     let validated_path = validate_project_path(&project_path)?;
 
     // Run git diff HEAD -- <filepath> to get all uncommitted changes
-    let output = crate::utils::git_command()?
+    let output = crate::utils::git_command_in(&validated_path)?
         .args(["diff", "HEAD", "--", &file_path])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -153,9 +149,8 @@ pub async fn get_file_diff(
     // If diff is empty, the file might be untracked (new file)
     if diff_content.trim().is_empty() {
         // Check if file is untracked
-        let status_output = crate::utils::git_command()?
+        let status_output = crate::utils::git_command_in(&validated_path)?
             .args(["status", "--porcelain", "--", &file_path])
-            .current_dir(&validated_path)
             .output()
             .map_err(|e| e.to_string())?;
 
@@ -235,9 +230,8 @@ pub async fn get_branch_status(project_path: String) -> Result<BranchStatus, Com
     }
 
     // Check if staging branch exists on remote
-    let staging_check = crate::utils::git_command()?
+    let staging_check = crate::utils::git_command_in(&validated_path)?
         .args(["ls-remote", "--heads", "origin", "staging"])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -247,14 +241,13 @@ pub async fn get_branch_status(project_path: String) -> Result<BranchStatus, Com
 
     // Get commits ahead/behind for staging
     let (staging_ahead, staging_behind) = if staging_exists {
-        let output = crate::utils::git_command()?
+        let output = crate::utils::git_command_in(&validated_path)?
             .args([
                 "rev-list",
                 "--left-right",
                 "--count",
                 "HEAD...origin/staging",
             ])
-            .current_dir(&validated_path)
             .output()
             .map_err(|e| e.to_string())?;
 
@@ -270,9 +263,8 @@ pub async fn get_branch_status(project_path: String) -> Result<BranchStatus, Com
     };
 
     // Get commits ahead/behind for main
-    let output = crate::utils::git_command()?
+    let output = crate::utils::git_command_in(&validated_path)?
         .args(["rev-list", "--left-right", "--count", "HEAD...origin/main"])
-        .current_dir(&validated_path)
         .output();
 
     let (main_ahead, main_behind) = if let Ok(output) = output {
@@ -317,9 +309,8 @@ pub async fn reset_to_branch(project_path: String, branch: String) -> Result<(),
     }
 
     // Reset hard to the remote branch
-    let reset = crate::utils::git_command()?
+    let reset = crate::utils::git_command_in(&validated_path)?
         .args(["reset", "--hard", remote_branch])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -329,9 +320,8 @@ pub async fn reset_to_branch(project_path: String, branch: String) -> Result<(),
     }
 
     // Clean untracked files
-    let clean = crate::utils::git_command()?
+    let clean = crate::utils::git_command_in(&validated_path)?
         .args(["clean", "-fd"])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/commands/git/sync.rs
+++ b/src-tauri/src/commands/git/sync.rs
@@ -103,9 +103,8 @@ pub async fn discard_changes(project_path: String) -> Result<(), CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
     // Discard changes to tracked files
-    let checkout_output = crate::utils::git_command()?
+    let checkout_output = crate::utils::git_command_in(&validated_path)?
         .args(["checkout", "."])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 
@@ -115,9 +114,8 @@ pub async fn discard_changes(project_path: String) -> Result<(), CommandError> {
     }
 
     // Remove untracked files
-    let clean_output = crate::utils::git_command()?
+    let clean_output = crate::utils::git_command_in(&validated_path)?
         .args(["clean", "-fd"])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/commands/git/worktree.rs
+++ b/src-tauri/src/commands/git/worktree.rs
@@ -174,9 +174,8 @@ fn pick_free_port(start: u16) -> Option<u16> {
 }
 
 fn run_worktree_git(cwd: &Path, args: &[&str]) -> Result<std::process::Output, CommandError> {
-    crate::utils::git_command()?
+    crate::utils::git_command_in(cwd)?
         .args(args)
-        .current_dir(cwd)
         .output()
         .map_err(|e| CommandError::Io {
             message: e.to_string(),

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -250,12 +250,11 @@ pub async fn get_project_github_status(project_path: String) -> ProjectGitHubSta
 
     // Get remote URL (with timeout)
     let step_start = std::time::Instant::now();
-    let Ok(mut remote_cmd) = crate::utils::git_command() else {
+    let Ok(mut remote_cmd) = crate::utils::git_command_in(&project) else {
         return not_a_repo;
     };
     remote_cmd
         .args(["remote", "get-url", "origin"])
-        .current_dir(&project)
         .env("PATH", get_extended_path());
 
     let remote_url = match run_command_with_timeout(remote_cmd, GITHUB_CLI_TIMEOUT_SECS).await {
@@ -353,16 +352,14 @@ pub async fn get_project_github_status(project_path: String) -> ProjectGitHubSta
 /// Ensures git user.name and user.email are configured for the repo.
 /// If not set, fetches the user's identity from GitHub CLI and sets it locally.
 pub fn ensure_git_identity(repo_path: &std::path::Path) -> Result<(), CommandError> {
-    let has_name = crate::utils::git_command()?
+    let has_name = crate::utils::git_command_in(repo_path)?
         .args(["config", "user.name"])
-        .current_dir(repo_path)
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);
 
-    let has_email = crate::utils::git_command()?
+    let has_email = crate::utils::git_command_in(repo_path)?
         .args(["config", "user.email"])
-        .current_dir(repo_path)
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);
@@ -391,9 +388,8 @@ pub fn ensure_git_identity(repo_path: &std::path::Path) -> Result<(), CommandErr
 
     if !has_name {
         let display_name = name.unwrap_or(login);
-        crate::utils::git_command()?
+        crate::utils::git_command_in(repo_path)?
             .args(["config", "user.name", display_name])
-            .current_dir(repo_path)
             .output()
             .map_err(|e| format!("Failed to set git user.name: {e}"))?;
     }
@@ -408,9 +404,8 @@ pub fn ensure_git_identity(repo_path: &std::path::Path) -> Result<(), CommandErr
         } else {
             user_email.to_string()
         };
-        crate::utils::git_command()?
+        crate::utils::git_command_in(repo_path)?
             .args(["config", "user.email", &final_email])
-            .current_dir(repo_path)
             .output()
             .map_err(|e| format!("Failed to set git user.email: {e}"))?;
     }
@@ -433,9 +428,8 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
     // Check if it's already a git repo, if not initialize
     let git_dir = validated_path.join(".git");
     if !git_dir.exists() {
-        crate::utils::git_command()?
+        crate::utils::git_command_in(&validated_path)?
             .args(["init"])
-            .current_dir(&validated_path)
             .output()
             .map_err(CommandError::from)?;
     }
@@ -454,22 +448,20 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
     );
 
     // Ensure at least one commit exists (gh repo create --push requires it)
-    let has_commits = crate::utils::git_command()?
+    let has_commits = crate::utils::git_command_in(&validated_path)?
         .args(["rev-parse", "HEAD"])
-        .current_dir(&validated_path)
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);
 
     if !has_commits {
-        let output = crate::utils::git_command()?
+        let output = crate::utils::git_command_in(&validated_path)?
             .args([
                 "commit",
                 "--allow-empty",
                 "-m",
                 "Initial commit from Ship Studio",
             ])
-            .current_dir(&validated_path)
             .output()
             .map_err(CommandError::from)?;
 

--- a/src-tauri/src/commands/plugins/mod.rs
+++ b/src-tauri/src/commands/plugins/mod.rs
@@ -291,10 +291,9 @@ fn plugins_owner_root(validated: &Path) -> PathBuf {
         }
     }
     let resolved = (|| {
-        let output = crate::utils::git_command()
+        let output = crate::utils::git_command_in(validated)
             .ok()?
             .args(["rev-parse", "--git-common-dir"])
-            .current_dir(validated)
             .output()
             .ok()?;
         if !output.status.success() {

--- a/src-tauri/src/commands/publishing.rs
+++ b/src-tauri/src/commands/publishing.rs
@@ -25,9 +25,8 @@ pub async fn publish_to_github(
     info!(message = %message, "Publishing to GitHub");
 
     // Get current branch name
-    let branch_output = crate::utils::git_command()?
+    let branch_output = crate::utils::git_command_in(&validated_path)?
         .args(["branch", "--show-current"])
-        .current_dir(&validated_path)
         .output()
         .map_err(CommandError::from)?;
 
@@ -205,9 +204,8 @@ pub async fn publish_branch(
     let message = resolve_commit_message(&validated_path, commit_message).await;
 
     // Get current branch name
-    let branch_output = crate::utils::git_command()?
+    let branch_output = crate::utils::git_command_in(&validated_path)?
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(&validated_path)
         .output()
         .map_err(CommandError::from)?;
 

--- a/src-tauri/src/commands/pull_requests.rs
+++ b/src-tauri/src/commands/pull_requests.rs
@@ -100,13 +100,10 @@ pub async fn create_pull_request(
     let validated_path = validate_project_path(&project_path)?;
 
     // Push the branch to the remote first (gh pr create requires this)
-    let mut push_cmd = crate::utils::git_command()?;
-    push_cmd
-        .args(["push", "-u", "origin", "HEAD"])
-        .envs(crate::commands::accounts::get_env_vars_for_project(
-            &validated_path,
-        ))
-        .current_dir(&validated_path);
+    let mut push_cmd = crate::utils::git_command_in(&validated_path)?;
+    push_cmd.args(["push", "-u", "origin", "HEAD"]).envs(
+        crate::commands::accounts::get_env_vars_for_project(&validated_path),
+    );
     let push_output = run_net(push_cmd, "git push").await?;
 
     if !push_output.status.success() {
@@ -189,9 +186,8 @@ pub async fn checkout_pull_request(
     }
 
     // Return the branch name that was checked out
-    let branch_output = crate::utils::git_command()?
+    let branch_output = crate::utils::git_command_in(&validated_path)?
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(&validated_path)
         .output()
         .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/commands/snapshots.rs
+++ b/src-tauri/src/commands/snapshots.rs
@@ -143,9 +143,8 @@ fn is_relevant_path(p: &Path, project_root: &Path) -> bool {
 /// Capture the current working tree as a stash commit. Returns the SHA, or
 /// empty string if the tree is clean (nothing to snapshot).
 fn capture_snapshot(project_path: &Path) -> Result<String, CommandError> {
-    let output = crate::utils::git_command()?
+    let output = crate::utils::git_command_in(project_path)?
         .args(["stash", "create"])
-        .current_dir(project_path)
         .output()
         .map_err(|e| CommandError::Io {
             message: format!("git stash create: {e}"),
@@ -177,12 +176,11 @@ fn diff_files(project_path: &Path, from_sha: &str, to_sha: &str) -> Vec<String> 
     if from_ref == to_ref {
         return Vec::new();
     }
-    let Ok(mut diff_cmd) = crate::utils::git_command() else {
+    let Ok(mut diff_cmd) = crate::utils::git_command_in(project_path) else {
         return Vec::new();
     };
     let output = match diff_cmd
         .args(["diff", "--name-only", from_ref, to_ref])
-        .current_dir(project_path)
         .output()
     {
         Ok(o) if o.status.success() => o,
@@ -202,9 +200,8 @@ fn diff_files(project_path: &Path, from_sha: &str, to_sha: &str) -> Vec<String> 
 fn apply_snapshot(project_path: &Path, sha: &str) -> Result<(), CommandError> {
     if sha.is_empty() {
         // Clean working tree: reset tracked files to HEAD.
-        let out = crate::utils::git_command()?
+        let out = crate::utils::git_command_in(project_path)?
             .args(["checkout-index", "-a", "-f"])
-            .current_dir(project_path)
             .output()
             .map_err(|e| CommandError::Io {
                 message: format!("git checkout-index: {e}"),
@@ -222,9 +219,8 @@ fn apply_snapshot(project_path: &Path, sha: &str) -> Result<(), CommandError> {
     // `stash create` produces a merge commit whose first parent is HEAD and
     // whose tree is the working tree. Apply that tree to both the index and
     // the working directory.
-    let read_tree = crate::utils::git_command()?
+    let read_tree = crate::utils::git_command_in(project_path)?
         .args(["read-tree", "-u", "--reset", sha])
-        .current_dir(project_path)
         .output()
         .map_err(|e| CommandError::Io {
             message: format!("git read-tree: {e}"),

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -395,6 +395,27 @@ pub fn git_command() -> Result<Command, crate::errors::CommandError> {
     }
 }
 
+/// Like [`git_command`], but scoped to a repository directory: sets the
+/// working directory and passes `-c safe.directory=<dir>` so git's
+/// dubious-ownership safeguard (CVE-2022-24765) doesn't hard-fail when the
+/// repo is owned by a different OS user than the one running Ship Studio —
+/// e.g. a project restored or synced from another Windows profile (issue
+/// #305). Trust is scoped per-invocation to this exact directory (which
+/// callers have already passed through `validate_project_path`); nothing is
+/// ever written to the user's global git config, and never a blanket `*`.
+pub fn git_command_in(
+    dir: impl AsRef<std::path::Path>,
+) -> Result<Command, crate::errors::CommandError> {
+    let dir = dir.as_ref();
+    let mut cmd = git_command()?;
+    // git compares safe.directory entries against forward-slash paths,
+    // including on Windows.
+    let safe = dir.to_string_lossy().replace('\\', "/");
+    cmd.arg("-c").arg(format!("safe.directory={safe}"));
+    cmd.current_dir(dir);
+    Ok(cmd)
+}
+
 /// Finds an executable by checking common installation paths.
 /// This is needed because bundled macOS apps don't inherit the user's shell PATH.
 /// On Windows, checks standard Program Files and AppData locations.

--- a/src/components/plugins/PluginManager.tsx
+++ b/src/components/plugins/PluginManager.tsx
@@ -120,7 +120,7 @@ export function PluginManager({
     } catch (err) {
       trackError('plugin_list_load', err, 'Plugin Manager');
       logger.error('Failed to load plugins', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
       setPlugins([]);
     } finally {
@@ -142,7 +142,7 @@ export function PluginManager({
     } catch (err) {
       trackError('plugin_registry_load', err, 'Plugin Manager');
       logger.error('Failed to fetch plugin registry', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
       setRegistry([]);
     } finally {
@@ -170,7 +170,7 @@ export function PluginManager({
     } catch (err) {
       trackError('plugin_uninstall', err, 'Plugin Manager');
       logger.error('Failed to uninstall plugin', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
     } finally {
       setRemovingId(null);
@@ -193,7 +193,7 @@ export function PluginManager({
     } catch (err) {
       trackError('plugin_toggle', err, 'Plugin Manager');
       logger.error('Failed to toggle plugin', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
     } finally {
       setTogglingId(null);
@@ -213,7 +213,7 @@ export function PluginManager({
     } catch (err) {
       trackError('plugin_update_check', err, 'Plugin Manager');
       logger.error('Failed to check for update', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
       setUpdateStates((prev) => ({ ...prev, [pluginId]: 'idle' }));
     }
@@ -232,7 +232,7 @@ export function PluginManager({
     } catch (err) {
       trackError('plugin_update', err, 'Plugin Manager');
       logger.error('Failed to update plugin', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
       setUpdateStates((prev) => ({ ...prev, [pluginId]: 'available' }));
     }
@@ -258,7 +258,7 @@ export function PluginManager({
     } catch (err) {
       trackError('plugin_install', err, 'Plugin Manager');
       logger.error('Failed to install plugin', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
       const msg = formatCommandError(asCommandError(err));
       setError(msg);
@@ -289,7 +289,7 @@ export function PluginManager({
     } catch (err) {
       trackError('plugin_install_url', err, 'Plugin Manager');
       logger.error('Failed to install plugin from URL', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
       const msg = formatCommandError(asCommandError(err));
       setError(msg);
@@ -318,7 +318,7 @@ export function PluginManager({
     } catch (err) {
       trackError('plugin_dev_link', err, 'Plugin Manager');
       logger.error('Failed to link dev plugin', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
       setError(formatCommandError(asCommandError(err)));
     } finally {
@@ -352,7 +352,7 @@ export function PluginManager({
     } catch (err) {
       trackError('plugin_dev_unlink', err, 'Plugin Manager');
       logger.error('Failed to unlink dev plugin', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
     } finally {
       setUnlinkingId(null);

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -727,25 +727,32 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         // subset of what the status checks search, so "installed ✓ but Unable
         // to spawn claude" was possible (issue #280). Resolution errors fail
         // OPEN — the spawn proceeds with the bare name as before.
-        try {
-          const resolved = await resolveCliPath(agent.binaryName);
-          if (resolved) {
-            const pathSep = isWin ? ';' : ':';
-            if (!env.PATH.split(pathSep).includes(resolved.dir)) {
-              env.PATH = `${env.PATH}${pathSep}${resolved.dir}`;
+        //
+        // Guard: only bare names go to the resolver. The raw Terminal tab's
+        // "binary" is an absolute path (/bin/zsh), which the backend rejects
+        // with a validation error on every open (issue #303).
+        const isBareName = !agent.binaryName.includes('/') && !agent.binaryName.includes('\\');
+        if (isBareName) {
+          try {
+            const resolved = await resolveCliPath(agent.binaryName);
+            if (resolved) {
+              const pathSep = isWin ? ';' : ':';
+              if (!env.PATH.split(pathSep).includes(resolved.dir)) {
+                env.PATH = `${env.PATH}${pathSep}${resolved.dir}`;
+              }
+              if (!isWin) {
+                // Spawn the resolved absolute path — deterministic, no PATH
+                // shadowing. (Windows keeps the cmd.exe wrapper; the appended
+                // PATH dir makes the shim resolvable there.)
+                spawnCmd = resolved.path;
+              }
             }
-            if (!isWin) {
-              // Spawn the resolved absolute path — deterministic, no PATH
-              // shadowing. (Windows keeps the cmd.exe wrapper; the appended
-              // PATH dir makes the shim resolvable there.)
-              spawnCmd = resolved.path;
-            }
+          } catch (err) {
+            logger.warn('[Terminal] resolveCliPath failed — spawning bare name', {
+              binary: agent.binaryName,
+              error: String(err),
+            });
           }
-        } catch (err) {
-          logger.warn('[Terminal] resolveCliPath failed — spawning bare name', {
-            binary: agent.binaryName,
-            error: String(err),
-          });
         }
 
         // The backend session id is the tab's sessionName UUID — it survives

--- a/src/hooks/useScreenshotManagement.ts
+++ b/src/hooks/useScreenshotManagement.ts
@@ -12,6 +12,16 @@ import { logger } from '../lib/logger';
 import { trackEvent } from '../lib/analytics';
 import { getThumbnailsEnabled, setThumbnailsEnabled } from '../lib/settings';
 import { decideAutoCapture, isPermissionDenialError } from '../lib/thumbnailGate';
+import { asCommandError, formatCommandError } from '../lib/errors';
+
+/** Backend rejection meaning the project's root directory no longer exists
+ *  (deleted, renamed, or moved while its session stayed hot). Permanent for
+ *  this path — retrying can never succeed. */
+function isProjectGoneError(error: unknown): boolean {
+  return formatCommandError(asCommandError(error)).includes(
+    'Invalid path in validate_project_path'
+  );
+}
 
 /** Delay after page load before capturing screenshot (8 seconds to allow Next.js/Vite to fully compile) */
 const SCREENSHOT_DELAY_MS = 8000;
@@ -189,6 +199,23 @@ export function useScreenshotManagement({
           // → Privacy & Security → Screen Recording).
           logger.error('[Thumbnail] Permission denied - disabling auto-capture', { error });
           void setThumbnailsEnabled(false);
+          return;
+        }
+        if (isProjectGoneError(error)) {
+          // The project's folder vanished while its session stayed hot —
+          // retrying can't succeed, and the 5-minute interval would re-burn
+          // 5 attempts forever with no user-facing signal (issue #300).
+          // Cancel the session and stop the schedule for this project;
+          // reopening it goes through the dashboard's missing-folder
+          // recovery (#266).
+          logger.warn('[Thumbnail] Project folder no longer exists — stopping auto-capture', {
+            projectPath,
+          });
+          captureSessionIdRef.current++;
+          if (screenshotIntervalRef.current) {
+            clearInterval(screenshotIntervalRef.current);
+            screenshotIntervalRef.current = null;
+          }
           return;
         }
         if (captureSessionIdRef.current !== sessionId) {


### PR DESCRIPTION
Round 6 of the auto-reported bug bash — four of the six issues filed from v0.18.1/0.18.2 telemetry this evening (#301 and #306 are upstream-blocked and got comments instead).

fixes #300
fixes #303
fixes #304
fixes #305

## #303 — spurious validation error on every raw Terminal tab open (regression from #280)
`Terminal.tsx` called `resolveCliPath` unconditionally; the Terminal tab's "binary" is the absolute path `/bin/zsh`, which the backend's bare-name validation rejects — a guaranteed false-positive report per open. Now guarded with the same `isBareName` check `OnboardingTerminal` already had.

## #304 — plugin telemetry hidden behind "[object Object]"
All ten catch blocks in `PluginManager.tsx` logged `String(err)` on plain `CommandError` objects. They now log `formatCommandError(asCommandError(err))` — same fix as #283, different file. The next Windows plugin-install failure (#244) will finally say *why*.

## #300 — thumbnail auto-capture retried forever against a deleted project folder
When a hot project's folder is deleted/moved, the 5-minute capture interval burned 5 retries per tick indefinitely. The capture loop now recognizes the "Invalid path in validate_project_path" rejection as permanent, cancels the session, and stops the interval.

## #305 — git "dubious ownership" hard-fails (Windows)
New `utils::git_command_in(dir)`: every repo-scoped git invocation (all ~85 sites, built on #297's resolver) now passes `-c safe.directory=<dir>` scoped to the exact validated project path per invocation. Git 2.35+'s CVE-2022-24765 safeguard no longer bricks branch listing/status/commit for projects owned by a different OS user — and nothing is ever written to the user's global git config (no blanket `*`, per the GitList-RCE caution in the issue).

## Verification
- `cargo test`: 748 passed; `pnpm test:run`: 1375 passed; `tsc --noEmit`, `eslint`, `pnpm check:patterns` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git operations across project workflows by ensuring commands run in the correct repository context.
  * Fixed terminal startup for agents configured with absolute executable paths.
  * Standardized plugin error reporting for clearer diagnostics.
  * Stopped repeated screenshot capture attempts when a project has been moved, renamed, or deleted.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->