### PR TITLE
Fix round-7 auto-reported bugs: telemetry noise, auth detection, OpenCode MCP, editor messaging

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -181,6 +181,17 @@ read_plugin_storage, write_plugin_storage, read_plugin_manifest
 Declaring anything outside this list fails the install; calling anything you
 didn't declare rejects at runtime.
 
+Like `shell` and `storage`, `invoke.call` automatically fills in the current
+project's `projectPath`, so project-scoped commands work without passing it:
+
+```ts
+const branch = await invoke.call<string>('get_current_branch');
+// equivalent to invoke.call('get_current_branch', { projectPath: project.path })
+```
+
+Pass `projectPath` explicitly in `args` only to target a *different* project —
+an explicit value always wins over the injected one.
+
 ### Without the SDK
 
 Raw-JS plugins (like hello-world) can use the window globals directly:

--- a/src-tauri/src/commands/code.rs
+++ b/src-tauri/src/commands/code.rs
@@ -143,6 +143,19 @@ fn should_skip_path(relative: &Path) -> bool {
     })
 }
 
+/// Map a failed canonicalize of a project-relative file to an error that names
+/// the file. A plain NotFound is usually a benign race — the frontend holds a
+/// stale reference (open tab, file-tree entry) to a file that a build tool,
+/// branch switch, or external editor removed — so it's `Expected` and stays
+/// out of telemetry; anything else keeps full context (issue #314).
+pub(crate) fn resolve_error(file_path: &str, e: &std::io::Error) -> CommandError {
+    if e.kind() == std::io::ErrorKind::NotFound {
+        CommandError::expected(format!("File not found: {file_path}"))
+    } else {
+        CommandError::from(format!("Failed to resolve file '{file_path}': {e}"))
+    }
+}
+
 /// Read a single file from the project.
 #[tauri::command]
 #[tracing::instrument(fields(project = %project_path))]
@@ -157,7 +170,7 @@ pub fn read_project_file(project_path: &str, file_path: &str) -> Result<FileCont
     let full_path = project.join(file_path);
 
     // Verify the file is within the project
-    let canonical = dunce::canonicalize(&full_path).map_err(|e| format!("File not found: {e}"))?;
+    let canonical = dunce::canonicalize(&full_path).map_err(|e| resolve_error(file_path, &e))?;
     if !canonical.starts_with(&project) {
         return Err(("Security error: path is outside project directory".to_string()).into());
     }
@@ -238,7 +251,7 @@ pub fn save_project_file(
     // Canonicalize the existing file and verify it stays within the project.
     // The editor only ever saves a file it already opened, so the target must
     // exist — this also resolves symlinks so we can reject escapes.
-    let canonical = dunce::canonicalize(&full_path).map_err(|e| format!("File not found: {e}"))?;
+    let canonical = dunce::canonicalize(&full_path).map_err(|e| resolve_error(file_path, &e))?;
     if !canonical.starts_with(&project) {
         return Err(("Security error: path is outside project directory".to_string()).into());
     }

--- a/src-tauri/src/commands/git/branches.rs
+++ b/src-tauri/src/commands/git/branches.rs
@@ -199,7 +199,10 @@ pub async fn get_current_branch(project_path: String) -> Result<String, CommandE
 
     let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
     if branch == "HEAD" {
-        return Err(("Detached HEAD state".to_string()).into());
+        // A normal git state (checked-out tag/commit, mid-rebase), not a
+        // malfunction — every caller already treats it as recoverable, so
+        // keep it out of telemetry (issue #317).
+        return Err(crate::errors::CommandError::expected("Detached HEAD state"));
     }
 
     // Cache the result

--- a/src-tauri/src/commands/git/sync.rs
+++ b/src-tauri/src/commands/git/sync.rs
@@ -9,6 +9,18 @@ use super::git_stage_and_commit;
 // the parent module so they authenticate as the project's workspace login.
 use super::run_git_net;
 
+/// Git's normal refusal to pull a branch that has never been pushed (no
+/// upstream configured) or whose upstream is gone — an anticipated state the
+/// frontend already turns into a "push it first" toast, not a malfunction.
+/// The message text is preserved verbatim so that frontend match keeps
+/// working; only the telemetry classification changes (issue #312).
+fn is_missing_upstream(stderr: &str) -> bool {
+    let lower = stderr.to_lowercase();
+    lower.contains("no tracking information")
+        || lower.contains("no such ref was fetched")
+        || lower.contains("couldn't find remote ref")
+}
+
 /// Fetch all branches from remotes
 #[tauri::command]
 #[tracing::instrument(skip(project_path), fields(project = %project_path))]
@@ -40,6 +52,9 @@ pub async fn git_pull(project_path: String) -> Result<(), CommandError> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        if is_missing_upstream(&stderr) {
+            return Err(CommandError::expected(format!("Failed to pull: {stderr}")));
+        }
         return Err((format!("Failed to pull: {stderr}")).into());
     }
 
