### PR TITLE
Fix round-8 auto-reported bugs: home-dir data-loss guards, window ACLs, auth detection, diagnostics

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for all app windows",
-  "windows": ["main", "project-*"],
+  "description": "Capability for all app windows. `window-*` covers blank windows from Window → New Window (spawn_blank_window) — they load the full app, so leaving them out silently stripped every permission: updater checks, fs reads for terminal fonts, event listeners (issues #327, #341, #328).",
+  "windows": ["main", "project-*", "window-*"],
   "permissions": [
     "core:default",
     "core:app:allow-version",

--- a/src-tauri/src/commands/assets.rs
+++ b/src-tauri/src/commands/assets.rs
@@ -48,7 +48,7 @@ fn assets_root_dir(repo_root: &Path, workspace: &Path) -> PathBuf {
 /// Prevents path traversal attacks.
 fn validate_asset_path(root_dir: &Path, asset_path: &str) -> Result<PathBuf, String> {
     // Check for obvious path traversal attempts
-    if asset_path.contains("..") {
+    if crate::utils::has_parent_dir_component(asset_path) {
         return Err("Invalid path: path traversal not allowed".to_string());
     }
 
@@ -252,7 +252,8 @@ pub async fn upload_asset(
     }
 
     // Validate filename
-    if file_name.contains('/') || file_name.contains('\\') || file_name.contains("..") {
+    if file_name.contains('/') || file_name.contains('\\') || file_name == ".." || file_name == "."
+    {
         return Err(("Invalid filename: path separators not allowed".to_string()).into());
     }
 
@@ -262,7 +263,7 @@ pub async fn upload_asset(
     } else {
         // Validate and resolve destination path
         let dest = destination.trim_start_matches('/');
-        if dest.contains("..") {
+        if crate::utils::has_parent_dir_component(dest) {
             return Err(("Invalid destination: path traversal not allowed".to_string()).into());
         }
         let dest_path = root_dir.join(dest);
@@ -341,7 +342,7 @@ pub async fn rename_asset(
     let old_path = validate_asset_path(&root_dir, &asset_path)?;
 
     // Validate new name
-    if new_name.contains('/') || new_name.contains('\\') || new_name.contains("..") {
+    if new_name.contains('/') || new_name.contains('\\') || new_name == ".." || new_name == "." {
         return Err(("Invalid name: path separators not allowed".to_string()).into());
     }
 
@@ -391,7 +392,7 @@ pub async fn create_asset_folder(
     }
 
     // Validate folder path
-    if folder_path.contains("..") {
+    if crate::utils::has_parent_dir_component(&folder_path) {
         return Err(("Invalid path: path traversal not allowed".to_string()).into());
     }
 

--- a/src-tauri/src/commands/code.rs
+++ b/src-tauri/src/commands/code.rs
@@ -163,7 +163,7 @@ pub fn read_project_file(project_path: &str, file_path: &str) -> Result<FileCont
     let project = validate_project_path(project_path)?;
 
     // Prevent path traversal
-    if file_path.contains("..") {
+    if crate::utils::has_parent_dir_component(file_path) {
         return Err(("Invalid path: path traversal not allowed".to_string()).into());
     }
 
@@ -242,7 +242,7 @@ pub fn save_project_file(
     let project = validate_project_path(project_path)?;
 
     // Prevent path traversal
-    if file_path.contains("..") {
+    if crate::utils::has_parent_dir_component(file_path) {
         return Err(("Invalid path: path traversal not allowed".to_string()).into());
     }
 

--- a/src-tauri/src/commands/external_projects.rs
+++ b/src-tauri/src/commands/external_projects.rs
@@ -95,6 +95,12 @@ pub fn is_registered_external_path(canonical: &Path) -> Result<bool, String> {
     for project in &config.projects {
         let project_path = Path::new(&project.path);
         if let Ok(project_canonical) = dunce::canonicalize(project_path) {
+            // Neutralize any pre-existing bad registration of $HOME (or wider):
+            // honoring it would make every path under the home directory pass
+            // validate_project_path via starts_with (issue #345).
+            if crate::utils::is_forbidden_project_root(&project_canonical) {
+                continue;
+            }
             if canonical.starts_with(&project_canonical) {
                 return Ok(true);
             }
@@ -122,6 +128,16 @@ pub async fn register_external_project(app: AppHandle) -> Result<Option<String>,
             .map_err(|e| format!("Invalid folder path: {e}"))?,
         None => return Ok(None), // User cancelled
     };
+
+    // The home directory (or anything above it) is never a project, even when
+    // a stray ~/.git or ~/.gitignore makes it look like one — registering it
+    // would scope destructive git ops to the whole home tree (issue #345).
+    if crate::utils::is_forbidden_project_root(&folder_path) {
+        return Err(CommandError::expected(
+            "That folder is your home directory (or a folder above it), which can't be added as a \
+             project. Pick the specific project folder instead.",
+        ));
+    }
 
     // Use the same predicate as dashboard discovery so removed projects can be
     // restored even when they were blank, git-only, or Ship Studio metadata-only.
@@ -291,6 +307,10 @@ fn clear_workspace_subpath_in_metadata(project_root: &Path) -> Result<(), String
 /// generous about *project* shapes but excludes things like ~/.ssh, ~/.aws.
 fn looks_like_project_root(path: &Path) -> bool {
     if !path.is_dir() {
+        return false;
+    }
+    // Never the home directory or above it, regardless of markers (#345).
+    if crate::utils::is_forbidden_project_root(path) {
         return false;
     }
     const MARKERS: &[&str] = &[

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -113,6 +113,14 @@ pub fn git_has_any_changes(path: &std::path::Path) -> Result<bool, String> {
 /// Stages all changes and commits with the given message.
 /// Returns true if a commit was made, false if nothing to commit.
 pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<bool, String> {
+    // Defense-in-depth backstop for #345: even if a too-broad path slipped past
+    // registration, never run `git add -A` across the home tree.
+    if crate::utils::is_forbidden_project_root(path) {
+        return Err(format!(
+            "Refusing to stage changes in '{}': it is the home directory or wider, not a project folder",
+            path.display()
+        ));
+    }
     // Stage all changes
     let add_output = crate::utils::git_command_in(path)?
         .args(["add", "-A"])

--- a/src-tauri/src/commands/git/sync.rs
+++ b/src-tauri/src/commands/git/sync.rs
@@ -114,11 +114,52 @@ pub async fn pull_and_merge(
     Ok(combined)
 }
 
+/// Guard for destructive git operations: confirm the repository git resolves
+/// from `dir` is rooted at `dir` itself. When the project's own `.git` is
+/// missing or broken, git discovery walks *up* the tree and can land on an
+/// unrelated ancestor repo (worst case a stray `~/.git`) — at which point
+/// `clean -fd` would treat every project file as untracked and delete the lot
+/// (issue #346). Refusing with a clear message beats silent data loss.
+fn ensure_repo_rooted_at(dir: &std::path::Path) -> Result<(), CommandError> {
+    let output = crate::utils::git_command_in(dir)?
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .map_err(|e| format!("Failed to locate the repository root: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(CommandError::expected(format!(
+            "This folder isn't a git repository, so there are no changes to discard: {stderr}"
+        )));
+    }
+
+    let toplevel = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let toplevel_canon =
+        dunce::canonicalize(&toplevel).unwrap_or_else(|_| std::path::PathBuf::from(&toplevel));
+    let dir_canon = dunce::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf());
+
+    if toplevel_canon != dir_canon {
+        return Err(CommandError::expected(format!(
+            "Refusing to discard changes: git resolves this project's repository to '{}', not the \
+             project folder itself. The project's .git folder may be missing or damaged — \
+             discarding here could delete files that belong to the wrong repository.",
+            toplevel_canon.display()
+        )));
+    }
+
+    Ok(())
+}
+
 /// Discard all uncommitted changes in the working directory
 #[tauri::command]
 #[tracing::instrument(skip(project_path), fields(project = %project_path))]
 pub async fn discard_changes(project_path: String) -> Result<(), CommandError> {
     let validated_path = validate_project_path(&project_path)?;
+
+    // `checkout .` and `clean -fd` operate on whatever repository git
+    // discovers, not the directory we were handed — verify they match first
+    // (issue #346).
+    ensure_repo_rooted_at(&validated_path)?;
 
     // Discard changes to tracked files
     let checkout_output = crate::utils::git_command_in(&validated_path)?
@@ -163,4 +204,42 @@ pub async fn commit_changes(project_path: String, message: String) -> Result<boo
         GIT_CACHE.invalidate_status(&project_path);
     }
     Ok(committed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_repo_rooted_at;
+    use std::process::Command;
+
+    fn init_repo(dir: &std::path::Path) {
+        assert!(Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(dir)
+            .status()
+            .expect("git init")
+            .success());
+    }
+
+    #[test]
+    fn accepts_a_directory_that_is_its_own_repo_root() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_repo(tmp.path());
+        assert!(ensure_repo_rooted_at(tmp.path()).is_ok());
+    }
+
+    // The #346 shape: no .git at the project itself, but an ancestor has one —
+    // git discovery walks up, and clean -fd would treat every project file as
+    // untracked garbage of the ancestor repo.
+    #[test]
+    fn refuses_when_git_resolves_an_ancestor_repo() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let nested = tmp.path().join("project");
+        std::fs::create_dir(&nested).unwrap();
+        let err = ensure_repo_rooted_at(&nested).expect_err("must refuse ancestor repo");
+        assert!(
+            err.to_string().contains("Refusing to discard changes"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -509,6 +509,20 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
     Ok(format!("https://github.com/{repo_name}"))
 }
 
+/// gh's stderr when a subcommand needs auth and none is configured — "To get
+/// started with GitHub CLI, please run:  gh auth login" plus the GH_TOKEN
+/// hint. Modeled as the app's first-class NotAuthenticated state (skipped by
+/// telemetry, and the frontend shows its connect-GitHub UI) instead of
+/// surfacing the raw CLI text (issue #326).
+pub(crate) fn gh_auth_error(stderr: &str) -> Option<CommandError> {
+    if stderr.contains("gh auth login") || stderr.contains("GH_TOKEN") {
+        return Some(CommandError::NotAuthenticated {
+            service: "github".to_string(),
+        });
+    }
+    None
+}
+
 /// Lists GitHub repositories for a given owner (user or organization)
 #[tauri::command]
 #[tracing::instrument]
@@ -527,6 +541,9 @@ pub async fn list_github_repos(owner: String) -> Result<Vec<GitHubRepo>, Command
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        if let Some(err) = gh_auth_error(&stderr) {
+            return Err(err);
+        }
         return Err(CommandError::Process {
             cmd: "gh repo list".to_string(),
             exit_code: output.status.code().unwrap_or(-1),
@@ -577,6 +594,9 @@ pub async fn list_collaborator_repos() -> Result<Vec<GitHubRepo>, CommandError> 
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        if let Some(err) = gh_auth_error(&stderr) {
+            return Err(err);
+        }
         return Err(CommandError::Process {
             cmd: "gh api /user/repos".to_string(),
             exit_code: output.status.code().unwrap_or(-1),

--- a/src-tauri/src/commands/ide/mod.rs
+++ b/src-tauri/src/commands/ide/mod.rs
@@ -161,7 +161,7 @@ pub async fn open_in_ide(
 
     // If a file path is provided, validate it's within the project
     let target_path = if let Some(ref fp) = file_path {
-        if fp.contains("..") {
+        if crate::utils::has_parent_dir_component(fp) {
             return Err(("Invalid path: path traversal not allowed".to_string()).into());
         }
         let full = validated_path.join(fp);

--- a/src-tauri/src/commands/ide/preview.rs
+++ b/src-tauri/src/commands/ide/preview.rs
@@ -10,6 +10,22 @@ use tauri::{Manager, Webview, WebviewUrl};
 /// Tracks whether a preview webview currently exists
 static PREVIEW_WEBVIEW_EXISTS: Mutex<bool> = Mutex::new(false);
 
+/// Clamp a child-webview rect so it never extends past the window's inner
+/// bounds. A child view is hard-clipped at the window edge, so an oversized or
+/// offset rect (e.g. the Sanity plugin's stale title-bar offset on overlay-
+/// titlebar windows) visibly chops off the bottom of the embedded content
+/// (issue #337). Clamping instead lets the page reflow into the visible area.
+fn clamp_to_window(window: &tauri::Window, x: f64, y: f64, width: f64, height: f64) -> (f64, f64) {
+    let scale = window.scale_factor().unwrap_or(1.0);
+    if let Ok(size) = window.inner_size() {
+        let logical: tauri::LogicalSize<f64> = size.to_logical(scale);
+        let w = width.min((logical.width - x).max(0.0));
+        let h = height.min((logical.height - y).max(0.0));
+        return (w, h);
+    }
+    (width, height)
+}
+
 /// Scroll dimensions returned from a webview
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct ScrollDimensions {
@@ -56,6 +72,7 @@ pub async fn create_preview_webview(
     let builder = tauri::webview::WebviewBuilder::new("preview", WebviewUrl::External(parsed_url))
         .auto_resize();
 
+    let (width, height) = clamp_to_window(&window, x, y, width, height);
     window
         .add_child(
             builder,
@@ -91,6 +108,7 @@ pub async fn resize_preview_webview(
     height: f64,
 ) -> Result<(), CommandError> {
     if let Some(webview) = app.get_webview("preview") {
+        let (width, height) = clamp_to_window(&webview.window(), x, y, width, height);
         webview
             .set_position(tauri::LogicalPosition::new(x, y))
             .map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/ide/screenshots/thumbnail.rs
+++ b/src-tauri/src/commands/ide/screenshots/thumbnail.rs
@@ -113,11 +113,21 @@ pub async fn capture_project_thumbnail(
         let temp_path_str = temp_path.to_string_lossy().to_string();
         let screenshot_arg = format!("--screenshot={temp_path_str}");
 
+        // An isolated profile dir is required, not an optimization: since the
+        // headless/headful merge, `--headless=new` on the default profile
+        // shares the singleton lock with any already-running instance of the
+        // same browser and instantly exits with code 21 — a developer's normal
+        // browser being open silently killed every thumbnail (issue #335).
+        let profile_dir = shipstudio_dir.join("thumbnail_profile");
+        let user_data_arg = format!("--user-data-dir={}", profile_dir.to_string_lossy());
+
         // Use new headless mode with explicit viewport control
         // Set background to white so any extra captured area isn't black
         let output = create_command(&browser)
             .args([
                 "--headless=new",
+                &user_data_arg,
+                "--no-first-run",
                 "--disable-gpu",
                 "--no-sandbox",
                 "--hide-scrollbars",
@@ -131,6 +141,9 @@ pub async fn capture_project_thumbnail(
             ])
             .output()
             .map_err(|e| format!("Failed to run browser: {e}"))?;
+
+        // The throwaway profile has served its purpose; don't let it grow.
+        let _ = std::fs::remove_dir_all(&profile_dir);
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -204,6 +204,11 @@ pub(crate) fn is_valid_project(path: &std::path::Path) -> bool {
         "build.gradle",
         "composer.json",
     ];
+    // A home directory very often carries a stray `.git`/`.gitignore`, but it
+    // must never count as a project — see is_forbidden_project_root (#345).
+    if crate::utils::is_forbidden_project_root(path) {
+        return false;
+    }
     path.is_dir()
         && (path.join("package.json").exists()
             || detection::static_site_dir(path).is_some()

--- a/src-tauri/src/commands/pty_session.rs
+++ b/src-tauri/src/commands/pty_session.rs
@@ -305,10 +305,22 @@ pub async fn pty_session_open(
         cmd.env(std::ffi::OsString::from(&k), std::ffi::OsString::from(&v));
     }
 
-    let mut child = pair
-        .slave
-        .spawn_command(cmd)
-        .map_err(|e| format!("spawn_command: {e}"))?;
+    let mut child = pair.slave.spawn_command(cmd).map_err(|e| {
+        let message = format!("spawn_command: {e}");
+        // portable_pty's binary-not-found phrasings. A missing/unresolvable
+        // agent CLI is an environment gap ("install X first") the frontend
+        // already turns into the agent's install hint — Expected keeps it out
+        // of telemetry, mirroring external_command.rs (issue #329).
+        let lower = message.to_lowercase();
+        if lower.contains("no viable candidates found in path")
+            || lower.contains("does not exist")
+            || lower.contains("not executable")
+        {
+            crate::errors::CommandError::expected(message)
+        } else {
+            crate::errors::CommandError::from(message)
+        }
+    })?;
     let pid = child.process_id().unwrap_or(0);
     let child_killer = child.clone_killer();
 

--- a/src-tauri/src/commands/publishing.rs
+++ b/src-tauri/src/commands/publishing.rs
@@ -14,6 +14,27 @@ use crate::types::PublishResult;
 use crate::utils::validate_project_path;
 use tracing::{debug, error, info, instrument, warn};
 
+/// GitHub's push-time auth/permission rejections. The phrasing varies by
+/// transport and failure mode: SSH's "Permission denied", the credential
+/// helper's "could not read Username", HTTPS "Permission to <repo>.git denied
+/// to <user>." (words split by the repo name — issue #321), and HTTPS
+/// "remote: Write access to repository not granted." with a 403
+/// (issue #343). All mean "reconnect GitHub or check your access", so all
+/// map to NotAuthenticated instead of an opaque process error.
+fn push_auth_error(stderr: &str) -> Option<CommandError> {
+    let lower = stderr.to_lowercase();
+    let is_auth = stderr.contains("Permission denied")
+        || stderr.contains("could not read Username")
+        || (lower.contains("permission to") && lower.contains("denied to"))
+        || lower.contains("write access to repository not granted");
+    if is_auth {
+        return Some(CommandError::NotAuthenticated {
+            service: format!("github (AUTH_ERROR: {stderr})"),
+        });
+    }
+    None
+}
+
 #[tauri::command]
 #[instrument(name = "publish_to_github", skip(project_path, commit_message), fields(project = %project_path))]
 pub async fn publish_to_github(
@@ -82,6 +103,10 @@ pub async fn publish_to_github(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        if let Some(err) = push_auth_error(&stderr) {
+            error!(error = %stderr, branch = %branch, "Authentication error");
+            return Err(err);
+        }
         if !stderr.contains("Everything up-to-date") {
             error!(error = %stderr, branch = %branch, "Push to GitHub failed");
             return Err(CommandError::Process {
@@ -133,6 +158,10 @@ pub async fn publish_to_staging(
                 "PUSH_REJECTED: Staging branch has diverged. Pull changes first or resolve conflicts.\n{stderr}"
             ) });
         }
+        if let Some(err) = push_auth_error(&stderr) {
+            error!(error = %stderr, "Authentication error");
+            return Err(err);
+        }
         if !stderr.contains("Everything up-to-date") {
             error!(error = %stderr, "Failed to push to staging");
             return Err(CommandError::Process {
@@ -176,6 +205,10 @@ pub async fn publish_to_production(
 
     if !push_output.status.success() {
         let stderr = String::from_utf8_lossy(&push_output.stderr);
+        if let Some(err) = push_auth_error(&stderr) {
+            error!(error = %stderr, "Authentication error");
+            return Err(err);
+        }
         if !stderr.contains("Everything up-to-date") {
             error!(error = %stderr, "Failed to push to production");
             return Err(CommandError::Process {
@@ -236,18 +269,9 @@ pub async fn publish_branch(
                 message: format!("PUSH_REJECTED:{stderr}"),
             });
         }
-        // "Permission to <owner>/<repo>.git denied to <user>." is GitHub's
-        // no-write-access rejection — the words "permission"/"denied" are split
-        // by the repo name, so it needs its own check (issue #321).
-        let lower = stderr.to_lowercase();
-        if stderr.contains("Permission denied")
-            || stderr.contains("could not read Username")
-            || (lower.contains("permission to") && lower.contains("denied to"))
-        {
+        if let Some(err) = push_auth_error(&stderr) {
             error!(error = %stderr, branch = %branch, "Authentication error");
-            return Err(CommandError::NotAuthenticated {
-                service: format!("github (AUTH_ERROR: {stderr})"),
-            });
+            return Err(err);
         }
         if !stderr.contains("Everything up-to-date") {
             error!(error = %stderr, branch = %branch, "Push failed");

--- a/src-tauri/src/commands/pull_requests.rs
+++ b/src-tauri/src/commands/pull_requests.rs
@@ -57,6 +57,11 @@ pub async fn list_pull_requests(
         {
             return Ok(Vec::new());
         }
+        // Auth-not-configured is an expected state, not an error to report
+        // with gh's raw multi-line stderr (issue #326).
+        if let Some(err) = crate::commands::github::gh_auth_error(&stderr) {
+            return Err(err);
+        }
         return Err((stderr.to_string()).into());
     }
 
@@ -125,6 +130,9 @@ pub async fn create_pull_request(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        if let Some(err) = crate::commands::github::gh_auth_error(&stderr) {
+            return Err(err);
+        }
         return Err((stderr.to_string()).into());
     }
 
@@ -150,6 +158,9 @@ pub async fn merge_pull_request(project_path: String, pr_number: i32) -> Result<
         let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
         if is_conflict_stderr(&stderr) {
             return Err(CommandError::MergeConflict { pr_number, stderr });
+        }
+        if let Some(err) = crate::commands::github::gh_auth_error(&stderr) {
+            return Err(err);
         }
         return Err(stderr.into());
     }
@@ -182,6 +193,9 @@ pub async fn checkout_pull_request(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        if let Some(err) = crate::commands::github::gh_auth_error(&stderr) {
+            return Err(err);
+        }
         return Err((format!("Failed to checkout PR: {stderr}")).into());
     }
 
@@ -210,6 +224,9 @@ pub async fn close_pull_request(project_path: String, pr_number: i32) -> Result<
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        if let Some(err) = crate::commands::github::gh_auth_error(&stderr) {
+            return Err(err);
+        }
         return Err((format!("Failed to close PR: {stderr}")).into());
     }
 

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -772,6 +772,41 @@ pub fn canonicalize_tagged(
         .map_err(|e| format!("Invalid path in {site} ('{}'): {e}", path.display()))
 }
 
+/// True when a user-supplied relative path contains an actual `..` path
+/// component (a traversal attempt). A naive `contains("..")` substring test
+/// also rejects legitimate names like `notes..bak` or `v1..2-draft`
+/// (issue #331); this checks whole components, and the canonicalize +
+/// `starts_with` containment checks at every call site remain the real
+/// defense against escapes.
+pub fn has_parent_dir_component(path: &str) -> bool {
+    std::path::Path::new(path)
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+}
+
+/// Directories that must never be treated as a project root, no matter what
+/// marker files they contain: the user's home directory (a stray `~/.git` or
+/// `~/.gitignore` is common), anything above it, and the filesystem root.
+/// Treating one of these as a project hands project-scoped git commands
+/// (`git add -A`, `git clean -fd`) the entire home tree to walk — observed
+/// as issues #345/#346, where a registered `$HOME` "project" made Discard
+/// Changes run `git clean -fd` across the user's home directory.
+pub(crate) fn is_forbidden_project_root(path: &std::path::Path) -> bool {
+    let candidate = dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    // Filesystem root ("/", "C:\") has no parent.
+    if candidate.parent().is_none() {
+        return true;
+    }
+    if let Some(home) = dirs::home_dir() {
+        let home = dunce::canonicalize(&home).unwrap_or(home);
+        // $HOME itself, or an ancestor of it (/Users, /home, C:\Users).
+        if candidate == home || home.starts_with(&candidate) {
+            return true;
+        }
+    }
+    false
+}
+
 /// Validates that a project path is inside an allowed projects root (the
 /// configured root or the default `~/ShipStudio`) or is a registered external
 /// project. Prevents path traversal where the frontend could pass arbitrary paths.
@@ -1096,6 +1131,26 @@ fn format_relative_time_from_now(timestamp_ms: u64, now_ms: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    mod is_forbidden_project_root {
+        use super::*;
+
+        #[test]
+        fn refuses_home_its_ancestors_and_fs_root() {
+            let home = dirs::home_dir().expect("home dir");
+            assert!(is_forbidden_project_root(&home));
+            if let Some(parent) = home.parent() {
+                assert!(is_forbidden_project_root(parent));
+            }
+            assert!(is_forbidden_project_root(std::path::Path::new("/")));
+        }
+
+        #[test]
+        fn allows_ordinary_directories() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            assert!(!is_forbidden_project_root(tmp.path()));
+        }
+    }
 
     mod normalize_separators {
         use super::*;

--- a/src/components/branches/BranchesTab.tsx
+++ b/src/components/branches/BranchesTab.tsx
@@ -369,6 +369,9 @@ export function BranchesTab({
     } catch (e) {
       trackError('branch_publish', e, 'Workspace');
       onToast?.(humanizeGitError(e, { branch: branchName }), 'error');
+      // Same recovery as handleSwitch: the ref is gone but a stale entry is
+      // still listed — refresh to drop the phantom (issue #334).
+      if (isBranchGoneError(e)) onRefresh();
     } finally {
       setPublishingBranch(null);
     }
@@ -388,6 +391,7 @@ export function BranchesTab({
     } catch (e) {
       trackError('branch_delete', e, 'Workspace');
       onToast?.(humanizeGitError(e, { branch: branchName }), 'error');
+      if (isBranchGoneError(e)) onRefresh();
     } finally {
       setDeletingBranch(null);
       setBranchToDelete(null);
@@ -456,6 +460,8 @@ export function BranchesTab({
     } catch (e) {
       trackError('branch_create', e, 'Workspace');
       onToast?.(humanizeGitError(e), 'error');
+      // e.g. the chosen base branch was deleted elsewhere — refresh the list.
+      if (isBranchGoneError(e)) onRefresh();
     } finally {
       setIsCreatingBranch(false);
     }

--- a/src/components/workspace/WorkspaceModals.tsx
+++ b/src/components/workspace/WorkspaceModals.tsx
@@ -134,7 +134,7 @@ export interface WorkspaceModalsProps {
   } | null;
   installTerminalExited: boolean;
   onCloseInstallTerminal: () => void;
-  onInstallTerminalExit: (exitCode: number | null) => void;
+  onInstallTerminalExit: (exitCode: number | null, outputTail: string) => void;
 
   // Dev command modal — read state via useModal('devCommand')
   customDevCommand: string | null;

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -177,7 +177,7 @@ interface IntegrationProps {
   } | null;
   installTerminalExited: boolean;
   onCloseInstallTerminal: () => void;
-  onInstallTerminalExit: (exitCode: number | null) => void;
+  onInstallTerminalExit: (exitCode: number | null, outputTail: string) => void;
 }
 
 interface ScreenshotProps {

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -767,6 +767,14 @@ export function useDevServer(currentProjectPath: string | null) {
             { projectPath }
           );
         }
+      } else if (detectedType === 'unknown') {
+        // No framework config, no package.json, no HTML — Ship Studio doesn't
+        // know how to preview this project. Spawning `npm run dev` anyway just
+        // produced a doomed spawn plus a spurious package.json read error in
+        // telemetry (issue #330).
+        logger.info('[OpenProject] Unknown project type; skipping dev server', {
+          projectPath,
+        });
       } else {
         try {
           s.outputBuffer = '';

--- a/src/hooks/useProjectCreation.ts
+++ b/src/hooks/useProjectCreation.ts
@@ -22,7 +22,8 @@
  * lib/setup (`checkNpmCachePermissions`), lib/plugins.
  *
  * Gotchas: `waitForPtyExit` treats a `null` exit code (process killed) as
- * SUCCESS, so a killed clone/install proceeds to the next step. The two zip
+ * SUCCESS, so a killed install proceeds to the next step; the clone step is
+ * the exception and treats `null` as an interruption (issue #342). The two zip
  * sources are mutually exclusive (`zipFile` from the browser vs `zipPath`
  * from Tauri drag-drop — selecting one clears the other), and the native
  * drag-drop listeners are only attached on the select-template step while
@@ -425,7 +426,18 @@ export function useProjectCreation({ onComplete, onCancel }: UseProjectCreationP
           windowLabel: getWindowLabel(),
         });
 
-        await waitForPtyExit(cloneId);
+        const cloneExitCode = await waitForPtyExit(cloneId);
+
+        // A null exit code means the clone PTY was killed (window closed,
+        // app reload) — possibly before git even created the target folder.
+        // Proceeding would run remove_git_history against a path that doesn't
+        // exist (issue #342). Unlike the install step below, a killed clone
+        // can never be treated as success.
+        if (cloneExitCode === null) {
+          throw new Error(
+            'Project creation was interrupted before the template finished downloading. Please try again.'
+          );
+        }
 
         // Remove .git folder so project starts fresh (not connected to template repo)
         setCurrentStep('init');

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -68,6 +68,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { logger } from '../lib/logger';
 import { trackEvent, trackError, setActiveProject } from '../lib/analytics';
 import { asCommandError, formatCommandError } from '../lib/errors';
+import { extractTerminalError } from '../lib/terminalDiagnostics';
 import { getProjectId } from '../lib/projectIdentity';
 import { startProjectSession, endProjectSession } from '../lib/session';
 import { basename } from '../lib/paths';
@@ -783,19 +784,29 @@ export function useProjectLifecycle({
     setInstallTerminalExited(false);
   };
 
-  const handleInstallTerminalExit = async (exitCode: number | null) => {
+  const handleInstallTerminalExit = async (exitCode: number | null, outputTail = '') => {
     const cfg = installTerminalConfig;
     if (!cfg) return;
     setInstallTerminalExited(true);
     // null = killed mid-run; treat as failure (don't auto-restart).
     if (exitCode !== 0) {
+      // The overlay terminal already collects the raw output tail — surface
+      // the actual npm/pnpm error instead of a bare exit code (issue #344).
+      // Home-dir paths are masked before the detail reaches analytics.
+      const detail = extractTerminalError(outputTail);
+      const scrubbedDetail = detail
+        ?.replace(/((?:\/Users|\/home|[A-Za-z]:[\\/]Users)[\\/])[^\\/\s]+/g, '$1~')
+        .slice(0, 300);
       void trackEvent('install_dependencies_failed', {
         package_manager: cfg.packageManager,
         exit_code: exitCode ?? -1,
+        error_detail: scrubbedDetail,
         $screen_name: 'Workspace',
       });
       showToast(
-        `Install exited with code ${exitCode ?? 'null'}. Check the terminal for details.`,
+        detail
+          ? `Install exited with code ${exitCode ?? 'null'}: ${detail} — check the terminal for the full output.`
+          : `Install exited with code ${exitCode ?? 'null'}. Check the terminal for details.`,
         'error'
       );
       return; // keep overlay open so user can read stderr + close manually

--- a/src/hooks/useTextEditing.ts
+++ b/src/hooks/useTextEditing.ts
@@ -151,7 +151,12 @@ export function useTextEditing({ iframeRef, projectPath, enabled, onToast }: Par
             void trackEvent('visual_text_saved');
             onToast?.('Saved to source', 'success');
           } catch (err) {
-            logger.error('[TextEditing] text write-back failed', { error: String(err) });
+            // CommandError rejections are plain objects — String() renders
+            // them as "[object Object]" (issue #336); use the same formatter
+            // as the toast below.
+            logger.error('[TextEditing] text write-back failed', {
+              error: formatCommandError(asCommandError(err)),
+            });
             onToast?.(formatCommandError(asCommandError(err)), 'error');
             // Couldn't save — put the original text back in the preview.
             post({ type: 'ss:textRevert' });

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -131,6 +131,12 @@ describe('humanizeGitError', () => {
       expect: /didn't accept the connection/i,
     },
     {
+      // HTTPS no-write-access rejection: "Write access to repository not
+      // granted." + 403 — must classify as auth, not network (issue #343).
+      raw: "remote: Write access to repository not granted.\nfatal: unable to access 'https://github.com/acme/site.git/': The requested URL returned error: 403",
+      expect: /didn't accept the connection/i,
+    },
+    {
       raw: 'fatal: unable to access https://github.com/a/b: Could not resolve host: github.com',
       expect: /couldn't reach GitHub/i,
     },

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -107,6 +107,7 @@ export function humanizeGitError(value: unknown, ctx: GitErrorContext = {}): str
   if (
     m.includes('permission denied') ||
     (m.includes('permission to') && m.includes('denied to')) ||
+    m.includes('write access to repository not granted') ||
     m.includes('could not read username') ||
     m.includes('authentication failed') ||
     m.includes('not authenticated') ||

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -15,6 +15,7 @@ import { listen, UnlistenFn } from '@tauri-apps/api/event';
 import { homeDir } from '@tauri-apps/api/path';
 import { logger } from './logger';
 import { readProjectFile } from './code';
+import { asCommandError, formatCommandError } from './errors';
 import { trackError } from './analytics';
 import { isWindows } from './setup';
 
@@ -387,7 +388,9 @@ export async function startDevServer(
       // Fall back to npm run dev with port forwarded via -- --port
       // (e.g. package.json genuinely missing, or not valid JSON)
       trackError('devserver_package_json', e, 'Workspace');
-      const errorMessage = e instanceof Error ? e.message : String(e);
+      // CommandError rejections are plain objects — String() renders them as
+      // "[object Object]" (issue #332); format them like the toasts do.
+      const errorMessage = formatCommandError(asCommandError(e));
       logger.error('[DevServer] Failed to read/parse package.json, falling back to npm run dev', {
         error: errorMessage,
         projectPath,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -61,10 +61,23 @@ window.addEventListener('error', (event) => {
     );
   }
 });
+// Promises are often rejected with plain objects rather than Errors (Tauri
+// IPC error payloads especially) — String() renders those as "[object
+// Object]", which both destroys the diagnostic and collapses every such
+// rejection onto one dedupe fingerprint (issue #333). Serialize the shape.
+const describeRejectionReason = (r: unknown): string => {
+  if (typeof r === 'string') return r;
+  try {
+    return JSON.stringify(r) ?? String(r);
+  } catch {
+    return String(r); // circular structures etc.
+  }
+};
+
 window.addEventListener('unhandledrejection', (event) => {
   const reason: unknown = event.reason;
-  const stack = reason instanceof Error ? reason.stack || '' : String(reason);
-  const message = reason instanceof Error ? reason.message : String(reason);
+  const stack = reason instanceof Error ? reason.stack || '' : describeRejectionReason(reason);
+  const message = reason instanceof Error ? reason.message : describeRejectionReason(reason);
 
   if (stack.includes('blob:')) {
     event.preventDefault();


### PR DESCRIPTION
Round 8 of the auto-reported bug bash — 17 issues, including two data-loss bugs.

## Data-loss guards (the serious ones)
- **#345** — `$HOME` (or anything above it) can no longer be registered or treated as a project, no matter what marker files it contains (a stray `~/.git`/`~/.gitignore` is common). Guarded in `is_valid_project`, `looks_like_project_root`, `register_external_project` (friendly error), and `is_registered_external_path` — the last one **neutralizes already-registered bad entries**, so the affected user is protected the moment they update. `git_stage_and_commit` refuses the home tree as a defense-in-depth backstop.
- **#346** — `discard_changes` now verifies `git rev-parse --show-toplevel` resolves to the project folder itself before running `checkout .` / `clean -fd`. Without this, a missing/broken project `.git` makes git discover an ancestor repo, and `clean -fd` deletes the entire project's files as "untracked garbage" of that repo. Refuses with a clear Expected error instead.

## Window capability gaps
- **#327 / #341 / #328** — `"window-*"` added to the capability's `windows` array: "Window → New Window" windows load the full app but matched no capability, silently losing the updater, terminal-font `fs` reads, and `event:listen` (the #328 ACL rejection). The `studio`/`preview` labels from #328 load remote content (`WebviewUrl::External`) and get no IPC by design — no change needed there.

## Auth/permission detection
- **#326** — gh's "please run `gh auth login`" stderr now maps to `NotAuthenticated` across `list_pull_requests`, `create/merge/checkout/close_pull_request`, `list_github_repos`, `list_collaborator_repos` (shared `gh_auth_error` helper).
- **#343** — "remote: Write access to repository not granted." + 403 now classifies as auth in all four publish paths (shared `push_auth_error` helper), and `humanizeGitError` recognizes the phrase (test added).

## Expected-state classification & correctness
- **#329** — PTY spawn failure for a missing agent binary → `CommandError::expected` (frontend install-hint UX unchanged; vendored plugin path never reported to telemetry, so `pty_session_open` was the only gap).
- **#331** — traversal guard now rejects only real `..` path components (`has_parent_dir_component`), so filenames like `notes..bak` work again; exact-`..`/`.` still rejected for single-name fields. Canonicalize+containment checks remain the real defense.
- **#330** — `unknown`-type projects skip the dev server instead of spawning a doomed `npm run dev`.
- **#342** — a killed template-clone PTY is treated as an interruption instead of success, so `remove_git_history` never runs against a folder that was never created.
- **#335** — Chromium thumbnail fallback gets an isolated `--user-data-dir` (removed after capture); since the headless/headful merge, sharing the default profile with an open browser exits 21 instantly.

## Diagnostics
- **#344** — `outputTail` threaded through `onInstallTerminalExit`; failure toast shows the actual npm/pnpm error line (via `extractTerminalError`) and the analytics event carries a home-dir-scrubbed excerpt.
- **#332 / #336** — two more `String(err)` → `formatCommandError(asCommandError(err))` "[object Object]" fixes (project.ts, useTextEditing.ts).
- **#333** — unhandled rejections with non-Error reasons are JSON-serialized, so reports carry the payload shape and stop collapsing onto one fingerprint.
- **#334** — `isBranchGoneError` → `onRefresh()` recovery applied to send-to-GitHub, delete, and create handlers (previously only switch).

## #337 mitigation (issue stays open)
Child preview webviews (`create/resize_preview_webview`) are clamped to the window's inner bounds. The Sanity plugin offsets its webview by a stale 31px title-bar constant — on our overlay-titlebar windows that pushes the studio's bottom past the window edge where macOS hard-clips it. With the clamp, the webview fits and the studio reflows, so the bottom bar is visible again even with the current plugin build. The proper alignment fix belongs in `plugin-sanity`.

## Tests
- 761 backend tests pass (new: `is_forbidden_project_root` home/ancestor/root refusal, `ensure_repo_rooted_at` accepts own root / refuses ancestor repo)
- 1380 frontend tests pass (new: #343 write-access-not-granted classification)

Closes #326, #327, #328, #329, #330, #331, #332, #333, #334, #335, #336, #341, #342, #343, #344, #345, #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against unsafe file and project paths, including prevention of unintended Git operations.
  * GitHub authentication and permission failures now provide clearer, actionable errors.
  * Prevented interrupted template downloads from continuing setup.
  * Unknown project types no longer attempt to start a development server.
  * Preview content is kept within window boundaries.
  * Branch lists refresh when remote branches are deleted or renamed.

* **Improvements**
  * Installation failures now show more detailed diagnostics.
  * New windows retain required application permissions.
  * Browser-based thumbnail capture uses isolated temporary data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->