### PR TITLE
Bug-bash round 9: thumbnail profile isolation, offline/OOM/old-git classification, clipboard feedback, dead-pin unpin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -100,14 +100,16 @@ export default tseslint.config(
       'src/lib/logger.ts',
       'src/lib/polling.ts',
       'src/**/*.test.{ts,tsx}',
-      // Block 5.4 — clipboard exceptions (xterm key handler, per-row copy state,
-      // postMessage handler). Rationale documented in DX_REFACTOR_PLAN.md.
+      // Block 5.4 — clipboard exceptions (xterm key handler). Rationale
+      // documented in DX_REFACTOR_PLAN.md. useAssetManagement and
+      // usePreviewConnection migrated to useCopyToClipboard (issues #355/#357).
       'src/components/terminal/Terminal.tsx',
       'src/components/setup/OnboardingTerminal.tsx',
-      'src/hooks/useAssetManagement.ts',
-      'src/hooks/usePreviewConnection.ts',
       // Block 5.7 — setInterval exceptions (library-level, state-machine timers,
       // keep-fresh caches). Rationale documented in DX_REFACTOR_PLAN.md.
+      // usePreviewConnection is here only for its server-check timers; its
+      // clipboard call migrated to useCopyToClipboard (issue #357).
+      'src/hooks/usePreviewConnection.ts',
       'src/lib/project.ts',
       'src/hooks/useCodeHealth.ts',
       'src/hooks/useScreenshotManagement.ts',

--- a/scripts/check-loc-limits.sh
+++ b/scripts/check-loc-limits.sh
@@ -47,7 +47,9 @@ echo "Components (.tsx limit 1200):"
 # for the agent-restart wiring (restartTerminalTab threaded to each Terminal +
 # the Agent Settings menu item) — small, on top of the Workspaces baseline.
 # Bumped by a hair for the Windows-compat pass: platform-aware shortcut labels
-# (kbd() import + two undo/redo hint lines). TerminalPanes extraction still owed.
+# (kbd() import + two undo/redo hint lines). Bumped by a hair again for the
+# dead-pin unpin wiring (issue #366): onUnpinProject threaded through to the
+# sidebar. TerminalPanes extraction still owed.
 # Bumped again (small) for plugin failure surfacing (#165): pluginFailures and
 # the hosting-plugin count threaded into PluginsDropdown, usePlugins onError
 # wired to showToast. Pure wiring; the logic lives in usePlugins/PluginsDropdown.
@@ -57,7 +59,7 @@ echo "Components (.tsx limit 1200):"
 # Bumped again (small) for worktrees: the hook call + worktree props threaded
 # to the sidebar, Branches tab, and create modal. Pure wiring; the logic lives
 # in useWorktreeWorkflow/useWorktrees.
-check_file src/components/workspace/WorkspaceView.tsx 1650
+check_file src/components/workspace/WorkspaceView.tsx 1660
 check_file src/components/dashboard/ProjectList.tsx 900
 check_file src/components/plugins/PluginManager.tsx 700
 check_file src/components/dashboard/ImportProject.tsx 500

--- a/src-tauri/src/commands/git/branches.rs
+++ b/src-tauri/src/commands/git/branches.rs
@@ -304,12 +304,23 @@ pub async fn switch_branch(
         }
 
         let stderr = String::from_utf8_lossy(&checkout_output.stderr);
+        // Pre-2.24 git doesn't understand the `--end-of-options` injection
+        // guard and fails resolving it as a pathspec — turn that confusing
+        // two-line error into a clear "your git is too old" (issue #364).
+        let error_message = if stderr.contains("pathspec '--end-of-options'") {
+            "Your installed Git is too old for Ship Studio (Git 2.24 from 2019 or newer is \
+             required). Update Git — on macOS, update the Xcode Command Line Tools or run \
+             `brew install git` — then try again."
+                .to_string()
+        } else {
+            stderr.to_string()
+        };
         return Ok(SwitchResult {
             success: false,
             stashed_changes: false,
             pending_stash_from: None,
             stash_applied: false,
-            error: Some(stderr.to_string()),
+            error: Some(error_message),
         });
     }
 

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -523,6 +523,30 @@ pub(crate) fn gh_auth_error(stderr: &str) -> Option<CommandError> {
     None
 }
 
+/// gh's stderr when the machine simply can't reach GitHub (offline, DNS or
+/// firewall block, flaky network). Covers Go's `net/http` dial errors —
+/// including the Windows-specific `connectex: A connection attempt failed…`
+/// wording, which contains none of the usual "timed out"/"refused"
+/// substrings (issue #375). A connectivity blip is the environment, not a
+/// malfunction: `Expected` keeps it out of telemetry and the message is
+/// something the user can act on.
+pub(crate) fn gh_network_error(stderr: &str) -> Option<CommandError> {
+    let s = stderr.to_lowercase();
+    let unreachable = s.contains("dial tcp")
+        || s.contains("connectex")
+        || s.contains("could not resolve host")
+        || s.contains("no such host")
+        || s.contains("connection refused")
+        || s.contains("network is unreachable")
+        || s.contains("i/o timeout")
+        || s.contains("tls handshake timeout");
+    unreachable.then(|| {
+        CommandError::expected(
+            "Couldn't reach GitHub. Check your internet connection and try again.",
+        )
+    })
+}
+
 /// Lists GitHub repositories for a given owner (user or organization)
 #[tauri::command]
 #[tracing::instrument]
@@ -878,5 +902,26 @@ mod tests {
             updated_at: api.updated_at,
         };
         assert_eq!(converted.name, "alice/shared");
