### PR TITLE
Bug-bash round 10: app-freeze fix, index.lock retry, error classification

### DIFF
--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -121,11 +121,18 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
             path.display()
         ));
     }
-    // Stage all changes
-    let add_output = crate::utils::git_command_in(path)?
-        .args(["add", "-A"])
-        .output()
-        .map_err(|e| e.to_string())?;
+    // Stage all changes. Retried on index.lock contention — the background
+    // snapshot watcher (and any agent CLI) can hold the lock at the exact
+    // moment a commit/publish fires (#377).
+    let add_output = crate::utils::output_retrying_index_lock(|| {
+        crate::utils::git_command_in(path)?
+            .args(["add", "-A"])
+            .output()
+            .map_err(|e| crate::errors::CommandError::Io {
+                message: e.to_string(),
+            })
+    })
+    .map_err(String::from)?;
 
     if !add_output.status.success() {
         let add_stderr = String::from_utf8_lossy(&add_output.stderr).to_string();
@@ -154,11 +161,16 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
         return Ok(false);
     }
 
-    // Commit
-    let commit_output = crate::utils::git_command_in(path)?
-        .args(["commit", "-m", message])
-        .output()
-        .map_err(|e| e.to_string())?;
+    // Commit — same index.lock retry as the staging step (#377).
+    let commit_output = crate::utils::output_retrying_index_lock(|| {
+        crate::utils::git_command_in(path)?
+            .args(["commit", "-m", message])
+            .output()
+            .map_err(|e| crate::errors::CommandError::Io {
+                message: e.to_string(),
+            })
+    })
+    .map_err(String::from)?;
 
     if !commit_output.status.success() {
         // `status --porcelain` can report entries `add -A` couldn't stage (e.g.

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -547,6 +547,22 @@ pub(crate) fn gh_network_error(stderr: &str) -> Option<CommandError> {
     })
 }
 
+/// gh's own wrapper for a failing internal git call — "failed to run git:
+/// <git's stderr>" (gh's git/errors.go, GitError). Most commonly hit when gh
+/// can't resolve repo context because the project isn't a git repository. The
+/// underlying git fatal text is locale-dependent (e.g. Russian installs print
+/// a translated "not a git repository"), so matching git's own words — as
+/// report_command_error does for issue #254 — silently fails on non-English
+/// machines; gh's wrapper prefix is an untranslated Go literal and therefore
+/// stable (issue #403). A by-design refusal, not a malfunction.
+pub(crate) fn gh_git_repo_error(stderr: &str) -> Option<CommandError> {
+    stderr.contains("failed to run git:").then(|| {
+        CommandError::expected(
+            "This project isn't set up with git yet, so GitHub pull request actions aren't available.",
+        )
+    })
+}
+
 /// Lists GitHub repositories for a given owner (user or organization)
 #[tauri::command]
 #[tracing::instrument]
@@ -917,6 +933,22 @@ mod tests {
             gh_network_error("error connecting to api.github.com: could not resolve host")
                 .is_some()
         );
+    }
+
+    #[test]
+    fn gh_git_repo_error_matches_localized_git_fatal() {
+        // gh's "failed to run git:" prefix is stable English; git's own fatal
+        // text is localized (Russian here) — the classification must not
+        // depend on git's words (issue #403).
+        let stderr = "failed to run git: fatal: не найден git репозиторий (или один из родительских каталогов): .git";
+        let err = gh_git_repo_error(stderr).expect("should classify as expected");
+        assert!(matches!(err, CommandError::Expected { .. }));
+    }
+
+    #[test]
+    fn gh_git_repo_error_ignores_unrelated_stderr() {
+        assert!(gh_git_repo_error("GraphQL: something else went wrong").is_none());
+        assert!(gh_git_repo_error("").is_none());
     }
 
     #[test]

--- a/src-tauri/src/commands/ide/screenshots/playwright.rs
+++ b/src-tauri/src/commands/ide/screenshots/playwright.rs
@@ -223,7 +223,16 @@ const {{ chromium }} = require('playwright');
         // Dev servers keep HMR/live-reload connections open forever, so
         // 'networkidle' may never arrive — wait for 'load', then settle
         // best-effort without ever failing the capture on it (issues #309/#310).
-        await page.goto('{}', {{ waitUntil: 'load', timeout: 30000 }});
+        // A TCP-accepting port can still take >30s to serve `load` when the dev
+        // server compiles the route on first request (issue #385): give the
+        // navigation a longer budget, and retry once on timeout — the compile
+        // keeps progressing server-side, so a warmed route answers quickly.
+        try {{
+            await page.goto('{}', {{ waitUntil: 'load', timeout: 60000 }});
+        }} catch (err) {{
+            if (!String((err && err.message) || err).includes('Timeout')) throw err;
+            await page.goto('{}', {{ waitUntil: 'load', timeout: 60000 }});
+        }}
         await page.waitForLoadState('networkidle', {{ timeout: 5000 }}).catch(() => {{}});
 
         // Hide dev tools and feedback overlays
@@ -285,6 +294,7 @@ const {{ chromium }} = require('playwright');
     process.exit(1);
 }});
 "#,
+        url,
         url,
         screenshot_path_str.replace('\\', "\\\\")
     );
@@ -374,8 +384,15 @@ const {{ chromium }} = require('playwright');
         const page = await browser.newPage({{ viewport: {{ width: {viewport_width}, height: 800 }} }});
 
         // Same wait strategy as the full-page capture: 'networkidle' may never