@@ -87,6 +102,9 @@ pub async fn pull_and_merge(
     }
 
     if !output.status.success() {
+        if is_missing_upstream(&stderr) {
+            return Err(CommandError::expected(format!("Failed to merge: {stderr}")));
+        }
         return Err((format!("Failed to merge: {stderr}")).into());
     }
 

--- a/src-tauri/src/commands/ide/mod.rs
+++ b/src-tauri/src/commands/ide/mod.rs
@@ -165,7 +165,8 @@ pub async fn open_in_ide(
             return Err(("Invalid path: path traversal not allowed".to_string()).into());
         }
         let full = validated_path.join(fp);
-        let canonical = dunce::canonicalize(&full).map_err(|e| format!("File not found: {e}"))?;
+        let canonical =
+            dunce::canonicalize(&full).map_err(|e| crate::commands::code::resolve_error(fp, &e))?;
         if !canonical.starts_with(&validated_path) {
             return Err(("Security error: path is outside project directory".to_string()).into());
         }

--- a/src-tauri/src/commands/ide/screenshots/playwright.rs
+++ b/src-tauri/src/commands/ide/screenshots/playwright.rs
@@ -209,7 +209,11 @@ const {{ chromium }} = require('playwright');
         browser = await chromium.launch();
         const page = await browser.newPage({{ viewport: {{ width: {viewport_width}, height: 800 }} }});
 
-        await page.goto('{}', {{ waitUntil: 'networkidle', timeout: 30000 }});
+        // Dev servers keep HMR/live-reload connections open forever, so
+        // 'networkidle' may never arrive — wait for 'load', then settle
+        // best-effort without ever failing the capture on it (issues #309/#310).
+        await page.goto('{}', {{ waitUntil: 'load', timeout: 30000 }});
+        await page.waitForLoadState('networkidle', {{ timeout: 5000 }}).catch(() => {{}});
 
         // Hide dev tools and feedback overlays
         await page.evaluate(() => {{
@@ -263,7 +267,12 @@ const {{ chromium }} = require('playwright');
     }} finally {{
         if (browser) await browser.close();
     }}
-}})();
+}})().catch((err) => {{
+    // Surface a clean one-line failure instead of Node's uncaught-exception
+    // stack dump (issues #309/#310).
+    console.error(String((err && err.message) || err));
+    process.exit(1);
+}});
 "#,
         url,
         screenshot_path_str.replace('\\', "\\\\")
@@ -342,7 +351,10 @@ const {{ chromium }} = require('playwright');
         browser = await chromium.launch();
         const page = await browser.newPage({{ viewport: {{ width: {viewport_width}, height: 800 }} }});
 
-        await page.goto('{}', {{ waitUntil: 'networkidle', timeout: 30000 }});
+        // Same wait strategy as the full-page capture: 'networkidle' may never
+        // arrive on dev servers with persistent connections (issues #309/#310).
+        await page.goto('{}', {{ waitUntil: 'load', timeout: 30000 }});
+        await page.waitForLoadState('networkidle', {{ timeout: 5000 }}).catch(() => {{}});
 
         // Hide dev tools and feedback overlays
         await page.evaluate(() => {{
@@ -373,7 +385,12 @@ const {{ chromium }} = require('playwright');
     }} finally {{
         if (browser) await browser.close();
     }}
-}})();
+}})().catch((err) => {{
+    // Surface a clean one-line failure instead of Node's uncaught-exception
+    // stack dump (issues #309/#310).
+    console.error(String((err && err.message) || err));
+    process.exit(1);
+}});
 "#,
         url,
         screenshot_path_str.replace('\\', "\\\\")

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -274,6 +274,134 @@ pub async fn list_mcp_servers(
     Ok(servers)
 }
 
