### PR TITLE
Bug-bash round 14: git/gh/spawn hardening, drift-guard edit recovery, expected-state sweep

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -583,6 +583,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,6 +1566,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,10 +2116,25 @@ checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.0",
  "tiff",
+ "zune-core 0.5.1",
+ "zune-jpeg 0.5.15",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -5337,7 +5368,7 @@ dependencies = [
  "half",
  "quick-error",
  "weezl",
- "zune-jpeg",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -7210,12 +7241,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
 name = "zune-jpeg"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
- "zune-core",
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core 0.5.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,7 +38,9 @@ base64 = "0.22"
 url = "2"
 tauri-plugin-screenshots = "2.2.0"
 tauri-plugin-fs = "2"
-image = { version = "0.25.9", default-features = false, features = ["png"] }
+# jpeg/gif/webp: custom thumbnail uploads decode whatever the user drags in
+# (saved back out as PNG); png-only rejected every JPEG upload (issue #561).
+image = { version = "0.25.9", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 tauri-plugin-updater = "2.9.0"
 tauri-plugin-process = "2.3.1"
 tauri-plugin-deep-link = "2"

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -1289,10 +1289,20 @@ pub fn claude_connect_start(
         cmd.env(k, v);
     }
 
-    let mut child = pair
-        .slave
-        .spawn_command(cmd)
-        .map_err(|e| format!("spawn_command: {e}"))?;
+    // Labeled + retried on transient EAGAIN; a persistent one is classified
+    // Expected instead of a bare "spawn_command: os error 35" (issue #587).
+    let mut child =
+        crate::external_command::retry_spawn_on_pressure("claude setup-token", || {
+            pair.slave.spawn_command(cmd.clone())
+        })
+        .map_err(|e| {
+            let message = format!("spawn_command `claude setup-token`: {e}");
+            if crate::external_command::is_spawn_resource_pressure(&message) {
+                crate::external_command::spawn_resource_pressure_error("claude setup-token")
+            } else {
+                CommandError::from(message)
+            }
+        })?;
     let child_killer = child.clone_killer();
 
     let session = Arc::new(ConnectSession {
@@ -1648,10 +1658,20 @@ pub fn workspace_connect_start(
         cmd.env(k, v);
     }
 
-    let mut child = pair
-        .slave
-        .spawn_command(cmd)
-        .map_err(|e| format!("spawn_command: {e}"))?;
+    // Labeled + retried on transient EAGAIN; a persistent one is classified
+    // Expected instead of a bare "spawn_command: os error 35" (issue #587).
+    let login_label = format!("{} login", svc.binary());
+    let mut child = crate::external_command::retry_spawn_on_pressure(&login_label, || {
+        pair.slave.spawn_command(cmd.clone())
+    })
+    .map_err(|e| {
+        let message = format!("spawn_command `{login_label}`: {e}");
+        if crate::external_command::is_spawn_resource_pressure(&message) {
+            crate::external_command::spawn_resource_pressure_error(&login_label)
+        } else {
+            CommandError::from(message)
+        }
+    })?;
     let child_killer = child.clone_killer();
 
     let session = Arc::new(ConnectSession {

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -1291,18 +1291,17 @@ pub fn claude_connect_start(
 
     // Labeled + retried on transient EAGAIN; a persistent one is classified
     // Expected instead of a bare "spawn_command: os error 35" (issue #587).
-    let mut child =
-        crate::external_command::retry_spawn_on_pressure("claude setup-token", || {
-            pair.slave.spawn_command(cmd.clone())
-        })
-        .map_err(|e| {
-            let message = format!("spawn_command `claude setup-token`: {e}");
-            if crate::external_command::is_spawn_resource_pressure(&message) {
-                crate::external_command::spawn_resource_pressure_error("claude setup-token")
-            } else {
-                CommandError::from(message)
-            }
-        })?;
+    let mut child = crate::external_command::retry_spawn_on_pressure("claude setup-token", || {
+        pair.slave.spawn_command(cmd.clone())
+    })
+    .map_err(|e| {
+        let message = format!("spawn_command `claude setup-token`: {e}");
+        if crate::external_command::is_spawn_resource_pressure(&message) {
+            crate::external_command::spawn_resource_pressure_error("claude setup-token")
+        } else {
+            CommandError::from(message)
+        }
+    })?;
     let child_killer = child.clone_killer();
 
     let session = Arc::new(ConnectSession {

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -177,7 +177,11 @@ async fn run_agent_headless(
                 format!("exit code {:?}: {snippet}", output.status.code())
             }
         } else {
-            stderr.trim().to_string()
+            // Cap like the stdout branch: an agent CLI can dump a whole
+            // session transcript (prompt, diff, paths) to stderr on failure —
+            // forwarding it unbounded is both noise and a data-exposure risk.
+            // The head carries the actual error (issue #578).
+            crate::external_command::truncate_output(&stderr)
         };
         error!("{} CLI failed: {}", agent.display_name, detail);
         return Err(format!("{} CLI failed: {}", agent.display_name, detail).into());

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -33,8 +33,14 @@ const GIT_TIMEOUT_SECS: u64 = 60;
 /// How the active agent can answer a one-shot prompt without a TTY.
 enum HeadlessInvocation {
     /// A real print mode (Claude `--print -p`, Cursor `-p --print`): the
-    /// answer is the process' stdout.
-    PrintMode(Vec<String>),
+    /// answer is the process' stdout. When `stdin_prompt` is set the prompt is
+    /// fed via stdin instead of argv — a prompt carrying a ~40KB diff as a
+    /// single argv element can blow the OS's combined argv+env exec limit
+    /// (E2BIG, "Argument list too long", issue #595).
+    PrintMode {
+        args: Vec<String>,
+        stdin_prompt: Option<String>,
+    },
     /// Codex `exec`: stdout is a session transcript (which echoes the prompt —
     /// unsafe to parse), so the final message is captured via
     /// `--output-last-message` into a temp file instead.
@@ -55,8 +61,17 @@ fn headless_invocation(agent: &AgentConfig, prompt: &str) -> Option<HeadlessInvo
             .iter()
             .map(|f| f.to_string())
             .collect();
-        args.push(prompt.to_string());
-        return Some(HeadlessInvocation::PrintMode(args));
+        // Claude's `-p`/`--print` reads the query from stdin when no
+        // positional argument is given — use that to dodge the argv size
+        // ceiling (issue #595). Cursor's print mode isn't verified to accept
+        // a stdin prompt, so it keeps the positional argument.
+        let stdin_prompt = if agent.id == "claude-code" {
+            Some(prompt.to_string())
+        } else {
+            args.push(prompt.to_string());
+            None
+        };
+        return Some(HeadlessInvocation::PrintMode { args, stdin_prompt });
     }
     if agent.id == "codex" {
         let output_file = std::env::temp_dir().join(format!(
@@ -100,10 +115,12 @@ async fn run_agent_headless(
             agent.display_name
         )
     })?;
-    let (args, output_file) = match &invocation {
-        HeadlessInvocation::PrintMode(args) => (args.clone(), None),
+    let (args, output_file, stdin_prompt) = match &invocation {
+        HeadlessInvocation::PrintMode { args, stdin_prompt } => {
+            (args.clone(), None, stdin_prompt.clone())
+        }
         HeadlessInvocation::CodexExec { args, output_file } => {
-            (args.clone(), Some(output_file.clone()))
+            (args.clone(), Some(output_file.clone()), None)
         }
     };
 
@@ -111,17 +128,22 @@ async fn run_agent_headless(
     cmd.args(&args)
         .env("PATH", get_extended_path())
         .envs(extra_envs)
+        .current_dir(cwd);
+    let label = format!("{} CLI", agent.display_name);
+    let output = if let Some(prompt_data) = &stdin_prompt {
+        // The prompt travels via stdin (piped, written in full, then closed so
+        // the CLI sees EOF) instead of argv — see HeadlessInvocation::PrintMode
+        // (issue #595).
+        let tokio_cmd = tokio::process::Command::from(cmd);
+        crate::external_command::run_with_timeout_stdin(tokio_cmd, prompt_data, label, timeout_secs)
+            .await
+    } else {
         // No TTY here: an EOF'd stdin keeps agents that read it (Codex exec)
         // from waiting on input that will never come.
-        .stdin(std::process::Stdio::null())
-        .current_dir(cwd);
-    let tokio_cmd = tokio::process::Command::from(cmd);
-    let output = run_with_timeout(
-        tokio_cmd,
-        format!("{} CLI", agent.display_name),
-        timeout_secs,
-    )
-    .await;
+        cmd.stdin(std::process::Stdio::null());
+        let tokio_cmd = tokio::process::Command::from(cmd);
+        run_with_timeout(tokio_cmd, label, timeout_secs).await
+    };
 
     // The temp file must not outlive the call, success or not.
     let read_and_cleanup = |file: &Option<PathBuf>| -> Option<String> {
@@ -597,12 +619,30 @@ mod tests {
 
     #[test]
     fn headless_invocation_uses_print_mode_when_available() {
+        // Claude: the prompt must NOT be an argv element (E2BIG on large
+        // diffs, issue #595) — it travels via stdin.
         let inv = headless_invocation(&crate::agent::CLAUDE_CODE, "hello").unwrap();
         match inv {
-            HeadlessInvocation::PrintMode(args) => {
-                assert_eq!(args, vec!["--print", "-p", "hello"]);
+            HeadlessInvocation::PrintMode { args, stdin_prompt } => {
+                assert_eq!(args, vec!["--print", "-p"]);
+                assert_eq!(stdin_prompt.as_deref(), Some("hello"));
             }
             HeadlessInvocation::CodexExec { .. } => panic!("Claude should use print mode"),
+        }
+    }
+
+    #[test]
+    fn headless_invocation_cursor_keeps_argv_prompt() {
+        // Cursor's print mode isn't verified to read the prompt from stdin,
+        // so it keeps the positional argument (and the E2BIG exposure —
+        // revisit if a report ever lands for Cursor).
+        let inv = headless_invocation(&crate::agent::CURSOR, "hello").unwrap();
+        match inv {
+            HeadlessInvocation::PrintMode { args, stdin_prompt } => {
+                assert_eq!(args, vec!["-p", "--print", "hello"]);
+                assert!(stdin_prompt.is_none());
+            }
+            HeadlessInvocation::CodexExec { .. } => panic!("Cursor should use print mode"),
         }
     }
 
@@ -622,7 +662,7 @@ mod tests {
                 // Prompt is the final argument.
                 assert_eq!(args.last().unwrap(), "hello");
             }
-            HeadlessInvocation::PrintMode(_) => panic!("Codex should use exec mode"),
+            HeadlessInvocation::PrintMode { .. } => panic!("Codex should use exec mode"),
         }
     }
 

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -203,11 +203,13 @@ pub async fn generate_pr_description(
     let validated_path = validate_project_path(&project_path)?;
 
     let agent = get_active_agent();
+    // A missing agent binary is an "install X first" environment state, not a
+    // malfunction — Expected keeps it out of telemetry (issue #548).
     let agent_path = find_agent_binary().ok_or_else(|| {
-        format!(
+        CommandError::expected(format!(
             "{} CLI is not installed. Install {} to use AI generation.",
             agent.display_name, agent.display_name
-        )
+        ))
     })?;
 
     info!(
@@ -489,8 +491,11 @@ pub async fn generate_commit_message_for_path(
         .into());
     }
 
-    let agent_path = find_agent_binary()
-        .ok_or_else(|| format!("{} CLI is not installed", agent.display_name))?;
+    // Same "install X first" state as generate_pr_description — Expected,
+    // never telemetry (issue #548); resolve_commit_message falls back anyway.
+    let agent_path = find_agent_binary().ok_or_else(|| {
+        CommandError::expected(format!("{} CLI is not installed", agent.display_name))
+    })?;
 
     // Cheap guard: if nothing changed, skip the agent call entirely.
     let status = git_status_porcelain(path)?;

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -515,8 +515,26 @@ pub async fn generate_commit_message_for_path(
         HashMap::new(),
         COMMIT_MSG_CLI_TIMEOUT_SECS,
     )
-    .await?;
+    .await
+    .map_err(soften_commit_timeout)?;
     parse_commit_message(&response).map_err(CommandError::from)
+}
+
+/// The 30s commit-message budget covers the whole CLI run (spawn, the agent's
+/// own startup/auth checks, generation), so a cold start or slow disk can blow
+/// it even for a tiny prompt — and the publish flow already swallows the error
+/// and falls back to [`DEFAULT_COMMIT_MESSAGE`]. That's a best-effort feature
+/// degrading as designed, not a malfunction: map `Timeout` to `Expected` (kept
+/// out of telemetry) and log at warn (issue #565). Other errors pass through
+/// unchanged.
+fn soften_commit_timeout(err: CommandError) -> CommandError {
+    match err {
+        CommandError::Timeout { cmd, secs } => {
+            warn!(cmd = %cmd, secs, "commit-message generation timed out; falling back to the default message");
+            CommandError::expected(format!("`{cmd}` timed out after {secs}s"))
+        }
+        other => other,
+    }
 }
 
 fn git_status_porcelain(path: &std::path::Path) -> Result<String, CommandError> {
@@ -676,6 +694,29 @@ mod tests {
         // Opencode has no headless mode — callers must show a friendly error
         // instead of spawning an interactive session ("stdin is not a terminal").
         assert!(headless_invocation(&crate::agent::OPENCODE, "hello").is_none());
+    }
+
+    // The #565 shape: a commit-message CLI timeout is best-effort noise (the
+    // caller falls back to the default message) — Expected, not telemetry.
+    #[test]
+    fn soften_commit_timeout_maps_timeout_to_expected() {
+        let softened = soften_commit_timeout(CommandError::Timeout {
+            cmd: "Claude Code CLI".into(),
+            secs: 30,
+        });
+        assert!(matches!(softened, CommandError::Expected { .. }));
+        assert_eq!(
+            softened.to_string(),
+            "`Claude Code CLI` timed out after 30s"
+        );
+    }
+
+    #[test]
+    fn soften_commit_timeout_passes_other_errors_through() {
+        let other = soften_commit_timeout(CommandError::Other {
+            message: "boom".into(),
+        });
+        assert!(matches!(other, CommandError::Other { .. }));
     }
 
     #[test]

--- a/src-tauri/src/commands/git/branches.rs
+++ b/src-tauri/src/commands/git/branches.rs
@@ -518,9 +518,14 @@ pub async fn create_branch(
                 || stderr.contains("commit your changes or stash")
             {
                 warn!(error = %stderr, "Branch creation blocked by uncommitted changes");
-            } else {
-                error!(error = %stderr, "Failed to create branch");
+                // Everyday user state, not a malfunction — Expected keeps it
+                // out of telemetry while preserving the stderr text verbatim
+                // (BranchesTab/humanizeGitError match its wording). Covers
+                // both the tracked-file and untracked-file ("untracked working
+                // tree files would be overwritten") variants (issue #566).
+                return Err(crate::errors::CommandError::expected(stderr.to_string()));
             }
+            error!(error = %stderr, "Failed to create branch");
             return Err((stderr.to_string()).into());
         }
     }

--- a/src-tauri/src/commands/git/branches.rs
+++ b/src-tauri/src/commands/git/branches.rs
@@ -590,6 +590,17 @@ pub async fn push_branch(project_path: String, branch_name: String) -> Result<()
     Ok(())
 }
 
+/// Git refusing `branch -D` because the branch is checked out in another
+/// worktree — a by-design guard, not a malfunction (issue #562). Wording
+/// varies across git versions: newer git says "cannot delete branch '…' used
+/// by worktree at '…'", older git says "Cannot delete branch '…' checked out
+/// at '…'".
+fn is_worktree_delete_refusal(stderr: &str) -> bool {
+    let lower = stderr.to_lowercase();
+    lower.contains("cannot delete branch")
+        && (lower.contains("used by worktree") || lower.contains("checked out at"))
+}
+
 /// Delete a branch (local and optionally remote)
 #[tauri::command]
 #[instrument(name = "delete_branch", skip(project_path), fields(project = %project_path, branch = %branch_name))]
@@ -635,6 +646,19 @@ pub async fn delete_branch(
 
     if !local_output.status.success() {
         let stderr = String::from_utf8_lossy(&local_output.stderr);
+        // Git refuses to delete a branch that's checked out in another
+        // worktree — a by-design guard exactly like the current-branch case
+        // above, not a malfunction. Replace the raw stderr (which leaks the
+        // other worktree's absolute path into the toast) with a clear,
+        // actionable message naming the branch (issue #562).
+        if is_worktree_delete_refusal(&stderr) {
+            warn!(error = %stderr, "Branch delete blocked: checked out in another worktree");
+            return Err(crate::errors::CommandError::expected(format!(
+                "The branch '{branch_name}' is checked out in another worktree, so it can't be \
+                 deleted. Remove that worktree first (Branches → Worktrees), then delete the \
+                 branch."
+            )));
+        }
         if !stderr.contains("not found") {
             return Err((stderr.to_string()).into());
         }
@@ -690,4 +714,35 @@ pub async fn delete_branch(
 
     info!("Branch deleted successfully");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_worktree_delete_refusal;
+
+    // The #562 shape: deleting a branch that another worktree has checked out.
+    #[test]
+    fn worktree_delete_refusal_matches_current_git_wording() {
+        let stderr = "error: cannot delete branch 'acss-prog/data-fetch-stats' used by worktree at '/Users/x/ShipStudio/acss-poc'";
+        assert!(is_worktree_delete_refusal(stderr));
+    }
+
+    #[test]
+    fn worktree_delete_refusal_matches_older_git_wording() {
+        let stderr =
+            "error: Cannot delete branch 'feature/x' checked out at '/Users/x/ShipStudio/proj'";
+        assert!(is_worktree_delete_refusal(stderr));
+    }
+
+    #[test]
+    fn worktree_delete_refusal_ignores_other_delete_failures() {
+        assert!(!is_worktree_delete_refusal(
+            "error: branch 'ghost' not found."
+        ));
+        // Checkout refusal (a *switch* problem, not a delete refusal).
+        assert!(!is_worktree_delete_refusal(
+            "fatal: 'feature/x' is already used by worktree at '/tmp/w'"
+        ));
+        assert!(!is_worktree_delete_refusal(""));
+    }
 }

--- a/src-tauri/src/commands/git/branches.rs
+++ b/src-tauri/src/commands/git/branches.rs
@@ -10,8 +10,9 @@ use std::time::{Duration, Instant};
 use tracing::{debug, error, info, instrument, warn};
 
 // Network git ops (fetch, push --delete) go through the workspace-scoped helper
-// in the parent module so they authenticate as the project's workspace login.
-use super::run_git_net;
+// in the parent module so they authenticate as the project's workspace login;
+// their failures classify through classify_git_net_error (issue #560).
+use super::{classify_git_net_error, run_git_net};
 
 /// Tracks the last time `git fetch` was run per project path.
 /// Prevents redundant network I/O when the frontend polls `list_branches` frequently.
@@ -568,8 +569,17 @@ pub async fn push_branch(project_path: String, branch_name: String) -> Result<()
         let stderr = String::from_utf8_lossy(&output.stderr);
         // An already-published, unchanged branch is a success, not an error.
         if !stderr.contains("Everything up-to-date") {
+            // run_git_net routes credential resolution through gh, so auth
+            // and connectivity failures wear gh/git wording — classify them
+            // as the expected states they are instead of raw telemetry-
+            // reported stderr (issue #560). Classified = environment, so log
+            // at warn (error! auto-files bug reports).
+            if let Some(err) = classify_git_net_error(&stderr) {
+                warn!(error = %stderr, "Publishing branch hit an expected gh/git failure");
+                return Err(err);
+            }
             error!(error = %stderr, "Failed to publish branch");
-            return Err((stderr.to_string()).into());
+            return Err(crate::external_command::truncate_output(&stderr).into());
         }
     }
 
@@ -645,8 +655,18 @@ pub async fn delete_branch(
         if !remote_output.status.success() {
             let stderr = String::from_utf8_lossy(&remote_output.stderr);
             if !stderr.contains("remote ref does not exist") {
+                // Same expected gh/git failure classification as push_branch
+                // (issue #560).
+                if let Some(err) = classify_git_net_error(&stderr) {
+                    warn!(error = %stderr, "Remote branch delete hit an expected gh/git failure");
+                    return Err(err);
+                }
                 error!(error = %stderr, "Failed to delete remote branch");
-                return Err((format!("Failed to delete remote branch: {stderr}")).into());
+                return Err(format!(
+                    "Failed to delete remote branch: {}",
+                    crate::external_command::truncate_output(&stderr)
+                )
+                .into());
             }
         }
 

--- a/src-tauri/src/commands/git/branches.rs
+++ b/src-tauri/src/commands/git/branches.rs
@@ -63,9 +63,14 @@ pub async fn list_branches(project_path: String) -> Result<Vec<BranchInfo>, Comm
     // polled frequently, so a transient spawn failure used to reach telemetry
     // as a bare "os error 35" with no call-site context (issue #555).
     let mut branch_cmd = crate::utils::git_command_in(&validated_path)?;
-    branch_cmd.args(["branch", "-a", "--format=%(refname:short)|%(objectname:short)|%(committerdate:unix)|%(authorname)|%(HEAD)"]);
-    let output =
-        crate::external_command::spawn_with_pressure_retry("git branch -a", || branch_cmd.output())?;
+    branch_cmd.args([
+        "branch",
+        "-a",
+        "--format=%(refname:short)|%(objectname:short)|%(committerdate:unix)|%(authorname)|%(HEAD)",
+    ]);
+    let output = crate::external_command::spawn_with_pressure_retry("git branch -a", || {
+        branch_cmd.output()
+    })?;
 
     if !output.status.success() {
         // Include git's stderr — a bare "Failed to list branches" is
@@ -257,10 +262,10 @@ pub async fn switch_branch(
             "-m",
             &format!("Auto-stash by Ship Studio (from {current_branch})"),
         ]);
-        let stash_output = crate::external_command::spawn_with_pressure_retry(
-            "git stash push",
-            || stash_cmd.output(),
-        )?;
+        let stash_output =
+            crate::external_command::spawn_with_pressure_retry("git stash push", || {
+                stash_cmd.output()
+            })?;
 
         if stash_output.status.success() {
             let stdout = String::from_utf8_lossy(&stash_output.stdout);
@@ -295,9 +300,10 @@ pub async fn switch_branch(
     // Try to checkout the branch
     let mut checkout_cmd = crate::utils::git_command_in(&validated_path)?;
     checkout_cmd.args(["checkout", "--end-of-options", &branch_name]);
-    let checkout_output = crate::external_command::spawn_with_pressure_retry("git checkout", || {
-        checkout_cmd.output()
-    })?;
+    let checkout_output =
+        crate::external_command::spawn_with_pressure_retry("git checkout", || {
+            checkout_cmd.output()
+        })?;
 
     if !checkout_output.status.success() {
         // Checkout failed - restore the stash if we made one

--- a/src-tauri/src/commands/git/branches.rs
+++ b/src-tauri/src/commands/git/branches.rs
@@ -58,11 +58,13 @@ pub async fn list_branches(project_path: String) -> Result<Vec<BranchInfo>, Comm
         });
     }
 
-    // Get all branches (local and remote)
-    let output = crate::utils::git_command_in(&validated_path)?
-        .args(["branch", "-a", "--format=%(refname:short)|%(objectname:short)|%(committerdate:unix)|%(authorname)|%(HEAD)"])
-        .output()
-        .map_err(|e| e.to_string())?;
+    // Get all branches (local and remote). Labeled + EAGAIN-retried: this is
+    // polled frequently, so a transient spawn failure used to reach telemetry
+    // as a bare "os error 35" with no call-site context (issue #555).
+    let mut branch_cmd = crate::utils::git_command_in(&validated_path)?;
+    branch_cmd.args(["branch", "-a", "--format=%(refname:short)|%(objectname:short)|%(committerdate:unix)|%(authorname)|%(HEAD)"]);
+    let output =
+        crate::external_command::spawn_with_pressure_retry("git branch -a", || branch_cmd.output())?;
 
     if !output.status.success() {
         // Include git's stderr — a bare "Failed to list branches" is
@@ -188,10 +190,10 @@ pub async fn get_current_branch(project_path: String) -> Result<String, CommandE
 
     let validated_path = validate_project_path(&project_path)?;
 
-    let output = crate::utils::git_command_in(&validated_path)?
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .output()
-        .map_err(|e| e.to_string())?;
+    let mut head_cmd = crate::utils::git_command_in(&validated_path)?;
+    head_cmd.args(["rev-parse", "--abbrev-ref", "HEAD"]);
+    let output =
+        crate::external_command::spawn_with_pressure_retry("git rev-parse", || head_cmd.output())?;
 
     if !output.status.success() {
         return Err(("Not a git repository".to_string()).into());
@@ -240,15 +242,17 @@ pub async fn switch_branch(
     let has_changes = git_has_any_changes(&validated_path)?;
 
     if has_changes && auto_stash {
-        let stash_output = crate::utils::git_command_in(&validated_path)?
-            .args([
-                "stash",
-                "push",
-                "-m",
-                &format!("Auto-stash by Ship Studio (from {current_branch})"),
-            ])
-            .output()
-            .map_err(|e| e.to_string())?;
+        let mut stash_cmd = crate::utils::git_command_in(&validated_path)?;
+        stash_cmd.args([
+            "stash",
+            "push",
+            "-m",
+            &format!("Auto-stash by Ship Studio (from {current_branch})"),
+        ]);
+        let stash_output = crate::external_command::spawn_with_pressure_retry(
+            "git stash push",
+            || stash_cmd.output(),
+        )?;
 
         if stash_output.status.success() {
             let stdout = String::from_utf8_lossy(&stash_output.stdout);
@@ -281,10 +285,11 @@ pub async fn switch_branch(
     }
 
     // Try to checkout the branch
-    let checkout_output = crate::utils::git_command_in(&validated_path)?
-        .args(["checkout", "--end-of-options", &branch_name])
-        .output()
-        .map_err(|e| e.to_string())?;
+    let mut checkout_cmd = crate::utils::git_command_in(&validated_path)?;
+    checkout_cmd.args(["checkout", "--end-of-options", &branch_name]);
+    let checkout_output = crate::external_command::spawn_with_pressure_retry("git checkout", || {
+        checkout_cmd.output()
+    })?;
 
     if !checkout_output.status.success() {
         // Checkout failed - restore the stash if we made one
@@ -436,10 +441,10 @@ pub async fn create_branch(
     }
 
     // Get the current branch name
-    let current_branch_output = crate::utils::git_command_in(&validated_path)?
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .output()
-        .map_err(|e| e.to_string())?;
+    let mut head_cmd = crate::utils::git_command_in(&validated_path)?;
+    head_cmd.args(["rev-parse", "--abbrev-ref", "HEAD"]);
+    let current_branch_output =
+        crate::external_command::spawn_with_pressure_retry("git rev-parse", || head_cmd.output())?;
 
     let current_branch = String::from_utf8_lossy(&current_branch_output.stdout)
         .trim()
@@ -457,10 +462,11 @@ pub async fn create_branch(
 
     if is_from_current {
         // Create branch from current HEAD (preserves local changes)
-        let output = crate::utils::git_command_in(&validated_path)?
-            .args(["checkout", "-b", &branch_name])
-            .output()
-            .map_err(|e| e.to_string())?;
+        let mut co_cmd = crate::utils::git_command_in(&validated_path)?;
+        co_cmd.args(["checkout", "-b", &branch_name]);
+        let output = crate::external_command::spawn_with_pressure_retry("git checkout -b", || {
+            co_cmd.output()
+        })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -496,10 +502,11 @@ pub async fn create_branch(
             format!("origin/{plain}")
         };
 
-        let output = crate::utils::git_command_in(&validated_path)?
-            .args(["checkout", "-b", &branch_name, &base_ref])
-            .output()
-            .map_err(|e| e.to_string())?;
+        let mut co_cmd = crate::utils::git_command_in(&validated_path)?;
+        co_cmd.args(["checkout", "-b", &branch_name, &base_ref]);
+        let output = crate::external_command::spawn_with_pressure_retry("git checkout -b", || {
+            co_cmd.output()
+        })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -606,10 +613,10 @@ pub async fn delete_branch(
     }
 
     // Get current branch to make sure we're not on it
-    let current = crate::utils::git_command_in(&validated_path)?
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .output()
-        .map_err(|e| e.to_string())?;
+    let mut head_cmd = crate::utils::git_command_in(&validated_path)?;
+    head_cmd.args(["rev-parse", "--abbrev-ref", "HEAD"]);
+    let current =
+        crate::external_command::spawn_with_pressure_retry("git rev-parse", || head_cmd.output())?;
 
     let current_branch = String::from_utf8_lossy(&current.stdout).trim().to_string();
     if current_branch == branch_name {
@@ -621,10 +628,10 @@ pub async fn delete_branch(
     }
 
     // Delete local branch
-    let local_output = crate::utils::git_command_in(&validated_path)?
-        .args(["branch", "-D", "--", &branch_name])
-        .output()
-        .map_err(|e| e.to_string())?;
+    let mut del_cmd = crate::utils::git_command_in(&validated_path)?;
+    del_cmd.args(["branch", "-D", "--", &branch_name]);
+    let local_output =
+        crate::external_command::spawn_with_pressure_retry("git branch -D", || del_cmd.output())?;
 
     if !local_output.status.success() {
         let stderr = String::from_utf8_lossy(&local_output.stderr);

--- a/src-tauri/src/commands/git/branches.rs
+++ b/src-tauri/src/commands/git/branches.rs
@@ -68,6 +68,13 @@ pub async fn list_branches(project_path: String) -> Result<Vec<BranchInfo>, Comm
         // Include git's stderr — a bare "Failed to list branches" is
         // undiagnosable from telemetry (issue #252).
         let stderr = String::from_utf8_lossy(&output.stderr);
+        // Environment gaps (unaccepted Xcode license, missing CLT, macOS TCC
+        // denial) mean git itself can't run — an expected machine state with a
+        // user-side fix, not an app malfunction (issues #603/#546).
+        if let Some(gap) = crate::utils::git_environment_gap(&stderr) {
+            warn!(error = %stderr.trim(), "git blocked by an environment gap while listing branches");
+            return Err(gap);
+        }
         return Err((format!("Failed to list branches: {}", stderr.trim())).into());
     }
 

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -88,6 +88,18 @@ pub(crate) async fn run_git_net(
     run_with_timeout(tokio_cmd, format!("git {label}"), GIT_NETWORK_TIMEOUT_SECS).await
 }
 
+/// Classify a failed [`run_git_net`] invocation's stderr into the expected
+/// gh/git environment states: auth not configured, a connectivity blip,
+/// GitHub's transient HTTP 400, or gh itself crashing. `run_git_net` routes
+/// credential resolution through `gh`, so its failures wear the same wording
+/// the gh classifiers in `commands::github` already cover — call sites must
+/// route through this instead of forwarding raw stderr (issue #560). Returns
+/// `None` for anything genuinely unexplained.
+pub(crate) fn classify_git_net_error(stderr: &str) -> Option<CommandError> {
+    crate::commands::github::gh_auth_error(stderr)
+        .or_else(|| crate::commands::github::gh_common_error(stderr))
+}
+
 // ============ Git Helper Functions ============
 
 /// Checks if there are uncommitted changes (staged or unstaged tracked files).
@@ -480,6 +492,31 @@ mod tests {
     use super::*;
     use std::process::Command;
     use tempfile::TempDir;
+
+    // The #560 shape: a connectivity blip during `git push` (credentials
+    // resolved via gh, so the error text is gh's GraphQL dial failure) must
+    // classify Expected instead of surfacing as raw stderr; auth failures map
+    // to NotAuthenticated; genuinely unexplained pushes stay unclassified.
+    #[test]
+    fn classify_git_net_error_covers_network_auth_and_passthrough() {
+        let net = r#"Post "https://api.github.com/graphql": dial tcp 20.205.243.168:443: connect: connection refused"#;
+        assert!(matches!(
+            classify_git_net_error(net),
+            Some(CommandError::Expected { .. })
+        ));
+        // git's own DNS wording (no gh involved) is covered too.
+        assert!(classify_git_net_error("fatal: unable to access 'https://github.com/o/r.git/': Could not resolve host: github.com").is_some());
+        assert!(matches!(
+            classify_git_net_error("To get started with GitHub CLI, please run:  gh auth login"),
+            Some(CommandError::NotAuthenticated { .. })
+        ));
+        // A real push rejection must NOT be swallowed as expected.
+        assert!(classify_git_net_error(
+            "! [rejected] main -> main (non-fast-forward)\nerror: failed to push some refs"
+        )
+        .is_none());
+        assert!(classify_git_net_error("").is_none());
+    }
 
     /// Initialize a fresh git repo in `dir` with a local user identity so
     /// commits work in CI environments without global git config.

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -91,21 +91,27 @@ pub(crate) async fn run_git_net(
 // ============ Git Helper Functions ============
 
 /// Checks if there are uncommitted changes (staged or unstaged tracked files).
-pub fn git_has_uncommitted_changes(path: &std::path::Path) -> Result<bool, String> {
-    let status = crate::utils::git_command_in(path)?
-        .args(["status", "--porcelain", "-uno"])
-        .output()
-        .map_err(|e| e.to_string())?;
+///
+/// Spawns are labeled and retried on transient EAGAIN — a bare "Resource
+/// temporarily unavailable (os error 35)" with no call-site context was
+/// reaching telemetry from these frequently-polled helpers (issue #555).
+pub fn git_has_uncommitted_changes(
+    path: &std::path::Path,
+) -> Result<bool, crate::errors::CommandError> {
+    let mut cmd = crate::utils::git_command_in(path)?;
+    cmd.args(["status", "--porcelain", "-uno"]);
+    let status =
+        crate::external_command::spawn_with_pressure_retry("git status", || cmd.output())?;
 
     Ok(!String::from_utf8_lossy(&status.stdout).trim().is_empty())
 }
 
 /// Checks if there are any changes (including untracked) in the working directory.
-pub fn git_has_any_changes(path: &std::path::Path) -> Result<bool, String> {
-    let status = crate::utils::git_command_in(path)?
-        .args(["status", "--porcelain"])
-        .output()
-        .map_err(|e| e.to_string())?;
+pub fn git_has_any_changes(path: &std::path::Path) -> Result<bool, crate::errors::CommandError> {
+    let mut cmd = crate::utils::git_command_in(path)?;
+    cmd.args(["status", "--porcelain"]);
+    let status =
+        crate::external_command::spawn_with_pressure_retry("git status", || cmd.output())?;
 
     Ok(!String::from_utf8_lossy(&status.stdout).trim().is_empty())
 }
@@ -184,12 +190,9 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
     // snapshot watcher (and any agent CLI) can hold the lock at the exact
     // moment a commit/publish fires (#377).
     let add_output = crate::utils::output_retrying_index_lock(|| {
-        crate::utils::git_command_in(path)?
-            .args(["add", "-A"])
-            .output()
-            .map_err(|e| crate::errors::CommandError::Io {
-                message: e.to_string(),
-            })
+        let mut cmd = crate::utils::git_command_in(path)?;
+        cmd.args(["add", "-A"]);
+        crate::external_command::spawn_with_pressure_retry("git add", || cmd.output())
     })
     .map_err(String::from)?;
 
@@ -201,10 +204,13 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
         // changes are fine (issue #275). Retry with --sparse, which stages
         // out-of-cone paths instead of refusing.
         if add_stderr.contains("outside of your sparse-checkout definition") {
-            let sparse_output = crate::utils::git_command_in(path)?
-                .args(["add", "-A", "--sparse"])
-                .output()
-                .map_err(|e| e.to_string())?;
+            let mut sparse_cmd = crate::utils::git_command_in(path)?;
+            sparse_cmd.args(["add", "-A", "--sparse"]);
+            let sparse_output = crate::external_command::spawn_with_pressure_retry(
+                "git add --sparse",
+                || sparse_cmd.output(),
+            )
+            .map_err(String::from)?;
             if !sparse_output.status.success() {
                 return Err(String::from_utf8_lossy(&sparse_output.stderr).to_string());
             }
@@ -222,12 +228,9 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
 
     // Commit — same index.lock retry as the staging step (#377).
     let commit_output = crate::utils::output_retrying_index_lock(|| {
-        crate::utils::git_command_in(path)?
-            .args(["commit", "-m", message])
-            .output()
-            .map_err(|e| crate::errors::CommandError::Io {
-                message: e.to_string(),
-            })
+        let mut cmd = crate::utils::git_command_in(path)?;
+        cmd.args(["commit", "-m", message]);
+        crate::external_command::spawn_with_pressure_retry("git commit", || cmd.output())
     })
     .map_err(String::from)?;
 

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -84,7 +84,12 @@ pub(crate) async fn run_git_net(
         .env("GIT_TERMINAL_PROMPT", "0")
         .envs(workspace_env);
 
-    let tokio_cmd = tokio::process::Command::from(cmd);
+    let mut tokio_cmd = tokio::process::Command::from(cmd);
+    // Reap the child when the timeout drops the future — otherwise a hung
+    // git (and its gh credential-helper subprocess) would keep running in the
+    // background, holding .git locks and stalling the next push/fetch too
+    // (issue #556; same pattern as projects/mod.rs et al.).
+    tokio_cmd.kill_on_drop(true);
     run_with_timeout(tokio_cmd, format!("git {label}"), GIT_NETWORK_TIMEOUT_SECS).await
 }
 

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -117,8 +117,7 @@ pub fn git_has_uncommitted_changes(
 ) -> Result<bool, crate::errors::CommandError> {
     let mut cmd = crate::utils::git_command_in(path)?;
     cmd.args(["status", "--porcelain", "-uno"]);
-    let status =
-        crate::external_command::spawn_with_pressure_retry("git status", || cmd.output())?;
+    let status = crate::external_command::spawn_with_pressure_retry("git status", || cmd.output())?;
 
     Ok(!String::from_utf8_lossy(&status.stdout).trim().is_empty())
 }
@@ -127,8 +126,7 @@ pub fn git_has_uncommitted_changes(
 pub fn git_has_any_changes(path: &std::path::Path) -> Result<bool, crate::errors::CommandError> {
     let mut cmd = crate::utils::git_command_in(path)?;
     cmd.args(["status", "--porcelain"]);
-    let status =
-        crate::external_command::spawn_with_pressure_retry("git status", || cmd.output())?;
+    let status = crate::external_command::spawn_with_pressure_retry("git status", || cmd.output())?;
 
     Ok(!String::from_utf8_lossy(&status.stdout).trim().is_empty())
 }
@@ -223,11 +221,11 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
         if add_stderr.contains("outside of your sparse-checkout definition") {
             let mut sparse_cmd = crate::utils::git_command_in(path)?;
             sparse_cmd.args(["add", "-A", "--sparse"]);
-            let sparse_output = crate::external_command::spawn_with_pressure_retry(
-                "git add --sparse",
-                || sparse_cmd.output(),
-            )
-            .map_err(String::from)?;
+            let sparse_output =
+                crate::external_command::spawn_with_pressure_retry("git add --sparse", || {
+                    sparse_cmd.output()
+                })
+                .map_err(String::from)?;
             if !sparse_output.status.success() {
                 return Err(String::from_utf8_lossy(&sparse_output.stderr).to_string());
             }

--- a/src-tauri/src/commands/git/status.rs
+++ b/src-tauri/src/commands/git/status.rs
@@ -21,7 +21,10 @@ fn truncate_stderr(stderr: &str) -> String {
         return stderr.to_string();
     }
     // Cut on a char boundary at or below MAX so multi-byte text can't panic.
-    let cut = (0..=MAX).rev().find(|i| stderr.is_char_boundary(*i)).unwrap_or(0);
+    let cut = (0..=MAX)
+        .rev()
+        .find(|i| stderr.is_char_boundary(*i))
+        .unwrap_or(0);
     format!("{}…", &stderr[..cut])
 }
 

--- a/src-tauri/src/commands/git/status.rs
+++ b/src-tauri/src/commands/git/status.rs
@@ -12,6 +12,19 @@ use super::run_git_net;
 
 use super::git_has_uncommitted_changes;
 
+/// Cap git stderr carried inside an error message so a pathological failure
+/// (e.g. a hook dumping its whole log) can't flood the toast/telemetry, while
+/// keeping enough text to diagnose the actual cause (issue #547).
+fn truncate_stderr(stderr: &str) -> String {
+    const MAX: usize = 500;
+    if stderr.len() <= MAX {
+        return stderr.to_string();
+    }
+    // Cut on a char boundary at or below MAX so multi-byte text can't panic.
+    let cut = (0..=MAX).rev().find(|i| stderr.is_char_boundary(*i)).unwrap_or(0);
+    format!("{}…", &stderr[..cut])
+}
+
 #[tauri::command]
 #[tracing::instrument(fields(project = %project_path))]
 pub async fn check_git_has_changes(project_path: String) -> Result<bool, CommandError> {
@@ -87,7 +100,22 @@ pub async fn get_changed_files(project_path: String) -> Result<Vec<ChangedFile>,
         .map_err(|e| e.to_string())?;
 
     if !output.status.success() {
-        return Err(("Failed to get git status".to_string()).into());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Environment gaps (unaccepted Xcode license, missing CLT, macOS TCC
+        // denial) are expected machine states with a user-side fix, not app
+        // malfunctions (issues #603/#546).
+        if let Some(gap) = crate::utils::git_environment_gap(&stderr) {
+            warn!(error = %stderr.trim(), "git blocked by an environment gap while getting status");
+            return Err(gap);
+        }
+        // Include (truncated) stderr — a bare "Failed to get git status" is
+        // undiagnosable and buckets unrelated root causes under one
+        // fingerprint (issue #547, same class as #252).
+        return Err((format!(
+            "Failed to get git status: {}",
+            truncate_stderr(stderr.trim())
+        ))
+        .into());
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -330,4 +358,32 @@ pub async fn reset_to_branch(project_path: String, branch: String) -> Result<(),
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_stderr;
+
+    #[test]
+    fn truncate_stderr_passes_short_text_through() {
+        let msg = "fatal: this repository is corrupt";
+        assert_eq!(truncate_stderr(msg), msg);
+        assert_eq!(truncate_stderr(""), "");
+    }
+
+    #[test]
+    fn truncate_stderr_caps_long_text_with_ellipsis() {
+        let long = "x".repeat(2000);
+        let out = truncate_stderr(&long);
+        assert!(out.len() < 600, "must be capped, got {} bytes", out.len());
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_stderr_respects_char_boundaries() {
+        // Multi-byte chars straddling the cap must not panic.
+        let long = "é".repeat(600);
+        let out = truncate_stderr(&long);
+        assert!(out.ends_with('…'));
+    }
 }

--- a/src-tauri/src/commands/git/sync.rs
+++ b/src-tauri/src/commands/git/sync.rs
@@ -35,6 +35,14 @@ fn is_overwrite_refusal(stderr: &str) -> bool {
         || lower.contains("commit your changes or stash")
 }
 
+/// Git reporting that a merge/pull produced conflicts. Matched on the combined
+/// stdout+stderr because git splits the "CONFLICT (content): …" lines and the
+/// final "Automatic merge failed; fix conflicts and then commit the result."
+/// across the two streams depending on version.
+fn is_merge_conflict_output(combined: &str) -> bool {
+    combined.contains("CONFLICT") || combined.contains("Automatic merge failed")
+}
+
 /// Classify a failed `git clean -fd` whose *only* failures are files another
 /// process is holding open (e.g. a running wrangler dev server's SQLite state
 /// on Windows — issue #520). Returns the affected paths when every reported
@@ -152,9 +160,14 @@ pub async fn pull_and_merge(
     let stderr = String::from_utf8_lossy(&output.stderr);
     let combined = format!("{stdout}{stderr}");
 
-    // Check for merge conflicts
-    if combined.contains("CONFLICT") || combined.contains("Automatic merge failed") {
-        return Err((format!("MERGE_CONFLICT:{combined}")).into());
+    // Check for merge conflicts. A conflict is a fully anticipated state with
+    // dedicated resolution UI (the frontend even calls pull_and_merge on
+    // purpose to reproduce one) — Expected keeps it out of telemetry (issue
+    // #609). The `MERGE_CONFLICT:` prefix and the raw git output are the
+    // frontend contract: useBranchManagement string-matches the prefix.
+    if is_merge_conflict_output(&combined) {
+        warn!("Merge produced conflicts; handing off to the resolution flow");
+        return Err(CommandError::expected(format!("MERGE_CONFLICT:{combined}")));
     }
 
     if !output.status.success() {
@@ -302,7 +315,9 @@ pub async fn commit_changes(project_path: String, message: String) -> Result<boo
 
 #[cfg(test)]
 mod tests {
-    use super::{clean_locked_paths, ensure_repo_rooted_at, is_overwrite_refusal};
+    use super::{
+        clean_locked_paths, ensure_repo_rooted_at, is_merge_conflict_output, is_overwrite_refusal,
+    };
     use std::process::Command;
 
     // The #521 shape: git refusing to merge over uncommitted local edits.
@@ -317,6 +332,23 @@ mod tests {
             "fatal: refusing to merge unrelated histories"
         ));
         assert!(!is_overwrite_refusal(""));
+    }
+
+    // The #609 shape: a real merge conflict is an anticipated state with
+    // dedicated resolution UI, classified Expected upstream.
+    #[test]
+    fn merge_conflict_output_matches_gits_conflict_report() {
+        let combined = "Auto-merging pnpm-lock.yaml\nCONFLICT (content): Merge conflict in pnpm-lock.yaml\nAutomatic merge failed; fix conflicts and then commit the result.\n";
+        assert!(is_merge_conflict_output(combined));
+        // Either half alone must still match (git splits across streams).
+        assert!(is_merge_conflict_output(
+            "CONFLICT (content): Merge conflict in a.txt"
+        ));
+        assert!(is_merge_conflict_output(
+            "Automatic merge failed; fix conflicts and then commit the result."
+        ));
+        assert!(!is_merge_conflict_output("Already up to date.\n"));
+        assert!(!is_merge_conflict_output(""));
     }
 
     // The #520 shape: a running dev server (wrangler) holding untracked files

--- a/src-tauri/src/commands/git/sync.rs
+++ b/src-tauri/src/commands/git/sync.rs
@@ -28,7 +28,7 @@ fn is_missing_upstream(stderr: &str) -> bool {
 /// malfunction (issue #521, same class as #312/#502). The raw stderr is
 /// preserved verbatim in the returned message because the frontend
 /// regex-matches its wording (`/would be overwritten by (merge|checkout)/i`).
-fn is_overwrite_refusal(stderr: &str) -> bool {
+pub(crate) fn is_overwrite_refusal(stderr: &str) -> bool {
     let lower = stderr.to_lowercase();
     lower.contains("would be overwritten by merge")
         || lower.contains("would be overwritten by checkout")
@@ -332,6 +332,14 @@ mod tests {
             "fatal: refusing to merge unrelated histories"
         ));
         assert!(!is_overwrite_refusal(""));
+    }
+
+    // The #601 shape: `gh pr checkout` refusing over uncommitted local edits —
+    // same underlying git message, surfaced through gh's stderr.
+    #[test]
+    fn overwrite_refusal_matches_pr_checkout_refusal() {
+        let stderr = "error: Your local changes to the following files would be overwritten by checkout:\n\thome/home-v1.html\nPlease commit your changes or stash them before you switch branches.\nAborting\n";
+        assert!(is_overwrite_refusal(stderr));
     }
 
     // The #609 shape: a real merge conflict is an anticipated state with

--- a/src-tauri/src/commands/git/sync.rs
+++ b/src-tauri/src/commands/git/sync.rs
@@ -224,22 +224,33 @@ pub async fn discard_changes(project_path: String) -> Result<(), CommandError> {
     // (issue #346).
     ensure_repo_rooted_at(&validated_path)?;
 
-    // Discard changes to tracked files
-    let checkout_output = crate::utils::git_command_in(&validated_path)?
-        .args(["checkout", "."])
-        .output()
-        .map_err(|e| e.to_string())?;
+    // Discard changes to tracked files. `checkout .` writes to the index, so
+    // it can lose the .git lock race against the background snapshot watcher
+    // or a concurrent commit exactly like add/commit — retry on contention the
+    // same way git_stage_and_commit does (issues #377/#597).
+    let checkout_output = crate::utils::output_retrying_index_lock(|| {
+        crate::utils::git_command_in(&validated_path)?
+            .args(["checkout", "."])
+            .output()
+            .map_err(|e| crate::errors::CommandError::Io {
+                message: e.to_string(),
+            })
+    })?;
 
     if !checkout_output.status.success() {
         let stderr = String::from_utf8_lossy(&checkout_output.stderr);
         return Err((format!("Failed to discard changes: {stderr}")).into());
     }
 
-    // Remove untracked files
-    let clean_output = crate::utils::git_command_in(&validated_path)?
-        .args(["clean", "-fd"])
-        .output()
-        .map_err(|e| e.to_string())?;
+    // Remove untracked files — same lock-retry as above (#597).
+    let clean_output = crate::utils::output_retrying_index_lock(|| {
+        crate::utils::git_command_in(&validated_path)?
+            .args(["clean", "-fd"])
+            .output()
+            .map_err(|e| crate::errors::CommandError::Io {
+                message: e.to_string(),
+            })
+    })?;
 
     if !clean_output.status.success() {
         let stderr = String::from_utf8_lossy(&clean_output.stderr);

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -5,7 +5,7 @@
 use crate::cache::TtlCache;
 use crate::commands::git::git_stage_and_commit;
 use crate::errors::CommandError;
-use crate::external_command::run_with_timeout;
+use crate::external_command::{run_with_timeout, truncate_output};
 use crate::types::{
     GitHubCliStatus, GitHubLanguage, GitHubRepo, ProjectGitHubStatus, PushToGitHubOptions,
 };
@@ -470,7 +470,7 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
             return Err(CommandError::Process {
                 cmd: "git commit".to_string(),
                 exit_code: output.status.code().unwrap_or(-1),
-                stderr: stderr.to_string(),
+                stderr: truncate_output(&stderr),
             });
         }
     }
@@ -506,7 +506,7 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
         return Err(CommandError::Process {
             cmd: "gh repo create".to_string(),
             exit_code: output.status.code().unwrap_or(-1),
-            stderr: stderr.to_string(),
+            stderr: truncate_output(&stderr),
         });
     }
 
@@ -592,12 +592,42 @@ pub(crate) fn gh_malformed_request_error(stderr: &str) -> Option<CommandError> {
         })
 }
 
+/// gh (a Go binary) crashing with a Go runtime panic/fatal error — stderr is
+/// the runtime's full crash dump ("fatal error: …\n\nruntime stack:\n…" or
+/// "panic: …\n\ngoroutine N [running]:\n…"), dozens of stack-trace lines that
+/// are useless to a user. The known real-world case is the runtime failing to
+/// reserve its heap arena at startup on a memory-starved Windows machine
+/// (issue #610, the child-process sibling of errors.rs's
+/// `windows_out_of_memory` for our own spawns, #356). The environment killed
+/// the child, not the app — `Expected` keeps the dump out of telemetry and the
+/// message is something the user can act on. The matched literals are
+/// untranslated Go-runtime strings, stable across Go versions.
+pub(crate) fn gh_crash_error(stderr: &str) -> Option<CommandError> {
+    if stderr.contains("out of memory allocating heap arena map") {
+        return Some(CommandError::expected(
+            "The GitHub CLI (gh) couldn't start because the system is low on memory. \
+             Close some other apps (on Windows, increasing the paging file size can also help) \
+             and try again.",
+        ));
+    }
+    let go_crash = (stderr.contains("fatal error:") && stderr.contains("runtime stack:"))
+        || (stderr.contains("panic:") && stderr.contains("goroutine "));
+    go_crash.then(|| {
+        CommandError::expected(
+            "The GitHub CLI (gh) crashed unexpectedly. Try again — if it keeps happening, \
+             reinstalling the GitHub CLI may help.",
+        )
+    })
+}
+
 /// A `gh` invocation that hits GitHub can fail these ways regardless of which
-/// subcommand ran: a connectivity blip or GitHub's transient HTTP 400.
-/// One-stop classification for the shared cases — call sites still layer
-/// their own auth / subcommand-specific checks on top.
+/// subcommand ran: a connectivity blip, GitHub's transient HTTP 400, or gh
+/// itself crashing. One-stop classification for the shared cases — call sites
+/// still layer their own auth / subcommand-specific checks on top.
 pub(crate) fn gh_common_error(stderr: &str) -> Option<CommandError> {
-    gh_network_error(stderr).or_else(|| gh_malformed_request_error(stderr))
+    gh_network_error(stderr)
+        .or_else(|| gh_malformed_request_error(stderr))
+        .or_else(|| gh_crash_error(stderr))
 }
 
 /// gh's own wrapper for a failing internal git call — "failed to run git:
@@ -645,7 +675,7 @@ pub async fn list_github_repos(owner: String) -> Result<Vec<GitHubRepo>, Command
         return Err(CommandError::Process {
             cmd: "gh repo list".to_string(),
             exit_code: output.status.code().unwrap_or(-1),
-            stderr: stderr.to_string(),
+            stderr: truncate_output(&stderr),
         });
     }
 
@@ -703,7 +733,7 @@ pub async fn list_collaborator_repos() -> Result<Vec<GitHubRepo>, CommandError> 
         return Err(CommandError::Process {
             cmd: "gh api /user/repos".to_string(),
             exit_code: output.status.code().unwrap_or(-1),
-            stderr: stderr.to_string(),
+            stderr: truncate_output(&stderr),
         });
     }
 
@@ -1063,6 +1093,36 @@ mod tests {
             .is_some());
         assert!(gh_common_error("GraphQL: something app-specific went wrong").is_none());
         assert!(gh_common_error("").is_none());
+    }
+
+    // The #610 shape: gh's Go runtime failing to reserve its heap arena at
+    // startup on a memory-starved Windows box — stderr is a full crash dump.
+    #[test]
+    fn gh_crash_error_classifies_heap_arena_oom_as_expected() {
+        let stderr = "fatal error: out of memory allocating heap arena map\n\nruntime stack:\nruntime.throw(...)\n\tC:/hostedtoolcache/windows/go/1.26.4/x64/src/runtime/panic.go:1229\nruntime.(*mheap).sysAlloc(...)\nruntime.cpuinit(...)\nruntime.schedinit(...)\nruntime.rt0_go()";
+        let err = gh_crash_error(stderr).expect("should classify as expected");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        let msg = err.to_string();
+        assert!(msg.contains("low on memory"), "got: {msg}");
+        assert!(!msg.contains("runtime stack"), "must not forward the dump");
+    }
+
+    #[test]
+    fn gh_crash_error_classifies_generic_go_panic() {
+        let stderr = "panic: runtime error: invalid memory address or nil pointer dereference\n\ngoroutine 1 [running]:\ngithub.com/cli/cli/v2/pkg/cmd/root.NewCmdRoot(...)";
+        let err = gh_crash_error(stderr).expect("should classify as expected");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        let fatal = "fatal error: concurrent map read and map write\n\nruntime stack:\nruntime.throw(...)";
+        assert!(gh_crash_error(fatal).is_some());
+    }
+
+    #[test]
+    fn gh_crash_error_ignores_non_crash_stderr() {
+        // git's "fatal:" prefix is not a Go "fatal error:" crash.
+        assert!(gh_crash_error("fatal: not a git repository").is_none());
+        // "panic:"/"fatal error:" alone without a runtime dump shouldn't match.
+        assert!(gh_crash_error("request failed: panic: see logs").is_none());
+        assert!(gh_crash_error("").is_none());
     }
 
     // The #592 shape: a mid-request TCP reset returned to gh's GraphQL client.

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1089,8 +1089,10 @@ mod tests {
     #[test]
     fn gh_common_error_covers_shared_families() {
         assert!(gh_common_error("dial tcp 1.2.3.4:443: connect: connection refused").is_some());
-        assert!(gh_common_error("HTTP 400: We received a malformed request from your client.")
-            .is_some());
+        assert!(
+            gh_common_error("HTTP 400: We received a malformed request from your client.")
+                .is_some()
+        );
         assert!(gh_common_error("GraphQL: something app-specific went wrong").is_none());
         assert!(gh_common_error("").is_none());
     }
@@ -1112,7 +1114,8 @@ mod tests {
         let stderr = "panic: runtime error: invalid memory address or nil pointer dereference\n\ngoroutine 1 [running]:\ngithub.com/cli/cli/v2/pkg/cmd/root.NewCmdRoot(...)";
         let err = gh_crash_error(stderr).expect("should classify as expected");
         assert!(matches!(err, CommandError::Expected { .. }));
-        let fatal = "fatal error: concurrent map read and map write\n\nruntime stack:\nruntime.throw(...)";
+        let fatal =
+            "fatal error: concurrent map read and map write\n\nruntime stack:\nruntime.throw(...)";
         assert!(gh_crash_error(fatal).is_some());
     }
 

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -498,8 +498,9 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
                 "A repository named \"{repo_name}\" already exists on this account. Choose a different name."
             )));
         }
-        // Connectivity blips are the environment, not a malfunction (#420).
-        if let Some(err) = gh_network_error(&stderr) {
+        // Connectivity blips and GitHub's transient API 400s are the
+        // environment/GitHub, not a malfunction (#420, #602).
+        if let Some(err) = gh_common_error(&stderr) {
             return Err(err);
         }
         return Err(CommandError::Process {
@@ -572,6 +573,33 @@ pub(crate) fn gh_network_error(stderr: &str) -> Option<CommandError> {
     })
 }
 
+/// gh's passthrough of GitHub's generic HTTP 400 GraphQL response — "HTTP 400:
+/// We received a malformed request from your client. Sorry about that. Please
+/// try resubmitting your request…". GitHub emits this when the API can't parse
+/// the request body (e.g. odd Unicode in a PR title/body getting serialized
+/// into the GraphQL payload) — a transient API-side failure with a built-in
+/// retry suggestion, not an app malfunction (issue #602). `Expected` keeps it
+/// out of telemetry.
+pub(crate) fn gh_malformed_request_error(stderr: &str) -> Option<CommandError> {
+    stderr
+        .to_lowercase()
+        .contains("we received a malformed request")
+        .then(|| {
+            CommandError::expected(
+                "GitHub couldn't process the request (a temporary GitHub API error). \
+                 Try again in a moment.",
+            )
+        })
+}
+
+/// A `gh` invocation that hits GitHub can fail these ways regardless of which
+/// subcommand ran: a connectivity blip or GitHub's transient HTTP 400.
+/// One-stop classification for the shared cases — call sites still layer
+/// their own auth / subcommand-specific checks on top.
+pub(crate) fn gh_common_error(stderr: &str) -> Option<CommandError> {
+    gh_network_error(stderr).or_else(|| gh_malformed_request_error(stderr))
+}
+
 /// gh's own wrapper for a failing internal git call — "failed to run git:
 /// <git's stderr>" (gh's git/errors.go, GitError). Most commonly hit when gh
 /// can't resolve repo context because the project isn't a git repository. The
@@ -609,8 +637,9 @@ pub async fn list_github_repos(owner: String) -> Result<Vec<GitHubRepo>, Command
         if let Some(err) = gh_auth_error(&stderr) {
             return Err(err);
         }
-        // Connectivity blips are the environment, not a malfunction (#420).
-        if let Some(err) = gh_network_error(&stderr) {
+        // Connectivity blips and GitHub's transient API 400s are the
+        // environment/GitHub, not a malfunction (#420, #602).
+        if let Some(err) = gh_common_error(&stderr) {
             return Err(err);
         }
         return Err(CommandError::Process {
@@ -666,8 +695,9 @@ pub async fn list_collaborator_repos() -> Result<Vec<GitHubRepo>, CommandError> 
         if let Some(err) = gh_auth_error(&stderr) {
             return Err(err);
         }
-        // Connectivity blips are the environment, not a malfunction (#420).
-        if let Some(err) = gh_network_error(&stderr) {
+        // Connectivity blips and GitHub's transient API 400s are the
+        // environment/GitHub, not a malfunction (#420, #602).
+        if let Some(err) = gh_common_error(&stderr) {
             return Err(err);
         }
         return Err(CommandError::Process {
@@ -1005,6 +1035,34 @@ mod tests {
     fn gh_network_error_ignores_unrelated_stderr() {
         assert!(gh_network_error("GraphQL: name already exists on this account").is_none());
         assert!(gh_network_error("").is_none());
+    }
+
+    // The #602 shape: GitHub's generic HTTP 400 GraphQL response passed
+    // through verbatim by gh — a transient API-side failure, not app text.
+    #[test]
+    fn gh_malformed_request_classifies_github_http_400_as_expected() {
+        let stderr = "HTTP 400: We received a malformed request from your client. Sorry about that. Please try resubmitting your request and contact us if the problem persists. (https://api.github.com/graphql)";
+        let err = gh_malformed_request_error(stderr).expect("should classify as expected");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        // The user-facing message must carry a retry suggestion.
+        assert!(err.to_string().contains("Try again"), "got: {err}");
+    }
+
+    #[test]
+    fn gh_malformed_request_ignores_unrelated_stderr() {
+        assert!(gh_malformed_request_error("HTTP 404: Not Found").is_none());
+        assert!(gh_malformed_request_error("").is_none());
+    }
+
+    // gh_common_error is the one-stop classifier every gh call site funnels
+    // through — it must cover each shared family and stay quiet otherwise.
+    #[test]
+    fn gh_common_error_covers_shared_families() {
+        assert!(gh_common_error("dial tcp 1.2.3.4:443: connect: connection refused").is_some());
+        assert!(gh_common_error("HTTP 400: We received a malformed request from your client.")
+            .is_some());
+        assert!(gh_common_error("GraphQL: something app-specific went wrong").is_none());
+        assert!(gh_common_error("").is_none());
     }
 
     // The #592 shape: a mid-request TCP reset returned to gh's GraphQL client.

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -555,6 +555,11 @@ pub(crate) fn gh_network_error(stderr: &str) -> Option<CommandError> {
         // Go's net/http error when the connection drops mid-request —
         // flaky wifi, VPN/proxy interference (issue #434).
         || s.contains("unexpected eof")
+        // Mid-request TCP reset ("read tcp …: read: connection reset by
+        // peer") — the read-time counterpart of "dial tcp"'s connect-time
+        // failures (issue #592).
+        || s.contains("connection reset by peer")
+        || s.contains("read tcp")
         // gh's own top-level DNS-failure handler swallows the raw Go error
         // and prints only "error connecting to <host>\ncheck your internet
         // connection or https://githubstatus.com" (issue #473).
@@ -1000,5 +1005,16 @@ mod tests {
     fn gh_network_error_ignores_unrelated_stderr() {
         assert!(gh_network_error("GraphQL: name already exists on this account").is_none());
         assert!(gh_network_error("").is_none());
+    }
+
+    // The #592 shape: a mid-request TCP reset returned to gh's GraphQL client.
+    // "dial tcp" only covers connect-time failures; the read-time wording is
+    // distinct and must classify as the same connectivity blip.
+    #[test]
+    fn gh_network_error_classifies_connection_reset_by_peer() {
+        let stderr = r#"Post "https://api.github.com/graphql": read tcp 198.18.0.1:59334->140.82.121.6:443: read: connection reset by peer"#;
+        let err = gh_network_error(stderr).expect("should classify as network error");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        assert!(err.to_string().contains("Couldn't reach GitHub"));
     }
 }

--- a/src-tauri/src/commands/ide/mod.rs
+++ b/src-tauri/src/commands/ide/mod.rs
@@ -183,11 +183,11 @@ pub async fn open_in_ide(
             _ => return Err((format!("Unknown IDE: {ide}")).into()),
         };
 
-        // Use 'open -a' on macOS which is more reliable
-        create_command("open")
-            .args(["-a", app_name, &target_path])
-            .spawn()
-            .map_err(|e| format!("Failed to open in {ide}: {e}"))?;
+        // Use 'open -a' on macOS which is more reliable. Retried on transient
+        // EAGAIN and labeled so a spawn failure is attributable (issue #585).
+        let mut cmd = create_command("open");
+        cmd.args(["-a", app_name, &target_path]);
+        crate::external_command::spawn_with_pressure_retry(&format!("open {ide}"), || cmd.spawn())?;
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -214,10 +214,11 @@ pub async fn open_in_ide(
             )));
         };
 
-        create_command(&resolved)
-            .arg(&target_path)
-            .spawn()
-            .map_err(|e| format!("Failed to open in {}: {}", ide, e))?;
+        let mut launch = create_command(&resolved);
+        launch.arg(&target_path);
+        crate::external_command::spawn_with_pressure_retry(&format!("open {ide}"), || {
+            launch.spawn()
+        })?;
     }
 
     Ok(())
@@ -279,10 +280,15 @@ pub async fn open_url_in_browser(url: String, browser_id: String) -> Result<(), 
             .map(|(_, name, _)| *name)
             .ok_or_else(|| format!("Unknown browser: {browser_id}"))?;
 
-        create_command("open")
-            .args(["-a", app_name, &url])
-            .spawn()
-            .map_err(|e| format!("Failed to open in {browser_id}: {e}"))?;
+        // Retried on transient EAGAIN (process-table pressure) and classified
+        // Expected when it persists — a bare "Failed to open in safari:
+        // Resource temporarily unavailable (os error 35)" was reaching
+        // telemetry as an app malfunction (issue #585).
+        let mut cmd = create_command("open");
+        cmd.args(["-a", app_name, &url]);
+        crate::external_command::spawn_with_pressure_retry(&format!("open {browser_id}"), || {
+            cmd.spawn()
+        })?;
 
         Ok(())
     }
@@ -298,10 +304,11 @@ pub async fn open_url_in_browser(url: String, browser_id: String) -> Result<(), 
         let browser_exe = find_windows_browser(relative_path)
             .ok_or_else(|| format!("Browser not found: {}", browser_id))?;
 
-        create_command(browser_exe)
-            .arg(&url)
-            .spawn()
-            .map_err(|e| format!("Failed to open in {}: {}", browser_id, e))?;
+        let mut cmd = create_command(browser_exe);
+        cmd.arg(&url);
+        crate::external_command::spawn_with_pressure_retry(&format!("open {browser_id}"), || {
+            cmd.spawn()
+        })?;
 
         Ok(())
     }

--- a/src-tauri/src/commands/plugins/mod.rs
+++ b/src-tauri/src/commands/plugins/mod.rs
@@ -333,7 +333,9 @@ pub(crate) fn get_plugins_dir(project_path: &str) -> Result<PathBuf, String> {
 }
 
 /// Read the plugin registry for a project
-pub(crate) fn read_registry(project_path: &str) -> Result<Registry, String> {
+pub(crate) fn read_registry(
+    project_path: &str,
+) -> Result<Registry, crate::errors::CommandError> {
     let plugins_dir = get_plugins_dir(project_path)?;
     let registry_path = plugins_dir.join("registry.json");
 
@@ -341,22 +343,33 @@ pub(crate) fn read_registry(project_path: &str) -> Result<Registry, String> {
         return Ok(Registry::default());
     }
 
-    let content =
-        fs::read_to_string(&registry_path).map_err(|e| format!("Failed to read registry: {e}"))?;
+    // classify_fs_error: macOS TCC's EPERM (project under Desktop/Documents/
+    // iCloud …) becomes an actionable Expected, not telemetry noise (#545).
+    let content = fs::read_to_string(&registry_path).map_err(|e| {
+        crate::utils::classify_fs_error("read this project's plugin registry", &registry_path, &e)
+    })?;
 
-    serde_json::from_str(&content).map_err(|e| format!("Failed to parse registry: {e}"))
+    serde_json::from_str(&content)
+        .map_err(|e| crate::errors::CommandError::from(format!("Failed to parse registry: {e}")))
 }
 
 /// Write the plugin registry for a project
-pub(crate) fn write_registry(project_path: &str, registry: &Registry) -> Result<(), String> {
+pub(crate) fn write_registry(
+    project_path: &str,
+    registry: &Registry,
+) -> Result<(), crate::errors::CommandError> {
     let plugins_dir = get_plugins_dir(project_path)?;
-    fs::create_dir_all(&plugins_dir).map_err(|e| format!("Failed to create plugins dir: {e}"))?;
+    fs::create_dir_all(&plugins_dir).map_err(|e| {
+        crate::utils::classify_fs_error("create this project's plugins folder", &plugins_dir, &e)
+    })?;
 
     let registry_path = plugins_dir.join("registry.json");
     let content = serde_json::to_string_pretty(registry)
         .map_err(|e| format!("Failed to serialize registry: {e}"))?;
 
-    fs::write(&registry_path, content).map_err(|e| format!("Failed to write registry: {e}"))
+    fs::write(&registry_path, content).map_err(|e| {
+        crate::utils::classify_fs_error("write this project's plugin registry", &registry_path, &e)
+    })
 }
 
 /// Read a plugin's manifest from its directory

--- a/src-tauri/src/commands/plugins/mod.rs
+++ b/src-tauri/src/commands/plugins/mod.rs
@@ -333,9 +333,7 @@ pub(crate) fn get_plugins_dir(project_path: &str) -> Result<PathBuf, String> {
 }
 
 /// Read the plugin registry for a project
-pub(crate) fn read_registry(
-    project_path: &str,
-) -> Result<Registry, crate::errors::CommandError> {
+pub(crate) fn read_registry(project_path: &str) -> Result<Registry, crate::errors::CommandError> {
     let plugins_dir = get_plugins_dir(project_path)?;
     let registry_path = plugins_dir.join("registry.json");
 

--- a/src-tauri/src/commands/plugins/plugin_storage.rs
+++ b/src-tauri/src/commands/plugins/plugin_storage.rs
@@ -152,15 +152,48 @@ pub async fn exec_plugin_shell(
     // to completion in the background (issue #294).
     let mut cmd = tokio::process::Command::from(std_cmd);
     cmd.kill_on_drop(true);
-    let output = tokio::time::timeout(std::time::Duration::from_secs(timeout), cmd.output())
-        .await
-        .map_err(|_| {
-            // Name the plugin and command — a bare "timed out (120s)" is the
-            // same message for every plugin on every platform, so telemetry
-            // can't tell a slow-but-legit install from a hung plugin (#379).
-            format!("Plugin '{plugin_id}' shell command '{command}' timed out after {timeout}s")
-        })?
-        .map_err(|e| format!("Failed to execute command: {e}"))?;
+    let mut attempt: u64 = 0;
+    let output = loop {
+        attempt += 1;
+        match tokio::time::timeout(std::time::Duration::from_secs(timeout), cmd.output()).await {
+            Err(_) => {
+                // Name the plugin and command — a bare "timed out (120s)" is the
+                // same message for every plugin on every platform, so telemetry
+                // can't tell a slow-but-legit install from a hung plugin (#379).
+                return Err(CommandError::from(format!(
+                    "Plugin '{plugin_id}' shell command '{command}' timed out after {timeout}s"
+                )));
+            }
+            Ok(Ok(output)) => break output,
+            Ok(Err(e)) => {
+                let rendered = e.to_string();
+                // Transient EAGAIN (process-table pressure): retry briefly,
+                // and classify a persistent one as an Expected environment
+                // condition instead of telemetry noise (issue #573).
+                if crate::external_command::is_spawn_resource_pressure(&rendered) {
+                    if attempt < 3 {
+                        tracing::warn!(
+                            plugin_id = %plugin_id,
+                            command = %command,
+                            attempt,
+                            "plugin shell spawn hit transient resource pressure (EAGAIN); retrying"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(100 * attempt)).await;
+                        continue;
+                    }
+                    return Err(crate::external_command::spawn_resource_pressure_error(
+                        &command,
+                    ));
+                }
+                // Name the plugin and command here too — this final branch
+                // used to drop both, leaving a bare unattributable OS error
+                // as the only telemetry signal (issue #573).
+                return Err(CommandError::from(format!(
+                    "Plugin '{plugin_id}' shell command '{command}' failed to start: {rendered}"
+                )));
+            }
+        }
+    };
 
     Ok(ShellResult {
         stdout: String::from_utf8_lossy(&output.stdout).to_string(),

--- a/src-tauri/src/commands/plugins/plugin_storage.rs
+++ b/src-tauri/src/commands/plugins/plugin_storage.rs
@@ -44,8 +44,11 @@ pub fn read_plugin_storage(
         return Ok(serde_json::Value::Object(serde_json::Map::new()));
     }
 
-    let content = fs::read_to_string(&storage_path)
-        .map_err(|e| format!("Failed to read plugin storage: {e}"))?;
+    // classify_fs_error: macOS TCC's EPERM (project under Desktop/Documents/
+    // iCloud …) becomes an actionable Expected, not telemetry noise (#605).
+    let content = fs::read_to_string(&storage_path).map_err(|e| {
+        crate::utils::classify_fs_error("read this project's plugin storage", &storage_path, &e)
+    })?;
 
     serde_json::from_str(&content).map_err(|e| CommandError::Other {
         message: format!("Failed to parse plugin storage: {e}"),
@@ -71,15 +74,16 @@ pub fn write_plugin_storage(
 
     // Ensure parent directory exists
     if let Some(parent) = storage_path.parent() {
-        fs::create_dir_all(parent)
-            .map_err(|e| format!("Failed to create storage directory: {e}"))?;
+        fs::create_dir_all(parent).map_err(|e| {
+            crate::utils::classify_fs_error("create this project's plugin storage folder", parent, &e)
+        })?;
     }
 
     let content = serde_json::to_string_pretty(&data)
         .map_err(|e| format!("Failed to serialize storage data: {e}"))?;
 
-    fs::write(&storage_path, content).map_err(|e| CommandError::Io {
-        message: format!("Failed to write plugin storage: {e}"),
+    fs::write(&storage_path, content).map_err(|e| {
+        crate::utils::classify_fs_error("write this project's plugin storage", &storage_path, &e)
     })
 }
 

--- a/src-tauri/src/commands/plugins/plugin_storage.rs
+++ b/src-tauri/src/commands/plugins/plugin_storage.rs
@@ -75,7 +75,11 @@ pub fn write_plugin_storage(
     // Ensure parent directory exists
     if let Some(parent) = storage_path.parent() {
         fs::create_dir_all(parent).map_err(|e| {
-            crate::utils::classify_fs_error("create this project's plugin storage folder", parent, &e)
+            crate::utils::classify_fs_error(
+                "create this project's plugin storage folder",
+                parent,
+                &e,
+            )
         })?;
     }
 

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -1056,6 +1056,33 @@ fn remove_dir_all_robust(path: &Path) -> std::io::Result<()> {
     }
 }
 
+/// Blocking rename with the same lock-retry treatment as
+/// [`remove_dir_all_robust`]: a transient Windows sharing violation
+/// (antivirus scan, Search indexer, a just-suspended session's child not
+/// fully exited) failed the single unretried `fs::rename` immediately with
+/// "os error 32" (issue #559). Call from `spawn_blocking` — the sleeps can
+/// hold a thread for seconds.
+fn rename_robust(from: &Path, to: &Path) -> std::io::Result<()> {
+    let mut delay = std::time::Duration::from_millis(100);
+    let mut retries = 10;
+    loop {
+        match std::fs::rename(from, to) {
+            Ok(()) => return Ok(()),
+            Err(e) if retries > 0 && is_retryable_delete_error(&e) => {
+                tracing::info!(
+                    "rename blocked by a file lock ({}), retrying: {}",
+                    from.display(),
+                    e
+                );
+                retries -= 1;
+                std::thread::sleep(delay);
+                delay = (delay * 2).min(std::time::Duration::from_secs(1));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
 /// Deletes a project directory. Only allows deletion from ~/ShipStudio.
 /// External projects cannot be deleted — use unregister_external_project instead.
 #[tauri::command]
@@ -1315,11 +1342,26 @@ pub async fn rename_project(
         return Ok(old_path);
     }
     if new_path.exists() {
-        return Err((format!("A project named \"{new_name}\" already exists.")).into());
+        // A by-design validation refusal the user corrects by picking another
+        // name — Expected keeps it out of telemetry (issue #599).
+        return Err(CommandError::expected(format!(
+            "A project named \"{new_name}\" already exists."
+        )));
     }
 
-    std::fs::rename(project_path, &new_path)
-        .map_err(|e| format!("Failed to rename project: {e}"))?;
+    // Robust rename: retry transient Windows file locks (antivirus, Search
+    // indexer, a just-suspended session's children still winding down) with
+    // the same backoff schedule delete_project uses — a single unretried
+    // rename surfaced "os error 32" straight to the user (issues #253/#559).
+    // spawn_blocking keeps the retry sleeps off the async runtime.
+    {
+        let src = project_path.to_path_buf();
+        let dst = new_path.clone();
+        tokio::task::spawn_blocking(move || rename_robust(&src, &dst))
+            .await
+            .map_err(|e| format!("Project rename task failed: {e}"))?
+            .map_err(|e| format!("Failed to rename project: {e}"))?;
+    }
 
     let new_path_str = new_path.to_string_lossy().to_string();
 
@@ -1762,6 +1804,54 @@ mod tests {
         let err = load_removed_projects_config().expect_err("invalid registry should fail closed");
 
         assert!(err.contains("Failed to parse removed projects config"));
+    }
+
+    // The #559/#253 shape: Windows sharing/lock violations are the transient
+    // states the rename/delete retry loops exist for; anything else must fail
+    // immediately.
+    #[test]
+    fn retryable_delete_error_matches_windows_lock_codes() {
+        assert!(is_retryable_delete_error(
+            &std::io::Error::from_raw_os_error(32) // ERROR_SHARING_VIOLATION
+        ));
+        assert!(is_retryable_delete_error(
+            &std::io::Error::from_raw_os_error(33) // ERROR_LOCK_VIOLATION
+        ));
+        assert!(is_retryable_delete_error(
+            &std::io::Error::from_raw_os_error(5) // ERROR_ACCESS_DENIED
+        ));
+        assert!(is_retryable_delete_error(&std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "denied"
+        )));
+        assert!(!is_retryable_delete_error(&std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "gone"
+        )));
+    }
+
+    #[test]
+    fn rename_robust_renames_a_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("old-name");
+        std::fs::create_dir(&src).unwrap();
+        std::fs::write(src.join("file.txt"), "hi").unwrap();
+        let dst = tmp.path().join("new-name");
+
+        rename_robust(&src, &dst).unwrap();
+
+        assert!(!src.exists());
+        assert_eq!(std::fs::read_to_string(dst.join("file.txt")).unwrap(), "hi");
+    }
+
+    #[test]
+    fn rename_robust_surfaces_non_retryable_errors_immediately() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+        let dst = tmp.path().join("dst");
+        let err = rename_robust(&missing, &dst).unwrap_err();
+        // NotFound is not a lock — must not burn ~8s of retries.
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     }
 
     #[test]

--- a/src-tauri/src/commands/pty/spawn.rs
+++ b/src-tauri/src/commands/pty/spawn.rs
@@ -144,7 +144,30 @@ pub async fn spawn_pty(
 
             // Wait for process to exit
             let status = child.wait().map_err(|e| e.to_string())?;
-            Ok(status.code().unwrap_or(-1))
+            match status.code() {
+                Some(code) => Ok(code),
+                None => {
+                    // Unix: code() is None when a signal terminated the
+                    // process (OOM-killer SIGKILL, crash, kill …). This used
+                    // to collapse to a silent -1 with zero context — emit the
+                    // signal as pty-output first so runPtyToExit can attach
+                    // it, same as the spawn-failure path below (issue #589).
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::process::ExitStatusExt;
+                        let detail = describe_signal_termination(status.signal());
+                        let _ = app_handle.emit_to(
+                            &label,
+                            "pty-output",
+                            serde_json::json!({
+                                "id": id,
+                                "data": format!("{detail}\r\n"),
+                            }),
+                        );
+                    }
+                    Ok(-1)
+                }
+            }
         })();
 
         // Remove from registry when process exits
@@ -183,6 +206,34 @@ pub async fn spawn_pty(
     });
 
     Ok(id)
+}
+
+/// Human-readable description of a signal-terminated child. `signal` is
+/// `ExitStatus::signal()` — `Some(n)` for the terminating signal, `None` if
+/// the platform couldn't report one. Names the common signals and hints at
+/// the usual culprit (the OOM killer sends SIGKILL to e.g. a pnpm install
+/// that exhausts memory — issue #589).
+#[cfg_attr(not(unix), allow(dead_code))]
+fn describe_signal_termination(signal: Option<i32>) -> String {
+    let Some(sig) = signal else {
+        return "Process was terminated abnormally (no exit code reported)".to_string();
+    };
+    let name = match sig {
+        1 => " (SIGHUP)",
+        2 => " (SIGINT)",
+        6 => " (SIGABRT)",
+        9 => " (SIGKILL)",
+        11 => " (SIGSEGV)",
+        13 => " (SIGPIPE)",
+        15 => " (SIGTERM)",
+        _ => "",
+    };
+    let hint = match sig {
+        9 => " — likely killed by the operating system, e.g. because it ran out of memory",
+        11 => " — the program crashed (segmentation fault)",
+        _ => "",
+    };
+    format!("Process was terminated by signal {sig}{name}{hint}")
 }
 
 /// Register an externally-spawned PTY process (like dev servers from tauri-pty).
@@ -242,5 +293,39 @@ pub fn unregister_external_pty(pty_id: u32) -> Result<(), CommandError> {
         Ok(())
     } else {
         Err(("Failed to lock PTY registry".to_string()).into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::describe_signal_termination;
+
+    // The #589 shape: pnpm install OOM-killed mid-import surfaced only as
+    // "Process exited with code -1". SIGKILL must name the likely OOM cause.
+    #[test]
+    fn sigkill_mentions_signal_name_and_oom_hint() {
+        let msg = describe_signal_termination(Some(9));
+        assert!(msg.contains("signal 9"), "got: {msg}");
+        assert!(msg.contains("SIGKILL"), "got: {msg}");
+        assert!(msg.contains("out of memory"), "got: {msg}");
+    }
+
+    #[test]
+    fn sigsegv_mentions_crash() {
+        let msg = describe_signal_termination(Some(11));
+        assert!(msg.contains("SIGSEGV"), "got: {msg}");
+        assert!(msg.contains("crashed"), "got: {msg}");
+    }
+
+    #[test]
+    fn unknown_signal_still_reports_the_number() {
+        let msg = describe_signal_termination(Some(31));
+        assert!(msg.contains("terminated by signal 31"), "got: {msg}");
+    }
+
+    #[test]
+    fn missing_signal_info_gets_a_generic_but_honest_message() {
+        let msg = describe_signal_termination(None);
+        assert!(msg.contains("terminated abnormally"), "got: {msg}");
     }
 }

--- a/src-tauri/src/commands/pty_session.rs
+++ b/src-tauri/src/commands/pty_session.rs
@@ -305,8 +305,19 @@ pub async fn pty_session_open(
         cmd.env(std::ffi::OsString::from(&k), std::ffi::OsString::from(&v));
     }
 
-    let mut child = pair.slave.spawn_command(cmd).map_err(|e| {
-        let message = format!("spawn_command: {e}");
+    // Retried on transient EAGAIN (process-table pressure) — and labeled with
+    // the spawned command, so the three spawn_command sites in this codebase
+    // no longer collapse into one indistinguishable telemetry bucket (#587).
+    let mut child = crate::external_command::retry_spawn_on_pressure(&command, || {
+        pair.slave.spawn_command(cmd.clone())
+    })
+    .map_err(|e| {
+        let message = format!("spawn_command `{command}`: {e}");
+        // A persistent EAGAIN is the environment (resource pressure), not an
+        // app malfunction — Expected with a human message (issue #587).
+        if crate::external_command::is_spawn_resource_pressure(&message) {
+            return crate::external_command::spawn_resource_pressure_error(&command);
+        }
         // portable_pty's binary-not-found phrasings. A missing/unresolvable
         // agent CLI is an environment gap ("install X first") the frontend
         // already turns into the agent's install hint — Expected keeps it out

--- a/src-tauri/src/commands/pull_requests.rs
+++ b/src-tauri/src/commands/pull_requests.rs
@@ -62,7 +62,7 @@ pub async fn list_pull_requests(
         if let Some(err) = crate::commands::github::gh_auth_error(&stderr) {
             return Err(err);
         }
-        if let Some(err) = crate::commands::github::gh_network_error(&stderr) {
+        if let Some(err) = crate::commands::github::gh_common_error(&stderr) {
             return Err(err);
         }
         if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
@@ -143,7 +143,7 @@ pub async fn create_pull_request(
         if let Some(err) = crate::commands::github::gh_auth_error(&stderr) {
             return Err(err);
         }
-        if let Some(err) = crate::commands::github::gh_network_error(&stderr) {
+        if let Some(err) = crate::commands::github::gh_common_error(&stderr) {
             return Err(err);
         }
         if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
@@ -196,7 +196,7 @@ pub async fn merge_pull_request(project_path: String, pr_number: i32) -> Result<
         if let Some(err) = crate::commands::github::gh_auth_error(&stderr) {
             return Err(err);
         }
-        if let Some(err) = crate::commands::github::gh_network_error(&stderr) {
+        if let Some(err) = crate::commands::github::gh_common_error(&stderr) {
             return Err(err);
         }
         if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
@@ -236,7 +236,7 @@ pub async fn checkout_pull_request(
         if let Some(err) = crate::commands::github::gh_auth_error(&stderr) {
             return Err(err);
         }
-        if let Some(err) = crate::commands::github::gh_network_error(&stderr) {
+        if let Some(err) = crate::commands::github::gh_common_error(&stderr) {
             return Err(err);
         }
         if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
@@ -273,7 +273,7 @@ pub async fn close_pull_request(project_path: String, pr_number: i32) -> Result<
         if let Some(err) = crate::commands::github::gh_auth_error(&stderr) {
             return Err(err);
         }
-        if let Some(err) = crate::commands::github::gh_network_error(&stderr) {
+        if let Some(err) = crate::commands::github::gh_common_error(&stderr) {
             return Err(err);
         }
         if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {

--- a/src-tauri/src/commands/pull_requests.rs
+++ b/src-tauri/src/commands/pull_requests.rs
@@ -242,6 +242,18 @@ pub async fn checkout_pull_request(
         if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
             return Err(err);
         }
+        // Git refusing to check out over uncommitted local edits ("would be
+        // overwritten by checkout" / "commit your changes or stash") is an
+        // anticipated user state, not a malfunction — same classification the
+        // branch-switch and merge paths already apply (issue #601, same class
+        // as #312/#502/#521).
+        if crate::commands::git::is_overwrite_refusal(&stderr) {
+            tracing::warn!(error = %stderr, "PR checkout blocked by uncommitted local changes");
+            return Err(CommandError::expected(
+                "You have unsaved changes that would be lost by checking out this pull request. \
+                 Commit or stash them first, then try again.",
+            ));
+        }
         return Err((format!("Failed to checkout PR: {stderr}")).into());
     }
 

--- a/src-tauri/src/commands/pull_requests.rs
+++ b/src-tauri/src/commands/pull_requests.rs
@@ -125,7 +125,12 @@ pub async fn create_pull_request(
         let stderr = String::from_utf8_lossy(&push_output.stderr);
         // Ignore "everything up-to-date" which isn't a real error
         if !stderr.contains("Everything up-to-date") {
-            return Err((format!("Failed to push branch: {stderr}")).into());
+            // A push that failed on auth or connectivity is an expected
+            // environment state, same as push_branch (issue #560).
+            if let Some(err) = crate::commands::git::classify_git_net_error(&stderr) {
+                return Err(err);
+            }
+            return Err(format!("Failed to push branch: {}", truncate_output(&stderr)).into());
         }
     }
 

--- a/src-tauri/src/commands/pull_requests.rs
+++ b/src-tauri/src/commands/pull_requests.rs
@@ -4,7 +4,7 @@
 
 use crate::commands::github::get_gh_command_for_project;
 use crate::errors::CommandError;
-use crate::external_command::run_with_timeout;
+use crate::external_command::{run_with_timeout, truncate_output};
 use crate::types::PullRequestInfo;
 use crate::utils::validate_project_path;
 
@@ -68,7 +68,7 @@ pub async fn list_pull_requests(
         if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
             return Err(err);
         }
-        return Err((stderr.to_string()).into());
+        return Err(truncate_output(&stderr).into());
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -159,7 +159,7 @@ pub async fn create_pull_request(
         {
             return Err(CommandError::expected(stderr.to_string()));
         }
-        return Err((stderr.to_string()).into());
+        return Err(truncate_output(&stderr).into());
     }
 
     // Output contains the PR URL
@@ -202,7 +202,7 @@ pub async fn merge_pull_request(project_path: String, pr_number: i32) -> Result<
         if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
             return Err(err);
         }
-        return Err(stderr.into());
+        return Err(truncate_output(&stderr).into());
     }
 
     Ok(())
@@ -242,7 +242,7 @@ pub async fn checkout_pull_request(
         if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
             return Err(err);
         }
-        return Err((format!("Failed to checkout PR: {stderr}")).into());
+        return Err(format!("Failed to checkout PR: {}", truncate_output(&stderr)).into());
     }
 
     // Return the branch name that was checked out
@@ -279,7 +279,7 @@ pub async fn close_pull_request(project_path: String, pr_number: i32) -> Result<
         if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
             return Err(err);
         }
-        return Err((format!("Failed to close PR: {stderr}")).into());
+        return Err(format!("Failed to close PR: {}", truncate_output(&stderr)).into());
     }
 
     Ok(())

--- a/src-tauri/src/commands/support.rs
+++ b/src-tauri/src/commands/support.rs
@@ -33,19 +33,25 @@ pub struct SupportIdentity {
 // ─── Internal helpers ────────────────────────────────────────────────────────
 
 /// Fetch the current GitHub user profile via `gh api user`.
-fn get_github_user() -> Result<(String, String, String), String> {
-    let output = get_gh_command()
-        .args([
-            "api",
-            "user",
-            "--jq",
-            r#"[.login, .email // "", .name // ""] | @tsv"#,
-        ])
-        .output()
-        .map_err(|e| format!("Failed to run gh: {e}"))?;
+fn get_github_user() -> Result<(String, String, String), CommandError> {
+    // Labeled + retried on transient EAGAIN; a persistent one is classified
+    // Expected instead of surfacing "Failed to run gh: Resource temporarily
+    // unavailable (os error 35)" as an app malfunction (issue #586).
+    let mut cmd = get_gh_command();
+    cmd.args([
+        "api",
+        "user",
+        "--jq",
+        r#"[.login, .email // "", .name // ""] | @tsv"#,
+    ]);
+    let output = crate::external_command::spawn_with_pressure_retry("gh api user", || {
+        cmd.output()
+    })?;
 
     if !output.status.success() {
-        return Err("GitHub CLI not authenticated. Please connect GitHub first.".to_string());
+        return Err(CommandError::expected(
+            "GitHub CLI not authenticated. Please connect GitHub first.",
+        ));
     }
 
     let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -56,7 +62,7 @@ fn get_github_user() -> Result<(String, String, String), String> {
     let name = parts.get(2).unwrap_or(&"").to_string();
 
     if login.is_empty() {
-        return Err("Could not determine GitHub username".to_string());
+        return Err(CommandError::from("Could not determine GitHub username"));
     }
 
     let email = if email.is_empty() {

--- a/src-tauri/src/commands/support.rs
+++ b/src-tauri/src/commands/support.rs
@@ -44,9 +44,8 @@ fn get_github_user() -> Result<(String, String, String), CommandError> {
         "--jq",
         r#"[.login, .email // "", .name // ""] | @tsv"#,
     ]);
-    let output = crate::external_command::spawn_with_pressure_retry("gh api user", || {
-        cmd.output()
-    })?;
+    let output =
+        crate::external_command::spawn_with_pressure_retry("gh api user", || cmd.output())?;
 
     if !output.status.success() {
         return Err(CommandError::expected(

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -75,6 +75,89 @@ pub async fn run_with_timeout(
     }
 }
 
+/// Like [`run_with_timeout`], but feeds `stdin_data` to the child's stdin.
+///
+/// Exists because passing a large payload (an AI prompt carrying a ~40KB diff)
+/// as a single argv element can exceed the OS's combined argv+env exec limit —
+/// `Argument list too long` / E2BIG (issue #595). Stdin has no such ceiling.
+///
+/// The write and the wait run concurrently (`tokio::join!`) so a child that
+/// interleaves reading stdin with writing output can't deadlock on a full
+/// pipe; once everything is written the stdin handle is shut down and dropped
+/// so the child sees EOF. A child that exits without draining stdin (e.g. an
+/// early CLI error) surfaces its own output — the resulting broken-pipe write
+/// error is deliberately ignored.
+pub async fn run_with_timeout_stdin(
+    mut cmd: Command,
+    stdin_data: &str,
+    cmd_label: impl Into<String>,
+    timeout_secs: u64,
+) -> Result<std::process::Output, CommandError> {
+    let label = cmd_label.into();
+    debug!(cmd = %label, timeout_secs, stdin_bytes = stdin_data.len(), "spawning external command (stdin-fed)");
+
+    cmd.stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let data = stdin_data.as_bytes().to_vec();
+    let run = async move {
+        let mut child = cmd.spawn()?;
+        let mut stdin = child.stdin.take();
+        let feed = async {
+            if let Some(mut handle) = stdin.take() {
+                use tokio::io::AsyncWriteExt;
+                match handle.write_all(&data).await {
+                    Ok(()) => {
+                        let _ = handle.shutdown().await;
+                    }
+                    // The child closed stdin early (exited or stopped
+                    // reading) — its exit status/stderr is the real story.
+                    Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {}
+                    Err(e) => warn!(error = %e, "failed writing to child stdin"),
+                }
+                // Dropping the handle closes the pipe: the child must see EOF.
+            }
+        };
+        let (output, ()) = tokio::join!(child.wait_with_output(), feed);
+        output
+    };
+
+    match tokio::time::timeout(Duration::from_secs(timeout_secs), run).await {
+        Ok(Ok(output)) => {
+            debug!(
+                cmd = %label,
+                status = ?output.status.code(),
+                "external command finished"
+            );
+            Ok(output)
+        }
+        // Same io-error mapping as run_with_timeout: missing binary and
+        // Windows pagefile exhaustion are environment states, not
+        // malfunctions (issues #296, #356).
+        Ok(Err(io_err)) => {
+            warn!(cmd = %label, error = %io_err, "external command spawn failed");
+            let message = format!("`{label}`: {io_err}");
+            if io_err.kind() == std::io::ErrorKind::NotFound {
+                Err(CommandError::expected(message))
+            } else if let Some(oom) =
+                crate::errors::windows_out_of_memory(&io_err, Some(label.as_str()))
+            {
+                Err(oom)
+            } else {
+                Err(CommandError::Io { message })
+            }
+        }
+        Err(_) => {
+            warn!(cmd = %label, timeout_secs, "external command timed out");
+            Err(CommandError::Timeout {
+                cmd: label,
+                secs: timeout_secs,
+            })
+        }
+    }
+}
+
 /// Convenience: run a command and require a successful (zero) exit, returning
 /// the captured stdout as a UTF-8 string. Maps non-zero exits to
 /// `CommandError::Process`.
@@ -149,6 +232,61 @@ mod tests {
         match err {
             CommandError::Timeout { secs, .. } => assert_eq!(secs, 1),
             other => panic!("expected Timeout, got {other:?}"),
+        }
+    }
+
+    /// `cat` only exits once stdin reaches EOF, so a passing test proves the
+    /// prompt is fully written *and* the handle closed before we wait —
+    /// exactly the plumbing issue #595 depends on.
+    #[tokio::test]
+    async fn run_with_timeout_stdin_writes_and_closes_stdin() {
+        let cmd = Command::new("cat");
+        let out = run_with_timeout_stdin(cmd, "hello stdin prompt", "cat", 5)
+            .await
+            .unwrap();
+        assert!(out.status.success());
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "hello stdin prompt");
+    }
+
+    /// A payload far beyond any argv limit and larger than a pipe buffer:
+    /// write/wait must interleave without deadlocking, and every byte must
+    /// arrive.
+    #[tokio::test]
+    async fn run_with_timeout_stdin_handles_large_payloads() {
+        let payload = "diff line with some content\n".repeat(10_000); // ~280KB
+        let cmd = Command::new("cat");
+        let out = run_with_timeout_stdin(cmd, &payload, "cat large", 10)
+            .await
+            .unwrap();
+        assert!(out.status.success());
+        assert_eq!(out.stdout.len(), payload.len());
+    }
+
+    /// A child that exits without reading stdin (early CLI error) must surface
+    /// its own status/stderr, not a broken-pipe write failure.
+    #[tokio::test]
+    async fn run_with_timeout_stdin_tolerates_child_ignoring_stdin() {
+        let big = "x".repeat(1_000_000);
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("echo boom 1>&2; exit 3");
+        let out = run_with_timeout_stdin(cmd, &big, "sh early-exit", 10)
+            .await
+            .unwrap();
+        assert_eq!(out.status.code(), Some(3));
+        assert!(String::from_utf8_lossy(&out.stderr).contains("boom"));
+    }
+
+    #[tokio::test]
+    async fn run_with_timeout_stdin_maps_missing_binary_to_expected() {
+        let cmd = Command::new("definitely-not-a-real-binary-shipstudio");
+        let err = run_with_timeout_stdin(cmd, "prompt", "ghost-stdin", 5)
+            .await
+            .unwrap_err();
+        match err {
+            CommandError::Expected { message } => {
+                assert!(message.contains("`ghost-stdin`"), "got: {message}")
+            }
+            other => panic!("expected Expected, got {other:?}"),
         }
     }
 

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -95,6 +95,95 @@ pub async fn run_to_stdout(
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+// ===== Transient spawn resource pressure (EAGAIN) =====
+//
+// Under macOS process/thread-table pressure, `fork()`/`posix_spawn()` can
+// transiently fail with EAGAIN ("Resource temporarily unavailable", os error
+// 35 on macOS/BSD, 11 on Linux). This surfaced as bare, unlabeled OS error
+// strings from many independent spawn sites (issues #555, #573, #585, #586,
+// #587). The helpers below give every spawn site one shared treatment:
+// a couple of short-backoff retries, and — if the pressure persists — a
+// human-readable `Expected` error instead of telemetry noise.
+
+/// True when a rendered error message is the transient EAGAIN spawn failure.
+///
+/// Message-based (rather than `raw_os_error`-based) so it works uniformly for
+/// `std::io::Error` and for portable_pty's `anyhow`-shaped errors, which only
+/// expose the underlying OS error through their `Display` text. The raw-code
+/// fallbacks are Unix-gated: on Windows os error 35/11 mean unrelated things.
+pub fn is_spawn_resource_pressure(message: &str) -> bool {
+    message.contains("Resource temporarily unavailable")
+        || (cfg!(unix) && (message.contains("(os error 35)") || message.contains("(os error 11)")))
+}
+
+/// The persistent-EAGAIN error: process-table/resource pressure is an
+/// environment condition with a user-side fix, not an app malfunction —
+/// `Expected` keeps it out of telemetry and swaps the raw OS string for
+/// actionable guidance.
+pub fn spawn_resource_pressure_error(label: &str) -> CommandError {
+    CommandError::expected(format!(
+        "Couldn't start `{label}` — your system is temporarily low on process resources. \
+         Close some apps or terminal tabs and try again."
+    ))
+}
+
+/// Run a spawn closure, retrying a couple of times with a short backoff when
+/// it fails with EAGAIN (see module comment above). Any other failure — and
+/// an EAGAIN that survives every retry — is returned unchanged so the
+/// caller's existing error mapping still applies; pair with
+/// [`is_spawn_resource_pressure`] / [`spawn_resource_pressure_error`] to
+/// classify the persistent case.
+///
+/// Blocking (uses `std::thread::sleep`); total added wait is ≤ 300ms and only
+/// on the rare EAGAIN path, matching `output_retrying_index_lock`'s tradeoff.
+pub fn retry_spawn_on_pressure<T, E: std::fmt::Display>(
+    label: &str,
+    mut spawn: impl FnMut() -> Result<T, E>,
+) -> Result<T, E> {
+    const ATTEMPTS: u64 = 3;
+    for attempt in 1..=ATTEMPTS {
+        match spawn() {
+            Ok(v) => return Ok(v),
+            Err(e) if attempt < ATTEMPTS && is_spawn_resource_pressure(&e.to_string()) => {
+                warn!(
+                    cmd = %label,
+                    attempt,
+                    error = %e,
+                    "spawn hit transient resource pressure (EAGAIN); retrying"
+                );
+                std::thread::sleep(Duration::from_millis(100 * attempt));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    unreachable!("loop returns on the final attempt")
+}
+
+/// Convenience for `std::process` spawn sites: run the spawn with the EAGAIN
+/// retry, then map any failure into a labeled `CommandError` — persistent
+/// EAGAIN becomes the human `Expected` message, a missing binary stays
+/// `Expected` (mirroring [`run_with_timeout`], #296), Windows pagefile
+/// exhaustion keeps its typed guidance (#356), and anything else is a
+/// labeled `Io` so telemetry can attribute the call site.
+pub fn spawn_with_pressure_retry<T>(
+    label: &str,
+    spawn: impl FnMut() -> std::io::Result<T>,
+) -> Result<T, CommandError> {
+    retry_spawn_on_pressure(label, spawn).map_err(|io_err| {
+        if is_spawn_resource_pressure(&io_err.to_string()) {
+            return spawn_resource_pressure_error(label);
+        }
+        let message = format!("`{label}`: {io_err}");
+        if io_err.kind() == std::io::ErrorKind::NotFound {
+            CommandError::expected(message)
+        } else if let Some(oom) = crate::errors::windows_out_of_memory(&io_err, Some(label)) {
+            oom
+        } else {
+            CommandError::Io { message }
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -131,6 +220,133 @@ mod tests {
             CommandError::Timeout { secs, .. } => assert_eq!(secs, 1),
             other => panic!("expected Timeout, got {other:?}"),
         }
+    }
+
+    /// Builds an io::Error whose Display matches the reported telemetry shapes
+    /// deterministically on every platform (from_raw_os_error(35) renders
+    /// differently on Windows CI).
+    fn eagain() -> std::io::Error {
+        std::io::Error::other("Resource temporarily unavailable (os error 35)")
+    }
+
+    // The #555/#573/#585/#586/#587 shapes: bare EAGAIN text from macOS spawns.
+    #[test]
+    fn spawn_pressure_matches_reported_eagain_shapes() {
+        assert!(is_spawn_resource_pressure(
+            "Resource temporarily unavailable (os error 35)"
+        ));
+        assert!(is_spawn_resource_pressure(
+            "spawn_command: Resource temporarily unavailable (os error 35)"
+        ));
+        assert!(is_spawn_resource_pressure(
+            "Failed to execute command: Resource temporarily unavailable (os error 35)"
+        ));
+        // Linux renders EAGAIN as os error 11.
+        #[cfg(unix)]
+        assert!(is_spawn_resource_pressure(
+            "Resource temporarily unavailable (os error 11)"
+        ));
+    }
+
+    #[test]
+    fn spawn_pressure_rejects_other_errors() {
+        assert!(!is_spawn_resource_pressure(
+            "No such file or directory (os error 2)"
+        ));
+        assert!(!is_spawn_resource_pressure(
+            "Operation not permitted (os error 1)"
+        ));
+        assert!(!is_spawn_resource_pressure(""));
+        // Don't match a larger error code that merely contains "35"/"11".
+        assert!(!is_spawn_resource_pressure("something (os error 110)"));
+        assert!(!is_spawn_resource_pressure("something (os error 355)"));
+    }
+
+    #[test]
+    fn retry_spawn_recovers_after_transient_eagain() {
+        let mut calls = 0;
+        let result: Result<i32, std::io::Error> = retry_spawn_on_pressure("git status", || {
+            calls += 1;
+            if calls < 3 {
+                Err(eagain())
+            } else {
+                Ok(42)
+            }
+        });
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(calls, 3);
+    }
+
+    #[test]
+    fn retry_spawn_does_not_retry_non_eagain_failures() {
+        let mut calls = 0;
+        let result: Result<(), std::io::Error> = retry_spawn_on_pressure("git status", || {
+            calls += 1;
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "No such file or directory (os error 2)",
+            ))
+        });
+        assert!(result.is_err());
+        assert_eq!(calls, 1);
+    }
+
+    #[test]
+    fn persistent_eagain_becomes_expected_with_human_message() {
+        let mut calls = 0;
+        let err = spawn_with_pressure_retry::<()>("open safari", || {
+            calls += 1;
+            Err(eagain())
+        })
+        .unwrap_err();
+        assert_eq!(calls, 3, "must exhaust the retries first");
+        assert!(matches!(err, CommandError::Expected { .. }), "got: {err:?}");
+        let msg = err.to_string();
+        assert!(msg.contains("`open safari`"), "got: {msg}");
+        assert!(msg.contains("low on process resources"), "got: {msg}");
+        // The raw OS string must not leak into the user-facing message.
+        assert!(!msg.contains("os error 35"), "got: {msg}");
+    }
+
+    #[test]
+    fn spawn_with_pressure_retry_keeps_not_found_expected_and_labeled() {
+        let err = spawn_with_pressure_retry::<()>("gh api user", || {
+            Err(std::io::Error::new(std::io::ErrorKind::NotFound, "missing"))
+        })
+        .unwrap_err();
+        match err {
+            CommandError::Expected { message } => {
+                assert!(message.contains("`gh api user`"), "got: {message}")
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn spawn_with_pressure_retry_labels_other_io_errors() {
+        let err = spawn_with_pressure_retry::<()>("gh api user", || {
+            Err(std::io::Error::other("boom"))
+        })
+        .unwrap_err();
+        match err {
+            CommandError::Io { message } => {
+                assert!(message.contains("`gh api user`"), "got: {message}");
+                assert!(message.contains("boom"), "got: {message}");
+            }
+            other => panic!("expected Io, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn spawn_with_pressure_retry_passes_success_through_untouched() {
+        let mut calls = 0;
+        let out = spawn_with_pressure_retry("echo", || {
+            calls += 1;
+            Ok(7)
+        })
+        .unwrap();
+        assert_eq!(out, 7);
+        assert_eq!(calls, 1, "no gratuitous retries on success");
     }
 
     #[tokio::test]

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -89,10 +89,29 @@ pub async fn run_to_stdout(
         return Err(CommandError::Process {
             cmd: label_for_err,
             exit_code: output.status.code().unwrap_or(-1),
-            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            stderr: truncate_output(&String::from_utf8_lossy(&output.stderr)),
         });
     }
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Cap on CLI output forwarded into user-facing error messages (and thus into
+/// telemetry). A crashing subprocess can dump arbitrarily much — a Go runtime
+/// stack trace, a full agent session transcript — and nothing past the head is
+/// useful in an error dialog (issues #578, #610).
+pub const MAX_ERROR_OUTPUT_CHARS: usize = 2048;
+
+/// Trim `text` and cap it at [`MAX_ERROR_OUTPUT_CHARS`], keeping the head (the
+/// useful part — CLIs print the actual error first, then detail/backtrace) and
+/// appending a truncation marker. Use this whenever raw stderr/stdout is
+/// embedded into a `CommandError`.
+pub fn truncate_output(text: &str) -> String {
+    let trimmed = text.trim();
+    if trimmed.chars().count() <= MAX_ERROR_OUTPUT_CHARS {
+        return trimmed.to_string();
+    }
+    let head: String = trimmed.chars().take(MAX_ERROR_OUTPUT_CHARS).collect();
+    format!("{}… (truncated)", head.trim_end())
 }
 
 #[cfg(test)]
@@ -131,6 +150,23 @@ mod tests {
             CommandError::Timeout { secs, .. } => assert_eq!(secs, 1),
             other => panic!("expected Timeout, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn truncate_output_passes_short_text_through_trimmed() {
+        assert_eq!(truncate_output("  short error  \n"), "short error");
+        assert_eq!(truncate_output(""), "");
+    }
+
+    // The #610/#578 shape: a crash dump / session transcript on stderr must be
+    // capped, keeping the head where the actual error line lives.
+    #[test]
+    fn truncate_output_caps_long_text_preserving_head() {
+        let long = format!("fatal error: the real cause\n{}", "x".repeat(10_000));
+        let capped = truncate_output(&long);
+        assert!(capped.starts_with("fatal error: the real cause"));
+        assert!(capped.ends_with("… (truncated)"), "got tail: {}", &capped[capped.len().saturating_sub(40)..]);
+        assert!(capped.chars().count() <= MAX_ERROR_OUTPUT_CHARS + "… (truncated)".len());
     }
 
     #[tokio::test]

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -481,10 +481,9 @@ mod tests {
 
     #[test]
     fn spawn_with_pressure_retry_labels_other_io_errors() {
-        let err = spawn_with_pressure_retry::<()>("gh api user", || {
-            Err(std::io::Error::other("boom"))
-        })
-        .unwrap_err();
+        let err =
+            spawn_with_pressure_retry::<()>("gh api user", || Err(std::io::Error::other("boom")))
+                .unwrap_err();
         match err {
             CommandError::Io { message } => {
                 assert!(message.contains("`gh api user`"), "got: {message}");
@@ -519,7 +518,11 @@ mod tests {
         let long = format!("fatal error: the real cause\n{}", "x".repeat(10_000));
         let capped = truncate_output(&long);
         assert!(capped.starts_with("fatal error: the real cause"));
-        assert!(capped.ends_with("… (truncated)"), "got tail: {}", &capped[capped.len().saturating_sub(40)..]);
+        assert!(
+            capped.ends_with("… (truncated)"),
+            "got tail: {}",
+            &capped[capped.len().saturating_sub(40)..]
+        );
         assert!(capped.chars().count() <= MAX_ERROR_OUTPUT_CHARS + "… (truncated)".len());
     }
 

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -1001,7 +1001,15 @@ async fn handle_websocket_upgrade(
                 target_port,
                 first_err
             );
-            let retried: Result<Response<hyper::body::Incoming>, String> = async {
+            // The reconnect's failure is kept as an io::Error so the final
+            // branch can classify refused/timed-out retries as the expected
+            // dev-server-restart state, exactly like the initial connect loop
+            // (issue #552). tokio's timeout Elapsed converts to ErrorKind::
+            // TimedOut — the same "SYN unanswered mid-restart" classification
+            // the loop above applies. Non-I/O arms (handshake, request build)
+            // are wrapped as ErrorKind::Other, which never classifies as
+            // expected.
+            let retried: Result<Response<hyper::body::Incoming>, std::io::Error> = async {
                 let remaining =
                     connect_deadline.saturating_duration_since(tokio::time::Instant::now());
                 let remaining = remaining.max(std::time::Duration::from_millis(500));
@@ -1010,28 +1018,46 @@ async fn handle_websocket_upgrade(
                     connect_loopback(target_port),
                 )
                 .await
-                .map_err(|_| "reconnect timed out".to_string())?
-                .map_err(|e| e.to_string())?;
+                .map_err(std::io::Error::from)
+                .and_then(|r| r)?;
                 let (mut retry_sender, retry_conn) = hyper::client::conn::http1::Builder::new()
                     .preserve_header_case(true)
                     .title_case_headers(true)
                     .handshake(TokioIo::new(stream))
                     .await
-                    .map_err(|e| e.to_string())?;
+                    .map_err(std::io::Error::other)?;
                 tokio::spawn(async move {
                     if let Err(e) = retry_conn.with_upgrades().await {
                         tracing::debug!("[Proxy] WebSocket retry client conn error: {}", e);
                     }
                 });
-                let req = build_forward(empty_body()).map_err(|e| e.to_string())?;
+                let req = build_forward(empty_body()).map_err(std::io::Error::other)?;
                 retry_sender
                     .send_request(req)
                     .await
-                    .map_err(|e| e.to_string())
+                    .map_err(std::io::Error::other)
             }
             .await;
             match retried {
                 Ok(r) => r,
+                Err(e) if ws_upstream_unavailable(e.kind()) => {
+                    // The retry's reconnect was refused or silent: the dev
+                    // server is still down/restarting — the same expected
+                    // state the initial connect loop logs at warn (issue
+                    // #532), so the retry path must not auto-file a bug
+                    // report either (issue #552). The browser-side HMR client
+                    // retries on its own after the 502.
+                    tracing::warn!(
+                        "[Proxy] WebSocket target 127.0.0.1:{} still unavailable on retry: {} (first attempt: {})",
+                        target_port,
+                        e,
+                        first_err
+                    );
+                    return Ok(Response::builder()
+                        .status(StatusCode::BAD_GATEWAY)
+                        .body(full_body(Bytes::from("WebSocket proxy error")))
+                        .unwrap());
+                }
                 Err(e) => {
                     // Include the upstream port: without it the report is
                     // uncorrelatable (issue #293).
@@ -1202,6 +1228,38 @@ mod tests {
             std::io::ErrorKind::AddrNotAvailable
         ));
         assert!(!ws_upstream_unavailable(std::io::ErrorKind::Other));
+    }
+
+    /// The one-shot WS retry path (issue #466) must feed the SAME
+    /// classification as the initial connect loop (issue #552): its error is
+    /// kept as an io::Error, with a refused reconnect keeping its kind, a
+    /// tokio timeout mapping to TimedOut, and non-I/O arms wrapped as Other
+    /// so they can never be misclassified as "expected".
+    #[tokio::test]
+    async fn ws_retry_errors_keep_their_classification() {
+        // A reconnect refusal keeps ConnectionRefused → expected (warn).
+        let refused = std::io::Error::from(std::io::ErrorKind::ConnectionRefused);
+        assert!(ws_upstream_unavailable(refused.kind()));
+
+        // The retry's reconnect timeout (tokio Elapsed → io::Error, the same
+        // `map_err(std::io::Error::from)` the initial loop uses) → TimedOut →
+        // expected (warn).
+        let elapsed: Result<(), _> = tokio::time::timeout(
+            std::time::Duration::from_millis(1),
+            std::future::pending::<()>(),
+        )
+        .await
+        .map_err(std::io::Error::from);
+        assert_eq!(
+            elapsed.unwrap_err().kind(),
+            std::io::ErrorKind::TimedOut,
+            "tokio Elapsed must convert to TimedOut for the expected-state classification"
+        );
+
+        // Handshake / request-build failures are wrapped via io::Error::other
+        // → NOT classified as expected: they stay at error level.
+        let other = std::io::Error::other("handshake failed");
+        assert!(!ws_upstream_unavailable(other.kind()));
     }
 
     #[test]

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -464,6 +464,33 @@ where
     unreachable!("loop always returns on the final attempt")
 }
 
+/// Classify a filesystem `io::Error` for a user-facing command error.
+///
+/// macOS TCC's EPERM denial (`os error 1` — Privacy & Security blocking
+/// Desktop/Documents/Downloads/iCloud/external volumes) is an environment
+/// condition with a user-side fix, so it becomes an actionable `Expected`
+/// with the Files & Folders remediation instead of a bare "Operation not
+/// permitted" telemetry bug — the same treatment `read_projects_dir` got in
+/// #307, shared here so every fs call site classifies identically (issues
+/// #545, #605). Anything else stays a labeled `Io` for diagnosability.
+pub fn classify_fs_error(
+    action: &str,
+    path: &std::path::Path,
+    e: &std::io::Error,
+) -> crate::errors::CommandError {
+    if cfg!(target_os = "macos") && e.raw_os_error() == Some(1) {
+        crate::errors::CommandError::expected(format!(
+            "Ship Studio isn't allowed to {action} ({}). Grant access in System Settings → \
+             Privacy & Security → Files & Folders (or Full Disk Access), then try again.",
+            path.display()
+        ))
+    } else {
+        crate::errors::CommandError::Io {
+            message: format!("Failed to {action} ({}): {e}", path.display()),
+        }
+    }
+}
+
 /// Finds an executable by checking common installation paths.
 /// This is needed because bundled macOS apps don't inherit the user's shell PATH.
 /// On Windows, checks standard Program Files and AppData locations.
@@ -1221,6 +1248,47 @@ mod tests {
                 if !matches!(err, crate::errors::CommandError::Expected { .. }) {
                     assert!(err.to_string().contains("test_site"));
                 }
+            }
+        }
+    }
+
+    mod classify_fs_errors {
+        use super::*;
+
+        // The #545/#605 shape: TCC denying a read under ~/Desktop etc.
+        #[test]
+        #[cfg(target_os = "macos")]
+        fn macos_eperm_becomes_expected_with_privacy_remediation() {
+            let e = std::io::Error::from_raw_os_error(1);
+            let err = classify_fs_error(
+                "read this project's plugin storage",
+                std::path::Path::new("/Users/x/Desktop/proj/.shipstudio"),
+                &e,
+            );
+            assert!(
+                matches!(err, crate::errors::CommandError::Expected { .. }),
+                "got: {err:?}"
+            );
+            let msg = err.to_string();
+            assert!(msg.contains("Privacy & Security"), "got: {msg}");
+            assert!(msg.contains("plugin storage"), "got: {msg}");
+            assert!(msg.contains("/Users/x/Desktop/proj"), "got: {msg}");
+        }
+
+        #[test]
+        fn other_io_errors_stay_labeled_io() {
+            let e = std::io::Error::new(std::io::ErrorKind::InvalidData, "corrupt");
+            let err = classify_fs_error(
+                "read this project's plugin registry",
+                std::path::Path::new("/p/registry.json"),
+                &e,
+            );
+            match err {
+                crate::errors::CommandError::Io { message } => {
+                    assert!(message.contains("plugin registry"), "got: {message}");
+                    assert!(message.contains("corrupt"), "got: {message}");
+                }
+                other => panic!("expected Io, got {other:?}"),
             }
         }
     }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -426,15 +426,22 @@ pub fn git_command_in(
     Ok(cmd)
 }
 
-/// True when git failed because another process held `.git/index.lock`.
+/// True when git failed because another process held one of its lock files.
 /// Concurrent git spawns against the same repo are unavoidable here: the
 /// snapshot watcher, commit/publish flows, and the user's own agent CLIs all
 /// run git independently. Git fails fast instead of waiting, so a collision
-/// surfaces as "Unable to create '….git/index.lock': File exists" — most
-/// visibly on Windows, where lock files also linger longer (AV scanning,
-/// handle-release timing) (issue #377).
+/// surfaces as "Unable to create '….lock': File exists" — most visibly on
+/// Windows, where lock files also linger longer (AV scanning, handle-release
+/// timing) (issue #377).
+///
+/// The same concurrency produces the same message for *every* git lock file,
+/// not just `.git/index.lock`: `git commit` also takes `HEAD.lock` and
+/// `refs/heads/<branch>.lock` when it updates the ref, and ref updates take
+/// `packed-refs.lock` — so the match is on the shared `….lock': File exists`
+/// shape rather than the literal `index.lock` (issue #567).
 pub fn is_index_lock_contention(stderr: &str) -> bool {
-    stderr.contains("index.lock") && stderr.contains("File exists")
+    (stderr.contains(".lock") && stderr.contains("File exists"))
+        || stderr.contains("Another git process seems to be running")
 }
 
 /// Run a git invocation built by `run`, retrying with a short backoff when it
@@ -1234,6 +1241,27 @@ mod tests {
             assert!(is_index_lock_contention(stderr));
             assert!(!is_index_lock_contention("fatal: not a git repository"));
             assert!(!is_index_lock_contention(""));
+        }
+
+        /// Issue #567: the same concurrency that produces index.lock collisions
+        /// also produces HEAD.lock / refs/heads/*.lock / packed-refs.lock
+        /// collisions — all must be retried, not just the index.lock wording.
+        #[test]
+        fn recognizes_head_and_ref_lock_collisions() {
+            let head = "fatal: cannot lock ref 'HEAD': Unable to create '/Users/x/acss-poc/.git/HEAD.lock': File exists.\n\nAnother git process seems to be running in this repository, e.g.\nan editor opened by 'git commit'.";
+            assert!(is_index_lock_contention(head));
+            let branch_ref = "fatal: cannot lock ref 'refs/heads/main': Unable to create '/repo/.git/refs/heads/main.lock': File exists.";
+            assert!(is_index_lock_contention(branch_ref));
+            let packed = "fatal: Unable to create '/repo/.git/packed-refs.lock': File exists.";
+            assert!(is_index_lock_contention(packed));
+            // Unrelated failures that merely mention a lock-ish word must not
+            // trigger retries.
+            assert!(!is_index_lock_contention(
+                "error: could not write config file .git/config: File exists"
+            ));
+            assert!(!is_index_lock_contention(
+                "fatal: pathspec 'package-lock.json' did not match any files"
+            ));
         }
 
         #[test]

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -1501,8 +1501,7 @@ mod tests {
         /// folder surfaces as git's own getcwd failure on stderr.
         #[test]
         fn classifies_macos_tcc_denial_as_expected() {
-            let stderr =
-                "fatal: Unable to read current working directory: Operation not permitted";
+            let stderr = "fatal: Unable to read current working directory: Operation not permitted";
             let err = git_environment_gap(stderr).expect("must classify");
             assert!(matches!(err, crate::errors::CommandError::Expected { .. }));
             assert!(err.to_string().contains("Privacy & Security"));
@@ -1514,10 +1513,10 @@ mod tests {
             assert!(git_environment_gap("").is_none());
             // "Operation not permitted" on some other operation isn't the TCC
             // getcwd signature — don't over-match.
-            assert!(
-                git_environment_gap("error: unable to unlink old 'a.txt': Operation not permitted")
-                    .is_none()
-            );
+            assert!(git_environment_gap(
+                "error: unable to unlink old 'a.txt': Operation not permitted"
+            )
+            .is_none());
         }
     }
 

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -491,6 +491,30 @@ pub fn classify_fs_error(
     }
 }
 
+/// Resolve `cmd` inside a single directory.
+///
+/// On Windows, executable (`.exe`) and batch (`.cmd`) shims are checked
+/// BEFORE an extensionless sibling: Node installs `npm`/`npx` both as
+/// `.cmd` batch shims AND as extensionless POSIX-shell scripts (for Git
+/// Bash) in the same directory. Preferring the bare name resolved the shell
+/// script, which `CreateProcess` cannot execute — every spawn then failed
+/// with "%1 is not a valid Win32 application" (os error 193, issue #590).
+/// `.cmd`/`.bat` are fine: Rust ≥ 1.77 spawns them through `cmd.exe` itself.
+fn resolve_executable_in_dir(dir: &std::path::Path, cmd: &str) -> Option<std::path::PathBuf> {
+    #[cfg(windows)]
+    for ext in ["exe", "cmd", "bat"] {
+        let with_ext = dir.join(format!("{cmd}.{ext}"));
+        if with_ext.is_file() {
+            return Some(with_ext);
+        }
+    }
+    let bare = dir.join(cmd);
+    if bare.is_file() {
+        return Some(bare);
+    }
+    None
+}
+
 /// Finds an executable by checking common installation paths.
 /// This is needed because bundled macOS apps don't inherit the user's shell PATH.
 /// On Windows, checks standard Program Files and AppData locations.
@@ -508,16 +532,8 @@ pub fn find_executable(cmd: &str) -> Option<std::path::PathBuf> {
         if dir.is_empty() {
             continue;
         }
-        let candidate = std::path::Path::new(dir).join(cmd);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        #[cfg(windows)]
-        for ext in ["exe", "cmd"] {
-            let win = std::path::Path::new(dir).join(format!("{cmd}.{ext}"));
-            if win.is_file() {
-                return Some(win);
-            }
+        if let Some(found) = resolve_executable_in_dir(std::path::Path::new(dir), cmd) {
+            return Some(found);
         }
     }
 
@@ -1290,6 +1306,48 @@ mod tests {
                 }
                 other => panic!("expected Io, got {other:?}"),
             }
+        }
+    }
+
+    mod resolve_executable {
+        use super::*;
+
+        #[test]
+        fn resolves_bare_name() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            std::fs::write(tmp.path().join("mytool"), "#!/bin/sh\n").unwrap();
+            let found = resolve_executable_in_dir(tmp.path(), "mytool").unwrap();
+            assert_eq!(found, tmp.path().join("mytool"));
+        }
+
+        #[test]
+        fn misses_cleanly_when_absent() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            assert!(resolve_executable_in_dir(tmp.path(), "ghost-tool").is_none());
+        }
+
+        // The #590 shape: nodejs ships BOTH an extensionless POSIX-shell
+        // `npm` and `npm.cmd` in the same directory. Resolving the shell
+        // script makes CreateProcess fail with os error 193 — the batch
+        // shim must win.
+        #[test]
+        #[cfg(windows)]
+        fn prefers_cmd_shim_over_extensionless_shell_script() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            std::fs::write(tmp.path().join("npm"), "#!/bin/sh\n").unwrap();
+            std::fs::write(tmp.path().join("npm.cmd"), "@echo off\r\n").unwrap();
+            let found = resolve_executable_in_dir(tmp.path(), "npm").unwrap();
+            assert_eq!(found, tmp.path().join("npm.cmd"));
+        }
+
+        #[test]
+        #[cfg(windows)]
+        fn prefers_exe_over_cmd_shim() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            std::fs::write(tmp.path().join("tool.cmd"), "@echo off\r\n").unwrap();
+            std::fs::write(tmp.path().join("tool.exe"), "MZ").unwrap();
+            let found = resolve_executable_in_dir(tmp.path(), "tool").unwrap();
+            assert_eq!(found, tmp.path().join("tool.exe"));
         }
     }
 

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -471,6 +471,47 @@ where
     unreachable!("loop always returns on the final attempt")
 }
 
+/// Classify git stderr that signals a *machine/environment* gap — git itself
+/// couldn't run (or couldn't read the project), through no fault of the app.
+/// Returns a `CommandError::expected` with actionable guidance so these don't
+/// page telemetry as malfunctions, or `None` for anything else.
+///
+/// Covered signatures:
+/// - macOS Xcode CLT license not accepted — git is a CLT shim on macOS, so
+///   every git call fails with the license text until the user accepts it
+///   (issue #603).
+/// - macOS Xcode CLT missing/broken (`xcrun: error: invalid active developer
+///   path`) — same shim, e.g. after a macOS upgrade removed the CLT.
+/// - macOS TCC denial (`Unable to read current working directory: Operation
+///   not permitted`) — the sandbox refused the app read access to the project
+///   folder, so spawned git can't even resolve its cwd (issue #546).
+pub fn git_environment_gap(stderr: &str) -> Option<crate::errors::CommandError> {
+    if stderr.contains("You have not agreed to the Xcode license agreements") {
+        return Some(crate::errors::CommandError::expected(
+            "Xcode's license hasn't been accepted yet, so git can't run. Open Terminal, run \
+             `sudo xcodebuild -license accept`, then try again.",
+        ));
+    }
+    if stderr.contains("invalid active developer path")
+        || stderr.contains("no developer tools were found")
+    {
+        return Some(crate::errors::CommandError::expected(
+            "The Xcode Command Line Tools (which provide git on macOS) are missing or broken. \
+             Run `xcode-select --install` in Terminal, then try again.",
+        ));
+    }
+    if stderr.contains("Unable to read current working directory")
+        && stderr.contains("Operation not permitted")
+    {
+        return Some(crate::errors::CommandError::expected(
+            "Ship Studio isn't allowed to read this project's folder — macOS blocked access. \
+             Grant access in System Settings → Privacy & Security → Files & Folders (or give \
+             Ship Studio Full Disk Access), then try again.",
+        ));
+    }
+    None
+}
+
 /// Finds an executable by checking common installation paths.
 /// This is needed because bundled macOS apps don't inherit the user's shell PATH.
 /// On Windows, checks standard Program Files and AppData locations.
@@ -1301,6 +1342,56 @@ mod tests {
             .unwrap();
             assert_eq!(calls, 1);
             assert!(result.status.success());
+        }
+    }
+
+    mod git_environment_gap {
+        use super::*;
+
+        /// Issue #603: unaccepted Xcode CLT license makes every git call fail
+        /// on macOS — an environment gap, not an app malfunction.
+        #[test]
+        fn classifies_unaccepted_xcode_license_as_expected() {
+            let stderr = "You have not agreed to the Xcode license agreements. Please run 'sudo xcodebuild -license' from within a Terminal window to review and agree to the Xcode and Apple SDKs license.";
+            let err = git_environment_gap(stderr).expect("must classify");
+            assert!(matches!(err, crate::errors::CommandError::Expected { .. }));
+            assert!(
+                err.to_string().contains("sudo xcodebuild -license accept"),
+                "message must carry the remediation, got: {err}"
+            );
+        }
+
+        /// Missing/broken CLT (e.g. after a macOS upgrade) fails through the
+        /// same git shim with the xcrun wording.
+        #[test]
+        fn classifies_missing_developer_tools_as_expected() {
+            let stderr = "xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools), missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun";
+            let err = git_environment_gap(stderr).expect("must classify");
+            assert!(matches!(err, crate::errors::CommandError::Expected { .. }));
+            assert!(err.to_string().contains("xcode-select --install"));
+        }
+
+        /// Issue #546: macOS TCC denying the app read access to the project
+        /// folder surfaces as git's own getcwd failure on stderr.
+        #[test]
+        fn classifies_macos_tcc_denial_as_expected() {
+            let stderr =
+                "fatal: Unable to read current working directory: Operation not permitted";
+            let err = git_environment_gap(stderr).expect("must classify");
+            assert!(matches!(err, crate::errors::CommandError::Expected { .. }));
+            assert!(err.to_string().contains("Privacy & Security"));
+        }
+
+        #[test]
+        fn leaves_ordinary_git_failures_unclassified() {
+            assert!(git_environment_gap("fatal: not a git repository").is_none());
+            assert!(git_environment_gap("").is_none());
+            // "Operation not permitted" on some other operation isn't the TCC
+            // getcwd signature — don't over-match.
+            assert!(
+                git_environment_gap("error: unable to unlink old 'a.txt': Operation not permitted")
+                    .is_none()
+            );
         }
     }
 

--- a/src/components/branches/BranchesTab.revert.test.tsx
+++ b/src/components/branches/BranchesTab.revert.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Regression tests for "Revert to GitHub" on a branch with no upstream (#539).
+ *
+ * `git pull` on a never-pushed branch fails with git's "There is no tracking
+ * information for the current branch" refusal — an expected user state, not an
+ * app malfunction (the backend classifies it Expected). The handler used to
+ * toast the raw git dump as an 'error' (which self-reports to telemetry); it
+ * must instead explain the situation as an info toast + warn log, and humanize
+ * any other failure instead of leaking raw stderr.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { BranchesTab } from './BranchesTab';
+import { ToastContext } from '../../contexts/ToastContext';
+import type { BranchInfo } from '../../lib/branches';
+
+vi.mock('../../lib/branches', () => ({
+  switchBranch: vi.fn(),
+  deleteBranch: vi.fn(),
+  createBranch: vi.fn(),
+  discardChanges: vi.fn().mockResolvedValue(undefined),
+  formatRelativeTime: vi.fn(() => 'just now'),
+  getBranchPrefixPreference: vi.fn().mockResolvedValue(true),
+  setBranchPrefixPreference: vi.fn().mockResolvedValue(undefined),
+  getDefaultBaseBranch: vi.fn().mockResolvedValue(null),
+  pushBranch: vi.fn(),
+  sanitizeBranchName: vi.fn((s: string) => s),
+}));
+vi.mock('../../lib/git', () => ({ gitPull: vi.fn() }));
+vi.mock('../../lib/worktrees', () => ({
+  listWorktrees: vi.fn().mockResolvedValue([]),
+  removeWorktree: vi.fn(),
+  pruneWorktrees: vi.fn(),
+}));
+vi.mock('../../lib/project', () => ({ openProjectInNewWindow: vi.fn() }));
+vi.mock('../../lib/conflicts', () => ({ getConflictInfo: vi.fn() }));
+vi.mock('../../lib/analytics', () => ({ trackEvent: vi.fn(), trackError: vi.fn() }));
+vi.mock('../../lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('./BranchGraph', () => ({ BranchGraph: () => null }));
+vi.mock('./UnsavedChangesModal', () => ({ UnsavedChangesModal: () => null }));
+vi.mock('./MergeConflictModal', () => ({ MergeConflictModal: () => null }));
+vi.mock('./CreateBranchConflictModal', () => ({ CreateBranchConflictModal: () => null }));
+
+import {
+  discardChanges,
+  formatRelativeTime,
+  getBranchPrefixPreference,
+  getDefaultBaseBranch,
+  sanitizeBranchName,
+} from '../../lib/branches';
+import { listWorktrees } from '../../lib/worktrees';
+import { gitPull } from '../../lib/git';
+import { logger } from '../../lib/logger';
+
+type Fn = ReturnType<typeof vi.fn>;
+
+const currentBranch: BranchInfo = {
+  name: 'feat/unpushed',
+  isCurrent: true,
+  isRemote: false,
+  isDefault: false,
+  lastCommitDate: Date.now(),
+  lastCommitAuthor: 'Test',
+  aheadOfMain: 1,
+  behindOfMain: 0,
+  pushed: false,
+};
+
+function renderWithToasts(ui: ReactNode) {
+  const showToast = vi.fn<(message: string, type?: 'success' | 'error' | 'info') => void>();
+  render(
+    <ToastContext.Provider value={{ toasts: [], showToast, dismissToast: vi.fn() }}>
+      {ui}
+    </ToastContext.Provider>
+  );
+  return { showToast };
+}
+
+async function clickThroughRevert() {
+  fireEvent.click(screen.getByRole('button', { name: /revert to github/i }));
+  // Confirm modal
+  fireEvent.click(await screen.findByRole('button', { name: /^revert$/i }));
+}
+
+describe('BranchesTab — Revert to GitHub with no upstream (#539)', () => {
+  const props = {
+    branches: [currentBranch],
+    currentBranch: 'feat/unpushed',
+    projectPath: '/test/project',
+    githubUsername: null,
+    openPRs: [],
+    onBranchSwitch: vi.fn(),
+    onSubmitForReview: vi.fn(),
+    onRefresh: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Re-seed implementations — clearing wipes the factory-time defaults.
+    vi.mocked(discardChanges).mockResolvedValue(undefined);
+    vi.mocked(getBranchPrefixPreference).mockResolvedValue(true);
+    vi.mocked(getDefaultBaseBranch).mockResolvedValue(null);
+    vi.mocked(formatRelativeTime).mockReturnValue('just now');
+    vi.mocked(sanitizeBranchName).mockImplementation((s: string) => s);
+    vi.mocked(listWorktrees).mockResolvedValue([]);
+  });
+
+  it('explains the missing upstream as an info toast + warn log, not a raw git error', async () => {
+    vi.mocked(gitPull).mockRejectedValue({
+      type: 'Other',
+      message:
+        'Failed to pull: There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.\nSee git-pull(1) for details.',
+    });
+
+    const { showToast } = renderWithToasts(<BranchesTab {...props} />);
+    await clickThroughRevert();
+
+    await waitFor(() => expect(showToast).toHaveBeenCalled());
+    const [message, type] = showToast.mock.calls[0];
+    expect(type).toBe('info');
+    expect(message).toContain('never been pushed');
+    expect(message).toContain('feat/unpushed');
+    // Honest about the discard that already happened.
+    expect(message).toContain('discarded');
+    // The raw git dump stays out of the toast.
+    expect(message).not.toContain('git-pull(1)');
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.warn as Fn).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
+    expect(props.onRefresh).toHaveBeenCalled();
+  });
+
+  it('humanizes other pull failures instead of leaking raw stderr', async () => {
+    vi.mocked(gitPull).mockRejectedValue({
+      type: 'Other',
+      message: 'fatal: unable to access https://github.com/a/b: Could not resolve host: github.com',
+    });
+
+    const { showToast } = renderWithToasts(<BranchesTab {...props} />);
+    await clickThroughRevert();
+
+    await waitFor(() => expect(showToast).toHaveBeenCalled());
+    const [message, type] = showToast.mock.calls[0];
+    expect(type).toBe('error');
+    expect(message).toContain('Failed to revert:');
+    expect(message).toMatch(/couldn't reach GitHub/i);
+    expect(message).not.toContain('fatal:');
+  });
+});

--- a/src/components/branches/BranchesTab.tsx
+++ b/src/components/branches/BranchesTab.tsx
@@ -49,6 +49,7 @@ import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { useOptionalToast } from '../../contexts/ToastContext';
 import { asCommandError, formatCommandError, humanizeGitError } from '../../lib/errors';
+import { logger } from '../../lib/logger';
 
 /** A Tauri-rejected `CommandError` is an object — `String(err)` renders it as
  *  "[object Object]". Format it to the real human message (the git stderr). */
@@ -136,7 +137,8 @@ export function BranchesTab({
   onCreateWorktree,
 }: BranchesTabProps) {
   const { showToast } = useOptionalToast();
-  const onToast = (message: string, type?: 'success' | 'error') => showToast(message, type);
+  const onToast = (message: string, type?: 'success' | 'error' | 'info') =>
+    showToast(message, type);
   const [switchingBranch, setSwitchingBranch] = useState<string | null>(null);
   const [deletingBranch, setDeletingBranch] = useState<string | null>(null);
   const [publishingBranch, setPublishingBranch] = useState<string | null>(null);
@@ -433,7 +435,23 @@ export function BranchesTab({
       onRefresh();
     } catch (e) {
       trackError('branch_revert', e, 'Workspace');
-      onToast?.(`Failed to revert: ${errText(e)}`, 'error');
+      if (/no tracking information/i.test(errText(e))) {
+        // Expected: the branch has never been pushed, so there's no GitHub
+        // version to pull — git's normal refusal, not an app malfunction
+        // (the backend classifies it Expected too). The discard above already
+        // ran, so local edits ARE gone — say so honestly. Info toast + warn
+        // log, never the error channels that auto-file bug reports (#539).
+        logger.warn('[BranchesTab] Revert pull skipped: branch has no upstream', {
+          error: errText(e),
+        });
+        onToast?.(
+          `Your local changes were discarded, but ${currentBranch} has never been pushed to GitHub, so there was no GitHub version to pull. Send the branch to GitHub first if you want a copy to revert to next time.`,
+          'info'
+        );
+        onRefresh();
+      } else {
+        onToast?.(`Failed to revert: ${humanizeGitError(e, { branch: currentBranch })}`, 'error');
+      }
     } finally {
       setIsReverting(false);
     }

--- a/src/components/branches/CreateBranchConflictModal.test.tsx
+++ b/src/components/branches/CreateBranchConflictModal.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Regression tests for the create-branch conflict modal's post-stash switch
+ * (#564). The modal exists to clear uncommitted changes, but stragglers can
+ * reappear between the stash/commit step and the switch (dev-server config
+ * writes, polling races) — the switch then failed with the raw "Uncommitted
+ * changes" string and the flow dead-ended. It must retry once with auto-stash
+ * (mirroring UnsavedChangesModal's #273/PR #281 fix) and, if that still
+ * fails, hand the user a path forward instead of a raw terminal failure.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { CreateBranchConflictModal } from './CreateBranchConflictModal';
+import { ToastContext } from '../../contexts/ToastContext';
+
+vi.mock('../../lib/branches', () => ({
+  createBranch: vi.fn(),
+  switchBranch: vi.fn(),
+}));
+vi.mock('../../lib/git', () => ({
+  commitChanges: vi.fn(),
+  stashChanges: vi.fn(),
+}));
+vi.mock('../../lib/ai', () => ({ generateCommitMessage: vi.fn() }));
+
+import { createBranch, switchBranch } from '../../lib/branches';
+import { stashChanges } from '../../lib/git';
+
+const okSwitch = {
+  success: true,
+  stashedChanges: false,
+  pendingStashFrom: null,
+  stashApplied: false,
+  error: null,
+};
+
+const uncommittedFailure = {
+  ...okSwitch,
+  success: false,
+  error: 'Uncommitted changes. Please stash or commit them first.',
+};
+
+function renderWithToasts(ui: ReactNode) {
+  const showToast = vi.fn<(message: string, type?: 'success' | 'error' | 'info') => void>();
+  render(
+    <ToastContext.Provider value={{ toasts: [], showToast, dismissToast: vi.fn() }}>
+      {ui}
+    </ToastContext.Provider>
+  );
+  return { showToast };
+}
+
+describe('CreateBranchConflictModal — post-stash switch retry (#564)', () => {
+  const props = {
+    projectPath: '/test/project',
+    currentBranch: 'main',
+    targetBranch: 'feat/new',
+    baseBranch: 'main',
+    onCreated: vi.fn(),
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(stashChanges).mockResolvedValue(true);
+    vi.mocked(createBranch).mockResolvedValue(undefined);
+  });
+
+  it('retries the switch with auto-stash when stragglers reappear, then succeeds', async () => {
+    vi.mocked(switchBranch)
+      .mockResolvedValueOnce(uncommittedFailure) // plain switch trips on stragglers
+      .mockResolvedValueOnce(okSwitch); // auto-stash retry wins
+
+    const { showToast } = renderWithToasts(<CreateBranchConflictModal {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /stash & create/i }));
+
+    await waitFor(() => expect(props.onClose).toHaveBeenCalled());
+    expect(switchBranch).toHaveBeenNthCalledWith(1, '/test/project', 'feat/new', false);
+    expect(switchBranch).toHaveBeenNthCalledWith(2, '/test/project', 'feat/new', true);
+    expect(props.onCreated).toHaveBeenCalledWith('feat/new');
+    expect(showToast).toHaveBeenCalledWith(
+      expect.stringContaining('Created and switched to feat/new'),
+      'success'
+    );
+  });
+
+  it('gives a path forward (not a raw dead-end) when even the retry fails', async () => {
+    vi.mocked(switchBranch).mockResolvedValue(uncommittedFailure);
+
+    const { showToast } = renderWithToasts(<CreateBranchConflictModal {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /stash & create/i }));
+
+    await waitFor(() => expect(showToast).toHaveBeenCalled());
+    // Retried once with auto-stash before giving up.
+    expect(switchBranch).toHaveBeenCalledTimes(2);
+    const [message, type] = showToast.mock.calls[0];
+    expect(type).toBe('error');
+    expect(message).toContain('Created "feat/new"');
+    expect(message).toContain('Branches tab');
+    // The modal closes rather than dead-ending (its actions would only trip
+    // over the now-existing branch), and the switched callback never fires.
+    expect(props.onClose).toHaveBeenCalled();
+    expect(props.onCreated).not.toHaveBeenCalled();
+  });
+
+  it('does not retry when the switch fails for an unrelated reason', async () => {
+    vi.mocked(switchBranch).mockResolvedValue({
+      ...okSwitch,
+      success: false,
+      error: "fatal: 'feat/new' is already used by worktree at '/x/.claude/worktrees/feat-new'",
+    });
+
+    const { showToast } = renderWithToasts(<CreateBranchConflictModal {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /stash & create/i }));
+
+    await waitFor(() => expect(showToast).toHaveBeenCalled());
+    expect(switchBranch).toHaveBeenCalledTimes(1);
+    const [message] = showToast.mock.calls[0];
+    // The raw fatal is humanized on the way out.
+    expect(message).toContain('already checked out in another worktree');
+    expect(message).not.toContain('fatal:');
+  });
+});

--- a/src/components/branches/CreateBranchConflictModal.tsx
+++ b/src/components/branches/CreateBranchConflictModal.tsx
@@ -19,7 +19,7 @@ import { WarningIcon } from '../icons';
 import { createBranch, switchBranch } from '../../lib/branches';
 import { commitChanges, stashChanges } from '../../lib/git';
 import { generateCommitMessage } from '../../lib/ai';
-import { asCommandError, formatCommandError } from '../../lib/errors';
+import { asCommandError, formatCommandError, humanizeGitError } from '../../lib/errors';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { useOptionalToast } from '../../contexts/ToastContext';
@@ -63,16 +63,32 @@ export function CreateBranchConflictModal({
   /** Create the branch (tree is clean by now) and switch to it. */
   const finishCreate = async (extra?: string) => {
     await createBranch(projectPath, targetBranch, baseBranch);
-    const result = await switchBranch(projectPath, targetBranch, false);
+    // The working tree can pick up new changes between the stash/commit step
+    // and this switch (dev-server config writes, background tooling), making
+    // the switch fail again with "Uncommitted changes" — a dead end inside the
+    // very modal meant to resolve it. Retry once with auto-stash, mirroring
+    // UnsavedChangesModal's #273/PR #281 fix (issue #564).
+    let result = await switchBranch(projectPath, targetBranch, false);
+    if (!result.success && result.error?.includes('Uncommitted changes')) {
+      result = await switchBranch(projectPath, targetBranch, true);
+    }
     if (result.success) {
       onCreated(targetBranch);
       onToast(`Created and switched to ${targetBranch}${extra ? ` — ${extra}` : ''}`, 'success');
       onClose();
     } else {
-      // Keep whatever detail git gave us; only explain when it gave none.
-      const detail =
-        result.error || '(git reported failure with no detail — check for uncommitted changes)';
-      onToast(`Created "${targetBranch}", but couldn't switch to it: ${detail}`, 'error');
+      // Even the auto-stash retry failed. The branch exists — re-running this
+      // modal's actions would only trip over the existing branch, so don't
+      // dead-end here: humanize the failure, point at the path forward
+      // (Branches tab), and close.
+      const detail = result.error
+        ? humanizeGitError(result.error, { branch: targetBranch })
+        : '(git reported failure with no detail)';
+      onToast(
+        `Created "${targetBranch}", but couldn't switch to it: ${detail} You can switch to it from the Branches tab.${extra ? ` (${extra})` : ''}`,
+        'error'
+      );
+      onClose();
     }
   };
 

--- a/src/components/branches/SubmitReviewModal.test.tsx
+++ b/src/components/branches/SubmitReviewModal.test.tsx
@@ -9,8 +9,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { SubmitReviewModal } from './SubmitReviewModal';
+import { ToastContext } from '../../contexts/ToastContext';
 
 vi.mock('../../lib/branches', () => ({
   createPullRequest: vi.fn(),
@@ -22,8 +24,25 @@ vi.mock('../../lib/branches', () => ({
 vi.mock('../../lib/ai', () => ({ generatePRDescription: vi.fn() }));
 vi.mock('../../lib/git', () => ({ commitChanges: vi.fn() }));
 vi.mock('../../lib/analytics', () => ({ trackEvent: vi.fn(), trackError: vi.fn() }));
+vi.mock('../../lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
 
 import { createPullRequest, getDefaultBaseBranch } from '../../lib/branches';
+import { logger } from '../../lib/logger';
+
+type Fn = ReturnType<typeof vi.fn>;
+
+/** Render with a toast spy so the tests can assert toast type routing. */
+function renderWithToasts(ui: ReactNode) {
+  const showToast = vi.fn();
+  render(
+    <ToastContext.Provider value={{ toasts: [], showToast, dismissToast: vi.fn() }}>
+      {ui}
+    </ToastContext.Provider>
+  );
+  return { showToast };
+}
 
 describe('SubmitReviewModal — PR create error display', () => {
   const props = {
@@ -69,5 +88,62 @@ describe('SubmitReviewModal — PR create error display', () => {
     // Humanized auth message, never "[object Object]".
     expect(await screen.findByText(/didn't accept the connection/i)).toBeInTheDocument();
     expect(screen.queryByText(/\[object Object\]/)).not.toBeInTheDocument();
+  });
+});
+
+describe('SubmitReviewModal — expected-refusal toast routing (#538)', () => {
+  const props = {
+    projectPath: '/path/to/project',
+    branchName: 'ptymoshenko/sanity',
+    baseBranches: ['main'],
+    aiAvailable: false,
+    onSuccess: vi.fn(),
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDefaultBaseBranch).mockResolvedValue(null);
+  });
+
+  it('toasts a recognized refusal as info (no generic error toast, warn log)', async () => {
+    // "PR already exists" — backend classifies this Expected and skips its own
+    // report; the frontend toast must not become the fallback reporter.
+    vi.mocked(createPullRequest).mockRejectedValue({
+      type: 'Process',
+      cmd: 'gh pr create',
+      exit_code: 1,
+      stderr: 'GraphQL: A pull request already exists for julian:ptymoshenko/sanity.',
+    });
+
+    const { showToast } = renderWithToasts(<SubmitReviewModal {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /create pull request/i }));
+
+    await waitFor(() => expect(showToast).toHaveBeenCalled());
+    expect(showToast).toHaveBeenCalledWith(
+      expect.stringMatching(/already an open pull request/i),
+      'info'
+    );
+    expect(showToast).not.toHaveBeenCalledWith('Failed to create pull request', 'error');
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.warn as Fn).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
+  });
+
+  it('keeps the generic error toast for genuinely unrecognized failures', async () => {
+    vi.mocked(createPullRequest).mockRejectedValue({
+      type: 'Other',
+      message: 'some completely novel gh failure',
+    });
+
+    const { showToast } = renderWithToasts(<SubmitReviewModal {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /create pull request/i }));
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith('Failed to create pull request', 'error')
+    );
+    // The inline modal error still carries the real detail.
+    expect(await screen.findByText(/some completely novel gh failure/)).toBeInTheDocument();
   });
 });

--- a/src/components/branches/SubmitReviewModal.tsx
+++ b/src/components/branches/SubmitReviewModal.tsx
@@ -24,6 +24,7 @@ import {
   formatCommandError,
   humanizeGitError,
   isMergeConflictError,
+  isRecognizedGitFailure,
 } from '../../lib/errors';
 import { logger } from '../../lib/logger';
 import { ModalFrame } from '../primitives/ModalFrame';
@@ -89,7 +90,8 @@ export function SubmitReviewModal({
   onClose,
 }: SubmitReviewModalProps) {
   const { showToast } = useOptionalToast();
-  const onToast = (message: string, type?: 'success' | 'error') => showToast(message, type);
+  const onToast = (message: string, type?: 'success' | 'error' | 'info') =>
+    showToast(message, type);
   const [baseBranch, setBaseBranch] = useState(baseBranches[0] || 'main');
 
   // Default the merge target to the project's configured default base branch
@@ -190,8 +192,21 @@ export function SubmitReviewModal({
       }
     } catch (e) {
       trackError('pr_create', e, 'Submit Review');
-      setError(humanizeGitError(e, { branch: branchName, base: baseBranch }));
-      onToast?.('Failed to create pull request', 'error');
+      const humanized = humanizeGitError(e, { branch: branchName, base: baseBranch });
+      setError(humanized);
+      if (isRecognizedGitFailure(e)) {
+        // A known, by-design refusal (nothing to review, PR already exists,
+        // auth, network, …) — the backend already classified these Expected
+        // and skipped its report; an unconditional 'error' toast here would
+        // re-report the same incident through the toast telemetry pipeline
+        // (issue #538). Surface the humanized cause as info + warn log.
+        logger.warn('[SubmitReview] PR creation refused for a recognized reason', {
+          error: formatCommandError(asCommandError(e)),
+        });
+        onToast?.(humanized, 'info');
+      } else {
+        onToast?.('Failed to create pull request', 'error');
+      }
     } finally {
       setIsSubmitting(false);
       setProgressLabel('Create Pull Request');

--- a/src/components/dashboard/ProjectList.tsx
+++ b/src/components/dashboard/ProjectList.tsx
@@ -408,10 +408,17 @@ export function ProjectList({
       void trackEvent('project_renamed', { $screen_name: 'Dashboard' });
       await loadAll();
     } catch (error) {
-      trackError('project_rename', error, 'Dashboard');
-      logger.error('Failed to rename project', {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      const message = formatCommandError(asCommandError(error));
+      // Anticipated refusals (name taken, project open elsewhere) are rendered
+      // inline by the modal — they're user states, not malfunctions.
+      const isExpectedRefusal =
+        message.includes('already exists') || message.includes('Close this project');
+      if (isExpectedRefusal) {
+        logger.warn('Rename refused', { error: message });
+      } else {
+        trackError('project_rename', error, 'Dashboard');
+        logger.error('Failed to rename project', { error: message });
+      }
       throw error;
     }
   };

--- a/src/components/plugins/McpModal.test.tsx
+++ b/src/components/plugins/McpModal.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Regression tests for the MCP modal's error-flow handling:
+ *
+ * - #588 — "Add" with a name but no command/URL must be caught by frontend
+ *   validation (inline feedback), never reach the CLI's raw usage error.
+ * - #594 — "agent CLI not installed" is Expected on the backend; the modal
+ *   must log it at warn level, not logger.error (which auto-files bug reports).
+ * - #550 — older Codex CLIs without `mcp add` fail with a raw clap usage
+ *   dump; the modal must show a friendly "update your CLI" message instead.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { McpModal } from './McpModal';
+
+vi.mock('../../lib/mcp', async (importOriginal) => ({
+  // Keep the real validators; mock only the invoke wrappers.
+  ...(await importOriginal<typeof import('../../lib/mcp')>()),
+  listMcpServers: vi.fn(),
+  addMcpServer: vi.fn(),
+  removeMcpServer: vi.fn(),
+}));
+vi.mock('../../lib/analytics', () => ({ trackEvent: vi.fn(), trackSearch: vi.fn() }));
+vi.mock('../../lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../../contexts/ModalContext', () => ({
+  useModal: () => ({ isOpen: true, close: vi.fn() }),
+}));
+
+import { listMcpServers, addMcpServer } from '../../lib/mcp';
+import { logger } from '../../lib/logger';
+
+type Fn = ReturnType<typeof vi.fn>;
+
+async function openAddTab() {
+  // The "Add" *tab* button (the submit button isn't rendered yet).
+  fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+  return await screen.findByPlaceholderText(/my-server/);
+}
+
+/** The Add-tab's submit button (distinct from the "Add" tab button). */
+function clickAddSubmit() {
+  const button = screen
+    .getAllByRole('button', { name: /^add$/i })
+    .find((b) => b.className.includes('mcp-add-btn'));
+  expect(button).toBeDefined();
+  fireEvent.click(button!);
+}
+
+describe('McpModal error flows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listMcpServers).mockResolvedValue([]);
+  });
+
+  it('logs "agent not installed" on load at warn level, not error (#594)', async () => {
+    vi.mocked(listMcpServers).mockRejectedValue({
+      type: 'Other',
+      message: 'Codex binary not found',
+    });
+
+    render(<McpModal agentId="codex" agentDisplayName="Codex" agentBinaryName="codex" />);
+
+    await waitFor(() => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+      expect(logger.warn as Fn).toHaveBeenCalledWith(
+        'Failed to load MCP servers',
+        expect.objectContaining({ error: 'Codex binary not found' })
+      );
+    });
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
+  });
+
+  it('rejects a name-only Add inline, without invoking the CLI (#588)', async () => {
+    render(<McpModal />);
+    const input = await openAddTab();
+
+    fireEvent.change(input, { target: { value: 'my-server' } });
+    clickAddSubmit();
+
+    // Inline guidance, not the CLI's raw usage error.
+    expect(await screen.findByText(/command after the name|--url/)).toBeInTheDocument();
+    expect(addMcpServer).not.toHaveBeenCalled();
+    // No toast-error / bug-report channel involved.
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.warn as Fn).not.toHaveBeenCalled();
+  });
+
+  it('still submits a valid Add command', async () => {
+    vi.mocked(addMcpServer).mockResolvedValue(undefined);
+    render(<McpModal />);
+    const input = await openAddTab();
+
+    fireEvent.change(input, { target: { value: 'my-server -- npx -y @some/mcp-server' } });
+    clickAddSubmit();
+
+    await waitFor(() =>
+      expect(addMcpServer).toHaveBeenCalledWith(
+        'my-server -- npx -y @some/mcp-server',
+        'user',
+        undefined,
+        undefined
+      )
+    );
+    // Success switches back to the Connected tab.
+    expect(await screen.findByPlaceholderText(/filter servers/i)).toBeInTheDocument();
+  });
+
+  it("maps an old CLI's missing `mcp add` subcommand to update guidance (#550)", async () => {
+    vi.mocked(addMcpServer).mockRejectedValue({
+      type: 'Other',
+      message:
+        "Failed to add MCP server: error: unexpected argument 'add' found\n\nUsage: codex mcp [OPTIONS]\n\nFor more information, try '--help'.",
+    });
+
+    render(<McpModal agentId="codex" agentDisplayName="Codex" agentBinaryName="codex" />);
+    const input = await openAddTab();
+
+    fireEvent.change(input, { target: { value: 'my-server -- npx -y @some/mcp-server' } });
+    clickAddSubmit();
+
+    // Friendly, actionable message — not clap's usage dump.
+    const message = await screen.findByText(/too old to manage MCP servers/i);
+    expect(message.textContent).toContain('update Codex');
+    expect(screen.queryByText(/unexpected argument/)).not.toBeInTheDocument();
+    // Environment state, not a bug: warn, not error.
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.warn as Fn).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
+  });
+
+  it('shows a friendly install prompt when adding with the CLI missing (#594)', async () => {
+    vi.mocked(addMcpServer).mockRejectedValue({
+      type: 'Other',
+      message: 'Codex binary not found',
+    });
+
+    render(<McpModal agentId="codex" agentDisplayName="Codex" agentBinaryName="codex" />);
+    const input = await openAddTab();
+
+    fireEvent.change(input, { target: { value: 'my-server -- npx -y @some/mcp-server' } });
+    clickAddSubmit();
+
+    expect(await screen.findByText(/doesn't appear to be installed/i)).toBeInTheDocument();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
+  });
+
+  it('keeps logger.error for genuinely unrecognized add failures', async () => {
+    vi.mocked(addMcpServer).mockRejectedValue({
+      type: 'Other',
+      message: 'Failed to add MCP server: something exploded',
+    });
+
+    render(<McpModal />);
+    const input = await openAddTab();
+
+    fireEvent.change(input, { target: { value: 'my-server -- npx -y @some/mcp-server' } });
+    clickAddSubmit();
+
+    expect(await screen.findByText(/something exploded/)).toBeInTheDocument();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).toHaveBeenCalled();
+  });
+});

--- a/src/components/plugins/McpModal.tsx
+++ b/src/components/plugins/McpModal.tsx
@@ -12,10 +12,17 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { SearchIcon } from '../icons';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Spinner } from '../primitives/Spinner';
-import { type McpServer, listMcpServers, addMcpServer, removeMcpServer } from '../../lib/mcp';
+import {
+  type McpServer,
+  listMcpServers,
+  addMcpServer,
+  removeMcpServer,
+  validateMcpAddCommand,
+  isMcpUnsupportedCliError,
+} from '../../lib/mcp';
 import { trackEvent, trackSearch } from '../../lib/analytics';
 import { logger } from '../../lib/logger';
-import { asCommandError, formatCommandError } from '../../lib/errors';
+import { asCommandError, formatCommandError, isAgentNotInstalledError } from '../../lib/errors';
 import { useModal } from '../../contexts/ModalContext';
 
 type Tab = 'connected' | 'add';
@@ -73,7 +80,11 @@ export function McpModal({
       const result = await listMcpServers(projectPath, agentId);
       setServers(result);
     } catch (err) {
-      logger.error('Failed to load MCP servers', {
+      // "Agent CLI not installed" (backend marks it Expected, issue #594) and
+      // "CLI too old for mcp subcommands" (issue #550) are user-environment
+      // states — logger.error would auto-file a bug report for them.
+      const expected = isAgentNotInstalledError(err) || isMcpUnsupportedCliError(err);
+      logger[expected ? 'warn' : 'error']('Failed to load MCP servers', {
         error: formatCommandError(asCommandError(err)),
       });
       setServers([]);
@@ -103,6 +114,17 @@ export function McpModal({
   const handleAdd = async () => {
     if (!addCommand.trim()) return;
 
+    // Validate before shelling out: a name with no command/URL would only
+    // fail at the CLI level with a raw "missing required argument
+    // 'commandOrUrl'" usage error (issue #588). Inline feedback, no toast,
+    // no log — the user just hasn't finished typing the command.
+    const validationError = validateMcpAddCommand(addCommand.trim(), agentBinaryName);
+    if (validationError) {
+      setAddError(validationError);
+      setAddSuccess(false);
+      return;
+    }
+
     setIsAdding(true);
     setAddError(null);
     setAddSuccess(false);
@@ -116,10 +138,26 @@ export function McpModal({
       await fetchServers();
       setActiveTab('connected');
     } catch (err) {
-      logger.error('Failed to add MCP server', {
-        error: formatCommandError(asCommandError(err)),
-      });
-      setAddError(formatCommandError(asCommandError(err)));
+      const message = formatCommandError(asCommandError(err));
+      if (isMcpUnsupportedCliError(err)) {
+        // The installed CLI predates `mcp add` entirely (older Codex builds) —
+        // a friendly "update your CLI" beats clap's raw usage dump (issue #550).
+        logger.warn('Failed to add MCP server: agent CLI lacks mcp subcommands', {
+          error: message,
+        });
+        setAddError(
+          `Your ${agentDisplayName} CLI is too old to manage MCP servers — update ${agentDisplayName} to its latest version, then try again.`
+        );
+      } else if (isAgentNotInstalledError(err)) {
+        // Missing CLI is a user-environment state, not a bug (issue #594).
+        logger.warn('Failed to add MCP server: agent CLI not installed', { error: message });
+        setAddError(
+          `${agentDisplayName} doesn't appear to be installed on this computer, so its MCP servers can't be managed. Install ${agentDisplayName} first, then try again.`
+        );
+      } else {
+        logger.error('Failed to add MCP server', { error: message });
+        setAddError(message);
+      }
     } finally {
       setIsAdding(false);
     }
@@ -143,7 +181,14 @@ export function McpModal({
       if (/no .*mcp server|not found|no such/i.test(message)) {
         // Already gone (e.g. the preview bridge's remove-then-re-add cycle
         // raced this click) — that's the outcome the user wanted, not an error.
+        // (This shape check also swallows "binary not found" — an uninstalled
+        // CLI has no servers to remove either way.)
         await fetchServers();
+      } else if (isMcpUnsupportedCliError(err)) {
+        // CLI too old for `mcp remove` — environment state, not a bug (#550).
+        logger.warn('Failed to remove MCP server: agent CLI lacks mcp subcommands', {
+          error: message,
+        });
       } else {
         logger.error('Failed to remove MCP server', { error: message });
       }

--- a/src/hooks/useBranchManagement.test.ts
+++ b/src/hooks/useBranchManagement.test.ts
@@ -364,10 +364,17 @@ describe('useBranchManagement', () => {
       });
 
       const [message, type] = vi.mocked(params.showToast).mock.calls[0];
-      expect(type).toBe('error');
+      // Expected, by-design refusal — info toast + warn log, never the error
+      // channels that auto-file bug reports (issue #600).
+      expect(type).toBe('info');
       expect(message).toContain("isn't on GitHub yet");
       expect(message).toContain('no tracking information');
       expect(result.current.showConflictResolution).toBe(false);
+      const { logger } = await import('../lib/logger');
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+      expect(vi.mocked(logger.warn)).toHaveBeenCalled();
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+      expect(vi.mocked(logger.error)).not.toHaveBeenCalled();
     });
 
     it('explains that git stopped safely when local changes would be overwritten', async () => {
@@ -384,10 +391,16 @@ describe('useBranchManagement', () => {
       });
 
       const [message, type] = vi.mocked(params.showToast).mock.calls[0];
-      expect(type).toBe('error');
+      // Expected refusal — git stopped safely; info toast + warn log (#600).
+      expect(type).toBe('info');
       expect(message).toContain('nothing was touched');
       expect(message).toContain('would be overwritten by merge');
       expect(result.current.showConflictResolution).toBe(false);
+      const { logger } = await import('../lib/logger');
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+      expect(vi.mocked(logger.warn)).toHaveBeenCalled();
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+      expect(vi.mocked(logger.error)).not.toHaveBeenCalled();
     });
 
     it('surfaces other failures verbatim with a Pull failed prefix', async () => {
@@ -495,6 +508,32 @@ describe('useBranchManagement', () => {
         'Couldn\'t switch to "feature/x": your local changes would be overwritten',
         'error'
       );
+    });
+
+    it('humanizes a worktree-collision switch failure instead of leaking the raw fatal', async () => {
+      // Raw git stderr when the branch is claimed by another worktree (e.g. an
+      // agent CLI's own scratch worktree) — must not reach the toast verbatim
+      // (issue #607; same wording humanizeGitError learned for #406).
+      vi.mocked(branches.switchBranch).mockResolvedValue({
+        success: false,
+        stashedChanges: false,
+        pendingStashFrom: null,
+        stashApplied: false,
+        error:
+          "fatal: 'user/mccu-merged' is already used by worktree at '/private/tmp/scratchpad/bmerge'",
+      });
+      const params = createParams();
+      const { result } = renderHook(() => useBranchManagement(params));
+
+      await act(async () => {
+        await result.current.handleResolveConflicts('user/mccu-merged', 'main');
+      });
+
+      const [message, type] = vi.mocked(params.showToast).mock.calls[1]; // [0] is the "Preparing..." toast
+      expect(type).toBe('error');
+      expect(message).toContain('already checked out in another worktree');
+      expect(message).not.toContain('fatal:');
+      expect(message).not.toContain('/private/tmp');
     });
 
     it('explains when git reported a switch failure with no detail', async () => {

--- a/src/hooks/useBranchManagement.ts
+++ b/src/hooks/useBranchManagement.ts
@@ -21,7 +21,7 @@ import {
 import { getChangedFiles, ChangedFile } from '../lib/git';
 import { invoke } from '@tauri-apps/api/core';
 import { logger } from '../lib/logger';
-import { asCommandError, formatCommandError } from '../lib/errors';
+import { asCommandError, formatCommandError, humanizeGitError } from '../lib/errors';
 import { trackEvent, trackError } from '../lib/analytics';
 import type { PreviewHandle } from '../components/preview/Preview';
 import type { HealthTabPanelRef } from '../components/code/HealthTabPanel';
@@ -261,16 +261,22 @@ export function useBranchManagement({
         logger.warn('Pull produced merge conflicts', { message });
         setShowConflictResolution(true);
       } else if (/no tracking information|no such ref was fetched/i.test(message)) {
+        // Expected, by-design refusal (unpushed branch) — info toast + warn
+        // log, NOT the error channels: error toasts and logger.error both
+        // auto-file bug reports, and this isn't a bug (issue #600).
+        logger.warn('Pull skipped: branch has no upstream', { message });
         showToast(
           `This branch isn't on GitHub yet, so there's nothing to pull — push it first. (git said: ${message})`,
-          'error'
+          'info'
         );
       } else if (/would be overwritten by (merge|checkout)/i.test(message)) {
         // Git refused because the incoming commits touch files with local
         // uncommitted edits. Nothing was changed — the working tree is safe.
+        // Same expected classification as above (issue #600).
+        logger.warn('Pull refused: local changes would be overwritten', { message });
         showToast(
           `The pull would overwrite unsaved changes, so git stopped — nothing was touched. Push (or discard) your changes first, then pull again. (git said: ${message})`,
-          'error'
+          'info'
         );
       } else {
         logger.error('Pull failed', { message });
@@ -313,10 +319,13 @@ export function useBranchManagement({
           // Switch to the PR's head branch
           const switchResult = await switchBranch(currentProject.path, headBranch, true);
           if (!switchResult.success) {
-            // Keep whatever detail git gave us; only explain when it gave none.
-            const detail =
-              switchResult.error ||
-              '(git reported failure with no detail — check for uncommitted changes)';
+            // Humanize the raw git stderr — worktree collisions and friends
+            // must not surface as raw fatals (issue #607; humanizeGitError
+            // falls back to the raw detail when it recognizes nothing). Only
+            // explain ourselves when git gave no detail at all.
+            const detail = switchResult.error
+              ? humanizeGitError(switchResult.error, { branch: headBranch })
+              : '(git reported failure with no detail — check for uncommitted changes)';
             showToast(`Couldn't switch to "${headBranch}": ${detail}`, 'error');
             return;
           }

--- a/src/hooks/useCssAnimations.ts
+++ b/src/hooks/useCssAnimations.ts
@@ -88,7 +88,9 @@ export function useCssAnimations({ projectPath, enabled, onToast }: Params) {
       });
       setAnimations(rows);
     } catch (err) {
-      logger.error('[CssAnimations] load failed', { error: String(err) });
+      logger.error('[CssAnimations] load failed', {
+        error: formatCommandError(asCommandError(err)),
+      });
       onToast(toastText(err), 'error');
     } finally {
       setLoading(false);
@@ -118,7 +120,9 @@ export function useCssAnimations({ projectPath, enabled, onToast }: Params) {
         baselineRef.current[selector] = newInner;
         void trackEvent('visual_style_saved', { mode: 'css-code', keyframes: true });
       } catch (err) {
-        logger.error('[CssAnimations] save failed', { error: String(err) });
+        logger.error('[CssAnimations] save failed', {
+          error: formatCommandError(asCommandError(err)),
+        });
         onToast(toastText(err), 'error');
       }
     },
@@ -167,7 +171,9 @@ export function useCssAnimations({ projectPath, enabled, onToast }: Params) {
         setAnimations((prev) => [...prev, { selector, name, file, body }]);
         void trackEvent('visual_style_saved', { mode: 'css-code', keyframes_added: true });
       } catch (err) {
-        logger.error('[CssAnimations] create failed', { error: String(err) });
+        logger.error('[CssAnimations] create failed', {
+          error: formatCommandError(asCommandError(err)),
+        });
         onToast(toastText(err), 'error');
       }
     },
@@ -204,7 +210,9 @@ export function useCssAnimations({ projectPath, enabled, onToast }: Params) {
         );
         void trackEvent('visual_style_saved', { mode: 'css-code', keyframes_renamed: true });
       } catch (err) {
-        logger.error('[CssAnimations] rename failed', { error: String(err) });
+        logger.error('[CssAnimations] rename failed', {
+          error: formatCommandError(asCommandError(err)),
+        });
         onToast(toastText(err), 'error');
       }
     },
@@ -223,7 +231,9 @@ export function useCssAnimations({ projectPath, enabled, onToast }: Params) {
         delete baselineRef.current[selector];
         void trackEvent('visual_style_saved', { mode: 'css-code', keyframes_deleted: true });
       } catch (err) {
-        logger.error('[CssAnimations] delete failed', { error: String(err) });
+        logger.error('[CssAnimations] delete failed', {
+          error: formatCommandError(asCommandError(err)),
+        });
         onToast(toastText(err), 'error');
       }
     },

--- a/src/hooks/useCssCascadeEditor.ts
+++ b/src/hooks/useCssCascadeEditor.ts
@@ -29,6 +29,7 @@ import {
   mergeCascade,
   rulesToLocate,
   rowKey,
+  isStaleCssRuleError,
   type MatchedRule,
   type RuleLocation,
   type CascadeRow,
@@ -450,10 +451,13 @@ export function useCssCascadeEditor({
         post({ type: 'ss:commitRulePreview', ruleKey: key });
         void trackEvent('visual_style_saved', { mode: 'css-code' });
       } catch (err) {
-        // The source drifted from our baseline (a prior save's formatting, an HMR
-        // re-read, an external edit). Re-read the current source and retry ONCE so
-        // editing stays "instant" instead of hitting a drift wall.
-        if (/source changed/i.test(toastText(err))) {
+        // The source went stale under the card: body drift (a prior save's
+        // formatting, an HMR re-read, an external edit) OR the rule no longer
+        // matching at all (renamed/rewritten since the card was seeded —
+        // issue #584). Both are recoverable: re-locate the rule in the current
+        // source and retry ONCE so editing stays "instant" instead of hitting
+        // a drift wall and dropping the edit.
+        if (isStaleCssRuleError(err)) {
           try {
             const locs = await locateCssRules(projectPath, [
               { selector: row.selector, mediaText: row.mediaText, href: null },
@@ -462,7 +466,9 @@ export function useCssCascadeEditor({
             if (loc && loc.status === 'resolved') {
               await applyCssRuleText(
                 projectPath,
-                row.file,
+                // The re-located rule may live in a different file than the
+                // (stale) card — write where the rule actually is now.
+                loc.file,
                 row.selector,
                 row.mediaText,
                 loc.inner_text,
@@ -475,6 +481,15 @@ export function useCssCascadeEditor({
           } catch {
             /* fall through to the toast below */
           }
+          // Still stale after re-locating: the rule is genuinely gone from
+          // source. Expected environment state (an agent/external edit) — warn
+          // so it doesn't auto-file a bug report; the toast below still tells
+          // the user their edit didn't land.
+          logger.warn('[CssCascade] write-back rejected as stale after retry', {
+            error: formatCommandError(asCommandError(err)),
+          });
+          onToast(toastText(err), 'error');
+          return;
         }
         logger.error('[CssCascade] write-back failed', {
           error: formatCommandError(asCommandError(err)),

--- a/src/hooks/useCssEditor.ts
+++ b/src/hooks/useCssEditor.ts
@@ -167,7 +167,7 @@ export function useCssEditor({ iframeRef, projectPath, enabled, onToast }: Param
             setSelection({ signature: sig, resolution, instanceCount });
           }
         } catch (err) {
-          logger.error('[CssEditor] resolve failed', { error: String(err) });
+          logger.error('[CssEditor] resolve failed', { error: toastText(err) });
           if (selTokenRef.current === token) {
             // A real failure — do NOT fall back to `not_found`, which would
             // wrongly offer "create rule" for a class that may already exist.
@@ -204,7 +204,7 @@ export function useCssEditor({ iframeRef, projectPath, enabled, onToast }: Param
           setSelection((prev) => (prev ? { ...prev, resolution } : prev));
         }
       } catch (err) {
-        logger.error('[CssEditor] reresolve failed', { error: String(err) });
+        logger.error('[CssEditor] reresolve failed', { error: toastText(err) });
       }
     },
     [projectPath]
@@ -357,7 +357,7 @@ export function useCssEditor({ iframeRef, projectPath, enabled, onToast }: Param
         editsCommittedRef.current += 1;
         void trackEvent('visual_style_saved', { mode: 'css', removed: value === null });
       } catch (err) {
-        logger.error('[CssEditor] write-back failed', { error: String(err) });
+        logger.error('[CssEditor] write-back failed', { error: toastText(err) });
         onToast(toastText(err), 'error');
       } finally {
         setSaving(false);
@@ -387,7 +387,7 @@ export function useCssEditor({ iframeRef, projectPath, enabled, onToast }: Param
         editsCommittedRef.current += changes.length;
         void trackEvent('visual_style_saved', { mode: 'css', bulk: changes.length });
       } catch (err) {
-        logger.error('[CssEditor] bulk write-back failed', { error: String(err) });
+        logger.error('[CssEditor] bulk write-back failed', { error: toastText(err) });
         onToast(toastText(err), 'error');
       } finally {
         setSaving(false);
@@ -410,7 +410,7 @@ export function useCssEditor({ iframeRef, projectPath, enabled, onToast }: Param
         void trackEvent('visual_style_saved', { mode: 'css', created_rule: true });
         onToast(`Created ${selector}`, 'success');
       } catch (err) {
-        logger.error('[CssEditor] create rule failed', { error: String(err) });
+        logger.error('[CssEditor] create rule failed', { error: toastText(err) });
         onToast(toastText(err), 'error');
       }
     },

--- a/src/hooks/useCssVariables.ts
+++ b/src/hooks/useCssVariables.ts
@@ -50,7 +50,9 @@ export function useCssVariables({ iframeRef, projectPath, enabled, onToast }: Pa
       const defs = await getCssVariables(projectPath);
       setVariables(defs.map((v) => ({ ...v, editable: v.selector === ':root' })));
     } catch (err) {
-      logger.error('[CssVariables] load failed', { error: String(err) });
+      logger.error('[CssVariables] load failed', {
+        error: formatCommandError(asCommandError(err)),
+      });
       onToast(toastText(err), 'error');
     } finally {
       setLoading(false);
@@ -82,7 +84,9 @@ export function useCssVariables({ iframeRef, projectPath, enabled, onToast }: Pa
           post({ type: 'ss:clearVar', name });
           void trackEvent('visual_style_saved', { mode: 'css-code', variable: true });
         } catch (err) {
-          logger.error('[CssVariables] save failed', { error: String(err) });
+          logger.error('[CssVariables] save failed', {
+            error: formatCommandError(asCommandError(err)),
+          });
           onToast(toastText(err), 'error');
         }
       }, SAVE_DEBOUNCE_MS);
@@ -120,7 +124,9 @@ export function useCssVariables({ iframeRef, projectPath, enabled, onToast }: Pa
         void trackEvent('visual_style_saved', { mode: 'css-code', variable_added: true });
         await reload();
       } catch (err) {
-        logger.error('[CssVariables] add failed', { error: String(err) });
+        logger.error('[CssVariables] add failed', {
+          error: formatCommandError(asCommandError(err)),
+        });
         onToast(toastText(err), 'error');
       }
     },

--- a/src/hooks/usePreviewConnection.test.ts
+++ b/src/hooks/usePreviewConnection.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { usePreviewConnection } from './usePreviewConnection';
 import { IFRAME_BLANK_TIMEOUT_MS } from './previewIframeWatchdog';
+import { logger } from '../lib/logger';
 
 // The hook reaches for Tauri IPC, the proxy, analytics, and a logger on the
 // readiness path; stub them all so the test exercises only the fetch-probe loop.
@@ -412,6 +413,58 @@ describe('usePreviewConnection stale-404 detection (issue #243)', () => {
     expect(result.current.serverReady).toBe(false);
     // Crashed, not stale — the restart affordance for stale is separate.
     expect(result.current.serverStale).toBe(false);
+
+    await act(async () => {
+      unmount();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+  });
+});
+
+describe('usePreviewConnection page-list load failures (issue #541)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('logs the real CommandError message, not "[object Object]"', async () => {
+    // `list_pages` rejects with a plain tagged CommandError object — the shape
+    // Tauri delivers for Result<_, CommandError> rejections. It is NOT an
+    // Error instance, so naive String() would render "[object Object]".
+    const { invoke } = await import('@tauri-apps/api/core');
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === 'start_preview_proxy') return Promise.resolve(8080);
+      if (cmd === 'list_pages')
+        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- deliberately a plain CommandError object, the shape under test
+        return Promise.reject({ type: 'Io', message: 'permission denied walking pages dir' });
+      return Promise.resolve(undefined);
+    });
+    const server = installSlowServerFetch();
+    const { unmount } = renderHook(() => usePreviewConnection(baseParams));
+
+    // Reach serverReady so the page-list polling kicks in and hits the reject.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    await act(async () => {
+      server.finishCompile();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the mock's calls, not invoking it bound
+    const errorCalls = vi.mocked(logger.error).mock.calls;
+    const pageCall = errorCalls.find(([msg]) => msg === 'Failed to load pages');
+    expect(pageCall).toBeDefined();
+    expect(pageCall?.[1]).toEqual({ error: 'I/O error: permission denied walking pages dir' });
+    // The regression this guards against: a useless opaque log line.
+    expect(JSON.stringify(errorCalls)).not.toContain('[object Object]');
 
     await act(async () => {
       unmount();

--- a/src/hooks/usePreviewConnection.ts
+++ b/src/hooks/usePreviewConnection.ts
@@ -16,6 +16,7 @@ import {
   IFRAME_BLANK_TIMEOUT_MS,
 } from './previewIframeWatchdog';
 import { logger } from '../lib/logger';
+import { asCommandError, formatCommandError } from '../lib/errors';
 import { getWindowLabel } from '../lib/window';
 import { trackEvent } from '../lib/analytics';
 
@@ -217,8 +218,10 @@ export function usePreviewConnection({
       const pageList = await invoke<PageInfo[]>('list_pages', { projectPath });
       setPages(pageList);
     } catch (error) {
+      // `list_pages` rejects with a plain CommandError object (not an Error
+      // instance) — String() renders it as "[object Object]" (issue #541).
       logger.error('Failed to load pages', {
-        error: error instanceof Error ? error.message : String(error),
+        error: formatCommandError(asCommandError(error)),
       });
     }
   }, [projectPath]);
@@ -305,7 +308,9 @@ export function usePreviewConnection({
         }
       })
       .catch((err) => {
-        logger.error('[Preview] Failed to start proxy, using direct URL', { error: err });
+        logger.error('[Preview] Failed to start proxy, using direct URL', {
+          error: formatCommandError(asCommandError(err)),
+        });
       });
 
     return () => {
@@ -509,7 +514,7 @@ export function usePreviewConnection({
         setHasError(false);
         setServerReady(true);
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = formatCommandError(asCommandError(err));
         logger.info('[Preview] Server check failed', {
           retry: retryCount,
           maxRetries: SERVER_MAX_RETRIES,

--- a/src/hooks/useProjectLifecycle.test.ts
+++ b/src/hooks/useProjectLifecycle.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Regression tests for `handleImportLocalFolder`'s expected-refusal routing.
+ *
+ * `register_external_project` refuses some folder picks by design (already
+ * registered, home directory, not a project, …) — the backend marks those
+ * `CommandError::Expected`, but the tag can't cross IPC, so the frontend
+ * re-checks the guidance phrases (issue #518). Those refusals must surface as
+ * *info* toasts and *warn* logs: an `'error'` toast re-reports through the
+ * toast telemetry pipeline and a `logger.error` files a bug report — for
+ * behavior that is working as intended (issue #535).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useProjectLifecycle, type UseProjectLifecycleParams } from './useProjectLifecycle';
+
+vi.mock('../lib/project', () => ({
+  getAutoAcceptMode: vi.fn().mockResolvedValue(false),
+  setAutoAcceptMode: vi.fn().mockResolvedValue(undefined),
+  detectWorkspaces: vi.fn().mockResolvedValue([]),
+  getWorkspaceSubpath: vi.fn().mockResolvedValue(''),
+  setWorkspaceSubpath: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../lib/github', () => ({
+  getProjectGitHubStatus: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('./useIntegrationStatus', () => ({
+  GITHUB_STATUS_FALLBACK: { connected: false },
+}));
+vi.mock('../lib/external-projects', () => ({
+  registerExternalProject: vi.fn(),
+  unregisterExternalProject: vi.fn().mockResolvedValue(undefined),
+  isProjectExternal: vi.fn().mockResolvedValue(false),
+}));
+vi.mock('../lib/projectSessions', () => ({
+  registerProjectSession: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../lib/sessionRegistry', () => ({
+  sessionRegistry: {
+    getOrCreate: vi.fn(),
+    resume: vi.fn(),
+    getCustomTitles: vi.fn(() => new Map()),
+    setTerminalTabs: vi.fn(),
+  },
+}));
+vi.mock('../lib/accounts', () => ({
+  assignActiveWorkspaceToNewProject: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../lib/agent', () => ({
+  getDefaultAgentId: vi.fn(() => 'claude-code'),
+}));
+vi.mock('../lib/window', () => ({
+  setWindowTitle: vi.fn().mockResolvedValue(undefined),
+  getWindowLabel: vi.fn(() => 'main'),
+  findAndReservePort: vi.fn().mockResolvedValue(3000),
+  getProjectWindow: vi.fn().mockResolvedValue(null),
+  focusWindowByLabel: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../lib/analytics', () => ({
+  trackEvent: vi.fn(),
+  trackError: vi.fn(),
+  setActiveProject: vi.fn(),
+}));
+vi.mock('../lib/terminalDiagnostics', () => ({
+  extractTerminalError: vi.fn(() => null),
+}));
+vi.mock('../lib/projectIdentity', () => ({
+  getProjectId: vi.fn(() => 'proj-id'),
+}));
+vi.mock('../lib/session', () => ({
+  startProjectSession: vi.fn(),
+  endProjectSession: vi.fn(() => null),
+}));
+
+import { registerExternalProject } from '../lib/external-projects';
+import { logger } from '../lib/logger';
+
+type Fn = ReturnType<typeof vi.fn>;
+
+function createParams(overrides?: Partial<UseProjectLifecycleParams>): UseProjectLifecycleParams {
+  return {
+    currentProject: null,
+    setCurrentProject: vi.fn(),
+    currentProjectPathRef: { current: null },
+    setView: vi.fn(),
+    setDevServerPort: vi.fn(),
+    startServerForProject: vi.fn().mockResolvedValue('nextjs'),
+    isServerRunning: vi.fn(() => false),
+    restartDevServer: vi.fn().mockResolvedValue(undefined),
+    clearNeedsInstall: vi.fn(),
+    pasteToActiveTerminal: vi.fn(),
+    terminalTabs: [],
+    activeTerminalTab: 0,
+    restoreTerminalTabs: vi.fn(),
+    ensureProjectSeeded: vi.fn(),
+    showToast: vi.fn(),
+    setCleanupStatus: vi.fn(),
+    clearScreenshotInterval: vi.fn(),
+    startScreenshotInterval: vi.fn(),
+    onPreviewReady: vi.fn(),
+    setWorkspaceTab: vi.fn(),
+    resetLayout: vi.fn(),
+    setProjectGitHubStatus: vi.fn(),
+    clearProjectStatuses: vi.fn(),
+    fetchBranchInfo: vi.fn().mockResolvedValue(undefined),
+    clearBranchState: vi.fn(),
+    checkPluginSuggestion: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('handleImportLocalFolder — expected-refusal routing (#518/#535)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes a by-design refusal to an info toast and a warn log', async () => {
+    vi.mocked(registerExternalProject).mockRejectedValue({
+      type: 'Other',
+      message: 'This project is already inside your projects folder. It will appear automatically.',
+    });
+    const params = createParams();
+    const { result } = renderHook(() => useProjectLifecycle(params));
+
+    await act(async () => {
+      await result.current.handleImportLocalFolder();
+    });
+
+    expect(params.showToast).toHaveBeenCalledWith(
+      'This project is already inside your projects folder. It will appear automatically.',
+      'info'
+    );
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.warn as Fn).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
+  });
+
+  it('keeps the friendly already-registered message, as info', async () => {
+    vi.mocked(registerExternalProject).mockRejectedValue({
+      type: 'Other',
+      message: 'This folder is already registered.',
+    });
+    const params = createParams();
+    const { result } = renderHook(() => useProjectLifecycle(params));
+
+    await act(async () => {
+      await result.current.handleImportLocalFolder();
+    });
+
+    const [message, type] = vi.mocked(params.showToast).mock.calls[0];
+    expect(type).toBe('info');
+    expect(message).toContain('already in Ship Studio');
+  });
+
+  it('still surfaces genuine failures as error toasts and error logs', async () => {
+    vi.mocked(registerExternalProject).mockRejectedValue({
+      type: 'Io',
+      message: 'disk exploded',
+    });
+    const params = createParams();
+    const { result } = renderHook(() => useProjectLifecycle(params));
+
+    await act(async () => {
+      await result.current.handleImportLocalFolder();
+    });
+
+    expect(params.showToast).toHaveBeenCalledWith('I/O error: disk exploded', 'error');
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -67,7 +67,7 @@ import {
 import { invoke } from '@tauri-apps/api/core';
 import { logger } from '../lib/logger';
 import { trackEvent, trackError, setActiveProject } from '../lib/analytics';
-import { asCommandError, formatCommandError } from '../lib/errors';
+import { asCommandError, formatCommandError, isExpectedProjectImportRefusal } from '../lib/errors';
 import { extractTerminalError } from '../lib/terminalDiagnostics';
 import { getProjectId } from '../lib/projectIdentity';
 import { startProjectSession, endProjectSession } from '../lib/session';
@@ -911,20 +911,16 @@ export function useProjectLifecycle({
       // register_external_project throws CommandError::Expected for by-design
       // refusals of the user's folder pick (issue #416), but Expected serializes
       // across IPC identically to Other, so re-check its known guidance phrases
-      // here. Those get logger.warn — the user already sees an accurate toast,
-      // and logger.error would file a bug report for correct behavior (#518).
-      const expectedRefusal =
-        message.includes('Please select that folder instead') ||
-        message.includes('Please select the specific project folder') ||
-        message.includes("doesn't appear to be a project") ||
-        message.includes('already inside your projects folder') ||
-        message.includes('already registered') ||
-        message.includes('your home directory');
+      // (shared list in lib/errors). Those get logger.warn — the user already
+      // sees an accurate toast, and logger.error would file a bug report for
+      // correct behavior (#518) — and an *info* toast: error toasts re-report
+      // through the toast telemetry pipeline too (#535).
+      const expectedRefusal = isExpectedProjectImportRefusal(message);
       logger[expectedRefusal ? 'warn' : 'error']('[ImportLocalFolder] failed', { error: message });
       const friendly = message.includes('already registered')
         ? "This folder is already in Ship Studio. To work on a different workspace from the same folder, clone the repo again via 'Import from GitHub' (each clone is independent), or duplicate the folder on disk first."
         : message;
-      showToast(friendly, 'error');
+      showToast(friendly, expectedRefusal ? 'info' : 'error');
     }
   };
 

--- a/src/hooks/useTextEditing.test.ts
+++ b/src/hooks/useTextEditing.test.ts
@@ -23,8 +23,13 @@ vi.mock('../lib/edit', async (importActual) => {
 // trackEvent would otherwise reach for a real Tauri IPC on a saved edit.
 vi.mock('../lib/analytics', () => ({ trackEvent: vi.fn().mockResolvedValue(undefined) }));
 
+vi.mock('../lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
 import { useTextEditing } from './useTextEditing';
 import { resolveTextSource, applyTextEdit } from '../lib/edit';
+import { logger } from '../lib/logger';
 
 type Fn = ReturnType<typeof vi.fn>;
 
@@ -128,6 +133,148 @@ describe('useTextEditing', () => {
     await dispatch({ type: 'ss:textCommit', text: 'Old copy' }, src);
     expect(applyTextEdit).not.toHaveBeenCalled();
     expect(posts(iframeRef)).toContainEqual({ type: 'ss:commit' });
+  });
+
+  describe('stale-save recovery (issue #557)', () => {
+    /** The drift guard's exact rejection shape from apply_text_edit. */
+    const DRIFT_REJECTION = {
+      type: 'Validation',
+      field: 'old_text',
+      reason: 'source no longer matches — reselect the element',
+    };
+
+    /** Extra microtask flushes: the recovery path chains re-resolve + re-apply. */
+    const settle = () =>
+      act(async () => {
+        for (let i = 0; i < 8; i++) await Promise.resolve();
+      });
+
+    it('re-resolves and re-applies the typed text when the drift guard rejects a stale save', async () => {
+      (applyTextEdit as Fn).mockRejectedValueOnce(DRIFT_REJECTION).mockResolvedValueOnce(undefined);
+      (resolveTextSource as Fn)
+        // Select-time resolve: the (about-to-be-stale) baseline.
+        .mockResolvedValueOnce({
+          status: 'resolved',
+          file: 'src/pages/index.astro',
+          line: 7,
+          column: 3,
+          text: 'Old copy',
+        })
+        // Recovery resolve: a formatter/HMR write moved the text and reflowed it.
+        .mockResolvedValueOnce({
+          status: 'resolved',
+          file: 'src/pages/index.astro',
+          line: 9,
+          column: 5,
+          text: 'Old copy, reflowed',
+        });
+      const { iframeRef, onToast } = setup();
+      const src = iframeRef.current!.contentWindow!;
+      await dispatch({ type: 'ss:select', signature: SIG, leafText: true }, src);
+      await dispatch({ type: 'ss:textCommit', text: 'New copy' }, src);
+      await settle();
+
+      // The retry wrote the user's text against the FRESH location + baseline —
+      // the typed copy was not discarded.
+      expect(applyTextEdit).toHaveBeenCalledTimes(2);
+      expect((applyTextEdit as Fn).mock.calls[1]).toEqual([
+        '/proj',
+        'src/pages/index.astro',
+        9,
+        5,
+        'Old copy, reflowed',
+        'New copy',
+      ]);
+      expect(posts(iframeRef)).toContainEqual({ type: 'ss:commit' });
+      expect(posts(iframeRef)).not.toContainEqual({ type: 'ss:textRevert' });
+      expect(onToast).toHaveBeenCalledWith('Saved to source', 'success');
+      // Recovered drift is an expected state — it must not auto-file a report.
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- asserting on the mock, not invoking it bound
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('re-baselines without writing when the fresh source already holds the typed text', async () => {
+      (applyTextEdit as Fn).mockRejectedValueOnce(DRIFT_REJECTION);
+      (resolveTextSource as Fn)
+        .mockResolvedValueOnce({
+          status: 'resolved',
+          file: 'src/pages/index.astro',
+          line: 7,
+          column: 3,
+          text: 'Old copy',
+        })
+        // e.g. the first write actually landed but its response was lost.
+        .mockResolvedValueOnce({
+          status: 'resolved',
+          file: 'src/pages/index.astro',
+          line: 7,
+          column: 3,
+          text: 'New copy',
+        });
+      const { iframeRef, onToast } = setup();
+      const src = iframeRef.current!.contentWindow!;
+      await dispatch({ type: 'ss:select', signature: SIG, leafText: true }, src);
+      await dispatch({ type: 'ss:textCommit', text: 'New copy' }, src);
+      await settle();
+
+      expect(applyTextEdit).toHaveBeenCalledTimes(1); // no second write needed
+      expect(posts(iframeRef)).toContainEqual({ type: 'ss:commit' });
+      expect(posts(iframeRef)).not.toContainEqual({ type: 'ss:textRevert' });
+      expect(onToast).toHaveBeenCalledWith('Saved to source', 'success');
+    });
+
+    it('is never silent when recovery fails: explains, reverts, and does not auto-file', async () => {
+      (applyTextEdit as Fn).mockRejectedValue(DRIFT_REJECTION);
+      (resolveTextSource as Fn)
+        .mockResolvedValueOnce({
+          status: 'resolved',
+          file: 'src/pages/index.astro',
+          line: 7,
+          column: 3,
+          text: 'Old copy',
+        })
+        // The element's text is gone from source — nothing to re-apply against.
+        .mockResolvedValueOnce({ status: 'read_only', reason: 'no longer found' });
+      const { iframeRef, onToast } = setup();
+      const src = iframeRef.current!.contentWindow!;
+      await dispatch({ type: 'ss:select', signature: SIG, leafText: true }, src);
+      await dispatch({ type: 'ss:textCommit', text: 'New copy' }, src);
+      await settle();
+
+      expect(applyTextEdit).toHaveBeenCalledTimes(1);
+      expect(posts(iframeRef)).toContainEqual({ type: 'ss:textRevert' });
+      expect(onToast).toHaveBeenCalledWith(
+        expect.stringContaining("Couldn't save your text"),
+        'error'
+      );
+      // Expected environment state (the file changed underneath us) — warn only.
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- asserting on the mock, not invoking it bound
+      expect(logger.warn).toHaveBeenCalled();
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- asserting on the mock, not invoking it bound
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('does not retry when the source has not actually drifted (identical re-resolve)', async () => {
+      // A Validation rejection whose re-resolve returns the SAME target would
+      // fail identically — the hook must not write the same thing twice.
+      (applyTextEdit as Fn).mockRejectedValue(DRIFT_REJECTION);
+      (resolveTextSource as Fn).mockResolvedValue({
+        status: 'resolved',
+        file: 'src/pages/index.astro',
+        line: 7,
+        column: 3,
+        text: 'Old copy',
+      });
+      const { iframeRef, onToast } = setup();
+      const src = iframeRef.current!.contentWindow!;
+      await dispatch({ type: 'ss:select', signature: SIG, leafText: true }, src);
+      await dispatch({ type: 'ss:textCommit', text: 'New copy' }, src);
+      await settle();
+
+      expect(applyTextEdit).toHaveBeenCalledTimes(1);
+      expect(posts(iframeRef)).toContainEqual({ type: 'ss:textRevert' });
+      expect(onToast).toHaveBeenCalledWith(expect.any(String), 'error');
+    });
   });
 
   it('ignores messages that do not originate from the preview iframe', async () => {

--- a/src/hooks/useTextEditing.ts
+++ b/src/hooks/useTextEditing.ts
@@ -154,11 +154,83 @@ export function useTextEditing({ iframeRef, projectPath, enabled, onToast }: Par
             // CommandError rejections are plain objects — String() renders
             // them as "[object Object]" (issue #336); use the same formatter
             // as the toast below.
-            logger.error('[TextEditing] text write-back failed', {
-              error: formatCommandError(asCommandError(err)),
-            });
-            onToast?.(formatCommandError(asCommandError(err)), 'error');
-            // Couldn't save — put the original text back in the preview.
+            const cmdErr = asCommandError(err);
+            // `old_text` Validation is the drift guard: the file changed between
+            // selection and save (a formatter, HMR re-write, an agent edit), so
+            // the baseline no longer matches. Don't discard the user's typed
+            // copy over that (issue #557) — re-resolve the element against the
+            // CURRENT source and re-apply the edit to the fresh location and
+            // baseline. The guard itself stays intact: the retry writes against
+            // a just-read baseline, it never forces a stale one through.
+            const isDrift = cmdErr.type === 'Validation' && cmdErr.field === 'old_text';
+            if (isDrift && sig) {
+              try {
+                const res = await resolveTextSource(projectPath, sig);
+                const stale = textTargetRef.current;
+                const sameTarget =
+                  res.status === 'resolved' &&
+                  stale != null &&
+                  res.file === stale.file &&
+                  res.line === stale.line &&
+                  res.column === stale.column &&
+                  res.text === stale.text;
+                // An identical re-resolve would just fail the same way — only
+                // retry when the fresh source actually differs.
+                if (res.status === 'resolved' && !sameTarget) {
+                  if (res.text !== next) {
+                    await applyTextEdit(
+                      projectPath,
+                      res.file,
+                      res.line,
+                      res.column,
+                      res.text,
+                      next
+                    );
+                  }
+                  textTargetRef.current = {
+                    file: res.file,
+                    line: res.line,
+                    column: res.column,
+                    text: next,
+                  };
+                  setTextResolution((prev) =>
+                    prev?.status === 'resolved'
+                      ? { ...prev, file: res.file, line: res.line, column: res.column, text: next }
+                      : prev
+                  );
+                  post({ type: 'ss:commit' });
+                  // Recovered drift is an expected environment state, not a bug
+                  // — warn, don't auto-file a report.
+                  logger.warn('[TextEditing] stale text save recovered by re-resolving', {
+                    error: formatCommandError(cmdErr),
+                  });
+                  void trackEvent('visual_text_saved');
+                  onToast?.('Saved to source', 'success');
+                  return;
+                }
+              } catch {
+                /* recovery failed — fall through to the non-silent failure below */
+              }
+            }
+            // Couldn't save. Never silent: toast the failure, then put the
+            // original text back in the preview (leaving the unsaved text up
+            // would look saved when it isn't).
+            if (isDrift) {
+              // Still stale after the retry — the source genuinely moved away
+              // from this element. Expected state; warn, don't auto-file.
+              logger.warn('[TextEditing] text write-back rejected as stale after retry', {
+                error: formatCommandError(cmdErr),
+              });
+              onToast?.(
+                "Couldn't save your text — the source file changed since you selected this element. The edit was undone; reselect the element and try again.",
+                'error'
+              );
+            } else {
+              logger.error('[TextEditing] text write-back failed', {
+                error: formatCommandError(cmdErr),
+              });
+              onToast?.(formatCommandError(cmdErr), 'error');
+            }
             post({ type: 'ss:textRevert' });
           }
         })();

--- a/src/hooks/useVisualEditor.test.ts
+++ b/src/hooks/useVisualEditor.test.ts
@@ -32,7 +32,12 @@ vi.mock('../lib/customClasses', () => ({
   classifyApplyTokens: vi.fn().mockResolvedValue([]),
 }));
 
+vi.mock('../lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
 import { useVisualEditor } from './useVisualEditor';
+import { logger } from '../lib/logger';
 import {
   resolveClassnameSource,
   applyClassnameEdit,
@@ -236,6 +241,64 @@ describe('useVisualEditor addFirstClass (class-less elements)', () => {
     const calls = post.mock.calls as Array<[{ type?: string; className?: string }]>;
     expect(calls.some((c) => c[0]?.type === 'ss:mutate' && c[0]?.className === 'mt-4')).toBe(true);
     expect(calls.some((c) => c[0]?.type === 'ss:commit')).toBe(true);
+  });
+});
+
+describe('useVisualEditor failure logging (issues #543/#544)', () => {
+  /** Calls to logger.error, as [message, context] tuples. */
+  function errorLogs() {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the mock's calls, not invoking it bound
+    return vi.mocked(logger.error).mock.calls;
+  }
+
+  it('write-back failure logs the real CommandError, not "[object Object]" (#544)', async () => {
+    // A rejected Tauri command delivers a plain tagged CommandError object —
+    // NOT an Error instance — so naive String(err) renders "[object Object]".
+
+    (applyClassnameEdit as Fn).mockRejectedValue({
+      type: 'Validation',
+      field: 'old_class',
+      reason: 'source no longer matches — reselect the element',
+    });
+    const { result, iframeRef } = setup();
+    act(() => result.current.toggleEditMode());
+    await select('p-3', iframeRef.current!.contentWindow!);
+
+    act(() => result.current.applyEnum('p-8', { padding: '2rem' }));
+    await act(async () => {
+      await result.current.commit();
+    });
+
+    const call = errorLogs().find(([msg]) => msg === '[VisualEditor] write-back failed');
+    expect(call).toBeDefined();
+    expect(call?.[1]).toEqual({
+      error: 'Validation failed for `old_class`: source no longer matches — reselect the element',
+    });
+    expect(JSON.stringify(errorLogs())).not.toContain('[object Object]');
+  });
+
+  it('add-first-class failure logs the real CommandError, not "[object Object]" (#543)', async () => {
+    (resolveClassnameSource as Fn).mockResolvedValue({ status: 'no_class' });
+
+    (insertClassAttr as Fn).mockRejectedValue({
+      type: 'Validation',
+      field: 'element',
+      reason: 'could not anchor the open tag',
+    });
+    const { result, iframeRef } = setup();
+    act(() => result.current.toggleEditMode());
+    await select('', iframeRef.current!.contentWindow!);
+
+    await act(async () => {
+      await result.current.addFirstClass('mt-4');
+    });
+
+    const call = errorLogs().find(([msg]) => msg === '[VisualEditor] add first class failed');
+    expect(call).toBeDefined();
+    expect(call?.[1]).toEqual({
+      error: 'Validation failed for `element`: could not anchor the open tag',
+    });
+    expect(JSON.stringify(errorLogs())).not.toContain('[object Object]');
   });
 });
 

--- a/src/hooks/useVisualEditor.ts
+++ b/src/hooks/useVisualEditor.ts
@@ -358,7 +358,9 @@ export function useVisualEditor({
             }
           }
         } catch (err) {
-          logger.error('[VisualEditor] resolve failed', { error: String(err) });
+          logger.error('[VisualEditor] resolve failed', {
+            error: formatCommandError(asCommandError(err)),
+          });
           onToast?.(formatCommandError(asCommandError(err)), 'error');
           setSelection({
             signature: sig,
@@ -379,7 +381,9 @@ export function useVisualEditor({
             // Ignore if the selection changed underneath us.
             if (usageTokenRef.current === usageToken) setImageTarget(imgRes);
           } catch (err) {
-            logger.error('[VisualEditor] image resolve failed', { error: String(err) });
+            logger.error('[VisualEditor] image resolve failed', {
+              error: formatCommandError(asCommandError(err)),
+            });
             if (usageTokenRef.current === usageToken)
               setImageTarget({
                 status: 'read_only',
@@ -409,7 +413,9 @@ export function useVisualEditor({
     try {
       setCustomClasses(await listCustomClasses(projectPath));
     } catch (err) {
-      logger.error('[VisualEditor] list custom classes failed', { error: String(err) });
+      logger.error('[VisualEditor] list custom classes failed', {
+        error: formatCommandError(asCommandError(err)),
+      });
     }
   }, [projectPath]);
 
@@ -537,7 +543,9 @@ export function useVisualEditor({
           // their live state via ss:commit rather than discarding it.
           if (!opts?.silent) onToast?.('Class saved', 'success');
         } catch (err) {
-          logger.error('[VisualEditor] class write-back failed', { error: String(err) });
+          logger.error('[VisualEditor] class write-back failed', {
+            error: formatCommandError(asCommandError(err)),
+          });
           onToast?.(formatCommandError(asCommandError(err)), 'error');
         }
         return;
@@ -585,7 +593,9 @@ export function useVisualEditor({
         });
         if (!opts?.silent) onToast?.('Saved to source', 'success');
       } catch (err) {
-        logger.error('[VisualEditor] write-back failed', { error: String(err) });
+        logger.error('[VisualEditor] write-back failed', {
+          error: formatCommandError(asCommandError(err)),
+        });
         onToast?.(formatCommandError(asCommandError(err)), 'error');
       }
     },
@@ -657,7 +667,9 @@ export function useVisualEditor({
         recordCommit('visual_class_added', { mode: 'tailwind', first: true });
         onToast?.('Class added', 'success');
       } catch (err) {
-        logger.error('[VisualEditor] add first class failed', { error: String(err) });
+        logger.error('[VisualEditor] add first class failed', {
+          error: formatCommandError(asCommandError(err)),
+        });
         onToast?.(formatCommandError(asCommandError(err)), 'error');
       }
     },
@@ -803,7 +815,9 @@ export function useVisualEditor({
         recordCommit('visual_image_saved');
         onToast?.('Image replaced', 'success');
       } catch (err) {
-        logger.error('[VisualEditor] image write-back failed', { error: String(err) });
+        logger.error('[VisualEditor] image write-back failed', {
+          error: formatCommandError(asCommandError(err)),
+        });
         onToast?.(formatCommandError(asCommandError(err)), 'error');
         throw err;
       }

--- a/src/lib/cssCascade.test.ts
+++ b/src/lib/cssCascade.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   rulesToLocate,
+  isStaleCssRuleError,
   mergeCascade,
   formatRuleCss,
   rowKey,
@@ -189,5 +190,37 @@ describe('rowKey', () => {
     )[0];
     expect(rowKey(a)).toBe(rowKey({ ...a }));
     expect(rowKey(a)).not.toBe(rowKey({ ...a, index: 1 }));
+  });
+});
+
+describe('isStaleCssRuleError (issue #584)', () => {
+  it('recognizes BOTH stale shapes from edit_css.rs', () => {
+    // Body drift: exactly one rule matches but its body moved on.
+    expect(
+      isStaleCssRuleError({
+        type: 'Validation',
+        field: 'css',
+        reason: 'source changed since you selected it — reselect to edit',
+      })
+    ).toBe(true);
+    // Zero-match: the selector no longer matches any source rule. This shape
+    // used to fall through the string-specific "source changed" retry check
+    // and drop the edit with no recovery.
+    expect(
+      isStaleCssRuleError({
+        type: 'Validation',
+        field: 'selector',
+        reason: 'rule no longer matches — reselect the element',
+      })
+    ).toBe(true);
+  });
+
+  it('does not classify real failures as stale (no retry for those)', () => {
+    expect(
+      isStaleCssRuleError({ type: 'Validation', field: 'file', reason: 'outside the project' })
+    ).toBe(false);
+    expect(isStaleCssRuleError({ type: 'Io', message: 'disk full' })).toBe(false);
+    expect(isStaleCssRuleError(new Error('rule no longer matches'))).toBe(false); // not a Validation error
+    expect(isStaleCssRuleError('boom')).toBe(false);
   });
 });

--- a/src/lib/cssCascade.ts
+++ b/src/lib/cssCascade.ts
@@ -12,6 +12,7 @@
  */
 
 import { invoke } from '@tauri-apps/api/core';
+import { asCommandError } from './errors';
 
 /** One declaration of a matched rule, as the iframe cascade walker reports it. */
 export interface CascadeDecl {
@@ -267,6 +268,19 @@ export function mediaChipLabel(row: Pick<CascadeRow, 'mediaText' | 'mediaMinPx'>
   if (min) return `≥${Math.round(parseFloat(min[1]))}`;
   if (row.mediaMinPx != null) return `≥${row.mediaMinPx}`;
   return text || null;
+}
+
+/**
+ * True when a css write-back rejection means the source went stale under the
+ * editor — recoverable by re-locating the rule and retrying. Covers BOTH backend
+ * shapes from `edit_css.rs`: body drift ("source changed since you selected it")
+ * and the zero-match case ("rule no longer matches"), which arises when the rule
+ * was renamed/rewritten since the card was seeded (issue #584). Anything else
+ * (Io, Process, non-stale Validation) is a real failure — don't retry it.
+ */
+export function isStaleCssRuleError(err: unknown): boolean {
+  const e = asCommandError(err);
+  return e.type === 'Validation' && /source changed|no longer matches/i.test(e.reason);
 }
 
 /** A stable key for a row — used both as the React key and the iframe preview key. */

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -5,7 +5,10 @@ import {
   formatCommandError,
   friendlyProcessError,
   humanizeGitError,
+  isAgentNotInstalledError,
+  isExpectedProjectImportRefusal,
   isMergeConflictError,
+  isRecognizedGitFailure,
   type CommandError,
 } from './errors';
 
@@ -252,6 +255,22 @@ describe('humanizeGitError', () => {
     );
   });
 
+  it('isRecognizedGitFailure mirrors whether humanizeGitError classified the error', () => {
+    // Recognized, by-design refusals (backend marks these Expected, but the
+    // tag can't cross IPC — issue #538).
+    expect(isRecognizedGitFailure('GraphQL: No commits between develop and feat/empty')).toBe(true);
+    expect(
+      isRecognizedGitFailure('GraphQL: A pull request already exists for julian:feat/x.')
+    ).toBe(true);
+    expect(isRecognizedGitFailure('remote: Permission denied (publickey).')).toBe(true);
+    expect(
+      isRecognizedGitFailure({ type: 'Process', cmd: 'gh', exit_code: 1, stderr: 'dial tcp: nope' })
+    ).toBe(true);
+    // Unrecognized failures fall through — those stay on the error channels.
+    expect(isRecognizedGitFailure('some completely novel git failure')).toBe(false);
+    expect(isRecognizedGitFailure(new Error('segfault in gh'))).toBe(false);
+  });
+
   it('accepts CommandError objects, not just strings', () => {
     const err: CommandError = {
       type: 'Timeout',
@@ -260,5 +279,45 @@ describe('humanizeGitError', () => {
     } as unknown as CommandError;
     // Timeout formats to a "timed out" message → the network case.
     expect(humanizeGitError(err)).toMatch(/couldn't reach GitHub/i);
+  });
+});
+
+describe('isExpectedProjectImportRefusal', () => {
+  // The backend's by-design refusals of a folder pick (issue #416) — each of
+  // these is user guidance, not a bug, and must classify as expected so the
+  // import flow logs at warn and toasts as info (issues #518/#535).
+  const expectedMessages = [
+    'This folder is inside a git repository rooted at /x. Please select that folder instead.',
+    'This looks like a monorepo. Please select the specific project folder you want to work on.',
+    "This folder doesn't appear to be a project (no package.json, index.html, or .git found).",
+    'This project is already inside your projects folder. It will appear automatically.',
+    'This folder is already registered.',
+    "That's your home directory — pick the project folder itself.",
+  ];
+
+  it.each(expectedMessages)('classifies as expected: %s', (message) => {
+    expect(isExpectedProjectImportRefusal(message)).toBe(true);
+  });
+
+  it('does not classify genuine failures as expected', () => {
+    expect(isExpectedProjectImportRefusal('EACCES: permission denied, open config.json')).toBe(
+      false
+    );
+    expect(isExpectedProjectImportRefusal('I/O error: disk full')).toBe(false);
+  });
+});
+
+describe('isAgentNotInstalledError', () => {
+  it("matches the backend's `<Agent> binary not found` Expected message", () => {
+    expect(isAgentNotInstalledError('Codex binary not found')).toBe(true);
+    expect(isAgentNotInstalledError('OpenCode binary not found')).toBe(true);
+    expect(isAgentNotInstalledError({ type: 'Other', message: 'Claude binary not found' })).toBe(
+      true
+    );
+  });
+
+  it('does not match other failures', () => {
+    expect(isAgentNotInstalledError('Failed to add MCP server: connection refused')).toBe(false);
+    expect(isAgentNotInstalledError(new Error('spawn ENOENT'))).toBe(false);
   });
 });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -173,6 +173,55 @@ export function humanizeGitError(value: unknown, ctx: GitErrorContext = {}): str
 }
 
 /**
+ * True when {@link humanizeGitError} recognized the failure as one of the
+ * known, user-actionable git/GitHub conditions (nothing to review, conflicts,
+ * out of date, auth, network, protected branch, existing PR, unsaved changes,
+ * worktree collision, missing ref, not a repo).
+ *
+ * The backend classifies many of these as `CommandError::Expected`, but that
+ * variant deliberately serializes identically to `Other` across IPC, so the
+ * frontend can't read the tag — this is the client-side mirror. Callers use it
+ * to route recognized conditions to info toasts / warn logs instead of the
+ * error channels that auto-file bug reports (issue #538).
+ */
+export function isRecognizedGitFailure(value: unknown, ctx: GitErrorContext = {}): boolean {
+  return humanizeGitError(value, ctx) !== formatCommandError(asCommandError(value));
+}
+
+/**
+ * Phrases from `register_external_project`'s by-design refusals of a folder
+ * pick (backend returns `CommandError::expected` for them, issue #416 — but
+ * Expected serializes identically to Other across IPC, so the frontend
+ * re-checks the guidance phrases). These are user-guidance states, not bugs:
+ * callers log them at warn level and toast them as info (issues #518/#535).
+ */
+const EXPECTED_IMPORT_REFUSAL_PHRASES = [
+  'Please select that folder instead',
+  'Please select the specific project folder',
+  "doesn't appear to be a project",
+  'already inside your projects folder',
+  'already registered',
+  'your home directory',
+];
+
+/** True when an import-local-folder failure message is one of the backend's
+ *  by-design refusals (see {@link EXPECTED_IMPORT_REFUSAL_PHRASES}). */
+export function isExpectedProjectImportRefusal(message: string): boolean {
+  return EXPECTED_IMPORT_REFUSAL_PHRASES.some((phrase) => message.includes(phrase));
+}
+
+/**
+ * True when a caught error means the selected agent's CLI isn't installed —
+ * the backend's `find_agent_binary` returns `CommandError::expected("<Agent>
+ * binary not found")` for exactly this (issue #250), but Expected can't cross
+ * the IPC boundary, so match the message shape. A missing CLI is a
+ * user-environment state, not a bug: log it at warn level (issue #594).
+ */
+export function isAgentNotInstalledError(value: unknown): boolean {
+  return /binary not found/i.test(formatCommandError(asCommandError(value)));
+}
+
+/**
  * Exit-code → actionable-message mappings shared by the PTY-driven flows
  * (project creation, GitHub import) that run `git clone` / package installs.
  */

--- a/src/lib/mcp.test.ts
+++ b/src/lib/mcp.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { validateMcpAddCommand, isMcpUnsupportedCliError } from './mcp';
+
+describe('validateMcpAddCommand (#588)', () => {
+  const validInputs = [
+    'my-server -- npx -y @some/mcp-server', // command after --
+    'my-server npx -y @some/mcp-server', // command without --
+    'my-server --url https://example.com/mcp', // remote via --url
+    'my-server https://example.com/mcp', // bare URL as commandOrUrl
+    '--transport http sentry https://mcp.sentry.dev/mcp', // flags before name
+    'my-server --env FOO=bar -- npx -y pkg', // env flag + separator
+    'claude mcp add my-server -- npx -y pkg', // optional CLI prefix
+    'mcp add my-server -- npx -y pkg', // partial prefix
+  ];
+
+  it.each(validInputs)('accepts: %s', (input) => {
+    expect(validateMcpAddCommand(input)).toBeNull();
+  });
+
+  const invalidInputs = [
+    'my-server', // name only — the exact #588 report shape
+    'claude mcp add my-server', // name only behind the prefix
+    'my-server --scope user', // name + flags, still no command/URL
+    'my-server --url', // --url with no value
+    'my-server --', // separator with nothing after it
+  ];
+
+  it.each(invalidInputs)('rejects with guidance: %s', (input) => {
+    const message = validateMcpAddCommand(input);
+    expect(message).not.toBeNull();
+    expect(message).toContain('--url');
+    expect(message).toContain('npx');
+  });
+
+  it('strips the prefix for the configured agent binary', () => {
+    expect(validateMcpAddCommand('codex mcp add my-server -- npx pkg', 'codex')).toBeNull();
+    expect(validateMcpAddCommand('codex mcp add my-server', 'codex')).not.toBeNull();
+  });
+});
+
+describe('isMcpUnsupportedCliError (#550)', () => {
+  it("matches older Codex CLIs' clap usage error for missing mcp subcommands", () => {
+    expect(
+      isMcpUnsupportedCliError(
+        "Failed to add MCP server: error: unexpected argument 'add' found\n\nUsage: codex mcp [OPTIONS]\n\nFor more information, try '--help'."
+      )
+    ).toBe(true);
+    expect(
+      isMcpUnsupportedCliError("error: unrecognized subcommand 'remove'\n\nUsage: codex mcp")
+    ).toBe(true);
+    // CommandError objects work too (Tauri rejections are plain objects).
+    expect(
+      isMcpUnsupportedCliError({
+        type: 'Other',
+        message: "Failed to list MCP servers: error: unexpected argument 'list' found",
+      })
+    ).toBe(true);
+  });
+
+  it('does not match unrelated failures', () => {
+    expect(isMcpUnsupportedCliError('Failed to add MCP server: connection refused')).toBe(false);
+    expect(isMcpUnsupportedCliError('Codex binary not found')).toBe(false);
+    // The CLI's *own* argument validation for a user typo is not a version gap.
+    expect(isMcpUnsupportedCliError("error: missing required argument 'commandOrUrl'")).toBe(false);
+  });
+});

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -10,6 +10,7 @@
  */
 
 import { invoke } from '@tauri-apps/api/core';
+import { asCommandError, formatCommandError } from './errors';
 
 /** Represents an MCP server configured for an agent. */
 export interface McpServer {
@@ -47,6 +48,91 @@ export async function addMcpServer(
   agentId?: string
 ): Promise<void> {
   return invoke('add_mcp_server', { rawArgs, scope, projectPath, agentId });
+}
+
+/**
+ * True when an `mcp add/list/remove` failure means the installed agent CLI is
+ * too old to have MCP subcommands at all. Older Codex CLIs (pre `codex mcp
+ * add|list|remove|get`) fail with clap's usage error — "error: unexpected
+ * argument 'add' found\n\nUsage: codex mcp [OPTIONS]" — which the backend
+ * forwards verbatim. That's a user-environment state ("update your CLI"), not
+ * an app bug (issue #550).
+ */
+export function isMcpUnsupportedCliError(value: unknown): boolean {
+  const message = formatCommandError(asCommandError(value));
+  return (
+    /unexpected argument '(add|list|remove|get)'/i.test(message) ||
+    /unrecognized subcommand/i.test(message)
+  );
+}
+
+/** Flags of `mcp add` that consume the next token as their value. */
+const MCP_ADD_VALUE_FLAGS = new Set([
+  '--transport',
+  '-t',
+  '--scope',
+  '-s',
+  '--env',
+  '-e',
+  '--header',
+  '-H',
+]);
+
+/**
+ * Frontend validation for the MCP modal's "Add" input (issue #588).
+ *
+ * `claude mcp add <name>` with no command/URL fails at the CLI level with a
+ * raw `error: missing required argument 'commandOrUrl'` — catch the shape
+ * before shelling out. Mirrors the backend's leniency: the
+ * `<binary> mcp add` prefix is optional, flags may precede the name
+ * (`--transport http name url`), and either a `--url <value>`, a URL token,
+ * or a command (bare token / `-- command...`) satisfies the requirement.
+ *
+ * @returns A user-facing error message, or `null` when the input looks valid.
+ */
+export function validateMcpAddCommand(rawArgs: string, agentBinaryName = 'claude'): string | null {
+  let text = rawArgs.trim();
+  // Strip the optional "<binary> mcp add" prefix exactly like the backend.
+  if (text.startsWith(agentBinaryName)) text = text.slice(agentBinaryName.length).trimStart();
+  if (text.startsWith('mcp add')) text = text.slice('mcp add'.length).trimStart();
+
+  const invalid =
+    'Include what the server runs or connects to: a command after the name (e.g. `my-server -- npx -y @some/mcp-server`) or a URL (e.g. `my-server --url https://example.com/mcp`).';
+  const tokens = text.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return invalid;
+
+  // Count "bare" tokens (name + command/URL positions), skipping flags and
+  // their values. A `--` separator means everything after is the command.
+  let bare = 0;
+  let hasUrl = false;
+  let hasSeparatorCommand = false;
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t === '--') {
+      hasSeparatorCommand = i < tokens.length - 1;
+      break;
+    }
+    if (t === '--url' || t === '-u') {
+      if (i + 1 >= tokens.length) return invalid;
+      hasUrl = true;
+      i++;
+      continue;
+    }
+    if (MCP_ADD_VALUE_FLAGS.has(t)) {
+      i++;
+      continue;
+    }
+    if (t.startsWith('-')) continue;
+    if (/^https?:\/\//i.test(t)) hasUrl = true;
+    bare++;
+  }
+
+  // Valid shapes: name + `-- command`, name + `--url <url>` / URL token, or
+  // name + command (two bare tokens).
+  if (hasSeparatorCommand && bare >= 1) return null;
+  if (hasUrl && bare >= 1) return null;
+  if (bare >= 2) return null;
+  return invalid;
 }
 
 /**


### PR DESCRIPTION
Five parallel workstreams over the ~60 issues auto-reported since round 13, merged and verified together, plus a live autonomous QA pass on this exact tree.

## Real behavior fixes
- **Inline text edits are never silently lost** (#557): a save rejected by the drift guard now re-resolves the element against current source and re-applies the text there (formatter/HMR touching the file mid-edit now recovers transparently); only an impossible recovery reverts, with a plain-language toast.
- **Hung git network processes die on timeout** (#556): `run_git_net` gets `kill_on_drop`, so a wedged push/fetch/pull can't keep holding `.git` locks. Lock retry now also covers `HEAD.lock`/ref locks (#567) and `discard_changes` (#597).
- **AI prompt via stdin** (#595): no more "Argument list too long" on big diffs; verified against the real Claude CLI.
- **EAGAIN spawn family** (#555 #573 #585 #586 #587): shared retry-with-backoff + classified message for macOS process-table pressure across git, plugins, browser-open, gh, and PTY spawns.
- **Windows npm/npx shim spawning** (#590): resolver prefers `.exe`/`.cmd` over the extensionless POSIX shims CreateProcess can't run (os error 193).
- **JPEG custom thumbnails** (#561), **signal-death diagnostics for PTYs** (#589), **rename retry on Windows file locks** (#559), **branch-conflict modal auto-stash retry instead of dead-end** (#564), **MCP add-server input validated client-side** (#588), **old Codex CLI without `mcp add` gets a friendly update prompt** (#550).

## Expected-state classification & error hygiene
- gh: transient GraphQL 400s (#602), Go runtime crashes incl. OOM heap-arena (#610), connection-reset blips (#592), push/delete network errors through the shared classifier (#560); all raw CLI output now capped at 2KB in error messages (#578, #610).
- git: PR-checkout overwrite refusal (#601), merge conflicts in pull_and_merge (#609), Xcode CLT license/missing-CLT and macOS TCC denials with actionable remediation (#603, #546), worktree-delete refusal without leaking paths (#562), stderr included in git-status failures (#547), untracked-file branch refusals stop paging telemetry (#566).
- Filesystem/platform: macOS TCC EPERM classified at plugin storage/registry reads (#605, #545), rename collision (#599), AI CLI not installed (#548), commit-message timeout (#565), unknown connect session et al via toast flows: #535 #538 #539 #594 #600 #607, `[object Object]` logging fixed across visual-editor/preview hooks (#541 #543 #544 + 20 more sites found in the same files), WS reconnect ECONNREFUSED aligned with the #532 initial-connect handling (#552), stale CSS-cascade edits retry against the re-located rule (#584).

## Verification
- Full suite on the merged tree: typecheck clean, pattern rules clean, **1444 frontend tests** (107 files), **843 cargo tests** — +102 tests vs main.
- **Live autonomous QA pass** on this build (background-driven via accessibility API): project create → workspace open → agent PTY spawn → static preview → Code mode → Backups modal → MCP modal → rename collision → project delete, with the app log watched throughout (zero unexpected error-level entries). The #599 collision message was verified rendering in the real UI.
- QA found two bugs: a pre-existing silent no-op "Create branch" affordance on GitHub-less repos (filed as #612) and a `[object Object]` error-report in the dashboard rename handler — the latter fixed in this PR's final commit.

Deliberately skipped: #540 (ENXIO from openpty) — the plausible cause is a real PTY fd-retention leak; classifying it as expected would hide it. Needs a session-lifecycle fix instead.

Closes #535, #538, #539, #541, #543, #544, #545, #546, #547, #548, #550, #552, #555, #556, #557, #559, #560, #561, #562, #564, #565, #566, #567, #573, #578, #584, #585, #586, #587, #588, #589, #590, #592, #594, #595, #597, #599, #600, #601, #602, #603, #605, #607, #609, #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JPEG, GIF, and WebP image decoding.
  * MCP server commands now validate input and provide clearer guidance for unsupported or missing CLI features.
  * Text and CSS editors can recover from source changes and retry safely.
  * Process termination errors now include clearer details.

* **Bug Fixes**
  * Improved Git, GitHub, branch, project rename, plugin, and preview error messages.
  * Added retries for temporary system, lock, and permission issues.
  * Expected conditions now show informative guidance instead of generic alerts.
  * Improved WebSocket retry and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->