### PR TITLE
Capture quick fixes: orphaned processes, timeout budgets, mid-capture races (#510 #527 #514 #526)

### DIFF
--- a/src-tauri/src/commands/ide/screenshots/playwright.rs
+++ b/src-tauri/src/commands/ide/screenshots/playwright.rs
@@ -5,8 +5,12 @@ use crate::errors::CommandError;
 use crate::external_command::run_with_timeout;
 use crate::utils::validate_project_path;
 
-/// Ceiling for one capture-script run (page load + scroll + shot).
-const CAPTURE_TIMEOUT_SECS: u64 = 180;
+/// Ceiling for one capture-script run (page load + scroll + shot). Must cover
+/// the script's own worst-case inner budgets — two 60s goto attempts, the
+/// capped scroll pass, and the 120s full-page stitch — or we kill captures
+/// that were progressing legitimately and would have failed (or succeeded)
+/// with a far better error on their own (issue #527).
+const CAPTURE_TIMEOUT_SECS: u64 = 300;
 /// Ceiling for downloading Chromium during self-heal (~130MB).
 const BROWSER_INSTALL_TIMEOUT_SECS: u64 = 600;
 
@@ -60,6 +64,21 @@ async fn run_capture_script(
 
     // Other failures pass through — callers report status + stderr in detail.
     Ok(output)
+}
+
+/// Map a failed capture-script run to a `CommandError`. A connection refused
+/// that survived the in-script retry means the dev server went away mid-flight
+/// (crashed, restarted on another port) — an expected state exactly like the
+/// pre-capture readiness miss (#349), not an app malfunction (issue #514).
+fn capture_script_error(what: &str, url: &str, output: &std::process::Output) -> CommandError {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("ERR_CONNECTION_REFUSED") {
+        return CommandError::expected(format!(
+            "The dev server at {url} stopped responding while the screenshot was being captured. Wait for the preview to finish reloading, then try again."
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    (format!("{what} failed. stdout: {stdout} stderr: {stderr}")).into()
 }
 
 /// Parse the major version out of `node --version` output ("v16.17.0" -> 16).
@@ -269,7 +288,16 @@ const {{ chromium }} = require('playwright');
         try {{
             await page.goto('{}', {{ waitUntil: 'load', timeout: 60000 }});
         }} catch (err) {{
-            if (!String((err && err.message) || err).includes('Timeout')) throw err;
+            const msg = String((err && err.message) || err);
+            // A refused connection here, right after the Rust-side TCP
+            // readiness check passed, means the dev server died or is
+            // restarting in the gap between check and capture (issue #514) —
+            // give it a short beat before the one retry.
+            if (msg.includes('ERR_CONNECTION_REFUSED')) {{
+                await new Promise((resolve) => setTimeout(resolve, 2000));
+            }} else if (!msg.includes('Timeout')) {{
+                throw err;
+            }}
             await page.goto('{}', {{ waitUntil: 'load', timeout: 60000 }});
         }}
         await page.waitForLoadState('networkidle', {{ timeout: 5000 }}).catch(() => {{}});
@@ -298,11 +326,14 @@ const {{ chromium }} = require('playwright');
         // must not kill the whole capture (issue #438).
         }}).catch(() => {{}});
 
-        // Scroll slowly through the page to trigger lazy content and animations
+        // Scroll slowly through the page to trigger lazy content and animations.
+        // Capped: an infinite-scroll page would otherwise walk forever and eat
+        // the whole outer budget (issue #527).
         const scrollHeight = await page.evaluate(() => document.documentElement.scrollHeight).catch(() => 0);
         const viewportHeight = 800;
+        const maxScrollSteps = 40;
 
-        for (let y = 0; y < scrollHeight; y += viewportHeight / 2) {{
+        for (let step = 0, y = 0; y < scrollHeight && step < maxScrollSteps; step++, y += viewportHeight / 2) {{
             await page.evaluate((scrollY) => window.scrollTo(0, scrollY), y).catch(() => {{}});
             await page.waitForTimeout(300); // Pause for animations to trigger
         }}
@@ -367,10 +398,7 @@ const {{ chromium }} = require('playwright');
         return Ok(screenshot_path_str);
     }
 
-    // If failed, return error with details
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    Err((format!("Playwright screenshot failed. stdout: {stdout} stderr: {stderr}")).into())
+    Err(capture_script_error("Playwright screenshot", &url, &output))
 }
 
 /// Capture a viewport screenshot using Playwright.
@@ -437,7 +465,16 @@ const {{ chromium }} = require('playwright');
         try {{
             await page.goto('{}', {{ waitUntil: 'load', timeout: 60000 }});
         }} catch (err) {{
-            if (!String((err && err.message) || err).includes('Timeout')) throw err;
+            const msg = String((err && err.message) || err);
+            // A refused connection here, right after the Rust-side TCP
+            // readiness check passed, means the dev server died or is
+            // restarting in the gap between check and capture (issue #514) —
+            // give it a short beat before the one retry.
+            if (msg.includes('ERR_CONNECTION_REFUSED')) {{
+                await new Promise((resolve) => setTimeout(resolve, 2000));
+            }} else if (!msg.includes('Timeout')) {{
+                throw err;
+            }}
             await page.goto('{}', {{ waitUntil: 'load', timeout: 60000 }});
         }}
         await page.waitForLoadState('networkidle', {{ timeout: 5000 }}).catch(() => {{}});
@@ -507,13 +544,47 @@ const {{ chromium }} = require('playwright');
         return Ok(screenshot_path_str);
     }
 