-        // arrive on dev servers with persistent connections (issues #309/#310).
-        await page.goto('{}', {{ waitUntil: 'load', timeout: 30000 }});
+        // arrive on dev servers with persistent connections (issues #309/#310),
+        // and a cold route compiling on first request can need >30s to reach
+        // `load` — long budget plus one retry on timeout (issue #385).
+        try {{
+            await page.goto('{}', {{ waitUntil: 'load', timeout: 60000 }});
+        }} catch (err) {{
+            if (!String((err && err.message) || err).includes('Timeout')) throw err;
+            await page.goto('{}', {{ waitUntil: 'load', timeout: 60000 }});
+        }}
         await page.waitForLoadState('networkidle', {{ timeout: 5000 }}).catch(() => {{}});
 
         // Hide dev tools and feedback overlays
@@ -414,6 +431,7 @@ const {{ chromium }} = require('playwright');
     process.exit(1);
 }});
 "#,
+        url,
         url,
         screenshot_path_str.replace('\\', "\\\\")
     );

--- a/src-tauri/src/commands/ide/screenshots/thumbnail.rs
+++ b/src-tauri/src/commands/ide/screenshots/thumbnail.rs
@@ -1,12 +1,57 @@
 //! Project thumbnail capture and retrieval.
 
 use crate::errors::CommandError;
+use crate::external_command::run_with_timeout;
 use crate::types::{ProjectMetadata, PROJECT_METADATA_SCHEMA_VERSION};
 use crate::utils::{create_command, validate_project_path};
+use std::collections::HashSet;
 use std::path::Path;
+use std::sync::{LazyLock, Mutex};
 
 use super::node_tool_command;
 use crate::commands::ide::{find_chromium_browser, resize_thumbnail_image};
+
+/// Ceiling for the `npx playwright screenshot` path. Generous — npx may fetch
+/// the package on first use and a dev server mid-compile is slow — but bounded:
+/// this used to be an untimed blocking `.output()` inside an async command, so
+/// a hung capture pinned a tokio worker thread forever. A few of those (multiple
+/// projects on the 5-minute capture timer, dev servers busy under the user's own
+/// Playwright runs) starved the runtime and froze every IPC call in the app
+/// (issue #387).
+const PLAYWRIGHT_THUMBNAIL_TIMEOUT_SECS: u64 = 120;
+/// Ceiling for the Chrome/Edge CLI fallback. Its virtual-time budget is 3s;
+/// the rest is browser startup + page load headroom.
+const BROWSER_THUMBNAIL_TIMEOUT_SECS: u64 = 60;
+
+/// Projects with a thumbnail capture currently in flight. The 5-minute timer,
+/// its retry ladder, and multiple windows can all invoke captures with no
+/// coordination; without this guard each overlapping call spawned another
+/// headless browser against an already-busy dev server (issue #387).
+static CAPTURES_IN_FLIGHT: LazyLock<Mutex<HashSet<String>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+/// RAII claim on a project's capture slot — released on every exit path,
+/// including timeouts and panics.
+struct CaptureClaim(String);
+
+impl CaptureClaim {
+    fn try_new(project: &Path) -> Option<Self> {
+        let key = project.to_string_lossy().to_string();
+        let mut in_flight = CAPTURES_IN_FLIGHT
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        in_flight.insert(key.clone()).then(|| Self(key))
+    }
+}
+
+impl Drop for CaptureClaim {
+    fn drop(&mut self) {
+        CAPTURES_IN_FLIGHT
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(&self.0);
+    }
+}
 
 /// Best-effort cleanup of thumbnail Chromium profiles left behind by earlier
 /// captures that never reached their own cleanup (app quit, crash, kill).
