### PR TITLE
Add Eve Agent starter template to the create-project picker

### DIFF
--- a/src/hooks/useProjectCreation.ts
+++ b/src/hooks/useProjectCreation.ts
@@ -156,6 +156,13 @@ export const TEMPLATES: Template[] = [
     skipInstall: true,
   },
   {
+    id: 'eve-agent',
+    name: 'Eve Agent',
+    description: "An AI agent built on Vercel's Eve framework, with a web chat UI.",
+    repo: 'https://github.com/ship-studio/eve-agent-starter',
+    category: 'other',
+  },
+  {
     id: 'blank',
     name: 'Blank Project',
     description: 'An empty folder. Start completely from scratch.',


### PR DESCRIPTION
Adds a new template card in the **Other** section, positioned between Shopify Theme and Blank Project, cloning [ship-studio/eve-agent-starter](https://github.com/ship-studio/eve-agent-starter).

- id `eve-agent`, name "Eve Agent", copy: "An AI agent built on Vercel's Eve framework, with a web chat UI."
- Standard flow: clone → remove git history → npm install (the starter is a Next.js app with a package.json, so no `skipInstall`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Eve Agent” template to the available project templates.
  * The template links to its starter repository for project creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->