### PR TITLE
Check dev-server readiness before Playwright captures

### DIFF
--- a/src-tauri/src/commands/ide/screenshots/mod.rs
+++ b/src-tauri/src/commands/ide/screenshots/mod.rs
@@ -19,6 +19,33 @@ pub use playwright::*;
 pub use stitch::*;
 pub use thumbnail::*;
 
+/// Quick TCP probe of the dev-server port in `url` (IPv4 and IPv6 — some dev
+/// servers, especially Vite, bind only IPv6; 500ms timeout each). Callers use
+/// this to fail fast with a clean "dev server not ready" message instead of
+/// letting Playwright's `page.goto` blow up with an ERR_CONNECTION_REFUSED
+/// stack trace (issue #349). Port defaults to 3000 when the URL carries none.
+pub(crate) fn dev_server_listening(url: &str) -> bool {
+    use std::net::TcpStream;
+    use std::time::Duration;
+
+    let port: u16 = url
+        .trim_start_matches("http://")
+        .trim_start_matches("https://")
+        .split('/')
+        .next()
+        .unwrap_or("")
+        .split(':')
+        .next_back()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000);
+
+    let ipv4_addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    let ipv6_addr = std::net::SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], port));
+
+    TcpStream::connect_timeout(&ipv4_addr, Duration::from_millis(500)).is_ok()
+        || TcpStream::connect_timeout(&ipv6_addr, Duration::from_millis(500)).is_ok()
+}
+
 use crate::utils::{create_command, find_executable, get_extended_path};
 use std::process::Command;
 

--- a/src-tauri/src/commands/ide/screenshots/playwright.rs
+++ b/src-tauri/src/commands/ide/screenshots/playwright.rs
@@ -174,6 +174,17 @@ pub async fn capture_fullpage_playwright(
     width: Option<u32>,
 ) -> Result<String, CommandError> {
     let project = validate_project_path(&project_path)?;
+
+    // Fail fast with a clean, expected error when nothing is listening on the
+    // dev-server port — otherwise Playwright's page.goto dies with a raw
+    // ERR_CONNECTION_REFUSED stack trace (issue #349). An expected state:
+    // the server may still be booting or was just restarted on another port.
+    if !super::dev_server_listening(&url) {
+        return Err(CommandError::expected(format!(
+            "The dev server isn't accepting connections at {url} yet. Wait for the preview to finish loading, then try again."
+        )));
+    }
+
     let screenshots_dir = project.join(".shipstudio").join("screenshots");
     // Match the preview's current viewport when given (agent bridge responsive
     // checks); clamp to sane bounds so a bad value can't wedge Chromium.
@@ -318,6 +329,17 @@ pub async fn capture_viewport_playwright(
     width: Option<u32>,
 ) -> Result<String, CommandError> {
     let project = validate_project_path(&project_path)?;
+
+    // Fail fast with a clean, expected error when nothing is listening on the
+    // dev-server port — otherwise Playwright's page.goto dies with a raw
+    // ERR_CONNECTION_REFUSED stack trace (issue #349). An expected state:
+    // the server may still be booting or was just restarted on another port.
+    if !super::dev_server_listening(&url) {
+        return Err(CommandError::expected(format!(
+            "The dev server isn't accepting connections at {url} yet. Wait for the preview to finish loading, then try again."
+        )));
+    }
+
     let screenshots_dir = project.join(".shipstudio").join("screenshots");
     // Match the preview's current viewport when given (agent bridge responsive
     // checks); clamp to sane bounds so a bad value can't wedge Chromium.

--- a/src-tauri/src/commands/ide/screenshots/thumbnail.rs
+++ b/src-tauri/src/commands/ide/screenshots/thumbnail.rs
@@ -3,9 +3,7 @@
 use crate::errors::CommandError;
 use crate::types::{ProjectMetadata, PROJECT_METADATA_SCHEMA_VERSION};
 use crate::utils::{create_command, validate_project_path};
-use std::net::TcpStream;
 use std::path::Path;
-use std::time::Duration;
 
 use super::node_tool_command;
 use crate::commands::ide::{find_chromium_browser, resize_thumbnail_image};
@@ -43,35 +41,10 @@ pub async fn capture_project_thumbnail(
 
     // Quick health check: verify the dev server is still responding before launching Playwright.
     // This reduces (but doesn't eliminate) race conditions where the server dies mid-capture.
-    // Extract port from URL (e.g., "http://localhost:3000" -> 3000)
-    let port: u16 = url
-        .trim_start_matches("http://")
-        .trim_start_matches("https://")
-        .split(':')
-        .next_back()
-        .and_then(|p| p.parse().ok())
-        .unwrap_or(3000);
-
-    // Try both IPv4 and IPv6 - some dev servers (especially Vite) may only bind to IPv6
-    let ipv4_addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
-    let ipv6_addr = std::net::SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], port)); // ::1
-
-    let ipv4_ok = TcpStream::connect_timeout(&ipv4_addr, Duration::from_millis(500)).is_ok();
-    let ipv6_ok = TcpStream::connect_timeout(&ipv6_addr, Duration::from_millis(500)).is_ok();
-
-    if !ipv4_ok && !ipv6_ok {
-        tracing::warn!(
-            "Dev server health check failed on both IPv4 and IPv6 for port {}",
-            port
-        );
+    if !super::dev_server_listening(&url) {
+        tracing::warn!("Dev server health check failed for {}", url);
         return Err(("Dev server not responding, skipping thumbnail capture".to_string()).into());
     }
-    tracing::info!(
-        "Dev server health check passed (IPv4: {}, IPv6: {}) on port {}",
-        ipv4_ok,
-        ipv6_ok,
-        port
-    );
 
     let shipstudio_dir = project.join(".shipstudio");
 

--- a/src/lib/agentBridge.ts
+++ b/src/lib/agentBridge.ts
@@ -355,6 +355,14 @@ async function captureScreenshot(
       'The preview is not running yet (no dev server URL). Ask the user to open the preview panel, or start the dev server first.'
     );
   }
+  // The URL can be stale (server crashed or restarted on another port) while
+  // serverReady is false — capturing anyway makes Playwright fail with
+  // ERR_CONNECTION_REFUSED (issue #348).
+  if (!ctx.serverReady) {
+    return errorResult(
+      'The dev server is not ready yet. Wait for the preview to finish loading, then try again.'
+    );
+  }
   const command = fullPage ? 'capture_fullpage_playwright' : 'capture_viewport_playwright';
   const path = await invoke<string>(command, {
     projectPath: ctx.projectPath,


### PR DESCRIPTION
Two fresh auto-reported issues, one root cause: screenshot capture against a port nothing is listening on.

- **#349 (backend)** — `capture_fullpage_playwright` / `capture_viewport_playwright` now run the same TCP probe the thumbnail path already had, factored into a shared `dev_server_listening` helper (which also fixes port parsing for URLs with trailing slashes/paths — the old inline version fell back to 3000 for `http://localhost:52641/`). When nothing is listening they fail fast with an `Expected` "server isn't accepting connections yet" message instead of Playwright's raw `ERR_CONNECTION_REFUSED` stack trace — cleaner for the agent, and out of telemetry.
- **#348 (frontend)** — the agent bridge's `preview_screenshot` tool short-circuits when `ctx.serverReady` is false: its cached URL can be stale after a dev-server crash or port change, so the null-URL guard alone wasn't enough.

Tests: 761 backend + typecheck green.

Closes #348, #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)