### PR TITLE
Native preview thumbnails: snapshot the app's own webview instead of headless Chrome (macOS)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -82,5 +82,5 @@ tempfile = "3"
 # macOS-specific dependencies for WebKit JavaScript evaluation
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"
-objc2-foundation = { version = "0.2", features = ["NSString"] }
+objc2-foundation = { version = "0.2", features = ["NSString", "NSGeometry"] }
 block2 = "0.5"

--- a/src-tauri/src/commands/ide/screenshots/mod.rs
+++ b/src-tauri/src/commands/ide/screenshots/mod.rs
@@ -8,16 +8,19 @@
 //! - `playwright` — Playwright environment management, full-page and viewport captures
 //! - `stitch` — stitch multiple screenshots into a single full-page image
 //! - `thumbnail` — project thumbnail capture and retrieval
+//! - `webview_snapshot` — native in-app preview snapshot (no headless browser)
 
 mod base;
 mod playwright;
 mod stitch;
 mod thumbnail;
+mod webview_snapshot;
 
 pub use base::*;
 pub use playwright::*;
 pub use stitch::*;
 pub use thumbnail::*;
+pub use webview_snapshot::*;
 
 /// Quick TCP probe of the dev-server port in `url` (IPv4 and IPv6 — some dev
 /// servers, especially Vite, bind only IPv6; 500ms timeout each). Callers use

--- a/src-tauri/src/commands/ide/screenshots/thumbnail.rs
+++ b/src-tauri/src/commands/ide/screenshots/thumbnail.rs
@@ -32,10 +32,10 @@ static CAPTURES_IN_FLIGHT: LazyLock<Mutex<HashSet<String>>> =
 
 /// RAII claim on a project's capture slot — released on every exit path,
 /// including timeouts and panics.
