### PR TITLE
fix(terminal): downgrade PTY spawn-failure log to warn when binary is missing (Fixes #522)

### DIFF
--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -1163,12 +1163,27 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           return true; // Allow all other keys
         });
       } catch (err) {
-        logger.error('[Terminal] Failed to spawn PTY', {
-          agent: agent.id,
-          binary: agent.binaryName,
-          error: formatCommandError(asCommandError(err)),
-          retry: retryCount,
-        });
+        const formatted = formatCommandError(asCommandError(err));
+        const lower = formatted.toLowerCase();
+        const isExpected =
+          lower.includes('no viable candidates found in path') ||
+          lower.includes('does not exist') ||
+          lower.includes('not executable');
+        if (isExpected) {
+          logger.warn('[Terminal] Failed to spawn PTY (expected — binary not found)', {
+            agent: agent.id,
+            binary: agent.binaryName,
+            error: formatted,
+            retry: retryCount,
+          });
+        } else {
+          logger.error('[Terminal] Failed to spawn PTY', {
+            agent: agent.id,
+            binary: agent.binaryName,
+            error: formatted,
+            retry: retryCount,
+          });
+        }
 
         if (!mounted) return;
 


### PR DESCRIPTION
## Summary

The Rust backend already classifies a 'binary not found' spawn failure as `CommandError::Expected` (issue #329), but that distinction is lost across IPC because the frontend's `CommandError` type has no `Expected` variant — it serializes as `Other`. The `setupPty` catch block in `Terminal.tsx` unconditionally calls `logger.error` for every spawn failure, so users whose agent CLI isn't installed or resolvable still generate a fresh bug report every time, tagged `frontend-log` instead of `command-error`.

## Changes

In `src/components/terminal/Terminal.tsx`'s `setupPty` catch block:

- Extract the formatted error message and check it against the same patterns the Rust side uses (`"no viable candidates found in path"`, `"does not exist"`, `"not executable"`)
- Use `logger.warn` for these expected failures, since the friendly `notFoundMessage` / `installHint` UI already covers the user-facing side
- Keep `logger.error` for all other (unexpected) spawn failures

## Related

- #329 — original fix that classified binary-not-found as `Expected` on the Rust side
- #402 — same pattern for `useElementStructure.ts`
- #490 — same pattern for `checkForUpdate()`

Fixes #522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of terminal startup failures caused by missing commands, invalid paths, or non-executable binaries.
  * These expected issues are now reported as warnings, while unexpected failures continue to be reported as errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->