-    // If failed, return error with details
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    Err(
-        (format!("Playwright viewport screenshot failed. stdout: {stdout} stderr: {stderr}"))
-            .into(),
-    )
+    Err(capture_script_error(
+        "Playwright viewport screenshot",
+        &url,
+        &output,
+    ))
+}
+
+#[cfg(test)]
+mod capture_error_tests {
+    use super::*;
+    use std::os::unix::process::ExitStatusExt;
+
+    fn failed_output(stderr: &str) -> std::process::Output {
+        std::process::Output {
+            status: std::process::ExitStatus::from_raw(256),
+            stdout: Vec::new(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+
+    #[test]
+    fn connection_refused_after_retry_is_expected_not_telemetry() {
+        // Issue #514: the server dying between readiness check and capture is
+        // an expected race, not an app bug.
+        let output =
+            failed_output("page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:3000/");
+        match capture_script_error("Playwright screenshot", "http://localhost:3000", &output) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("stopped responding"), "got: {message}")
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn other_failures_stay_real_errors_with_detail() {
+        let output = failed_output("SyntaxError: something broke");
+        let err = capture_script_error("Playwright screenshot", "http://localhost:3000", &output);
+        assert!(!matches!(err, CommandError::Expected { .. }));
+        assert!(format!("{err}").contains("something broke"));
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/ide/screenshots/playwright.rs
+++ b/src-tauri/src/commands/ide/screenshots/playwright.rs
@@ -557,11 +557,25 @@ const {{ chromium }} = require('playwright');
 #[cfg(test)]
 mod capture_error_tests {
     use super::*;
-    use std::os::unix::process::ExitStatusExt;
+
+    /// A non-zero ExitStatus, built via the platform's own extension trait so
+    /// these tests compile and run on Windows CI too.
+    fn failed_status() -> std::process::ExitStatus {
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::ExitStatusExt;
+            std::process::ExitStatus::from_raw(256)
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::ExitStatusExt;
+            std::process::ExitStatus::from_raw(1)
+        }
+    }
 
     fn failed_output(stderr: &str) -> std::process::Output {
         std::process::Output {
-            status: std::process::ExitStatus::from_raw(256),
+            status: failed_status(),
             stdout: Vec::new(),
             stderr: stderr.as_bytes().to_vec(),
         }

--- a/src-tauri/src/commands/ide/screenshots/playwright.rs
+++ b/src-tauri/src/commands/ide/screenshots/playwright.rs
@@ -504,8 +504,11 @@ const {{ chromium }} = require('playwright');
         // Wait for animations to complete
         await page.waitForTimeout(3000);
 
-        // Take viewport screenshot (not full page)
-        await page.screenshot({{ path: '{}' }});
+        // Take viewport screenshot (not full page). Explicit timeout replaces
+        // Playwright's 30s action default, which slow machines exceeded — the
+        // full-page capture already has this, the viewport one was missed
+        // (issue #568).
+        await page.screenshot({{ path: '{}', timeout: 120000 }});
     }} finally {{
         if (browser) await browser.close();
     }}

--- a/src-tauri/src/commands/ide/screenshots/thumbnail.rs
+++ b/src-tauri/src/commands/ide/screenshots/thumbnail.rs
@@ -336,7 +336,18 @@ pub async fn capture_project_thumbnail(
                         .code()
                         .map(|c| c.to_string())
                         .unwrap_or_else(|| "killed by signal".to_string());
-                    if stdout.is_empty() {
+                    if output.status.success() && stdout.is_empty() {
+                        // Exit 0 + silence + no file: the browser thinks it
+                        // succeeded but nothing landed on disk — seen on
+                        // Windows when rendering fails internally or security
+                        // software intercepts the write (issue #526). Name the
+                        // shape so reports are diagnosable, instead of the
+                        // meaningless "exit code 0, no output".
+                        format!(
+                            "browser exited successfully but wrote no screenshot file at {} — page render failed silently or the file write was blocked",
+                            temp_path.display()
+                        )
+                    } else if stdout.is_empty() {
                         format!("exit code {code}, no output")
                     } else {
                         let snippet: String = stdout.chars().take(300).collect();

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -35,9 +35,10 @@ pub async fn run_with_timeout(
     debug!(cmd = %label, timeout_secs, "spawning external command");
 
     // When the timeout fires, the output() future is dropped — without
-    // kill_on_drop the child would keep running (and e.g. a timed-out
-    // `git diff` keeps grinding a big repo in the background, issue #608;
-    // same class as run_git_net's #556).
+    // kill_on_drop the child would keep running (a timed-out headless-browser
+    // capture lingered forever, issue #510; a timed-out `git diff` keeps
+    // grinding a big repo in the background, issue #608; same class as
+    // run_git_net's #556).
     cmd.kill_on_drop(true);
 
     // Retry transient EAGAIN spawn failures in place (issue #616): the
@@ -612,6 +613,31 @@ mod tests {
             &capped[capped.len().saturating_sub(40)..]
         );
         assert!(capped.chars().count() <= MAX_ERROR_OUTPUT_CHARS + "… (truncated)".len());
+    }
+
+    #[tokio::test]
+    async fn timed_out_child_is_killed_not_orphaned() {
+        // The child would touch the marker at t=2s; the 1s timeout must kill
+        // it (issue #510), so after waiting past t=2s the marker can't exist.
+        let marker = std::env::temp_dir().join(format!(
+            "shipstudio-kill-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c")
+            .arg(format!("sleep 2 && touch '{}'", marker.display()));
+        let err = run_with_timeout(cmd, "orphan probe", 1).await.unwrap_err();
+        assert!(matches!(err, CommandError::Timeout { .. }));
+        tokio::time::sleep(Duration::from_millis(2500)).await;
+        assert!(
+            !marker.exists(),
+            "child survived the timeout and touched the marker"
+        );
+        let _ = std::fs::remove_file(&marker);
     }
 
     #[tokio::test]

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -616,31 +616,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn timed_out_child_is_killed_not_orphaned() {
-        // The child would touch the marker at t=2s; the 1s timeout must kill
-        // it (issue #510), so after waiting past t=2s the marker can't exist.
-        let marker = std::env::temp_dir().join(format!(
-            "shipstudio-kill-test-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        let mut cmd = Command::new("sh");
-        cmd.arg("-c")
-            .arg(format!("sleep 2 && touch '{}'", marker.display()));
-        let err = run_with_timeout(cmd, "orphan probe", 1).await.unwrap_err();
-        assert!(matches!(err, CommandError::Timeout { .. }));
-        tokio::time::sleep(Duration::from_millis(2500)).await;
-        assert!(
-            !marker.exists(),
-            "child survived the timeout and touched the marker"
-        );
-        let _ = std::fs::remove_file(&marker);
-    }
-
-    #[tokio::test]
     async fn run_to_stdout_maps_nonzero_to_process_error() {
         let mut cmd = Command::new("sh");
         cmd.arg("-c").arg("echo err 1>&2; exit 2");


### PR DESCRIPTION
Fixes the four capture bugs still present in v0.18.4 (the five SingletonLock reports from this week are all v0.18.3 echoes of #358, already fixed).

- **#510** — `run_with_timeout` now sets `kill_on_drop`, so a timed-out external process (e.g. a hung headless-browser capture) is killed instead of orphaned. Benefits every CLI call in the app. New test proves the child dies.
- **#527** — Playwright capture outer ceiling 180s → 300s to cover its own worst-case inner budgets (2× 60s goto + 120s full-page stitch); the full-page scroll pass is capped at 40 steps so infinite-scroll pages can't eat the budget.
- **#514** — `page.goto` now retries once on `ERR_CONNECTION_REFUSED` (dev server died in the gap between the TCP readiness check and the capture) after a 2s beat; a refusal that survives the retry maps to `CommandError::Expected` instead of a raw stack trace in telemetry.
- **#526** — the Chrome fallback's exit-0-with-no-file case now reports its actual shape (no screenshot written at the target path) instead of the meaningless "exit code 0, no output".

**Draft on purpose — do not merge until Julian confirms** (also applies to the companion native-snapshot prototype PR).

Fixes #510. Fixes #527. Fixes #514. Fixes #526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Rebased onto main 2026-08-10: the `kill_on_drop` fix landed on main separately via #619 (same change, deduped here). Also folds in #467's explicit `page.screenshot()` timeout for the viewport capture (thanks @heyabdulwahab) — Closes #568.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser screenshot reliability by retrying temporary connection failures.
  * Increased capture time limits for complex or slow-loading pages.
  * Added safeguards to prevent excessively long full-page scrolling.
  * Improved diagnostics when a browser exits without producing a screenshot, including the expected file location.
  * Clarified handling of screenshot capture failures and timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->