-struct CaptureClaim(String);
+pub(super) struct CaptureClaim(String);
 
 impl CaptureClaim {
-    fn try_new(project: &Path) -> Option<Self> {
+    pub(super) fn try_new(project: &Path) -> Option<Self> {
         let key = project.to_string_lossy().to_string();
         let mut in_flight = CAPTURES_IN_FLIGHT
             .lock()
@@ -129,7 +129,7 @@ fn browser_failure_detail(stderr: &str) -> Option<String> {
 /// Returns true when the project's metadata marks the thumbnail as
 /// user-supplied — auto-capture must skip these so it doesn't clobber
 /// the upload on the next dev-server boot.
-fn is_thumbnail_locked(project: &Path) -> bool {
+pub(super) fn is_thumbnail_locked(project: &Path) -> bool {
     let metadata_path = project.join(".shipstudio").join("project.json");
     let Ok(contents) = std::fs::read_to_string(&metadata_path) else {
         return false;

--- a/src-tauri/src/commands/ide/screenshots/webview_snapshot.rs
+++ b/src-tauri/src/commands/ide/screenshots/webview_snapshot.rs
@@ -134,7 +134,16 @@ async fn snapshot_webview_region(
 
                 let block = block2::RcBlock::new(
                     move |image: *mut AnyObject, error: *mut AnyObject| {
-                        let _ = tx.send(png_bytes_from_snapshot(image, error));
+                        // A panic here unwinds across the Objective-C block
+                        // boundary and aborts the entire app — degrade any
+                        // internal error to a failed capture instead.
+                        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+                            || png_bytes_from_snapshot(image, error),
+                        ))
+                        .unwrap_or_else(|_| {
+                            Err("internal panic during snapshot conversion".to_string())
+                        });
+                        let _ = tx.send(result);
                     },
                 );
                 let _: () = msg_send![wk, takeSnapshotWithConfiguration: config, completionHandler: &*block];
@@ -203,12 +212,15 @@ unsafe fn png_bytes_from_snapshot(
     if png.is_null() {
         return Err("PNG encoding of the snapshot failed".to_string());
     }
-    let bytes: *const u8 = msg_send![png, bytes];
+    // NB: -[NSData bytes] returns `const void *` (objc type code `^v`) — typing
+    // this as `*const u8` (code `*`) trips objc2's encoding verification and
+    // panics in debug builds.
+    let bytes: *const std::ffi::c_void = msg_send![png, bytes];
     let len: usize = msg_send![png, length];
     if bytes.is_null() || len == 0 {
         return Err("PNG encoding produced empty data".to_string());
     }
-    Ok(std::slice::from_raw_parts(bytes, len).to_vec())
+    Ok(std::slice::from_raw_parts(bytes.cast::<u8>(), len).to_vec())
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/src-tauri/src/commands/ide/screenshots/webview_snapshot.rs
+++ b/src-tauri/src/commands/ide/screenshots/webview_snapshot.rs
@@ -1,0 +1,262 @@
+//! Native in-app thumbnail capture: snapshot the preview region of the app's
+//! own webview instead of spawning a headless browser.
+//!
+//! Why: every recurring thumbnail failure class — Chromium SingletonLock
+//! collisions (#358 + ~70 duplicates), crashpad pipe races (#421/#422),
+//! updater/GCM noise (#498–#500), silent exit-0 captures (#526), orphaned
+//! timed-out processes (#510), "no browser installed" — comes from shelling
+//! out to an external browser to re-render a page the app is *already
+//! displaying*. Snapshotting our own webview has none of those failure modes,
+//! needs no Screen Recording permission (it renders in-process, unlike the
+//! `screencapture` path), and costs no per-capture browser launch.
+//!
+//! macOS-only for now (`WKWebView takeSnapshot`). Other platforms return an
+//! Expected error so the frontend silently falls back to the headless path;
+//! Windows can follow via WebView2 `CapturePreview`.
+
+use crate::errors::CommandError;
+use crate::utils::validate_project_path;
+use serde::Deserialize;
+
+use super::thumbnail::{is_thumbnail_locked, CaptureClaim};
+
+/// The preview pane's on-screen rectangle in CSS pixels, relative to the
+/// webview's top-left — exactly what `getBoundingClientRect()` reports.
+/// WKWebView is a flipped view, so its snapshot coordinate space matches.
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub struct SnapshotRect {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+impl SnapshotRect {
+    fn validate(&self) -> Result<(), CommandError> {
+        let finite = [self.x, self.y, self.width, self.height]
+            .iter()
+            .all(|v| v.is_finite());
+        if !finite || self.width < 50.0 || self.height < 50.0 {
+            return Err(CommandError::expected(format!(
+                "Preview region too small or invalid for a thumbnail snapshot ({}x{})",
+                self.width, self.height
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Capture the preview region of the calling window's webview and save it as
+/// the project thumbnail. Returns the thumbnail path, mirroring
+/// `capture_project_thumbnail` so callers can treat the two paths uniformly.
+#[tauri::command]
+#[tracing::instrument(skip(webview_window), fields(project = %project_path))]
+pub async fn capture_thumbnail_from_webview(
+    webview_window: tauri::WebviewWindow,
+    project_path: String,
+    rect: SnapshotRect,
+) -> Result<String, CommandError> {
+    let project = validate_project_path(&project_path)?;
+    rect.validate()?;
+
+    // Same claim as the headless path — both write the same thumbnail.png,
+    // and a native snapshot racing a slow headless capture must not
+    // interleave writes.
+    let Some(_claim) = CaptureClaim::try_new(&project) else {
+        return Err(CommandError::expected(
+            "A thumbnail capture for this project is already in progress",
+        ));
+    };
+
+    if is_thumbnail_locked(&project) {
+        let thumbnail_path = project.join(".shipstudio").join("thumbnail.png");
+        tracing::info!("Skipping native snapshot; custom thumbnail in place");
+        return Ok(thumbnail_path.to_string_lossy().to_string());
+    }
+
+    let png_bytes = snapshot_webview_region(&webview_window, rect).await?;
+
+    let shipstudio_dir = project.join(".shipstudio");
+    if !shipstudio_dir.exists() {
+        std::fs::create_dir_all(&shipstudio_dir)
+            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
+    }
+    let thumbnail_path = shipstudio_dir.join("thumbnail.png");
+    std::fs::write(&thumbnail_path, &png_bytes)
+        .map_err(|e| format!("Failed to write thumbnail: {e}"))?;
+    // A Retina snapshot comes back at 2x pixels; normalize to the same 640px
+    // width the headless path produces so the dashboard renders consistently.
+    crate::commands::ide::resize_thumbnail_image(&thumbnail_path, 640);
+
+    tracing::info!("Thumbnail captured via native webview snapshot");
+    Ok(thumbnail_path.to_string_lossy().to_string())
+}
+
+#[cfg(target_os = "macos")]
+async fn snapshot_webview_region(
+    webview_window: &tauri::WebviewWindow,
+    rect: SnapshotRect,
+) -> Result<Vec<u8>, CommandError> {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+    use objc2_foundation::{CGPoint, CGRect, CGSize};
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Result<Vec<u8>, String>>();
+
+    webview_window
+        .with_webview(move |webview| {
+            // Runs on the main thread. All Obj-C work happens here; only the
+            // finished PNG bytes cross back to the async command.
+            let wk: *mut AnyObject = webview.inner().cast();
+            if wk.is_null() {
+                let _ = tx.send(Err("webview handle is null".to_string()));
+                return;
+            }
+            unsafe {
+                let config: *mut AnyObject = msg_send![class!(WKSnapshotConfiguration), new];
+                let cg_rect = CGRect {
+                    origin: CGPoint {
+                        x: rect.x,
+                        y: rect.y,
+                    },
+                    size: CGSize {
+                        width: rect.width,
+                        height: rect.height,
+                    },
+                };
+                let _: () = msg_send![config, setRect: cg_rect];
+                // Ask WebKit to hand back a pre-scaled image: 640pt wide, the
+                // dashboard thumbnail size. (Retina still doubles the pixels;
+                // resize_thumbnail_image normalizes after the write.)
+                let width_num: *mut AnyObject =
+                    msg_send![class!(NSNumber), numberWithDouble: 640.0f64];
+                let _: () = msg_send![config, setSnapshotWidth: width_num];
+
+                let block = block2::RcBlock::new(
+                    move |image: *mut AnyObject, error: *mut AnyObject| {
+                        let _ = tx.send(png_bytes_from_snapshot(image, error));
+                    },
+                );
+                let _: () = msg_send![wk, takeSnapshotWithConfiguration: config, completionHandler: &*block];
+                let _: () = msg_send![config, release];
+            }
+        })
+        .map_err(|e| CommandError::from(format!("Could not reach the app webview: {e}")))?;
+
+    // WebKit renders snapshots in-process off the live layer tree — normally
+    // milliseconds. The ceiling only guards a wedged web process.
+    match tokio::time::timeout(std::time::Duration::from_secs(10), rx.recv()).await {
+        Ok(Some(Ok(bytes))) => Ok(bytes),
+        Ok(Some(Err(message))) => Err(CommandError::from(format!(
+            "Webview snapshot failed: {message}"
+        ))),
+        Ok(None) => Err(CommandError::from(
+            "Webview snapshot callback dropped without a result".to_string(),
+        )),
+        Err(_) => Err(CommandError::from(
+            "Webview snapshot timed out after 10s".to_string(),
+        )),
+    }
+}
+
+/// Convert the `takeSnapshot` completion values into PNG bytes.
+///
+/// # Safety
+/// Must be called with the (possibly null) `NSImage*` / `NSError*` pointers
+/// exactly as delivered by WebKit's completion handler, on the main thread.
+#[cfg(target_os = "macos")]
+unsafe fn png_bytes_from_snapshot(
+    image: *mut objc2::runtime::AnyObject,
+    error: *mut objc2::runtime::AnyObject,
+) -> Result<Vec<u8>, String> {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+
+    if image.is_null() {
+        if error.is_null() {
+            return Err("snapshot returned neither image nor error".to_string());
+        }
+        let desc: *mut AnyObject = msg_send![error, localizedDescription];
+        if desc.is_null() {
+            return Err("snapshot failed with an undescribed error".to_string());
+        }
+        let utf8: *const std::os::raw::c_char = msg_send![desc, UTF8String];
+        if utf8.is_null() {
+            return Err("snapshot failed with an undescribed error".to_string());
+        }
+        return Err(std::ffi::CStr::from_ptr(utf8)
+            .to_string_lossy()
+            .into_owned());
+    }
+
+    let tiff: *mut AnyObject = msg_send![image, TIFFRepresentation];
+    if tiff.is_null() {
+        return Err("snapshot image produced no TIFF data".to_string());
+    }
+    let rep: *mut AnyObject = msg_send![class!(NSBitmapImageRep), imageRepWithData: tiff];
+    if rep.is_null() {
+        return Err("could not decode snapshot bitmap".to_string());
+    }
+    let props: *mut AnyObject = msg_send![class!(NSDictionary), dictionary];
+    // 4 == NSBitmapImageFileTypePNG
+    let png: *mut AnyObject = msg_send![rep, representationUsingType: 4usize, properties: props];
+    if png.is_null() {
+        return Err("PNG encoding of the snapshot failed".to_string());
+    }
+    let bytes: *const u8 = msg_send![png, bytes];
+    let len: usize = msg_send![png, length];
+    if bytes.is_null() || len == 0 {
+        return Err("PNG encoding produced empty data".to_string());
+    }
+    Ok(std::slice::from_raw_parts(bytes, len).to_vec())
+}
+
+#[cfg(not(target_os = "macos"))]
+async fn snapshot_webview_region(
+    _webview_window: &tauri::WebviewWindow,
+    _rect: SnapshotRect,
+) -> Result<Vec<u8>, CommandError> {
+    // Expected: the frontend probes this path first on every platform and
+    // falls back to the headless capture when it isn't available.
+    Err(CommandError::expected(
+        "Native webview snapshot is not supported on this platform yet",
+    ))
+}
+
+#[cfg(test)]
+mod rect_tests {
+    use super::*;
+
+    #[test]
+    fn tiny_or_invalid_rects_are_rejected_as_expected() {
+        let too_small = SnapshotRect {
+            x: 0.0,
+            y: 0.0,
+            width: 40.0,
+            height: 300.0,
+        };
+        assert!(matches!(
+            too_small.validate(),
+            Err(CommandError::Expected { .. })
+        ));
+
+        let nan = SnapshotRect {
+            x: f64::NAN,
+            y: 0.0,
+            width: 800.0,
+            height: 600.0,
+        };
+        assert!(nan.validate().is_err());
+    }
+
+    #[test]
+    fn normal_preview_rect_passes() {
+        let rect = SnapshotRect {
+            x: 320.5,
+            y: 48.0,
+            width: 900.0,
+            height: 640.0,
+        };
+        assert!(rect.validate().is_ok());
+    }
+}

--- a/src-tauri/src/commands/ide/screenshots/webview_snapshot.rs
+++ b/src-tauri/src/commands/ide/screenshots/webview_snapshot.rs
@@ -82,14 +82,92 @@ pub async fn capture_thumbnail_from_webview(
             .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
     }
     let thumbnail_path = shipstudio_dir.join("thumbnail.png");
-    std::fs::write(&thumbnail_path, &png_bytes)
-        .map_err(|e| format!("Failed to write thumbnail: {e}"))?;
+    // The iframe's layout box can extend a few CSS pixels past its rendered
+    // page, leaking a sliver of the app's dark background into the snapshot
+    // edge (observed: ~10px of --bg-primary on the right). Trim near-uniform
+    // edge slivers before saving; the per-edge cap keeps real content safe.
+    match image::load_from_memory(&png_bytes) {
+        Ok(img) => {
+            let trimmed = trim_uniform_edges(img);
+            trimmed
+                .save(&thumbnail_path)
+                .map_err(|e| format!("Failed to save thumbnail: {e}"))?;
+        }
+        Err(_) => {
+            std::fs::write(&thumbnail_path, &png_bytes)
+                .map_err(|e| format!("Failed to write thumbnail: {e}"))?;
+        }
+    }
     // A Retina snapshot comes back at 2x pixels; normalize to the same 640px
     // width the headless path produces so the dashboard renders consistently.
     crate::commands::ide::resize_thumbnail_image(&thumbnail_path, 640);
 
     tracing::info!("Thumbnail captured via native webview snapshot");
     Ok(thumbnail_path.to_string_lossy().to_string())
+}
+
+/// Max per-channel spread within a row/column for it to count as a uniform
+/// sliver (tolerates anti-aliased boundary pixels; real content spreads far
+/// wider — the observed background sliver measured spread ≤ 12).
+const EDGE_UNIFORMITY_SPREAD: u8 = 16;
+/// Per-edge trim cap as a fraction of the dimension. Big enough for the
+/// observed ~10px background sliver, small enough that a legitimately
+/// uniform page region only ever loses an invisible sliver of itself.
+const EDGE_TRIM_CAP_FRACTION: f32 = 0.03;
+
+/// Trim near-uniform slivers from the snapshot's edges. Each edge is trimmed
+/// while its outermost row/column is a single flat color, up to the cap.
+fn trim_uniform_edges(img: image::DynamicImage) -> image::DynamicImage {
+    let rgb = img.to_rgb8();
+    let (w, h) = rgb.dimensions();
+    if w < 40 || h < 40 {
+        return img;
+    }
+
+    let col_uniform = |x: u32, y0: u32, y1: u32| -> bool {
+        let (mut min, mut max) = ([255u8; 3], [0u8; 3]);
+        for y in y0..y1 {
+            let p = rgb.get_pixel(x, y).0;
+            for c in 0..3 {
+                min[c] = min[c].min(p[c]);
+                max[c] = max[c].max(p[c]);
+            }
+        }
+        (0..3).all(|c| max[c] - min[c] <= EDGE_UNIFORMITY_SPREAD)
+    };
+    let row_uniform = |y: u32, x0: u32, x1: u32| -> bool {
+        let (mut min, mut max) = ([255u8; 3], [0u8; 3]);
+        for x in x0..x1 {
+            let p = rgb.get_pixel(x, y).0;
+            for c in 0..3 {
+                min[c] = min[c].min(p[c]);
+                max[c] = max[c].max(p[c]);
+            }
+        }
+        (0..3).all(|c| max[c] - min[c] <= EDGE_UNIFORMITY_SPREAD)
+    };
+
+    let cap_x = ((w as f32) * EDGE_TRIM_CAP_FRACTION) as u32;
+    let cap_y = ((h as f32) * EDGE_TRIM_CAP_FRACTION) as u32;
+
+    let (mut left, mut right, mut top, mut bottom) = (0u32, 0u32, 0u32, 0u32);
+    while right < cap_x && col_uniform(w - 1 - right, 0, h) {
+        right += 1;
+    }
+    while left < cap_x && col_uniform(left, 0, h) {
+        left += 1;
+    }
+    while bottom < cap_y && row_uniform(h - 1 - bottom, 0, w) {
+        bottom += 1;
+    }
+    while top < cap_y && row_uniform(top, 0, w) {
+        top += 1;
+    }
+
+    if left + right == 0 && top + bottom == 0 {
+        return img;
+    }
+    img.crop_imm(left, top, w - left - right, h - top - bottom)
 }
 
 #[cfg(target_os = "macos")]
@@ -233,6 +311,65 @@ async fn snapshot_webview_region(
     Err(CommandError::expected(
         "Native webview snapshot is not supported on this platform yet",
     ))
+}
+
+#[cfg(test)]
+mod trim_tests {
+    use super::*;
+    use image::{DynamicImage, Rgb, RgbImage};
+
+    /// Noisy "content" image: checkerboard so no row/column is uniform.
+    fn content_image(w: u32, h: u32) -> RgbImage {
+        RgbImage::from_fn(w, h, |x, y| {
+            if (x + y) % 2 == 0 {
+                Rgb([240, 238, 230])
+            } else {
+                Rgb([40, 60, 90])
+            }
+        })
+    }
+
+    #[test]
+    fn dark_right_sliver_is_trimmed() {
+        // Reproduces the observed bug: ~10px of app background (30,30,30)
+        // on the right edge of an 800x600 snapshot.
+        let mut img = content_image(800, 600);
+        for x in 790..800 {
+            for y in 0..600 {
+                img.put_pixel(x, y, Rgb([30, 30, 30]));
+            }
+        }
+        let out = trim_uniform_edges(DynamicImage::ImageRgb8(img));
+        assert_eq!(out.width(), 790, "sliver columns must be removed");
+        assert_eq!(out.height(), 600);
+    }
+
+    #[test]
+    fn clean_content_is_untouched() {
+        let out = trim_uniform_edges(DynamicImage::ImageRgb8(content_image(640, 480)));
+        assert_eq!((out.width(), out.height()), (640, 480));
+    }
+
+    #[test]
+    fn uniform_page_only_loses_capped_sliver() {
+        // A fully flat page (e.g. a solid splash screen) must survive — the
+        // per-edge cap stops the trim from eating the whole image.
+        let img = RgbImage::from_pixel(600, 400, Rgb([250, 250, 250]));
+        let out = trim_uniform_edges(DynamicImage::ImageRgb8(img));
+        assert!(out.width() >= 564, "width {} trimmed past cap", out.width());
+        assert!(
+            out.height() >= 376,
+            "height {} trimmed past cap",
+            out.height()
+        );
+    }
+
+    #[test]
+    fn tiny_images_are_left_alone() {
+        let img = RgbImage::from_pixel(30, 30, Rgb([30, 30, 30]));
+        let out = trim_uniform_edges(DynamicImage::ImageRgb8(img));
+        assert_eq!((out.width(), out.height()), (30, 30));
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -499,6 +499,7 @@ pub fn run() {
             commands::ide::check_preview_can_scroll,
             commands::ide::open_studio_window,
             commands::ide::capture_project_thumbnail,
+            commands::ide::capture_thumbnail_from_webview,
             commands::ide::capture_fullpage_playwright,
             commands::ide::capture_viewport_playwright,
             commands::ide::get_project_thumbnail,

--- a/src/hooks/useScreenshotManagement.ts
+++ b/src/hooks/useScreenshotManagement.ts
@@ -13,6 +13,7 @@ import { trackEvent } from '../lib/analytics';
 import { getThumbnailsEnabled, setThumbnailsEnabled } from '../lib/settings';
 import { decideAutoCapture, isPermissionDenialError } from '../lib/thumbnailGate';
 import { asCommandError, formatCommandError } from '../lib/errors';
+import { captureThumbnailFromPreview } from '../lib/previewSnapshot';
 
 /** Backend rejection meaning the project's root directory no longer exists
  *  (deleted, renamed, or moved while its session stayed hot). Permanent for
@@ -185,6 +186,17 @@ export function useScreenshotManagement({
           pendingConsentCaptureRef.current = { projectPath, sessionId };
           setShowThumbnailConsent(true);
         }
+        return;
+      }
+      // Preferred path: snapshot the preview straight out of the app's own
+      // webview — no headless browser, none of its failure modes. Falls
+      // through to the headless path when unavailable (non-macOS, preview
+      // hidden/covered, backend error). Never throws.
+      if (await captureThumbnailFromPreview(projectPath)) {
+        logger.info('[Thumbnail] Captured via native webview snapshot', {
+          projectPath,
+          attempt,
+        });
         return;
       }
       try {

--- a/src/lib/previewSnapshot.test.ts
+++ b/src/lib/previewSnapshot.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { previewSnapshotRect } from './previewSnapshot';
+
+function mountPreviewIframe(rect: Partial<DOMRect>): HTMLIFrameElement {
+  const iframe = document.createElement('iframe');
+  iframe.className = 'preview-iframe';
+  iframe.getBoundingClientRect = () =>
+    ({
+      left: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      x: rect.left ?? 0,
+      y: rect.top ?? 0,
+      width: 0,
+      height: 0,
+      toJSON: () => ({}),
+      ...rect,
+    }) as DOMRect;
+  document.body.appendChild(iframe);
+  return iframe;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  // jsdom lacks elementFromPoint by default; individual tests stub it.
+  // @ts-expect-error test cleanup of an optional stub
+  delete document.elementFromPoint;
+});
+
+describe('previewSnapshotRect', () => {
+  it('returns null when no preview iframe is mounted', () => {
+    expect(previewSnapshotRect(document)).toBeNull();
+  });
+
+  it('returns null for a collapsed preview pane', () => {
+    mountPreviewIframe({ left: 100, top: 50, width: 120, height: 80 });
+    expect(previewSnapshotRect(document)).toBeNull();
+  });
+
+  it('returns the on-screen rect for a visible, unobstructed preview', () => {
+    const iframe = mountPreviewIframe({ left: 320, top: 48, width: 400, height: 300 });
+    document.elementFromPoint = () => iframe;
+    expect(previewSnapshotRect(document)).toEqual({
+      x: 320,
+      y: 48,
+      width: 400,
+      height: 300,
+    });
+  });
+
+  it('returns null when an overlay covers the preview center', () => {
+    mountPreviewIframe({ left: 320, top: 48, width: 400, height: 300 });
+    const overlay = document.createElement('div');
+    document.body.appendChild(overlay);
+    document.elementFromPoint = () => overlay;
+    expect(previewSnapshotRect(document)).toBeNull();
+  });
+
+  it('treats a null elementFromPoint probe as unobstructed', () => {
+    mountPreviewIframe({ left: 320, top: 48, width: 400, height: 300 });
+    document.elementFromPoint = () => null;
+    expect(previewSnapshotRect(document)).not.toBeNull();
+  });
+
+  it('returns null when the preview center is scrolled off-screen', () => {
+    const iframe = mountPreviewIframe({
+      left: window.innerWidth + 10,
+      top: 48,
+      width: 400,
+      height: 300,
+    });
+    document.elementFromPoint = () => iframe;
+    expect(previewSnapshotRect(document)).toBeNull();
+  });
+});

--- a/src/lib/previewSnapshot.ts
+++ b/src/lib/previewSnapshot.ts
@@ -37,16 +37,26 @@ const MIN_SNAPSHOT_HEIGHT = 150;
  */
 export function previewSnapshotRect(doc: Document = document): SnapshotRect | null {
   const iframe = doc.querySelector<HTMLIFrameElement>(PREVIEW_IFRAME_SELECTOR);
-  if (!iframe) return null;
+  if (!iframe) {
+    logger.info('[Thumbnail] Native snapshot declined: no preview iframe mounted');
+    return null;
+  }
 
   const rect = iframe.getBoundingClientRect();
-  if (rect.width < MIN_SNAPSHOT_WIDTH || rect.height < MIN_SNAPSHOT_HEIGHT) return null;
+  if (rect.width < MIN_SNAPSHOT_WIDTH || rect.height < MIN_SNAPSHOT_HEIGHT) {
+    logger.info('[Thumbnail] Native snapshot declined: preview too small', {
+      width: rect.width,
+      height: rect.height,
+    });
+    return null;
+  }
 
   const win = doc.defaultView;
   if (!win) return null;
   const centerX = rect.left + rect.width / 2;
   const centerY = rect.top + rect.height / 2;
   if (centerX < 0 || centerY < 0 || centerX > win.innerWidth || centerY > win.innerHeight) {
+    logger.info('[Thumbnail] Native snapshot declined: preview center off-screen');
     return null;
   }
 
@@ -55,7 +65,12 @@ export function previewSnapshotRect(doc: Document = document): SnapshotRect | nu
   // overlay (modal, dropdown, edit-mode chrome) is covering it. A null
   // result (jsdom, exotic edge cases) is treated as clear.
   const topmost = doc.elementFromPoint(centerX, centerY);
-  if (topmost && topmost !== iframe) return null;
+  if (topmost && topmost !== iframe) {
+    logger.info('[Thumbnail] Native snapshot declined: preview covered by overlay', {
+      coveredBy: `${topmost.tagName.toLowerCase()}.${String(topmost.className).slice(0, 60)}`,
+    });
+    return null;
+  }
 
   return { x: rect.left, y: rect.top, width: rect.width, height: rect.height };
 }
@@ -66,7 +81,10 @@ export function previewSnapshotRect(doc: Document = document): SnapshotRect | nu
  * headless capture path. Never throws.
  */
 export async function captureThumbnailFromPreview(projectPath: string): Promise<boolean> {
-  if (document.hidden) return false;
+  if (document.hidden) {
+    logger.info('[Thumbnail] Native snapshot declined: window hidden/occluded');
+    return false;
+  }
   const rect = previewSnapshotRect();
   if (!rect) return false;
 
@@ -82,6 +100,9 @@ export async function captureThumbnailFromPreview(projectPath: string): Promise<
       message.includes('not supported on this platform') ||
       message.includes('already in progress') ||
       message.includes('too small or invalid');
+    if (quietFallback) {
+      logger.info('[Thumbnail] Native snapshot declined by backend', { reason: message });
+    }
     if (!quietFallback) {
       logger.warn('[Thumbnail] Native webview snapshot failed, falling back to headless', {
         error: message,

--- a/src/lib/previewSnapshot.ts
+++ b/src/lib/previewSnapshot.ts
@@ -1,0 +1,92 @@
+/**
+ * Native in-app thumbnail capture: snapshot the preview pane straight out of
+ * the app's own webview (WKWebView takeSnapshot on macOS) instead of spawning
+ * a headless browser against the dev server.
+ *
+ * This is the preferred thumbnail path — it has none of the external-browser
+ * failure modes (profile locks, crashpad races, missing browsers, zombie
+ * processes) and costs no per-capture browser launch. When it can't run
+ * (platform unsupported, preview hidden or covered), callers fall back to the
+ * headless `capture_project_thumbnail` path.
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+import { logger } from './logger';
+import { asCommandError, formatCommandError } from './errors';
+
+export interface SnapshotRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Selector for the live preview iframe rendered by Preview.tsx. */
+const PREVIEW_IFRAME_SELECTOR = 'iframe.preview-iframe';
+
+/** Below this on-screen size a snapshot would make a useless thumbnail —
+ *  matches the backend's own floor. */
+const MIN_SNAPSHOT_WIDTH = 200;
+const MIN_SNAPSHOT_HEIGHT = 150;
+
+/**
+ * Compute the preview pane's snapshot rect, or null when a snapshot taken now
+ * would be wrong: preview unmounted, collapsed, scrolled off-screen, or
+ * covered by an overlay (a modal over the preview would be baked into the
+ * thumbnail — the app UI is part of the same webview content).
+ */
+export function previewSnapshotRect(doc: Document = document): SnapshotRect | null {
+  const iframe = doc.querySelector<HTMLIFrameElement>(PREVIEW_IFRAME_SELECTOR);
+  if (!iframe) return null;
+
+  const rect = iframe.getBoundingClientRect();
+  if (rect.width < MIN_SNAPSHOT_WIDTH || rect.height < MIN_SNAPSHOT_HEIGHT) return null;
+
+  const win = doc.defaultView;
+  if (!win) return null;
+  const centerX = rect.left + rect.width / 2;
+  const centerY = rect.top + rect.height / 2;
+  if (centerX < 0 || centerY < 0 || centerX > win.innerWidth || centerY > win.innerHeight) {
+    return null;
+  }
+
+  // Occlusion probe: from the parent document, the topmost element at the
+  // preview's center should be the iframe itself. Anything else means an
+  // overlay (modal, dropdown, edit-mode chrome) is covering it. A null
+  // result (jsdom, exotic edge cases) is treated as clear.
+  const topmost = doc.elementFromPoint(centerX, centerY);
+  if (topmost && topmost !== iframe) return null;
+
+  return { x: rect.left, y: rect.top, width: rect.width, height: rect.height };
+}
+
+/**
+ * Try to capture the project thumbnail via the native webview snapshot.
+ * Returns true on success; false whenever the caller should fall back to the
+ * headless capture path. Never throws.
+ */
+export async function captureThumbnailFromPreview(projectPath: string): Promise<boolean> {
+  if (document.hidden) return false;
+  const rect = previewSnapshotRect();
+  if (!rect) return false;
+
+  try {
+    await invoke('capture_thumbnail_from_webview', { projectPath, rect });
+    return true;
+  } catch (error) {
+    const message = formatCommandError(asCommandError(error));
+    // Known quiet fallbacks (Expected on the backend, which mirrors to a
+    // plain message here): platform unsupported, capture already running,
+    // rect raced to something unusable.
+    const quietFallback =
+      message.includes('not supported on this platform') ||
+      message.includes('already in progress') ||
+      message.includes('too small or invalid');
+    if (!quietFallback) {
+      logger.warn('[Thumbnail] Native webview snapshot failed, falling back to headless', {
+        error: message,
+      });
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
Prototype for killing the headless-browser thumbnail architecture — the source of every recurring capture failure class (SingletonLock ×~70 duplicates, crashpad pipe races, updater/GCM noise, silent exit-0 captures, orphaned processes, "no browser installed").

**How it works**
- New `capture_thumbnail_from_webview` command: `WKWebView takeSnapshot` of the preview pane's on-screen rect (the frontend passes `getBoundingClientRect`), written to the same `.shipstudio/thumbnail.png`.
- `useScreenshotManagement` tries the native path first on every auto-capture (preview-ready + 5-minute timer); any unavailability silently falls back to the existing headless path.
- Occlusion probe (`elementFromPoint`) skips the snapshot when a modal/overlay covers the preview — the app UI shares the webview, so it would be baked into the thumbnail.
- Respects the custom-thumbnail lock, the per-project capture claim, and the Settings thumbnails toggle.
- Renders in-process: no subprocess, no Chromium profile dirs, **no Screen Recording permission**, no browser launch every 5 minutes per project.
- Windows/Linux: `Expected` error → headless path unchanged. Windows can follow later via WebView2 `CapturePreview`.

**What still uses headless capture:** agent-bridge full-page screenshots (Playwright scroll-and-stitch), non-macOS thumbnails, and thumbnails while the preview is hidden/covered.

**Testing needed before merge** (this is a prototype — snapshot coordinate space needs eyeballing on a real run):
- [ ] Thumbnail appears/refreshes on dashboard after opening a project (macOS)
- [ ] Captured region matches the preview pane exactly (not offset/flipped)
- [ ] Retina output is crisp at 640px
- [ ] Modal open over preview → falls back to headless (no modal baked in)
- [ ] Custom thumbnail stays locked

**Draft on purpose — do not merge until Julian confirms.** Companion quick-fix PR: #529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)