### PR TITLE
Stop blaming the shell when a setup command is silent

### DIFF
--- a/src/components/setup/OnboardingTerminal.tsx
+++ b/src/components/setup/OnboardingTerminal.tsx
@@ -479,11 +479,19 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
             return;
           }
           logger.error('[OnboardingTerminal] Still no output after respawn', { command });
-          const failure = `${command} did not respond.`;
-          terminalRef.current?.write(
-            `\r\n\x1b[31m${failure}\x1b[0m\r\n` +
-              `\x1b[33mMake sure "${command}" is installed and on your PATH, then close this window and try again.\x1b[0m\r\n`
-          );
+          // When the command is a shell (/bin/bash, powershell), "make sure
+          // it's installed" misdirects the user toward a nonexistent problem —
+          // the shell exists; whatever ran inside it was silent (issue #245's
+          // user-facing symptom). Point at the likely causes instead.
+          const isShell =
+            /(^|[\\/])(bash|sh|zsh|cmd(\.exe)?|powershell(\.exe)?|pwsh(\.exe)?)$/i.test(command);
+          const failure = isShell
+            ? 'The setup command produced no output.'
+            : `${command} did not respond.`;
+          const hint = isShell
+            ? 'This is usually a temporary glitch or a blocked download — check your internet connection, then close this window and try again.'
+            : `Make sure "${command}" is installed and on your PATH, then close this window and try again.`;
+          terminalRef.current?.write(`\r\n\x1b[31m${failure}\x1b[0m\r\n\x1b[33m${hint}\x1b[0m\r\n`);
           // Tell the parent the flow failed so the checklist offers a retry —
           // without this the terminal showed the message but the wizard sat
           // in "connecting" forever (issue #245).


### PR DESCRIPTION
## Summary
A support screenshot (macOS user stuck on a pre-0.18.2 build, hitting #245's watchdog bug) showed our give-up message verbatim: `/bin/bash did not respond. Make sure "/bin/bash" is installed and on your PATH…` — advice that misdirects the user toward a nonexistent problem: the shell always exists, and the real issue is that the command running inside it was silent (or, pre-0.18.2, that our watchdog killed a healthy quiet download).

When the spawned command is a shell (`bash`/`sh`/`zsh`/`cmd`/`powershell`/`pwsh`, bare or full path), the watchdog's final message now reads:

> The setup command produced no output.
> This is usually a temporary glitch or a blocked download — check your internet connection, then close this window and try again.

Non-shell commands keep the original "installed and on your PATH" wording, which is correct for them.

## Testing
- `npx vitest run src/components/setup` — 120 tests green (pre-commit re-ran the full suite too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding terminal error messages when no output is received after restarting.
  * Shell-related failures now suggest checking execution, connection, or download issues.
  * Non-shell command failures continue to provide guidance on installation and PATH configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->