+    }
+
+    #[test]
+    fn gh_network_error_classifies_windows_connectex_as_expected() {
+        let stderr = r#"Post "https://api.github.com/graphql": dial tcp 20.207.73.85:443: connectex: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond."#;
+        let err = gh_network_error(stderr).expect("should classify as network error");
+        assert!(matches!(err, CommandError::Expected { .. }));
+    }
+
+    #[test]
+    fn gh_network_error_classifies_dns_failure() {
+        assert!(
+            gh_network_error("error connecting to api.github.com: could not resolve host")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn gh_network_error_ignores_unrelated_stderr() {
+        assert!(gh_network_error("GraphQL: name already exists on this account").is_none());
+        assert!(gh_network_error("").is_none());
     }
 }

--- a/src-tauri/src/commands/ide/screenshots/thumbnail.rs
+++ b/src-tauri/src/commands/ide/screenshots/thumbnail.rs
@@ -8,6 +8,37 @@ use std::path::Path;
 use super::node_tool_command;
 use crate::commands::ide::{find_chromium_browser, resize_thumbnail_image};
 
+/// Best-effort cleanup of thumbnail Chromium profiles left behind by earlier
+/// captures that never reached their own cleanup (app quit, crash, kill).
+/// Removes the legacy fixed `thumbnail_profile` dir unconditionally — nothing
+/// uses that path anymore, and a stale SingletonLock inside it permanently
+/// broke every capture (issue #358) — plus any per-capture
+/// `thumbnail_profile_*` dir older than an hour. The age gate keeps this from
+/// yanking a profile out from under a concurrent capture, which only lives
+/// for seconds.
+fn sweep_stale_thumbnail_profiles(shipstudio_dir: &Path) {
+    let _ = std::fs::remove_dir_all(shipstudio_dir.join("thumbnail_profile"));
+    let Ok(entries) = std::fs::read_dir(shipstudio_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with("thumbnail_profile_") {
+            continue;
+        }
+        let stale = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.elapsed().ok())
+            .is_some_and(|age| age > std::time::Duration::from_secs(60 * 60));
+        if stale {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
 /// Returns true when the project's metadata marks the thumbnail as
 /// user-supplied — auto-capture must skip these so it doesn't clobber
 /// the upload on the next dev-server boot.
@@ -91,7 +122,20 @@ pub async fn capture_project_thumbnail(
         // shares the singleton lock with any already-running instance of the
         // same browser and instantly exits with code 21 — a developer's normal
         // browser being open silently killed every thumbnail (issue #335).
-        let profile_dir = shipstudio_dir.join("thumbnail_profile");
+        //
+        // The dir must also be unique per capture: a fixed path recreates the
+        // same singleton collision between two overlapping captures, and a
+        // capture interrupted before cleanup leaves a stale SingletonLock that
+        // blocks every subsequent capture forever (issue #358 and its many
+        // duplicates). PID + a process-wide counter is collision-free across
+        // both concurrent captures and app restarts into a dirty .shipstudio.
+        static PROFILE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        sweep_stale_thumbnail_profiles(&shipstudio_dir);
+        let profile_dir = shipstudio_dir.join(format!(
+            "thumbnail_profile_{}_{}",
+            std::process::id(),
+            PROFILE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
         let user_data_arg = format!("--user-data-dir={}", profile_dir.to_string_lossy());
 
         // Use new headless mode with explicit viewport control
@@ -118,7 +162,22 @@ pub async fn capture_project_thumbnail(
         // The throwaway profile has served its purpose; don't let it grow.
         let _ = std::fs::remove_dir_all(&profile_dir);
 
-        if !output.status.success() {
+        // Success is "the screenshot file exists", not "the exit code was 0":
+        // headless Chromium on Windows can write the PNG and still exit
+        // non-zero over unrelated internal warnings, and failing on the exit
+        // code alone throws away a perfectly good capture (issue #374).
+        let capture_written = std::fs::metadata(&temp_path)
+            .map(|m| m.len() > 0)
+            .unwrap_or(false);
+
+        if capture_written && !output.status.success() {
+            tracing::warn!(
+                "Browser exited with {:?} but wrote the screenshot; proceeding",
+                output.status.code()
+            );
+        }
+
+        if !capture_written {
             let stderr = String::from_utf8_lossy(&output.stderr);
             let stderr = stderr.trim();
             // Headless Chromium can die with EMPTY stderr (crash, killed by
@@ -145,27 +204,25 @@ pub async fn capture_project_thumbnail(
         }
 
         // Read the captured image and resize using the image crate (cross-platform)
-        if temp_path.exists() {
-            if let Ok(img) = image::open(&temp_path) {
-                let (width_val, height_val) = (img.width(), img.height());
+        if let Ok(img) = image::open(&temp_path) {
+            let (width_val, height_val) = (img.width(), img.height());
 
-                // If captured at 2x (Retina) or oversized, resize to 1280 width first
-                let processed = if width_val > 1280 || height_val > 800 {
-                    img.resize(1280, 800, image::imageops::FilterType::Lanczos3)
-                } else {
-                    img
-                };
-
-                // Save as thumbnail at 640px width
-                let thumb = processed.resize(640, 400, image::imageops::FilterType::Lanczos3);
-                let _ = thumb.save(&thumbnail_path);
+            // If captured at 2x (Retina) or oversized, resize to 1280 width first
+            let processed = if width_val > 1280 || height_val > 800 {
+                img.resize(1280, 800, image::imageops::FilterType::Lanczos3)
             } else {
-                // If image crate can't read it, just copy as-is
-                let _ = std::fs::copy(&temp_path, &thumbnail_path);
-            }
-            // Clean up temp file
-            let _ = std::fs::remove_file(&temp_path);
+                img
+            };
+
+            // Save as thumbnail at 640px width
+            let thumb = processed.resize(640, 400, image::imageops::FilterType::Lanczos3);
+            let _ = thumb.save(&thumbnail_path);
+        } else {
+            // If image crate can't read it, just copy as-is
+            let _ = std::fs::copy(&temp_path, &thumbnail_path);
         }
+        // Clean up temp file
+        let _ = std::fs::remove_file(&temp_path);
 
         Ok(thumbnail_path_str)
     } else {

--- a/src-tauri/src/commands/pty_session.rs
+++ b/src-tauri/src/commands/pty_session.rs
@@ -453,8 +453,11 @@ pub fn pty_session_write(session_id: String, data: Vec<u8>) -> Result<(), Comman
         .lock()
         .map_err(|e| format!("writer lock poisoned: {e}"))?;
     w.write_all(&data).map_err(|e| {
-        if e.raw_os_error() == Some(5) {
-            // Benign race, not a malfunction — keep it out of telemetry (issue #323).
+        // Benign race — a write landing just as the PTY's process exits — not
+        // a malfunction; keep it out of telemetry (issue #323). Unix surfaces
+        // it as EIO (5), Windows as ERROR_NO_DATA 232, "The pipe is being
+        // closed" (issue #354); the codes don't collide across platforms.
+        if e.raw_os_error() == Some(5) || e.raw_os_error() == Some(232) {
             CommandError::expected("terminal session has ended")
         } else {
             CommandError::from(format!("write: {e}"))

--- a/src-tauri/src/commands/pull_requests.rs
+++ b/src-tauri/src/commands/pull_requests.rs
@@ -62,6 +62,9 @@ pub async fn list_pull_requests(
         if let Some(err) = crate::commands::github::gh_auth_error(&stderr) {
             return Err(err);
         }
+        if let Some(err) = crate::commands::github::gh_network_error(&stderr) {
+            return Err(err);
+        }
         return Err((stderr.to_string()).into());
     }
 
@@ -133,6 +136,9 @@ pub async fn create_pull_request(
         if let Some(err) = crate::commands::github::gh_auth_error(&stderr) {
             return Err(err);
         }
+        if let Some(err) = crate::commands::github::gh_network_error(&stderr) {
+            return Err(err);
+        }
         return Err((stderr.to_string()).into());
     }
 
@@ -160,6 +166,9 @@ pub async fn merge_pull_request(project_path: String, pr_number: i32) -> Result<
             return Err(CommandError::MergeConflict { pr_number, stderr });
         }
         if let Some(err) = crate::commands::github::gh_auth_error(&stderr) {
+            return Err(err);
+        }
+        if let Some(err) = crate::commands::github::gh_network_error(&stderr) {
             return Err(err);
         }
         return Err(stderr.into());
@@ -196,6 +205,9 @@ pub async fn checkout_pull_request(
         if let Some(err) = crate::commands::github::gh_auth_error(&stderr) {
             return Err(err);
         }
+        if let Some(err) = crate::commands::github::gh_network_error(&stderr) {
+            return Err(err);
+        }
         return Err((format!("Failed to checkout PR: {stderr}")).into());
     }
 
@@ -225,6 +237,9 @@ pub async fn close_pull_request(project_path: String, pr_number: i32) -> Result<
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         if let Some(err) = crate::commands::github::gh_auth_error(&stderr) {
+            return Err(err);
+        }
+        if let Some(err) = crate::commands::github::gh_network_error(&stderr) {
             return Err(err);
         }
         return Err((format!("Failed to close PR: {stderr}")).into());

--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -124,8 +124,32 @@ impl Serialize for CommandError {
     }
 }
 
+/// Windows refusing a memory commit — usually a process spawn — because the
+/// paging file is too small or the machine is under memory pressure
+/// (ERROR_COMMITMENT_LIMIT, os error 1455). That's an environment condition
+/// with a user-side fix, not an app malfunction; returning `Expected` keeps
+/// it out of telemetry and swaps the bare OS string for actionable guidance
+/// (issue #356). The code is Windows-only; matching it unconditionally is
+/// safe because Unix errno values don't reach 1455.
+pub fn windows_out_of_memory(err: &std::io::Error, label: Option<&str>) -> Option<CommandError> {
+    if err.raw_os_error() != Some(1455) {
+        return None;
+    }
+    let doing = label
+        .map(|l| format!(" while running `{l}`"))
+        .unwrap_or_default();
+    Some(CommandError::expected(format!(
+        "Windows ran out of virtual memory{doing} (the paging file is too small). \
+         Close some other apps or increase the paging file size (Settings → System → About → \
+         Advanced system settings → Performance → Virtual memory), then try again."
+    )))
+}
+
 impl From<std::io::Error> for CommandError {
     fn from(err: std::io::Error) -> Self {
+        if let Some(oom) = windows_out_of_memory(&err, None) {
+            return oom;
+        }
         CommandError::Io {
             message: err.to_string(),
         }
@@ -222,5 +246,25 @@ mod tests {
             CommandError::Io { message } => assert!(message.contains("missing")),
             _ => panic!("expected Io variant"),
         }
+    }
+
+    #[test]
+    fn windows_pagefile_exhaustion_becomes_expected_with_guidance() {
+        let io_err = std::io::Error::from_raw_os_error(1455);
+        let err = windows_out_of_memory(&io_err, Some("npm install")).expect("should classify");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        let msg = err.to_string();
+        assert!(msg.contains("`npm install`"), "got: {msg}");
+        assert!(msg.contains("paging file"), "got: {msg}");
+
+        // And the blanket io::Error conversion picks it up too.
+        let err: CommandError = std::io::Error::from_raw_os_error(1455).into();
+        assert!(matches!(err, CommandError::Expected { .. }));
+    }
+
+    #[test]
+    fn windows_out_of_memory_ignores_other_os_errors() {
+        let io_err = std::io::Error::from_raw_os_error(5);
+        assert!(windows_out_of_memory(&io_err, None).is_none());
     }
 }

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -55,6 +55,12 @@ pub async fn run_with_timeout(
             // not an app malfunction — Expected keeps it out of telemetry.
             if io_err.kind() == std::io::ErrorKind::NotFound {
                 Err(CommandError::expected(message))
+            } else if let Some(oom) =
+                crate::errors::windows_out_of_memory(&io_err, Some(label.as_str()))
+            {
+                // Pagefile exhaustion is likewise the environment, not us
+                // (issue #356).
+                Err(oom)
             } else {
                 Err(CommandError::Io { message })
             }

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -822,9 +822,16 @@ async fn handle_websocket_upgrade(
     // upgrade with BAD_GATEWAY instead of riding out the gap (issue #258). The
     // retry loop stays bounded by UPSTREAM_CONNECT_TIMEOUT overall.
     let connect_deadline = tokio::time::Instant::now() + UPSTREAM_CONNECT_TIMEOUT;
+    // Each attempt gets its own short timeout (capped to what's left of the
+    // overall budget) rather than racing the whole deadline: an unready port
+    // doesn't always refuse the connection — on Windows especially, the SYN
+    // can just go unanswered — and a single hung attempt must not eat the
+    // entire retry window (issue #353).
+    let per_attempt = std::time::Duration::from_secs(1);
     let target_stream = loop {
-        let attempt = tokio::time::timeout_at(
-            connect_deadline,
+        let remaining = connect_deadline.saturating_duration_since(tokio::time::Instant::now());
+        let attempt = tokio::time::timeout(
+            remaining.min(per_attempt),
             TcpStream::connect(format!("localhost:{target_port}")),
         )
         .await
@@ -833,11 +840,18 @@ async fn handle_websocket_upgrade(
         match attempt {
             Ok(s) => break s,
             Err(e) => {
-                let retryable = e.kind() == std::io::ErrorKind::ConnectionRefused
-                    && tokio::time::Instant::now() + std::time::Duration::from_millis(250)
-                        < connect_deadline;
+                let retryable = matches!(
+                    e.kind(),
+                    std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::TimedOut
+                ) && tokio::time::Instant::now()
+                    + std::time::Duration::from_millis(250)
+                    < connect_deadline;
                 if retryable {
-                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                    // A timed-out attempt already consumed its slice of the
+                    // budget; only refused connections need the backoff pause.
+                    if e.kind() == std::io::ErrorKind::ConnectionRefused {
+                        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                    }
                     continue;
                 }
                 tracing::error!("[Proxy] WebSocket target connection failed: {}", e);

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -821,6 +821,19 @@ async fn handle_websocket_upgrade(
     // mid dev-server restart, and a single missed connect used to hard-fail the
     // upgrade with BAD_GATEWAY instead of riding out the gap (issue #258). The
     // retry loop stays bounded by UPSTREAM_CONNECT_TIMEOUT overall.
+    // Race IPv4 and IPv6 loopback concurrently rather than connecting to
+    // "localhost": some dev servers (Vite notably) bind only one family, and
+    // the sequential address walk behind a hostname connect can burn a whole
+    // per-attempt timeout on the dead family before reaching the live one
+    // (observed on Windows CI). First successful connection wins; the error
+    // surfaces only when both families fail.
+    async fn connect_loopback(port: u16) -> std::io::Result<TcpStream> {
+        use futures_util::future::select_ok;
+        let v4 = Box::pin(TcpStream::connect(("127.0.0.1", port)));
+        let v6 = Box::pin(TcpStream::connect(("::1", port)));
+        select_ok([v4, v6]).await.map(|(stream, _)| stream)
+    }
+
     let connect_deadline = tokio::time::Instant::now() + UPSTREAM_CONNECT_TIMEOUT;
     // Each attempt gets its own short timeout (capped to what's left of the
     // overall budget) rather than racing the whole deadline: an unready port
@@ -830,13 +843,11 @@ async fn handle_websocket_upgrade(
     let per_attempt = std::time::Duration::from_secs(1);
     let target_stream = loop {
         let remaining = connect_deadline.saturating_duration_since(tokio::time::Instant::now());
-        let attempt = tokio::time::timeout(
-            remaining.min(per_attempt),
-            TcpStream::connect(format!("localhost:{target_port}")),
-        )
-        .await
-        .map_err(std::io::Error::from)
-        .and_then(|r| r);
+        let attempt =
+            tokio::time::timeout(remaining.min(per_attempt), connect_loopback(target_port))
+                .await
+                .map_err(std::io::Error::from)
+                .and_then(|r| r);
         match attempt {
             Ok(s) => break s,
             Err(e) => {

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -376,13 +376,23 @@ fn build_extended_path() -> String {
 /// on every call, so installing git mid-session (the onboarding wizard does
 /// exactly this) starts working without an app restart.
 pub fn git_command() -> Result<Command, crate::errors::CommandError> {
+    // Hand git the extended PATH, not for git itself (already resolved
+    // absolutely) but for whatever it spawns: pre-commit/pre-push hooks
+    // inherit this environment, and under a GUI-launched app's minimal PATH
+    // a lefthook/husky hook can't find pnpm/node/etc. even though they work
+    // fine in the user's terminal (issue #363). Same treatment `run_git_net`
+    // already applies to fetch/pull/push.
+    fn with_extended_path(mut cmd: Command) -> Command {
+        cmd.env("PATH", get_extended_path());
+        cmd
+    }
     static GIT_PATH: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
     if let Some(path) = GIT_PATH.get() {
-        return Ok(create_command(path));
+        return Ok(with_extended_path(create_command(path)));
     }
     match find_executable("git") {
         Some(path) => {
-            let cmd = create_command(&path);
+            let cmd = with_extended_path(create_command(&path));
             let _ = GIT_PATH.set(path);
             Ok(cmd)
         }
@@ -766,10 +776,25 @@ pub fn normalize_separators(path: &str) -> String {
 pub fn canonicalize_tagged(
     path: impl AsRef<std::path::Path>,
     site: &str,
-) -> Result<std::path::PathBuf, String> {
+) -> Result<std::path::PathBuf, crate::errors::CommandError> {
     let path = path.as_ref();
-    dunce::canonicalize(path)
-        .map_err(|e| format!("Invalid path in {site} ('{}'): {e}", path.display()))
+    dunce::canonicalize(path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            // A folder disappearing out from under the app — deleted, renamed,
+            // or moved in Finder/Explorer — is an environment change, not a
+            // malfunction: say so plainly and keep it out of telemetry
+            // (issues #365/#372, same family as #300/#342).
+            crate::errors::CommandError::expected(format!(
+                "The folder '{}' no longer exists — it may have been moved, renamed, or deleted outside Ship Studio",
+                path.display()
+            ))
+        } else {
+            crate::errors::CommandError::from(format!(
+                "Invalid path in {site} ('{}'): {e}",
+                path.display()
+            ))
+        }
+    })
 }
 
 /// True when a user-supplied relative path contains an actual `..` path
@@ -1131,6 +1156,36 @@ fn format_relative_time_from_now(timestamp_ms: u64, now_ms: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    mod canonicalize_tagged_errors {
+        use super::*;
+
+        #[test]
+        fn missing_folder_is_expected_not_reported() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let gone = tmp.path().join("vanished-project");
+            let err = canonicalize_tagged(&gone, "test_site").unwrap_err();
+            // A folder deleted/moved outside the app is an environment change
+            // (issues #365/#372) — must be Expected so telemetry skips it.
+            assert!(matches!(err, crate::errors::CommandError::Expected { .. }));
+            assert!(err.to_string().contains("no longer exists"));
+        }
+
+        #[test]
+        fn other_failures_keep_the_diagnosable_tagged_format() {
+            // A file used as a directory component fails with NotADirectory
+            // (not NotFound) on Unix — that's still a diagnosable anomaly.
+            let tmp = tempfile::TempDir::new().unwrap();
+            let file = tmp.path().join("plain.txt");
+            std::fs::write(&file, "x").unwrap();
+            let bad = file.join("child");
+            if let Err(err) = canonicalize_tagged(&bad, "test_site") {
+                if !matches!(err, crate::errors::CommandError::Expected { .. }) {
+                    assert!(err.to_string().contains("test_site"));
+                }
+            }
+        }
+    }
 
     mod is_forbidden_project_root {
         use super::*;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -491,7 +491,7 @@ function AppContents({ initialProjectPath }: AppProps) {
   // Register palette commands with real handlers — see src/commands/useAppCommands.tsx
   // `pinnedPaths` is passed after the rail hook runs; done below.
 
-  const { pinnedProjects, handleTogglePin, handleRailClick } = useProjectRail({
+  const { pinnedProjects, handleTogglePin, handleRailClick, handleRailUnpin } = useProjectRail({
     currentProjectPath: currentProject?.path ?? null,
     handleSelectProject,
     showToast,
@@ -1271,6 +1271,7 @@ function AppContents({ initialProjectPath }: AppProps) {
         projectRows={pinnedProjects.rows}
         onSelectProject={handleRailClick}
         onCloseProject={handleCloseProject}
+        onUnpinProject={handleRailUnpin}
         onSelectProjectTab={handleSelectProjectTab}
         onGoHome={handleBackToProjects}
         onOpenProjectPicker={openProjectPicker}

--- a/src/components/branches/ConflictResolutionModal.tsx
+++ b/src/components/branches/ConflictResolutionModal.tsx
@@ -22,7 +22,7 @@ import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { Spinner } from '../primitives/Spinner';
 import { useAsyncState } from '../../hooks/useAsyncState';
-import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
+import { describeClipboardError, useCopyToClipboard } from '../../hooks/useCopyToClipboard';
 import { useOptionalToast } from '../../contexts/ToastContext';
 
 interface ConflictResolutionModalProps {
@@ -68,7 +68,8 @@ export function ConflictResolutionModal({
   const error = loadError ? loadError.message : null;
   const { copy } = useCopyToClipboard({
     onCopy: () => onToast?.('Copied to clipboard', 'success'),
-    onError: () => onToast?.('Failed to copy to clipboard', 'error'),
+    onError: (err) =>
+      onToast?.(`Failed to copy to clipboard (${describeClipboardError(err)})`, 'error'),
   });
 
   const loadConflicts = useCallback(async () => {

--- a/src/components/branches/GitErrorHandler.tsx
+++ b/src/components/branches/GitErrorHandler.tsx
@@ -10,7 +10,7 @@
 import { WarningIcon, CopyIcon } from '../icons';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
-import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
+import { describeClipboardError, useCopyToClipboard } from '../../hooks/useCopyToClipboard';
 import { useOptionalToast } from '../../contexts/ToastContext';
 
 interface GitErrorHandlerProps {
@@ -85,7 +85,8 @@ Please help me understand what went wrong and how to fix it.`,
   const errorInfo = getErrorInfo();
   const { copy } = useCopyToClipboard({
     onCopy: () => onToast?.('Prompt copied to clipboard', 'success'),
-    onError: () => onToast?.('Failed to copy to clipboard', 'error'),
+    onError: (err) =>
+      onToast?.(`Failed to copy to clipboard (${describeClipboardError(err)})`, 'error'),
   });
 
   const handleCopyPrompt = () => {

--- a/src/components/workspace/WorkspaceSidebar.tsx
+++ b/src/components/workspace/WorkspaceSidebar.tsx
@@ -81,6 +81,10 @@ interface Props {
    *  entry, and (if it was the current project) route back to home. Called
    *  by the per-row close button. */
   onCloseProject?: (projectPath: string) => void;
+  /** Unpin a pinned row. Rendered as the row's hover action when there's no
+   *  live session to close — without it, a pin whose folder was moved or
+   *  deleted outside the app could never be removed (issue #366). */
+  onUnpinProject?: (projectPath: string) => void;
   /**
    * Switch to a non-current project and focus a specific tab (by session id)
    * once the restore completes. The caller is responsible for persisting
@@ -248,6 +252,7 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
   currentProjectName,
   onSelectProject,
   onCloseProject,
+  onUnpinProject,
   onSelectProjectTab,
   terminalTabs,
   activeTerminalTab,
@@ -618,8 +623,11 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
     const isCurrent = currentFamily !== null && familyKeyOf(row.projectPath) === currentFamily;
     const expanded = isProjectExpanded(row.projectPath);
     // Only rows with a live session can be closed. Pinned rows that have
-    // never been opened this launch show status 'inactive' and get no X.
+    // never been opened this launch show status 'inactive' and instead get
+    // an unpin affordance — critically including pins whose folder no longer
+    // exists and which therefore can never become active (issue #366).
     const canClose = !!onCloseProject && row.status !== 'inactive';
+    const canUnpin = !canClose && !!onUnpinProject && pinnedPaths.has(row.projectPath);
     // Closing a family row shuts down every member session (main checkout
     // and worktrees alike) — leaving invisible hot sessions behind would
     // silently keep dev servers and PTYs running.
@@ -659,6 +667,7 @@ export const WorkspaceSidebar = memo(function WorkspaceSidebar({
         onToggleExpand={() => toggleProjectExpanded(row.projectPath)}
         onSelectProject={onSelectProject}
         onClose={canClose ? closeFamily : undefined}
+        onUnpin={canUnpin ? () => onUnpinProject?.(row.projectPath) : undefined}
       >
         {expanded &&
           (isCurrent ? (
@@ -999,6 +1008,7 @@ function ProjectGroup({
   onToggleExpand,
   onSelectProject,
   onClose,
+  onUnpin,
   children,
 }: {
   row: PinnedProjectRow;
@@ -1010,6 +1020,9 @@ function ProjectGroup({
   onSelectProject: (path: string) => void;
   /** Shown as a hover-only X when defined. */
   onClose?: () => void;
+  /** Hover-only unpin action for rows with no live session (issue #366).
+   *  Ignored when `onClose` is present — one hover action per row. */
+  onUnpin?: () => void;
   children?: React.ReactNode;
 }) {
   const initials = projectInitials(row.fallbackName);
@@ -1075,6 +1088,27 @@ function ProjectGroup({
             }}
             aria-label={`Close ${row.fallbackName}`}
             title="Close project (stops dev server)"
+          >
+            <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+              <path
+                d="M1 1 L9 9 M9 1 L1 9"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        )}
+        {!onClose && onUnpin && (
+          <button
+            type="button"
+            className="sidebar-project-close"
+            onClick={(e) => {
+              e.stopPropagation();
+              onUnpin();
+            }}
+            aria-label={`Unpin ${row.fallbackName}`}
+            title="Unpin from sidebar"
           >
             <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
               <path

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -361,6 +361,9 @@ export interface WorkspaceViewProps {
   onOpenProjectPicker: () => void;
   /** Open the "Switch Workspace" picker from the sidebar footer. */
   onSwitchAccount: () => void;
+  /** Unpin a project from the sidebar (used for rows without a live session,
+   *  including pins whose folder no longer exists — issue #366). */
+  onUnpinProject?: (projectPath: string) => void;
   /** Predicate: is a dev server currently tracked for the given project path?
    *  Used by the sidebar to populate background projects' Commands section. */
   isProjectDevServerRunning: (projectPath: string) => boolean;
@@ -390,6 +393,7 @@ export const WorkspaceView = memo(function WorkspaceView({
   onSelectProjectTab,
   onGoHome,
   onSwitchAccount,
+  onUnpinProject,
   onOpenProjectPicker,
   isProjectDevServerRunning,
 }: WorkspaceViewProps) {
@@ -1093,6 +1097,7 @@ export const WorkspaceView = memo(function WorkspaceView({
               onOpenProjectPicker={onOpenProjectPicker}
               projects={projectRows}
               onCloseProject={onCloseProject}
+              onUnpinProject={onUnpinProject}
               currentProjectPath={currentProject.path}
               currentProjectName={currentProject.name}
               onSelectProject={onSelectProject}

--- a/src/hooks/useAssetManagement.ts
+++ b/src/hooks/useAssetManagement.ts
@@ -22,6 +22,7 @@ import {
   type Asset,
 } from '../lib/assets';
 import { asCommandError, formatCommandError } from '../lib/errors';
+import { describeClipboardError, useCopyToClipboard } from './useCopyToClipboard';
 import { trackEvent, trackError, trackSearch } from '../lib/analytics';
 import { logger } from '../lib/logger';
 
@@ -52,6 +53,11 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
   const [isDragging, setIsDragging] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [copiedPath, setCopiedPath] = useState<string | null>(null);
+  const { copy: copyToClipboard } = useCopyToClipboard({
+    // A silent failure here left users clicking "copy path" into the void
+    // (issue #355) — surface it like every other failed action in this hook.
+    onError: (err) => onToast?.(`Failed to copy path (${describeClipboardError(err)})`, 'error'),
+  });
   const [viewMode, setViewMode] = useState<'list' | 'grid'>('grid');
   const [searchQuery, setSearchQuery] = useState('');
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
@@ -286,13 +292,10 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
   const handleCopyPath = async (asset: Asset) => {
     const webPath =
       assetsRoot === DEFAULT_ASSETS_ROOT ? `/${asset.path}` : `${assetsRoot}/${asset.path}`;
-    try {
-      await navigator.clipboard.writeText(webPath);
+    if (await copyToClipboard(webPath)) {
       setCopiedPath(asset.path);
       setTimeout(() => setCopiedPath(null), 2000);
       onToast?.(`Copied ${webPath}`, 'success');
-    } catch (e) {
-      logger.error('Failed to copy path', { error: e instanceof Error ? e.message : String(e) });
     }
   };
 

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -17,6 +17,19 @@ interface Options {
 }
 
 /**
+ * Human-readable reason for a clipboard write failure, suitable for a toast.
+ * The webview's NotAllowedError text is long and technical; the practical
+ * cause is almost always a missing user-activation or an unfocused window
+ * (issue #357), so map it to something the user can act on.
+ */
+export function describeClipboardError(error: Error): string {
+  if (error.name === 'NotAllowedError' || error.message.includes('not allowed')) {
+    return 'clipboard access was denied — click the Ship Studio window, then try again';
+  }
+  return error.message;
+}
+
+/**
  * Copy text to the OS clipboard. Prefer this over calling `navigator.clipboard`
  * directly — it centralizes error handling, tracking, and the "copied!" flag.
  */

--- a/src/hooks/usePreviewConnection.ts
+++ b/src/hooks/usePreviewConnection.ts
@@ -9,6 +9,7 @@ import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { useClickOutside } from './useClickOutside';
+import { useCopyToClipboard } from './useCopyToClipboard';
 import {
   decideIframeWatchdogArm,
   isPreviewProofOfLife,
@@ -121,6 +122,10 @@ export function usePreviewConnection({
   // Last time the HMR watchdog auto-reloaded the preview — throttles recovery
   // so a flapping HMR socket can't put the iframe in a reload loop.
   const lastHmrRecoveryRef = useRef(0);
+  // Options-less so `copy` stays referentially stable — it's a dependency of
+  // the message-handler effect below, and per-render options would make that
+  // effect re-subscribe on every render.
+  const { copy: copyErrorText } = useCopyToClipboard();
   const isStoppedRef = useRef(false);
   isStoppedRef.current = isStopped;
   const retryCountRef = useRef(0);
@@ -402,10 +407,19 @@ export function usePreviewConnection({
         });
       }
       if (data && data.type === 'shipstudio:copy-error' && data.message) {
-        navigator.clipboard.writeText(data.message).then(
-          () => onToast?.('Error copied to clipboard', 'success'),
-          () => onToast?.('Failed to copy to clipboard', 'error')
-        );
+        void copyErrorText(data.message).then((ok) => {
+          if (ok) {
+            onToast?.('Error copied to clipboard', 'success');
+          } else {
+            // The click happened inside the preview iframe, so the app window
+            // itself may lack the user-activation the clipboard API wants
+            // (issue #357).
+            onToast?.(
+              'Failed to copy to clipboard — click the Ship Studio window, then try again',
+              'error'
+            );
+          }
+        });
       }
       if (data && data.type === 'shipstudio:send-error-to-claude' && data.message) {
         const prompt = `My dev server is returning an error:\n\n${data.message}\n\nPlease help me fix this.`;
@@ -446,6 +460,7 @@ export function usePreviewConnection({
     serverReady,
     devServerUrl,
     clearIframeWatchdogTimer,
+    copyErrorText,
   ]);
 
   // Auto-reload for static HTML projects when files change on disk

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -318,10 +318,13 @@ export function useProjectLifecycle({
       }
     } catch (e) {
       logger.warn('[OpenProject] Failed to ensure external project registration', { error: e });
-      showToast(
-        `Can't open "${project.name}" — its folder isn't a recognized project location. Re-add it via "Select Project Folder".`,
-        'error'
-      );
+      // Distinguish "the folder is gone" (moved/renamed/deleted outside the
+      // app — issue #365) from "the path isn't in an allowed location"; the
+      // "re-add via Select Project Folder" advice only fits the latter.
+      const message = formatCommandError(asCommandError(e)).includes('no longer exists')
+        ? `Can't open "${project.name}" — its folder no longer exists. It may have been moved, renamed, or deleted outside Ship Studio.`
+        : `Can't open "${project.name}" — its folder isn't a recognized project location. Re-add it via "Select Project Folder".`;
+      showToast(message, 'error');
       return;
     }
 

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -141,6 +141,12 @@ describe('humanizeGitError', () => {
       expect: /couldn't reach GitHub/i,
     },
     {
+      // Windows Go dial error from the gh CLI — contains none of the usual
+      // timeout/refused/resolve substrings (issue #375).
+      raw: 'Post "https://api.github.com/graphql": dial tcp 20.207.73.85:443: connectex: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.',
+      expect: /couldn't reach GitHub/i,
+    },
+    {
       raw: 'remote: error: GH006: Protected branch update failed for refs/heads/main',
       expect: /protected, so changes can't be pushed/i,
     },

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -117,12 +117,16 @@ export function humanizeGitError(value: unknown, ctx: GitErrorContext = {}): str
     return `GitHub didn't accept the connection. Your sign-in may have expired, or your account may not have write access to this repository. Reconnect GitHub (top right) or check your access, then try again.`;
   }
 
-  // Couldn't reach GitHub at all.
+  // Couldn't reach GitHub at all. 'dial tcp'/'connectex' cover Go's dial
+  // errors from the gh CLI — the Windows connectex wording contains none of
+  // the usual timeout/refused substrings (issue #375).
   if (
     m.includes('could not resolve host') ||
     m.includes('unable to access') ||
     m.includes('connection refused') ||
     m.includes('network is unreachable') ||
+    m.includes('dial tcp') ||
+    m.includes('connectex') ||
     m.includes('timed out') ||
     m.includes('timeout')
   ) {


### PR DESCRIPTION
Fixes the entire round-9 wave of auto-reported issues (22 issues, 10 root causes).

## Thumbnail capture (11 issues, one root cause)
The #335 fix pointed headless Chromium at a **fixed** profile dir, which traded one singleton-lock collision for another: overlapping captures fought over `.shipstudio/thumbnail_profile`, and an interrupted capture left a stale `SingletonLock` that permanently broke every subsequent capture. Now each capture gets a unique `thumbnail_profile_<pid>_<seq>` dir, a sweep removes the legacy dir plus any orphaned per-capture dir older than an hour (age-gated so it can't yank a live concurrent capture), and success is judged by the screenshot file existing rather than the exit code — Windows Chromium can write the PNG and still exit non-zero over unrelated internal warnings.

## Error classification (typed at the throw site, kept out of telemetry)
- **Proxy WebSocket (HMR) upgrade**: retries on `TimedOut` as well as `ConnectionRefused`, with a per-attempt timeout capped to the remaining budget so one hung SYN can't eat the whole retry window.
- **pty_session_write**: Windows os error 232 ("pipe is being closed") treated as the same benign end-of-session race as Unix EIO.
- **Windows pagefile exhaustion** (os error 1455): actionable "increase your paging file" guidance instead of the raw OS string, in both `run_with_timeout` and the blanket `io::Error` conversion.
- **gh network failures**: `dial tcp` / `connectex` / DNS errors in the five PR commands become a friendly "Couldn't reach GitHub"; `humanizeGitError` also matches the Windows `connectex` wording.
- **Pre-2.24 git**: `switch_branch` detects the `pathspec '--end-of-options'` failure signature and says plainly that Git needs updating.
- **Missing project folder**: `canonicalize_tagged` turns `NotFound` into an Expected error with a plain-language message — folders deleted/moved outside the app are an environment change, not a malfunction. The open-project toast now distinguishes "folder is gone" from "location not recognized".

## UX
- **Clipboard**: asset "copy path" migrated to `useCopyToClipboard` and surfaces failures (it was silent); all clipboard failure toasts now carry a mapped, actionable reason (`describeClipboardError`); both remaining raw `navigator.clipboard` call sites migrated and the ESLint exception list shrunk accordingly.
- **Dead pins**: sidebar pinned rows without a live session get an Unpin hover action, so a pin whose folder was moved or deleted can finally be removed.
- **git hooks**: `git_command` children now get the extended PATH, so lefthook/husky hooks can resolve pnpm/node exactly like the user's terminal.

## Verification
- `cargo test`: 771 pass (3 new classifier tests + 2 canonicalize tests)
- `pnpm test:run`: 1382 pass (new connectex case)
- `tsc --noEmit`, `eslint`, `pnpm check:patterns`: clean

Closes #353
Closes #354
Closes #355
Closes #356
Closes #357
Closes #358
Closes #359
Closes #360
Closes #361
Closes #362
Closes #363
Closes #364
Closes #365
Closes #366
Closes #367
Closes #369
Closes #370
Closes #371
Closes #372
Closes #373
Closes #374
Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an unpin action for inactive pinned projects in the workspace sidebar.
  - Improved clipboard error messages with clearer, actionable explanations.
  - Added guidance for Windows memory-limit errors.

- **Bug Fixes**
  - Improved GitHub and proxy network error handling with clearer retry guidance.
  - Added compatibility messaging for older Git versions.
  - Improved screenshot reliability and cleanup.
  - Fixed Git hooks launched from GUI environments.
  - Added clearer messages when project folders are missing.
  - Reduced spurious errors when terminal sessions end unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->