+/// OpenCode's global config file (`~/.config/opencode/opencode.json` — the
+/// path OpenCode documents on every platform).
+fn opencode_config_path() -> Result<std::path::PathBuf, CommandError> {
+    let home = dirs::home_dir()
+        .ok_or_else(|| CommandError::from("Could not determine home directory".to_string()))?;
+    Ok(home.join(".config").join("opencode").join("opencode.json"))
+}
+
+/// Load OpenCode's config for editing. A config that exists but isn't valid
+/// JSON fails closed with an actionable message — never risk rewriting (and
+/// destroying) another tool's configuration.
+fn opencode_config_load() -> Result<(std::path::PathBuf, serde_json::Value), CommandError> {
+    let path = opencode_config_path()?;
+    let root = if path.exists() {
+        let raw = std::fs::read_to_string(&path)
+            .map_err(|e| format!("Failed to read OpenCode config {}: {e}", path.display()))?;
+        serde_json::from_str(&raw).map_err(|e| {
+            CommandError::expected(format!(
+                "OpenCode's config ({}) isn't valid JSON, so Ship Studio won't edit it. Fix the file, then try again. (parse error: {e})",
+                path.display()
+            ))
+        })?
+    } else {
+        serde_json::json!({ "$schema": "https://opencode.ai/config.json" })
+    };
+    Ok((path, root))
+}
+
+fn opencode_config_save(
+    path: &std::path::Path,
+    root: &serde_json::Value,
+) -> Result<(), CommandError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create OpenCode config directory: {e}"))?;
+    }
+    let serialized = serde_json::to_string_pretty(root)
+        .map_err(|e| format!("Failed to serialize OpenCode config: {e}"))?;
+    std::fs::write(path, serialized)
+        .map_err(|e| format!("Failed to write OpenCode config {}: {e}", path.display()))?;
+    Ok(())
+}
+
+/// Add (or overwrite — OpenCode adds are upserts by name) an MCP server in
+/// OpenCode's config file. OpenCode's `opencode mcp add` is an interactive
+/// wizard with no scriptable form, so shelling out just prints its usage
+/// banner and fails (issue #308) — instead we merge the entry into its config
+/// directly, the same way the preview bridge merges into Cursor's
+/// `~/.cursor/mcp.json` (`register_cursor_mcp`).
+///
+/// Accepts the same shapes the modal/bridge already produce:
+/// `<name> --url <url>` (remote server) or `<name> [--] <command...>` (local).
+fn opencode_mcp_entry(args_str: &str) -> Result<(String, serde_json::Value), CommandError> {
+    let tokens = shell_split(args_str);
+    let Some((name, rest)) = tokens.split_first() else {
+        return Err(("No arguments provided for mcp add".to_string()).into());
+    };
+    let entry = if rest.first().map(String::as_str) == Some("--url") {
+        let Some(url) = rest.get(1) else {
+            return Err(CommandError::expected(
+                "mcp add: --url needs a value, e.g. `my-server --url https://example.com/mcp`",
+            ));
+        };
+        serde_json::json!({ "type": "remote", "url": url, "enabled": true })
+    } else {
+        // Strip the optional `--` separator between the name and the command.
+        let command = if rest.first().map(String::as_str) == Some("--") {
+            &rest[1..]
+        } else {
+            rest
+        };
+        if command.is_empty() {
+            return Err(CommandError::expected(
+                "OpenCode MCP servers need a command or a --url, e.g. `my-server -- npx -y @some/mcp-server`",
+            ));
+        }
+        serde_json::json!({ "type": "local", "command": command, "enabled": true })
+    };
+    Ok((name.clone(), entry))
+}
+
+fn add_opencode_mcp_server(args_str: &str) -> Result<(), CommandError> {
+    let (name, entry) = opencode_mcp_entry(args_str)?;
+
+    let (path, mut root) = opencode_config_load()?;
+    let Some(root_obj) = root.as_object_mut() else {
+        return Err(CommandError::expected(format!(
+            "OpenCode's config ({}) doesn't have a JSON object at its root, so Ship Studio won't edit it.",
+            path.display()
+        )));
+    };
+    let servers = root_obj
+        .entry("mcp")
+        .or_insert_with(|| serde_json::json!({}));
+    let Some(servers_obj) = servers.as_object_mut() else {
+        return Err(CommandError::expected(format!(
+            "OpenCode's config ({}) has a non-object `mcp` key, so Ship Studio won't edit it.",
+            path.display()
+        )));
+    };
+    servers_obj.insert(name.clone(), entry);
+    opencode_config_save(&path, &root)?;
+    tracing::info!(server = %name, "Added MCP server to OpenCode config");
+    Ok(())
+}
+
+/// Remove an MCP server from OpenCode's config file (OpenCode has no
+/// `mcp remove` subcommand). Already-absent entries are the goal state, not an
+/// error — matching the CLI path's idempotent-remove semantics (issue #295).
+fn remove_opencode_mcp_server(name: &str) -> Result<(), CommandError> {
+    let path = opencode_config_path()?;
+    if !path.exists() {
+        return Ok(());
+    }
+    let (path, mut root) = opencode_config_load()?;
+    let removed = root
+        .as_object_mut()
+        .and_then(|o| o.get_mut("mcp"))
+        .and_then(|m| m.as_object_mut())
+        .map(|servers| servers.remove(name).is_some())
+        .unwrap_or(false);
+    if removed {
+        opencode_config_save(&path, &root)?;
+        tracing::info!(server = %name, "Removed MCP server from OpenCode config");
+    }
+    Ok(())
+}
+
 /// Add an MCP server using the agent's CLI.
 ///
 /// The `raw_args` parameter contains the arguments after `mcp add`, e.g.:
