### PR TITLE
Ride out Windows antivirus locks when installing plugins

### DIFF
--- a/src-tauri/src/commands/plugins/plugin_lifecycle.rs
+++ b/src-tauri/src/commands/plugins/plugin_lifecycle.rs
@@ -57,19 +57,56 @@ fn resolve_git() -> Result<PathBuf, CommandError> {
     })
 }
 
-/// `fs::rename` with a few retries. On Windows a rename briefly fails with a
-/// sharing violation while antivirus / the search indexer scan files git just
-/// wrote; a moment later the same rename succeeds.
+/// `fs::rename` with retries and a copy fallback. On Windows a rename fails
+/// with a sharing violation / "Access is denied" while antivirus or the search
+/// indexer scans files git just wrote. The old ~600ms retry window regularly
+/// lost that race — Defender scans of a fresh clone can hold locks for
+/// seconds (issue #244) — so back off up to ~5s, then fall back to
+/// copy+delete: copying only needs read access to the source files, not the
+/// exclusive lock on the whole tree that a rename requires.
 fn rename_with_retry(from: &Path, to: &Path) -> std::io::Result<()> {
     let mut result = fs::rename(from, to);
-    for _ in 0..4 {
+    let mut delay = std::time::Duration::from_millis(100);
+    for _ in 0..6 {
         if result.is_ok() {
             return Ok(());
         }
-        std::thread::sleep(std::time::Duration::from_millis(120));
+        std::thread::sleep(delay);
+        delay = (delay * 2).min(std::time::Duration::from_millis(1600));
         result = fs::rename(from, to);
     }
-    result
+    let Err(rename_err) = result else {
+        return Ok(());
+    };
+    tracing::warn!(
+        "rename {} -> {} still failing after retries ({rename_err}); falling back to copy",
+        from.display(),
+        to.display()
+    );
+    if let Err(copy_err) = copy_dir_recursive(from, to) {
+        // Don't leave a half-copied plugin behind — it would load broken.
+        let _ = remove_dir_all_relaxed(to);
+        return Err(copy_err);
+    }
+    // Source cleanup is best-effort: the plugin is installed either way, and
+    // the stale `.tmp-install` dir is cleared at the start of the next install.
+    let _ = remove_dir_all_relaxed(from);
+    Ok(())
+}
+
+/// Recursively copy a directory tree. Fallback path for `rename_with_retry`.
+fn copy_dir_recursive(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let target = to.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&entry.path(), &target)?;
+        } else {
+            fs::copy(entry.path(), &target)?;
+        }
+    }
+    Ok(())
 }
 
 /// `fs::remove_dir_all` that first clears read-only attributes. Git marks pack
@@ -671,6 +708,24 @@ mod tests {
         rename_with_retry(&from, &to).unwrap();
         assert!(!from.exists());
         assert!(to.join("f.txt").exists());
+    }
+
+    #[test]
+    fn copy_dir_recursive_copies_nested_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let from = tmp.path().join("src");
+        let to = tmp.path().join("dst");
+        fs::create_dir_all(from.join("a/b")).unwrap();
+        fs::write(from.join("top.txt"), b"1").unwrap();
+        fs::write(from.join("a/mid.txt"), b"2").unwrap();
+        fs::write(from.join("a/b/leaf.txt"), b"3").unwrap();
+
+        super::copy_dir_recursive(&from, &to).unwrap();
+        assert_eq!(fs::read(to.join("top.txt")).unwrap(), b"1");
+        assert_eq!(fs::read(to.join("a/mid.txt")).unwrap(), b"2");
+        assert_eq!(fs::read(to.join("a/b/leaf.txt")).unwrap(), b"3");
+        // Source is untouched by the copy itself.
+        assert!(from.join("a/b/leaf.txt").exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes the concrete failure finally captured for #244: `Failed to move plugin to final location: Access is denied. (os error 5)` (Hadi Aslam's Webflow-to-Code install, Slack).

The install flow clones to `plugins/.tmp-install`, then renames to the final dir. On Windows, Defender / the search indexer scan the freshly written files and hold locks that make the rename fail with a sharing violation — and the existing retry window (5 attempts × 120ms ≈ 600ms) regularly loses to scans that run for seconds.

- `rename_with_retry` now backs off exponentially up to ~5s total.
- If the rename still fails, it falls back to **copy + delete**: copying needs only read access to the source files, not the exclusive lock on the entire tree that a rename requires, so it succeeds under an active scan.
- A failed fallback removes the half-copied destination (never leaves a broken plugin that would load), and the leftover `.tmp-install` is already cleared at the start of the next install.

This addresses the "Install button / Install from URL fails" half of #244. The "installed plugin then non-functional" half remains unverified pending a Windows repro — leaving #244 open with a comment.

## Testing
- New unit test for `copy_dir_recursive` (nested tree, content fidelity); existing `rename_with_retry_moves_dir` still green
- `cargo test` full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin moves on Windows by retrying when files are temporarily locked.
  * Added a fallback process to copy plugin files when a rename cannot be completed, helping prevent failed plugin operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->