@@ -61,6 +106,14 @@ pub async fn capture_project_thumbnail(
 ) -> Result<String, CommandError> {
     let project = validate_project_path(&project_path)?;
 
+    // One capture per project at a time. Expected, not an error state: the
+    // previous capture is still running and the timer will simply try again.
+    let Some(_claim) = CaptureClaim::try_new(&project) else {
+        return Err(CommandError::expected(
+            "A thumbnail capture for this project is already in progress",
+        ));
+    };
+
     // Skip capture entirely when the user has uploaded a custom thumbnail.
     // Returns the existing thumbnail path so the caller still treats the
     // call as success (the user's image stays put).
@@ -88,7 +141,8 @@ pub async fn capture_project_thumbnail(
     let thumbnail_path_str = thumbnail_path.to_string_lossy().to_string();
 
     // Try using Playwright first (more reliable viewport control)
-    let npx_result = node_tool_command("npx")
+    let mut npx_cmd = node_tool_command("npx");
+    npx_cmd
         .args([
             "playwright",
             "screenshot",
@@ -97,15 +151,26 @@ pub async fn capture_project_thumbnail(
             &url,
             &thumbnail_path_str,
         ])
-        .current_dir(&project)
-        .output();
+        .current_dir(&project);
+    let npx_result = run_with_timeout(
+        tokio::process::Command::from(npx_cmd),
+        "npx playwright screenshot",
+        PLAYWRIGHT_THUMBNAIL_TIMEOUT_SECS,
+    )
+    .await;
 
-    if let Ok(output) = npx_result {
-        if output.status.success() && thumbnail_path.exists() {
+    match npx_result {
+        Ok(output) if output.status.success() && thumbnail_path.exists() => {
             // Resize to thumbnail width using image crate (cross-platform)
             resize_thumbnail_image(&thumbnail_path, 640);
             return Ok(thumbnail_path_str);
         }
+        Err(e) => {
+            // Timeout or spawn failure — fall through to the Chrome fallback,
+            // which has its own (shorter) budget.
+            tracing::warn!("Playwright thumbnail path failed, trying browser fallback: {e}");
+        }
+        Ok(_) => {}
     }
 
     // Fall back to Chrome/Edge CLI if Playwright not available
@@ -140,27 +205,34 @@ pub async fn capture_project_thumbnail(
 
         // Use new headless mode with explicit viewport control
         // Set background to white so any extra captured area isn't black
-        let output = create_command(&browser)
-            .args([
-                "--headless=new",
-                &user_data_arg,
-                "--no-first-run",
-                "--disable-gpu",
-                "--no-sandbox",
-                "--hide-scrollbars",
-                "--force-device-scale-factor=1",
-                "--default-background-color=FFFFFFFF",
-                "--window-position=0,0",
-                "--window-size=1280,800",
-                "--virtual-time-budget=3000",
-                &screenshot_arg,
-                &url,
-            ])
-            .output()
-            .map_err(|e| format!("Failed to run browser: {e}"))?;
+        let mut browser_cmd = create_command(&browser);
+        browser_cmd.args([
+            "--headless=new",
+            &user_data_arg,
+            "--no-first-run",
+            "--disable-gpu",
+            "--no-sandbox",
+            "--hide-scrollbars",
+            "--force-device-scale-factor=1",
+            "--default-background-color=FFFFFFFF",
+            "--window-position=0,0",
+            "--window-size=1280,800",
+            "--virtual-time-budget=3000",
+            &screenshot_arg,
+            &url,
+        ]);
+        let result = run_with_timeout(
+            tokio::process::Command::from(browser_cmd),
+            "headless browser thumbnail",
+            BROWSER_THUMBNAIL_TIMEOUT_SECS,
+        )
+        .await;
 
         // The throwaway profile has served its purpose; don't let it grow.
+        // On timeout the killed browser can leave it half-written — the stale
+        // sweep above mops those up on later captures.
         let _ = std::fs::remove_dir_all(&profile_dir);
+        let output = result?;
 
         // Success is "the screenshot file exists", not "the exit code was 0":
         // headless Chromium on Windows can write the PNG and still exit
@@ -311,4 +383,31 @@ pub async fn upload_project_thumbnail(
     let bytes = std::fs::read(&thumbnail_path).map_err(|e| e.to_string())?;
     let base64_data = base64::engine::general_purpose::STANDARD.encode(&bytes);
     Ok(format!("data:image/png;base64,{base64_data}"))
+}
+
+#[cfg(test)]
+mod capture_claim_tests {
+    use super::*;
+
+    #[test]
+    fn second_claim_for_same_project_is_rejected_until_first_drops() {
+        let project = Path::new("/tmp/shipstudio-claim-test-project");
+        let first = CaptureClaim::try_new(project);
+        assert!(first.is_some(), "first claim should succeed");
+        assert!(
+            CaptureClaim::try_new(project).is_none(),
+            "overlapping claim must be rejected while the first is alive"
+        );
+        drop(first);
+        assert!(
+            CaptureClaim::try_new(project).is_some(),
+            "slot must be released when the claim drops"
+        );
+    }
+
+    #[test]
+    fn claims_for_different_projects_are_independent() {
+        let _a = CaptureClaim::try_new(Path::new("/tmp/shipstudio-claim-test-a")).unwrap();
+        assert!(CaptureClaim::try_new(Path::new("/tmp/shipstudio-claim-test-b")).is_some());
+    }
 }

--- a/src-tauri/src/commands/mobile.rs
+++ b/src-tauri/src/commands/mobile.rs
@@ -327,6 +327,15 @@ pub async fn simulator_app_running(
             if msg.contains("Domain is tearing down") || msg.contains("LaunchdSimError") {
                 return Ok(false);
             }
+            // Same teardown race, slower failure mode: CoreSimulator doesn't
+            // always answer fast — sometimes the spawn just hangs until the
+            // timeout instead of returning the teardown error. The poller
+            // already tolerates a false tick and retries, so a timeout here
+            // is "not running right now", not a reportable malfunction
+            // (issue #411, gap left by #311).
+            if matches!(e, CommandError::Timeout { .. }) {
+                return Ok(false);
+            }
             return Err(e);
         }
     };

--- a/src-tauri/src/commands/plugins/plugin_lifecycle.rs
+++ b/src-tauri/src/commands/plugins/plugin_lifecycle.rs
@@ -282,6 +282,18 @@ pub async fn install_plugin(
 
     warn_on_setup_items(&manifest);
 
+    // Validate the built bundle exists before registering anything — a repo
+    // without a committed dist/ otherwise installs "successfully" and only
+    // fails later with a confusing "Plugin bundle not found" when the app
+    // tries to load it (issue #381). Mirrors link_dev_plugin's check.
+    if !temp_dir.join("dist").join("index.js").exists() {
+        let _ = remove_dir_all_relaxed(&temp_dir);
+        return Err(CommandError::expected(
+            "This plugin can't be installed: its repository has no built bundle (dist/index.js). \
+             The plugin author needs to build it and commit the dist folder.",
+        ));
+    }
+
     // Validate manifest has required fields
     if manifest.id.is_empty() || manifest.name.is_empty() {
         let _ = remove_dir_all_relaxed(&temp_dir);

--- a/src-tauri/src/commands/plugins/plugin_storage.rs
+++ b/src-tauri/src/commands/plugins/plugin_storage.rs
@@ -150,7 +150,12 @@ pub async fn exec_plugin_shell(
     cmd.kill_on_drop(true);
     let output = tokio::time::timeout(std::time::Duration::from_secs(timeout), cmd.output())
         .await
-        .map_err(|_| format!("Plugin shell command timed out ({timeout}s)"))?
+        .map_err(|_| {
+            // Name the plugin and command — a bare "timed out (120s)" is the
+            // same message for every plugin on every platform, so telemetry
+            // can't tell a slow-but-legit install from a hung plugin (#379).
+            format!("Plugin '{plugin_id}' shell command '{command}' timed out after {timeout}s")
+        })?
         .map_err(|e| format!("Failed to execute command: {e}"))?;
 
     Ok(ShellResult {

--- a/src-tauri/src/commands/pull_requests.rs
+++ b/src-tauri/src/commands/pull_requests.rs
@@ -65,6 +65,9 @@ pub async fn list_pull_requests(
         if let Some(err) = crate::commands::github::gh_network_error(&stderr) {
             return Err(err);
         }
+        if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
+            return Err(err);
+        }
         return Err((stderr.to_string()).into());
     }
 
@@ -139,6 +142,9 @@ pub async fn create_pull_request(
         if let Some(err) = crate::commands::github::gh_network_error(&stderr) {
             return Err(err);
         }
+        if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
+            return Err(err);
+        }
         return Err((stderr.to_string()).into());
     }
 
@@ -169,6 +175,9 @@ pub async fn merge_pull_request(project_path: String, pr_number: i32) -> Result<
             return Err(err);
         }
         if let Some(err) = crate::commands::github::gh_network_error(&stderr) {
+            return Err(err);
+        }
+        if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
             return Err(err);
         }
         return Err(stderr.into());
@@ -208,6 +217,9 @@ pub async fn checkout_pull_request(
         if let Some(err) = crate::commands::github::gh_network_error(&stderr) {
             return Err(err);
         }
+        if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
+            return Err(err);
+        }
         return Err((format!("Failed to checkout PR: {stderr}")).into());
     }
 
@@ -240,6 +252,9 @@ pub async fn close_pull_request(project_path: String, pr_number: i32) -> Result<
             return Err(err);
         }
         if let Some(err) = crate::commands::github::gh_network_error(&stderr) {
+            return Err(err);
+        }
+        if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
             return Err(err);
         }
         return Err((format!("Failed to close PR: {stderr}")).into());

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -151,7 +151,21 @@ pub fn set_projects_root(path: String) -> Result<(), CommandError> {
         }
         // Confirm the folder is writable (creating projects needs write access).
         let probe = pb.join(".shipstudio-write-test");
-        std::fs::write(&probe, b"test").map_err(|e| format!("Folder isn't writable: {e}"))?;
+        std::fs::write(&probe, b"test").map_err(|e| {
+            // "Folder isn't writable" for every failure was misleading: on
+            // Windows, a folder that vanished between the is_dir() check and
+            // this write (removable/network drive, concurrent delete) reports
+            // os error 2 NotFound — a permissions message with no path made
+            // that undiagnosable (issue #397).
+            if e.kind() == std::io::ErrorKind::NotFound {
+                format!(
+                    "The folder '{trimmed}' is no longer accessible — it may have been \
+                     deleted, renamed, or be on a disconnected drive ({e})"
+                )
+            } else {
+                format!("Folder '{trimmed}' isn't writable: {e}")
+            }
+        })?;
         let _ = std::fs::remove_file(&probe);
         Some(trimmed.to_string())
     };

--- a/src-tauri/src/commands/snapshots.rs
+++ b/src-tauri/src/commands/snapshots.rs
@@ -143,12 +143,16 @@ fn is_relevant_path(p: &Path, project_root: &Path) -> bool {
 /// Capture the current working tree as a stash commit. Returns the SHA, or
 /// empty string if the tree is clean (nothing to snapshot).
 fn capture_snapshot(project_path: &Path) -> Result<String, CommandError> {
-    let output = crate::utils::git_command_in(project_path)?
-        .args(["stash", "create"])
-        .output()
-        .map_err(|e| CommandError::Io {
-            message: format!("git stash create: {e}"),
-        })?;
+    // Retry on index.lock contention: this fires from the background watcher,
+    // so it routinely races user/agent-initiated git in the same repo (#377).
+    let output = crate::utils::output_retrying_index_lock(|| {
+        crate::utils::git_command_in(project_path)?
+            .args(["stash", "create"])
+            .output()
+            .map_err(|e| CommandError::Io {
+                message: format!("git stash create: {e}"),
+            })
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -426,6 +426,44 @@ pub fn git_command_in(
     Ok(cmd)
 }
 
+/// True when git failed because another process held `.git/index.lock`.
+/// Concurrent git spawns against the same repo are unavoidable here: the
+/// snapshot watcher, commit/publish flows, and the user's own agent CLIs all
+/// run git independently. Git fails fast instead of waiting, so a collision
+/// surfaces as "Unable to create '….git/index.lock': File exists" — most
+/// visibly on Windows, where lock files also linger longer (AV scanning,
+/// handle-release timing) (issue #377).
+pub fn is_index_lock_contention(stderr: &str) -> bool {
+    stderr.contains("index.lock") && stderr.contains("File exists")
+}
+
+/// Run a git invocation built by `run`, retrying with a short backoff when it
+/// loses the `.git/index.lock` race. The closure rebuilds and executes the
+/// command each attempt. Non-contention failures and successes return
+/// immediately; contention is retried a couple of times, then returned as-is
+/// so the caller's normal error path reports it.
+pub fn output_retrying_index_lock<F>(
+    mut run: F,
+) -> Result<std::process::Output, crate::errors::CommandError>
+where
+    F: FnMut() -> Result<std::process::Output, crate::errors::CommandError>,
+{
+    const ATTEMPTS: u64 = 3;
+    for attempt in 1..=ATTEMPTS {
+        let output = run()?;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if output.status.success() || !is_index_lock_contention(&stderr) || attempt == ATTEMPTS {
+            return Ok(output);
+        }
+        tracing::warn!(
+            attempt,
+            "git lost the index.lock race; retrying after backoff"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(200 * attempt));
+    }
+    unreachable!("loop always returns on the final attempt")
+}
+
 /// Finds an executable by checking common installation paths.
 /// This is needed because bundled macOS apps don't inherit the user's shell PATH.
 /// On Windows, checks standard Program Files and AppData locations.
@@ -1184,6 +1222,57 @@ mod tests {
                     assert!(err.to_string().contains("test_site"));
                 }
             }
+        }
+    }
+
+    mod index_lock_retry {
+        use super::*;
+
+        #[test]
+        fn recognizes_gits_lock_collision_message() {
+            let stderr = "fatal: Unable to create 'C:/Users/x/ShipStudio/p/.git/index.lock': File exists.\n\nAnother git process seems to be running in this repository";
+            assert!(is_index_lock_contention(stderr));
+            assert!(!is_index_lock_contention("fatal: not a git repository"));
+            assert!(!is_index_lock_contention(""));
+        }
+
+        #[test]
+        #[cfg(unix)]
+        fn retries_contention_then_returns_final_output() {
+            // Fails with the lock message every time — the helper must retry
+            // (3 attempts total) and then hand back the failing output rather
+            // than swallowing it.
+            let mut calls = 0;
+            let result = output_retrying_index_lock(|| {
+                calls += 1;
+                std::process::Command::new("sh")
+                    .arg("-c")
+                    .arg("echo \"fatal: Unable to create '.git/index.lock': File exists.\" 1>&2; exit 128")
+                    .output()
+                    .map_err(|e| crate::errors::CommandError::Io {
+                        message: e.to_string(),
+                    })
+            })
+            .unwrap();
+            assert_eq!(calls, 3);
+            assert!(!result.status.success());
+        }
+
+        #[test]
+        #[cfg(unix)]
+        fn success_returns_immediately_without_retry() {
+            let mut calls = 0;
+            let result = output_retrying_index_lock(|| {
+                calls += 1;
+                std::process::Command::new("true").output().map_err(|e| {
+                    crate::errors::CommandError::Io {
+                        message: e.to_string(),
+                    }
+                })
+            })
+            .unwrap();
+            assert_eq!(calls, 1);
+            assert!(result.status.success());
         }
     }
 

--- a/src/components/branches/BranchesTab.tsx
+++ b/src/components/branches/BranchesTab.tsx
@@ -30,7 +30,12 @@ import {
   sanitizeBranchName,
 } from '../../lib/branches';
 import { gitPull } from '../../lib/git';
-import { removeWorktree, pruneWorktrees, type WorktreeInfo } from '../../lib/worktrees';
+import {
+  listWorktrees,
+  removeWorktree,
+  pruneWorktrees,
+  type WorktreeInfo,
+} from '../../lib/worktrees';
 import { openProjectInNewWindow } from '../../lib/project';
 import { BranchIcon, PlusIcon, TrashIcon, ExternalLinkIcon } from '../icons';
 import { Spinner } from '../primitives/Spinner';
@@ -283,6 +288,22 @@ export function BranchesTab({
         setPendingSwitch(branchName);
       } else {
         const raw = result.error ?? 'Failed to switch branch';
+        // The worktree redirect above works off a list that can go stale —
+        // another tool (an agent CLI managing .claude/worktrees, a manual
+        // `git worktree add`) may have claimed the branch since the list
+        // loaded. Git's refusal proves the worktree exists NOW: re-fetch and
+        // finish the redirect instead of toasting a raw fatal (issue #406).
+        if (/already used by worktree|already checked out/i.test(raw) && onOpenWorktree) {
+          const fresh = await listWorktrees(projectPath).catch(() => []);
+          const home = fresh.find((w) => !w.isCurrent && w.branch === branchName);
+          if (home) {
+            onWorktreesChanged?.();
+            onToast?.(`${branchName} is checked out in a worktree — opening it`, 'success');
+            void trackEvent('worktree_switched', { via: 'branch_switch_redirect' });
+            onOpenWorktree(home.path);
+            return;
+          }
+        }
         onToast?.(humanizeGitError(raw, { branch: branchName }), 'error');
         // The branch is gone (deleted/renamed elsewhere) but still showing in a
         // stale list — refresh to drop the phantom entry.

--- a/src/components/plugins/PluginsDropdown.tsx
+++ b/src/components/plugins/PluginsDropdown.tsx
@@ -175,8 +175,17 @@ function PluginDropdownRow({
       button.click();
       return;
     }
-    // No button — the plugin crashed (error chip) or rendered nothing.
-    // Say so instead of silently ignoring the click.
+    // No button rendered. A plugin with no toolbar slot at all (e.g. Sanity
+    // CMS, whose button lives in the preview toolbar) is working as designed —
+    // reporting it as crashed was a false alarm (issue #390).
+    if (!plugin.module.slots?.toolbar) {
+      pluginActions.showToast(
+        `${plugin.info.manifest.name} doesn't add an action to this menu — look for its controls in the preview toolbar.`
+      );
+      return;
+    }
+    // The plugin declares a toolbar slot but rendered no button — it crashed
+    // (error chip) or rendered nothing. Say so instead of ignoring the click.
     pluginActions.showToast(
       `${plugin.info.manifest.name} is unavailable — it may have crashed. Check the plugin manager.`,
       'error'

--- a/src/hooks/useAgentBridge.ts
+++ b/src/hooks/useAgentBridge.ts
@@ -8,6 +8,7 @@
  */
 
 import { useEffect, useRef } from 'react';
+import { asCommandError, formatCommandError } from '../lib/errors';
 import { listen } from '@tauri-apps/api/event';
 import {
   executeBridgeTool,
@@ -89,7 +90,11 @@ export function useAgentBridge({
       try {
         url = await getAgentBridgeUrl(projectPath);
       } catch (err) {
-        logger.error('[AgentBridge] Failed to get bridge URL', { error: String(err) });
+        logger.error('[AgentBridge] Failed to get bridge URL', {
+          // CommandError rejections are plain objects — String() logs
+          // "[object Object]" (issue #405).
+          error: formatCommandError(asCommandError(err)),
+        });
         return;
       }
       if (cancelled) return;
@@ -103,7 +108,7 @@ export function useAgentBridge({
         () => logger.info('[AgentBridge] Preview MCP server registration ensured', { projectPath }),
         (err) => {
           logger.warn('[AgentBridge] Could not register preview MCP server', {
-            error: String(err),
+            error: formatCommandError(asCommandError(err)),
           });
         }
       );
@@ -136,7 +141,7 @@ export function useAgentBridge({
             await respondToBridgeRequest(request.requestId, result);
           } catch (err) {
             logger.error('[AgentBridge] Failed to deliver tool response', {
-              error: String(err),
+              error: formatCommandError(asCommandError(err)),
             });
           }
         })();
@@ -149,7 +154,9 @@ export function useAgentBridge({
       }
       // Listener is live — let tool calls route here instead of failing fast.
       setAgentBridgeAttached(projectPath, true).catch((err: unknown) => {
-        logger.warn('[AgentBridge] Failed to mark preview attached', { error: String(err) });
+        logger.warn('[AgentBridge] Failed to mark preview attached', {
+          error: formatCommandError(asCommandError(err)),
+        });
       });
     };
 

--- a/src/hooks/useCssCascadeEditor.ts
+++ b/src/hooks/useCssCascadeEditor.ts
@@ -379,7 +379,9 @@ export function useCssCascadeEditor({
             baselineInner.current = nextBaseline;
             setOverridden(nextOverridden);
           } catch (err) {
-            logger.error('[CssCascade] locate failed', { error: String(err) });
+            logger.error('[CssCascade] locate failed', {
+              error: formatCommandError(asCommandError(err)),
+            });
             if (selTokenRef.current === token) {
               setRows(mergeCascade(matched, new Map(), { cssModulesHint }));
               onToast(toastText(err), 'error');
@@ -432,7 +434,7 @@ export function useCssCascadeEditor({
           try {
             await createCssRule(projectPath, row.file, row.selector);
           } catch (err) {
-            if (!String(err).includes('already exists')) throw err;
+            if (!formatCommandError(asCommandError(err)).includes('already exists')) throw err;
           }
           draftKeysRef.current.delete(key);
         }
@@ -474,7 +476,9 @@ export function useCssCascadeEditor({
             /* fall through to the toast below */
           }
         }
-        logger.error('[CssCascade] write-back failed', { error: String(err) });
+        logger.error('[CssCascade] write-back failed', {
+          error: formatCommandError(asCommandError(err)),
+        });
         onToast(toastText(err), 'error');
       } finally {
         setSavingKeys((prev) => {
@@ -520,7 +524,9 @@ export function useCssCascadeEditor({
         delete baselineInner.current[key];
         void trackEvent('visual_style_saved', { mode: 'css-code', deleted: true });
       } catch (err) {
-        logger.error('[CssCascade] delete failed', { error: String(err) });
+        logger.error('[CssCascade] delete failed', {
+          error: formatCommandError(asCommandError(err)),
+        });
         onToast(toastText(err), 'error');
       }
     },
@@ -551,7 +557,9 @@ export function useCssCascadeEditor({
         else onToast('Wrapped — reselect the element to keep editing.', 'success');
         void trackEvent('visual_style_saved', { mode: 'css-code', wrapped: true });
       } catch (err) {
-        logger.error('[CssCascade] wrap failed', { error: String(err) });
+        logger.error('[CssCascade] wrap failed', {
+          error: formatCommandError(asCommandError(err)),
+        });
         onToast(toastText(err), 'error');
       }
     },
@@ -703,7 +711,10 @@ export function useCssCascadeEditor({
           conditional: condition != null,
         });
       } catch (err) {
-        const msg = String(err);
+        // A Tauri-rejected CommandError is a plain object — String(err) renders
+        // "[object Object]", which both broke the already-exists detection below
+        // and made the logged error useless (issue #380).
+        const msg = formatCommandError(asCommandError(err));
         // The rule already exists in source but doesn't match this element (so it
         // isn't in the cascade). Surface the real rule for editing instead of erroring
         // — typing an existing selector should just open it.
@@ -787,7 +798,9 @@ export function useCssCascadeEditor({
         saveTimers.current[newKey] = setTimeout(() => void saveRule(newKey), SAVE_DEBOUNCE_MS);
         void trackEvent('visual_style_saved', { mode: 'css-code', renamed: true });
       } catch (err) {
-        logger.error('[CssCascade] rename failed', { error: String(err) });
+        logger.error('[CssCascade] rename failed', {
+          error: formatCommandError(asCommandError(err)),
+        });
         onToast(toastText(err), 'error');
       }
     },
@@ -850,7 +863,9 @@ export function useCssCascadeEditor({
         saveTimers.current[newKey] = setTimeout(() => void saveRule(newKey), SAVE_DEBOUNCE_MS);
         void trackEvent('visual_style_saved', { mode: 'css-code', renamedAtRule: true });
       } catch (err) {
-        logger.error('[CssCascade] rename at-rule failed', { error: String(err) });
+        logger.error('[CssCascade] rename at-rule failed', {
+          error: formatCommandError(asCommandError(err)),
+        });
         onToast(toastText(err), 'error');
       }
     },

--- a/src/hooks/useElementStructure.ts
+++ b/src/hooks/useElementStructure.ts
@@ -198,8 +198,18 @@ export function useElementStructure({ iframeRef, projectPath, enabled, onToast }
         await action();
       } catch (err) {
         const message = formatCommandError(asCommandError(err));
-        logger.error('[ElementStructure] structural edit failed', { error: message });
-        onToast?.(structuralEditMessage(message), 'error');
+        const friendly = structuralEditMessage(message);
+        if (friendly === message) {
+          // Unrecognized failure — a genuine bug candidate, report it.
+          logger.error('[ElementStructure] structural edit failed', { error: message });
+        } else {
+          // A known by-design refusal (ambiguous/unanchorable element). The
+          // user already gets an accurate toast; logger.error would ship it
+          // to the bug pipeline on every occurrence even though #299 already
+          // classified these as non-reportable on the Rust side (issue #402).
+          logger.warn('[ElementStructure] structural edit refused', { error: message });
+        }
+        onToast?.(friendly, 'error');
       } finally {
         busyRef.current = false;
         setBusy(false);

--- a/src/hooks/useFileTree.ts
+++ b/src/hooks/useFileTree.ts
@@ -89,7 +89,9 @@ export function useFileTree(projectPath: string): UseFileTreeResult {
       const entries = await listProjectFiles(path);
       return buildFileTree(entries);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      // CommandError rejections are plain objects — String() renders
+      // "[object Object]" (issue #396); format to the real message.
+      const msg = formatCommandError(asCommandError(err));
       logger.error('Failed to load file tree', { error: msg });
       throw err;
     }
@@ -107,7 +109,9 @@ export function useFileTree(projectPath: string): UseFileTreeResult {
     try {
       return await readProjectFile(proj, path);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      // CommandError rejections are plain objects — String() renders
+      // "[object Object]" (issue #396); format to the real message.
+      const msg = formatCommandError(asCommandError(err));
       logger.error('Failed to read file', { path, error: msg });
       throw err;
     }

--- a/src/hooks/usePlugins.ts
+++ b/src/hooks/usePlugins.ts
@@ -123,7 +123,9 @@ export function usePlugins(
             const info = compatible[i];
             logger.error('Failed to load plugin', {
               plugin: info.manifest.id,
-              error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+              // Mirror failed.push below — String() on a CommandError object
+              // logs "[object Object]" (issue #408).
+              error: formatCommandError(asCommandError(result.reason)),
             });
             failed.push({
               id: info.manifest.id,
@@ -139,7 +141,7 @@ export function usePlugins(
         }
       } catch (e) {
         logger.error('Failed to list plugins', {
-          error: e instanceof Error ? e.message : String(e),
+          error: formatCommandError(asCommandError(e)),
         });
         if (mountedRef.current && currentPathRef.current === path) {
           setPlugins([]);

--- a/src/hooks/useScreenshotManagement.ts
+++ b/src/hooks/useScreenshotManagement.ts
@@ -23,6 +23,14 @@ function isProjectGoneError(error: unknown): boolean {
   );
 }
 
+/** Backend rejection meaning a capture for this project is already running
+ *  (the backend's per-project in-flight guard, issue #387). Not a failure —
+ *  the periodic timer will try again; retrying immediately would just keep
+ *  bouncing off the guard and end in a logged "failed after retries". */
+function isCaptureInFlightError(error: unknown): boolean {
+  return formatCommandError(asCommandError(error)).includes('already in progress');
+}
+
 /** Delay after page load before capturing screenshot (8 seconds to allow Next.js/Vite to fully compile) */
 const SCREENSHOT_DELAY_MS = 8000;
 /** Maximum number of retry attempts for thumbnail capture */
@@ -192,6 +200,10 @@ export function useScreenshotManagement({
         });
         logger.info('Thumbnail captured successfully', { projectPath, attempt });
       } catch (error) {
+        if (isCaptureInFlightError(error)) {
+          logger.info('[Thumbnail] Skipping - a capture for this project is already in progress');
+          return;
+        }
         if (isPermissionDenialError(error)) {
           // Denied at the OS level. Persist the opt-out so background capture
           // never re-triggers the macOS prompt; re-enable via Settings →

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -159,6 +159,17 @@ describe('humanizeGitError', () => {
       expect: /unsaved changes that would be lost/i,
     },
     {
+      // Branch held by another worktree (e.g. an agent CLI's own
+      // .claude/worktrees) — must not surface as a raw fatal (issue #406).
+      raw: "fatal: 'worktree-kasus-trainer' is already used by worktree at '/Users/x/proj/.claude/worktrees/kasus-trainer'",
+      expect: /already checked out in another worktree/i,
+    },
+    {
+      // Newer git wording for the same refusal.
+      raw: "fatal: 'feat/x' is already checked out at '/Users/x/proj/.claude/worktrees/feat-x'",
+      expect: /already checked out in another worktree/i,
+    },
+    {
       raw: "error: pathspec 'feat/gone' did not match any file(s) known to git",
       expect: /no longer exists/i,
     },

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -148,6 +148,13 @@ export function humanizeGitError(value: unknown, ctx: GitErrorContext = {}): str
     return `You have unsaved changes that would be lost. Save or discard them first, then try again.`;
   }
 
+  // The branch lives in another worktree — git refuses to check it out twice.
+  // Wording varies across git versions ("is already used by worktree at …",
+  // "is already checked out at …") — cover both (issue #406).
+  if (m.includes('already used by worktree') || m.includes('already checked out')) {
+    return `${branch} is already checked out in another worktree, so it can't be switched to here. Open it from the worktrees list instead.`;
+  }
+
   // The ref is gone — git couldn't find the branch, so it treated it as a path.
   if (
     m.includes('did not match') ||

--- a/src/lib/plugin-loader.ts
+++ b/src/lib/plugin-loader.ts
@@ -9,6 +9,7 @@
  * @module lib/plugin-loader
  */
 
+import { asCommandError, formatCommandError } from './errors';
 import { readPluginBundle } from './plugins';
 import { trackError } from './analytics';
 import { logger } from './logger';
@@ -120,7 +121,7 @@ export async function loadPluginModule(
       } catch (e) {
         trackError('plugin_onactivate', e, 'Workspace');
         logger.error(`Plugin ${pluginId} onActivate failed`, {
-          error: e instanceof Error ? e.message : String(e),
+          error: formatCommandError(asCommandError(e)),
         });
         onError?.(pluginModule.name, e);
       }
@@ -131,7 +132,7 @@ export async function loadPluginModule(
     // Clean up blob URL on failure
     URL.revokeObjectURL(blobUrl);
     blobUrlCache.delete(key);
-    throw new Error(`Failed to load plugin ${pluginId}: ${String(e)}`);
+    throw new Error(`Failed to load plugin ${pluginId}: ${formatCommandError(asCommandError(e))}`);
   }
 }
 
@@ -152,7 +153,7 @@ export function unloadPluginModule(
     } catch (e) {
       trackError('plugin_ondeactivate', e, 'Workspace');
       logger.error(`Plugin ${pluginId} onDeactivate failed`, {
-        error: e instanceof Error ? e.message : String(e),
+        error: formatCommandError(asCommandError(e)),
       });
       onError?.(mod.name, e);
     }


### PR DESCRIPTION
## The headline: the multi-project freeze (#387)

`capture_project_thumbnail` was an `async` Tauri command making **blocking, untimed** `std::process` `.output()` calls — both the `npx playwright screenshot` path and the Chrome CLI fallback. Every hung capture pinned a tokio worker thread permanently. With several projects on the 5-minute capture timer and dev servers busy under the user's own Playwright runs (exactly the workflow reported in Slack), hung captures accumulated until the async runtime was starved and **every IPC call in the app stopped** — the "frozen, must force-quit" symptom.

Fix: both spawns now run through `run_with_timeout` (120s playwright / 60s Chrome, both far under the 5-min timer), and a per-project RAII in-flight claim (`CaptureClaim`) prevents overlapping captures from piling on; the frontend treats the "already in progress" rejection as a skip, not a retryable failure.

## Also in this round

- **#385** — viewport/fullpage capture: 60s `page.goto` budget + one retry, for routes that compile on first request behind a TCP-accepting port
- **#377** — `.git/index.lock` contention: shared `output_retrying_index_lock` helper wrapping the snapshot watcher's `stash create` and the stage/commit path (the auto-firing collision pair); backoff 200/400ms
- **#403** — gh's locale-proof `failed to run git:` wrapper classified as an expected "not a git repo" state at all five `gh pr` sites
- **#406** — `humanizeGitError` learns git's worktree-held refusal (both wordings), and `BranchesTab` re-fetches the worktree list on that error and completes the open-the-worktree redirect
- **#411** — `simulator_app_running` maps poll timeouts during simulator teardown to `Ok(false)` (gap left by #311)
- **#381** — `install_plugin` validates `dist/index.js` before registering, mirroring `link_dev_plugin`
- **#379** — plugin shell timeouts name the plugin and command
- **#397** — projects-root write probe distinguishes a vanished folder from a permissions failure and names the path
- **#390** — Plugins dropdown: a plugin with no `toolbar` slot (Sanity CMS) is no longer reported as crashed
- **#402** — recognized structural-edit refusals log as `warn` (no bug report), unrecognized ones still `error`
- **#380 / #396 / #405 / #408** — `String(err)` → `formatCommandError(asCommandError(err))` in useCssCascadeEditor (where it also broke already-exists detection), useFileTree, useAgentBridge, usePlugins, plugin-loader

## Tests

- 775 Rust tests pass (new: CaptureClaim exclusivity ×2, index-lock retry ×3, gh_git_repo_error ×2)
- 1383 frontend tests pass (new: worktree-held humanize cases)
- `check:patterns` / `check:loc` clean

Closes #377
Closes #379
Closes #380
Closes #381
Closes #385
Closes #387
Closes #390
Closes #396
Closes #397
Closes #402
Closes #403
Closes #405
Closes #406
Closes #408
Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git operations now recover from temporary index locks through automatic retries.
  * Branch switching redirects to the existing worktree when a branch is already checked out elsewhere.
  * Screenshot and thumbnail capture is more reliable, with retries, timeouts, and protection against overlapping captures.
  * Simulator status checks tolerate transient timeouts.
  * Pull request and GitHub errors now provide clearer guidance when a project is not a Git repository.
  * Plugin installation detects missing build bundles and reports actionable errors.

* **Improvements**
  * Error messages now include relevant plugin, command, path, and timeout details.
  * Project-folder and structural-edit errors provide clearer user guidance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->