@@ -311,6 +439,13 @@ pub async fn add_mcp_server(
 
     if args_str.is_empty() {
         return Err(("No arguments provided for mcp add".to_string()).into());
+    }
+
+    // OpenCode's `mcp add` is interactive-only — edit its config file instead
+    // (issue #308). The binary lookup above still gates on OpenCode actually
+    // being installed.
+    if agent.id == "opencode" {
+        return add_opencode_mcp_server(args_str);
     }
 
     // Build the command: <binary> mcp add <args>
@@ -394,6 +529,12 @@ pub async fn remove_mcp_server(
     let home = dirs::home_dir()
         .map(|h| h.to_string_lossy().to_string())
         .unwrap_or_default();
+
+    // OpenCode has no `mcp remove` subcommand — edit its config file instead
+    // (issue #308).
+    if agent.id == "opencode" {
+        return remove_opencode_mcp_server(&name);
+    }
 
     let mut cmd = create_command(&binary);
     cmd.args(["mcp", "remove"])
@@ -492,6 +633,42 @@ fn shell_split(input: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn opencode_entry_remote_url() {
+        let (name, entry) =
+            opencode_mcp_entry("shipstudio-preview --url http://127.0.0.1:4923/mcp/active")
+                .unwrap();
+        assert_eq!(name, "shipstudio-preview");
+        assert_eq!(entry["type"], "remote");
+        assert_eq!(entry["url"], "http://127.0.0.1:4923/mcp/active");
+        assert_eq!(entry["enabled"], true);
+    }
+
+    #[test]
+    fn opencode_entry_local_command_with_separator() {
+        let (name, entry) = opencode_mcp_entry("my-server -- npx -y @some/mcp-server").unwrap();
+        assert_eq!(name, "my-server");
+        assert_eq!(entry["type"], "local");
+        assert_eq!(
+            entry["command"],
+            serde_json::json!(["npx", "-y", "@some/mcp-server"])
+        );
+    }
+
+    #[test]
+    fn opencode_entry_local_command_without_separator() {
+        let (_, entry) = opencode_mcp_entry("my-server npx -y pkg").unwrap();
+        assert_eq!(entry["type"], "local");
+        assert_eq!(entry["command"], serde_json::json!(["npx", "-y", "pkg"]));
+    }
+
+    #[test]
+    fn opencode_entry_rejects_bare_name_and_dangling_url() {
+        assert!(opencode_mcp_entry("just-a-name").is_err());
+        assert!(opencode_mcp_entry("just-a-name --url").is_err());
+        assert!(opencode_mcp_entry("").is_err());
+    }
 
     #[test]
     fn test_strip_ansi() {

--- a/src-tauri/src/commands/mobile.rs
+++ b/src-tauri/src/commands/mobile.rs
@@ -309,12 +309,27 @@ pub async fn simulator_app_running(
     udid: String,
     bundle_id: Option<String>,
 ) -> Result<bool, CommandError> {
-    let stdout = simctl_stdout(
+    let stdout = match simctl_stdout(
         &["spawn", udid.as_str(), "launchctl", "list"],
         "xcrun simctl spawn launchctl list",
         SIMCTL_TIMEOUT_SECS,
     )
-    .await?;
+    .await
+    {
+        Ok(stdout) => stdout,
+        Err(e) => {
+            // The frontend polls this every few seconds, so a tick can race a
+            // simulator that's mid-shutdown (project close, platform switch,
+            // mirror heal). CoreSimulator answers "Domain is tearing down" —
+            // the app clearly isn't running, and the poll recovers on its own
+            // once a new session boots (issue #311).
+            let msg = e.to_string();
+            if msg.contains("Domain is tearing down") || msg.contains("LaunchdSimError") {
+                return Ok(false);
+            }
+            return Err(e);
+        }
+    };
     let running = match bundle_id.as_deref() {
         Some(id) => stdout.contains(&format!("UIKitApplication:{id}")),
         None => stdout

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -412,6 +412,26 @@ pub(crate) fn restore_removed_project(canonical: &Path) -> Result<bool, CommandE
 
 // ============ Tauri Commands ============
 
+/// Open the projects root for scanning, naming the folder on failure. On
+/// macOS, TCC answers EPERM (os error 1) when the app lacks Files-and-Folders
+/// access to the folder (Desktop/Documents/iCloud/external volumes) — an
+/// environment gap with a user-side fix, not a malfunction (issue #307).
+fn read_projects_dir(dir: &std::path::Path) -> Result<std::fs::ReadDir, CommandError> {
+    std::fs::read_dir(dir).map_err(|e| {
+        if cfg!(target_os = "macos") && e.raw_os_error() == Some(1) {
+            CommandError::expected(format!(
+                "Ship Studio isn't allowed to read your projects folder ({}). Grant access in System Settings → Privacy & Security → Files & Folders (or Full Disk Access), then reload the dashboard.",
+                dir.display()
+            ))
+        } else {
+            CommandError::from(format!(
+                "Failed to read projects folder {}: {e}",
+                dir.display()
+            ))
+        }
+    })
+}
+
 #[tauri::command]
 #[tracing::instrument]
 pub async fn list_projects() -> Result<Vec<ProjectInfo>, CommandError> {
@@ -428,10 +448,15 @@ pub async fn list_projects() -> Result<Vec<ProjectInfo>, CommandError> {
     }
 
     let mut projects = Vec::new();
-    let entries = std::fs::read_dir(&shipstudio_dir).map_err(|e| e.to_string())?;
+    let entries = read_projects_dir(&shipstudio_dir)?;
 
     for entry in entries {
-        let entry = entry.map_err(|e| e.to_string())?;
+        let entry = entry.map_err(|e| {
+            format!(
+                "Failed to read an entry in projects folder {}: {e}",
+                shipstudio_dir.display()
+            )
+        })?;
         let path = entry.path();
         if is_valid_project(&path) {
             let canonical = canonical_or_original(&path);
@@ -561,10 +586,15 @@ pub async fn get_dashboard_projects() -> Result<Vec<DashboardProject>, CommandEr
     // stall the whole dashboard (issue #168).
     let mut projects = Vec::new();
     let mut scan_paths: Vec<PathBuf> = Vec::new();
-    let entries = std::fs::read_dir(&shipstudio_dir).map_err(|e| e.to_string())?;
+    let entries = read_projects_dir(&shipstudio_dir)?;
 
     for entry in entries {
-        let entry = entry.map_err(|e| e.to_string())?;
+        let entry = entry.map_err(|e| {
+            format!(
+                "Failed to read an entry in projects folder {}: {e}",
+                shipstudio_dir.display()
+            )
+        })?;
         let path = entry.path();
         if is_valid_project(&path) {
             let canonical = canonical_or_original(&path);

--- a/src-tauri/src/commands/pty_session.rs
+++ b/src-tauri/src/commands/pty_session.rs
@@ -434,7 +434,7 @@ pub fn pty_session_write(session_id: String, data: Vec<u8>) -> Result<(), Comman
     // surface it as the expected "session ended" state, not a raw
     // "Input/output error (os error 5)" (issue #260).
     if !session.alive.load(std::sync::atomic::Ordering::Relaxed) {
-        return Err("terminal session has ended".to_string().into());
+        return Err(CommandError::expected("terminal session has ended"));
     }
     let mut w = session
         .writer
@@ -442,9 +442,10 @@ pub fn pty_session_write(session_id: String, data: Vec<u8>) -> Result<(), Comman
         .map_err(|e| format!("writer lock poisoned: {e}"))?;
     w.write_all(&data).map_err(|e| {
         if e.raw_os_error() == Some(5) {
-            "terminal session has ended".to_string()
+            // Benign race, not a malfunction — keep it out of telemetry (issue #323).
+            CommandError::expected("terminal session has ended")
         } else {
-            format!("write: {e}")
+            CommandError::from(format!("write: {e}"))
         }
     })?;
     Ok(())

--- a/src-tauri/src/commands/publishing.rs
+++ b/src-tauri/src/commands/publishing.rs
@@ -236,7 +236,14 @@ pub async fn publish_branch(
                 message: format!("PUSH_REJECTED:{stderr}"),
             });
         }
-        if stderr.contains("Permission denied") || stderr.contains("could not read Username") {
+        // "Permission to <owner>/<repo>.git denied to <user>." is GitHub's
+        // no-write-access rejection — the words "permission"/"denied" are split
+        // by the repo name, so it needs its own check (issue #321).
+        let lower = stderr.to_lowercase();
+        if stderr.contains("Permission denied")
+            || stderr.contains("could not read Username")
+            || (lower.contains("permission to") && lower.contains("denied to"))
+        {
             error!(error = %stderr, branch = %branch, "Authentication error");
             return Err(CommandError::NotAuthenticated {
                 service: format!("github (AUTH_ERROR: {stderr})"),

--- a/src/components/plugins/PluginSlot.tsx
+++ b/src/components/plugins/PluginSlot.tsx
@@ -19,7 +19,12 @@ import {
   type PluginThemeData,
 } from '../../contexts/PluginContext';
 import { execPluginShell, readPluginStorage, writePluginStorage } from '../../lib/plugins';
-import { markPluginCrashed, isPluginCrashed, wasPluginUnloaded } from '../../lib/plugin-loader';
+import {
+  markPluginCrashed,
+  isPluginCrashed,
+  wasPluginUnloaded,
+  unloadPluginModule,
+} from '../../lib/plugin-loader';
 import { asCommandError, formatCommandError } from '../../lib/errors';
 import { logger } from '../../lib/logger';
 import { invoke } from '@tauri-apps/api/core';
@@ -179,7 +184,20 @@ export function buildContext(
       });
       throw e;
     }
-    actions.showToast(`Plugin "${pluginName}": ${formatCommandError(asCommandError(e))}`, 'error');
+    const message = formatCommandError(asCommandError(e));
+    // The plugin's backing files vanished without an in-app unlink/uninstall
+    // (dev-linked folder deleted or moved, branch switch). Deactivate it like
+    // an explicit unload — one clear toast now, and any background calls it
+    // keeps making are suppressed instead of toasting every tick (issue #315).
+    if (message.includes(`Plugin '${pluginId}' not found`)) {
+      unloadPluginModule(projectPath, pluginId);
+      actions.showToast(
+        `Plugin "${pluginName}" was deactivated because its files are no longer on disk. Unlink or reinstall it from the Plugins menu.`,
+        'error'
+      );
+      throw e;
+    }
+    actions.showToast(`Plugin "${pluginName}": ${message}`, 'error');
     throw e;
   };
 
@@ -198,8 +216,14 @@ export function buildContext(
     },
     invoke: {
       call: <T = unknown,>(command: string, args?: Record<string, unknown>): Promise<T> => {
+        // Auto-inject the current project's path, matching how shell/storage
+        // already close over it — most allow-listed commands require it, and
+        // omitting it surfaced Tauri's raw "missing required key projectPath"
+        // under the plugin's name (issue #322). Commands that don't take it
+        // ignore extra args; an explicit args.projectPath still wins.
+        const mergedArgs = projectPath ? { projectPath, ...args } : args;
         const result: Promise<T> = allowedCommands.has(command)
-          ? invoke<T>(command, args)
+          ? invoke<T>(command, mergedArgs)
           : Promise.reject(new Error(`Plugin "${pluginId}" is not allowed to call "${command}"`));
         return result.catch(report);
       },

--- a/src/hooks/useElementStructure.test.ts
+++ b/src/hooks/useElementStructure.test.ts
@@ -26,7 +26,7 @@ vi.mock('../lib/edit-html', () => ({
 // trackEvent would otherwise reach for a real Tauri IPC on a saved edit.
 vi.mock('../lib/analytics', () => ({ trackEvent: vi.fn().mockResolvedValue(undefined) }));
 
-import { useElementStructure } from './useElementStructure';
+import { useElementStructure, structuralEditMessage } from './useElementStructure';
 import { insertElement, duplicateElement, deleteElement } from '../lib/edit-structure';
 import { resolveElementHtml } from '../lib/edit-html';
 
@@ -198,8 +198,10 @@ describe('useElementStructure', () => {
     await act(async () => {
       await result.current.insert('after', 'div');
     });
+    // The multi-instance resolution failure is rephrased for the structural
+    // context (issues #318/#320), not passed through verbatim.
     expect(onToast).toHaveBeenCalledWith(
-      expect.stringContaining('several identical places'),
+      expect.stringContaining('appears in several places in your code'),
       'error'
     );
     expect(onToast).not.toHaveBeenCalledWith(expect.stringContaining('object Object'), 'error');
@@ -233,5 +235,35 @@ describe('useElementStructure', () => {
     const source = iframeRef.current!.contentWindow as unknown as MessageEventSource;
     await dispatch({ type: 'ss:select', signature: SIG, count: 1 }, source);
     expect(result.current.selection).toBeNull();
+  });
+});
+
+describe('structuralEditMessage', () => {
+  // The backend's resolution errors are worded for the raw-markup editor;
+  // canvas insert/duplicate/delete rephrase the known ones (issues #318/#320).
+  it('rephrases the no-class resolution failure', () => {
+    const msg = structuralEditMessage(
+      "Validation failed for 'element': This element has no class in source to anchor its markup on. Add a class to it first (the Add class action), then its markup becomes editable."
+    );
+    expect(msg).toContain('Add a class to it first');
+    expect(msg).not.toContain('markup');
+  });
+
+  it('rephrases both multi-instance failures', () => {
+    for (const raw of [
+      'This element appears in several places whose markup differs, so editing it here could change the wrong one. Ask your agent to edit it instead.',
+      'This element appears in several identical places, so editing its markup here could change the wrong one. Ask your agent to edit it instead.',
+    ]) {
+      expect(structuralEditMessage(raw)).toContain('appears in several places in your code');
+    }
+  });
+
+  it('rephrases the dynamic-class failure and passes unknown messages through', () => {
+    expect(
+      structuralEditMessage(
+        "This element can't be matched to its source markup (it has no static class to anchor on). Edit it with your agent instead."
+      )
+    ).toContain('generated dynamically');
+    expect(structuralEditMessage('disk full')).toBe('disk full');
   });
 });

--- a/src/hooks/useElementStructure.ts
+++ b/src/hooks/useElementStructure.ts
@@ -65,6 +65,29 @@ interface Params {
 /** How long after a write the iframe `load` handler still replays the reselect. */
 const RESELECT_WINDOW_MS = 8000;
 
+/**
+ * The backend's element-resolution errors are worded for the raw-markup editor
+ * ("its markup becomes editable", "editing it here") — confusing when the user
+ * clicked insert/duplicate/delete on the canvas. Rephrase the known resolution
+ * failures for the structural-edit context (issues #318/#320); anything else
+ * passes through unchanged.
+ */
+export function structuralEditMessage(message: string): string {
+  if (message.includes('no class in source to anchor')) {
+    return 'This element has no class for Ship Studio to find it in your code. Add a class to it first (the Add class action), then try again.';
+  }
+  if (
+    message.includes('several places whose markup differs') ||
+    message.includes('several identical places')
+  ) {
+    return 'This element appears in several places in your code, so changing it from the canvas could affect the wrong one. Select a more specific element, or ask your agent to make this change.';
+  }
+  if (message.includes("can't be matched to its source markup")) {
+    return "This element can't be matched to its source code (its classes are generated dynamically). Ask your agent to make this change instead.";
+  }
+  return message;
+}
+
 export function useElementStructure({ iframeRef, projectPath, enabled, onToast }: Params) {
   const [selection, setSelection] = useState<StructureSelection | null>(null);
   // Inline text editing is in progress — the toolbar hides so it can't cover
@@ -176,7 +199,7 @@ export function useElementStructure({ iframeRef, projectPath, enabled, onToast }
       } catch (err) {
         const message = formatCommandError(asCommandError(err));
         logger.error('[ElementStructure] structural edit failed', { error: message });
-        onToast?.(message, 'error');
+        onToast?.(structuralEditMessage(message), 'error');
       } finally {
         busyRef.current = false;
         setBusy(false);

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -2,7 +2,9 @@
  * Hook for project lifecycle operations — owns the dashboard ⇄ workspace
  * navigation, orchestrating every other subsystem on project open/close.
  *
- * `handleSelectProject` phases: monorepo workspace gate (pauses for picker) →
+ * `handleSelectProject` phases: external-project registration (fatal on
+ * refusal; must precede anything that validates the path, issue #319) →
+ * monorepo workspace gate (pauses for picker) →
  * claim navigation version + duplicate-open guard → save outgoing project's
  * terminal state + read auto-accept → show workspace IMMEDIATELY (server spins
  * up in background) → restore/seed terminal tabs → duplicate-window check +
@@ -295,6 +297,33 @@ export function useProjectLifecycle({
     const totalStart = performance.now();
     let stepStart = performance.now();
 
+    // Ensure external projects are registered BEFORE anything validates the
+    // path. Projects outside ~/ShipStudio can enter the app via session
+    // restore, URL params, or direct path — without this, all
+    // validate_project_path() calls would fail. A refusal is fatal: proceeding
+    // used to land the user in a broken workspace where every backend call
+    // toasted "Security error: path ... is outside the projects directory"
+    // with no way out (issue #266). Must also run before the monorepo gate:
+    // getWorkspaceSubpath validates the path too, so an unregistered external
+    // project would otherwise always fail its first-open gate check — skipping
+    // the workspace picker and logging a spurious security error (issue #319).
+    // Idempotent local config read/write, ~ms.
+    try {
+      const wasRegistered = await invoke<boolean>('ensure_external_project_registered', {
+        path: project.path,
+      });
+      if (wasRegistered) {
+        logger.info(`[OpenProject] Auto-registered external project: ${project.path}`);
+      }
+    } catch (e) {
+      logger.warn('[OpenProject] Failed to ensure external project registration', { error: e });
+      showToast(
+        `Can't open "${project.name}" — its folder isn't a recognized project location. Re-add it via "Select Project Folder".`,
+        'error'
+      );
+      return;
+    }
+
     // Pre-flight monorepo gate: runs BEFORE we claim a navigation slot so
     // pausing for the picker doesn't bump the version counter or set the
     // "opening" ref — both would make a concurrent open look superseded
@@ -319,34 +348,6 @@ export function useProjectLifecycle({
       return;
     }
     openingProjectPathRef.current = project.path;
-
-    // Ensure external projects are registered BEFORE the workspace opens.
-    // Projects outside ~/ShipStudio can enter the app via session restore, URL
-    // params, or direct path — without this, all validate_project_path() calls
-    // would fail. Checked up front (not mid-open) because a refusal is fatal:
-    // proceeding used to land the user in a broken workspace where every
-    // backend call toasted "Security error: path ... is outside the projects
-    // directory" with no way out (issue #266). Local config read/write, ~ms.
-    try {
-      const wasRegistered = await invoke<boolean>('ensure_external_project_registered', {
-        path: project.path,
-      });
-      if (wasRegistered) {
-        logger.info(`[OpenProject] Auto-registered external project: ${project.path}`);
-      }
-    } catch (e) {
-      logger.warn('[OpenProject] Failed to ensure external project registration', { error: e });
-      openingProjectPathRef.current = null;
-      showToast(
-        `Can't open "${project.name}" — its folder isn't a recognized project location. Re-add it via "Select Project Folder".`,
-        'error'
-      );
-      return;
-    }
-    if (navVersion !== navigationVersionRef.current) {
-      openingProjectPathRef.current = null;
-      return; // Superseded while awaiting registration
-    }
 
     // Set the active project so every subsequent event in this session
     // auto-tags project context. The hash is sync (FNV-1a) so this never

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -125,6 +125,12 @@ describe('humanizeGitError', () => {
       expect: /didn't accept the connection/i,
     },
     {
+      // GitHub's no-write-access rejection splits "permission"/"denied" with
+      // the repo name — must still classify as an auth failure (issue #321).
+      raw: 'ERROR: Permission to acme/site.git denied to somebody.\nfatal: Could not read from remote repository.',
+      expect: /didn't accept the connection/i,
+    },
+    {
       raw: 'fatal: unable to access https://github.com/a/b: Could not resolve host: github.com',
       expect: /couldn't reach GitHub/i,
     },

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -101,16 +101,19 @@ export function humanizeGitError(value: unknown, ctx: GitErrorContext = {}): str
     return `There are newer changes on GitHub than you have locally. Pull the latest changes first, then try again.`;
   }
 
-  // GitHub wouldn't authenticate.
+  // GitHub wouldn't authenticate. GitHub's no-write-access rejection reads
+  // "Permission to <owner>/<repo>.git denied to <user>." — the words are split
+  // by the repo name, so it needs the two-part check (issue #321).
   if (
     m.includes('permission denied') ||
+    (m.includes('permission to') && m.includes('denied to')) ||
     m.includes('could not read username') ||
     m.includes('authentication failed') ||
     m.includes('not authenticated') ||
     m.includes('bad credentials') ||
     m.includes('403')
   ) {
-    return `GitHub didn't accept the connection. Your sign-in may have expired. Reconnect GitHub (top right) and try again.`;
+    return `GitHub didn't accept the connection. Your sign-in may have expired, or your account may not have write access to this repository. Reconnect GitHub (top right) or check your access, then try again.`;
   }
 
   // Couldn't reach GitHub at all.


### PR DESCRIPTION
## Summary

Round 7 of auto-reported bug fixes — 14 issues: #307, #308, #309, #310, #311, #312, #314, #315, #317, #318, #319, #320, #321, #322, #323.

### Telemetry noise → `CommandError::Expected` (typed at the throw site)
- **#317** `get_current_branch`: "Detached HEAD state" is a normal git state every caller already handles.
- **#312** `pull_and_merge` / `git_pull`: git's missing-upstream refusal ("no tracking information", "no such ref was fetched", "couldn't find remote ref") — message text preserved verbatim so the frontend's "push it first" toast keeps matching.
- **#323** `pty_session_write`: both "terminal session has ended" branches (the #260 benign race).
- **#311** `simulator_app_running`: CoreSimulator's "Domain is tearing down" during teardown races now returns `Ok(false)` — the poll recovers on its own.
- **#314** Code tab / Open in IDE: canonicalize failures now name the file; a plain NotFound (stale tab/tree reference) is Expected.

### Real fixes
- **#321** GitHub's no-write-access rejection ("Permission to X.git denied to Y") is split by the repo name so neither the backend `"Permission denied"` check nor the frontend `humanizeGitError` matched — both now classify it as an auth failure with actionable messaging. Locked with a test case.
- **#319** External-project registration now runs *before* the monorepo workspace gate in `handleSelectProject` — first-open of external folders (e.g. worktrees) no longer logs spurious "outside the projects directory" errors, and the workspace picker actually evaluates for them.
- **#309/#310** Playwright captures: `waitUntil: 'networkidle'` never resolves on dev servers with persistent HMR/websocket connections. Both scripts now wait for `'load'` plus a bounded best-effort `waitForLoadState('networkidle', 5s)` that never fails the capture, and the IIFE has a `.catch` so failures print one clean line instead of Node's uncaught-exception dump.
- **#315** A dev-linked plugin whose folder vanished outside "Unlink Dev Plugin" is now deactivated like an explicit unload: one clear toast ("its files are no longer on disk"), background calls suppressed via the #288 tombstone instead of toasting every tick.
- **#308** OpenCode's `mcp add` is an interactive wizard with no scriptable form, so add/remove now write `~/.config/opencode/opencode.json` directly (mirroring the `register_cursor_mcp` merge pattern): upsert by name, idempotent remove, fail-closed on unparseable configs. Also fixes the preview-bridge registration for OpenCode, which went through the same broken CLI path. Parser unit-tested (remote `--url`, local with/without `--` separator, rejects).
- **#322** Plugin `invoke.call` now auto-injects `projectPath` (explicit args still win), consistent with `shell`/`storage`; docs updated with the contract.
- **#307** Dashboard project scans name the folder on read failures; macOS TCC `EPERM` maps to an actionable Files-and-Folders/Full-Disk-Access message (Expected — environment gap).

### Editor messaging (#318, #320)
Canvas insert/duplicate/delete surfaced resolution errors worded for the raw-markup editor ("then its markup becomes editable", "editing it here"). `structuralEditMessage` rephrases the three known resolution failures (no class / multi-instance / dynamic class) for the structural context; unknown messages pass through. Unit-tested. Full class-free anchoring for structural ops remains future work — noted on #318.

## Testing
- `cargo test` — full backend suite green (includes 4 new OpenCode parser tests, Expected-classification unchanged serialization)
- `pnpm test:run` — 1380 tests green (new: #321 auth-classification case, `structuralEditMessage` cases; 1 assertion updated for the new structural wording)
- `tsc --noEmit`, `pnpm lint`, `pnpm check:patterns` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #307. Closes #308. Closes #309. Closes #310. Closes #311. Closes #312. Closes #314. Closes #315. Closes #317. Closes #319. Closes #320. Closes #321. Closes #322. Closes #323.
(#318 stays open: the message fix shipped here; class-free anchoring for structural ops is tracked there.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenCode MCP servers can now be added and removed through configuration management.
  * Plugin commands automatically use the current project path when applicable.
  * Missing plugins are automatically deactivated with a clear notification.

* **Bug Fixes**
  * Improved Git authentication, upstream, detached-branch, and terminal-session error messages.
  * Added clearer guidance for macOS project-folder permissions.
  * Improved simulator detection during shutdown and screenshot reliability.
  * Structural editing errors now display more understandable messages.

* **Documentation**
  * Clarified automatic project-path handling for plugin invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->