### PR TITLE
Quick sweep: per-call gh timeout labels, push-rejected as Expected, EAGAIN retry in run_with_timeout

### DIFF
--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -38,12 +38,18 @@ const GITHUB_CLI_TIMEOUT_SECS: u64 = 15;
 
 /// Run a gh command with a timeout via the shared external_command helper.
 /// Returns CommandError so callers can discriminate timeout vs IO vs process.
+///
+/// `label` names the specific invocation ("gh auth status", "gh repo create
+/// --push", …): the timeout error message and its telemetry fingerprint are
+/// derived from it, so a bare "gh" would collapse every distinct hang into one
+/// undiagnosable bucket (issue #611).
 async fn run_command_with_timeout(
     cmd: Command,
+    label: &str,
     timeout_secs: u64,
 ) -> Result<std::process::Output, CommandError> {
     let tokio_cmd = tokio::process::Command::from(cmd);
-    run_with_timeout(tokio_cmd, "gh", timeout_secs).await
+    run_with_timeout(tokio_cmd, label, timeout_secs).await
 }
 
 /// Returns a Command for gh with extended PATH set, scoped to the globally
@@ -127,7 +133,13 @@ pub async fn check_github_cli_status() -> GitHubCliStatus {
     let start = std::time::Instant::now();
     let mut auth_cmd = get_gh_command();
     auth_cmd.args(["auth", "status"]);
-    let authenticated = match run_command_with_timeout(auth_cmd, GITHUB_CLI_TIMEOUT_SECS).await {
+    let authenticated = match run_command_with_timeout(
+        auth_cmd,
+        "gh auth status",
+        GITHUB_CLI_TIMEOUT_SECS,
+    )
+    .await
+    {
         Ok(output) => {
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -187,7 +199,7 @@ pub async fn get_github_username(project_path: Option<String>) -> Result<String,
     }
 
     cmd.args(["api", "user", "--jq", ".login"]);
-    let output = run_command_with_timeout(cmd, GITHUB_CLI_TIMEOUT_SECS).await?;
+    let output = run_command_with_timeout(cmd, "gh api user", GITHUB_CLI_TIMEOUT_SECS).await?;
 
     if !output.status.success() {
         return Err(CommandError::NotAuthenticated {
@@ -207,7 +219,7 @@ pub async fn get_github_orgs(project_path: Option<String>) -> Result<Vec<String>
     // login so org choices match the account the repo will be created under.
     let (mut cmd, _account_id) = gh_command_and_account(project_path.as_deref())?;
     cmd.args(["api", "user/orgs", "--jq", ".[].login"]);
-    let output = run_command_with_timeout(cmd, GITHUB_CLI_TIMEOUT_SECS).await?;
+    let output = run_command_with_timeout(cmd, "gh api user/orgs", GITHUB_CLI_TIMEOUT_SECS).await?;
 
     if !output.status.success() {
         // Return empty list if we can't get orgs (user might not have any)
@@ -257,7 +269,13 @@ pub async fn get_project_github_status(project_path: String) -> ProjectGitHubSta
         .args(["remote", "get-url", "origin"])
         .env("PATH", get_extended_path());
 
-    let remote_url = match run_command_with_timeout(remote_cmd, GITHUB_CLI_TIMEOUT_SECS).await {
+    let remote_url = match run_command_with_timeout(
+        remote_cmd,
+        "git remote get-url origin",
+        GITHUB_CLI_TIMEOUT_SECS,
+    )
+    .await
+    {
         Ok(output) if output.status.success() => {
             let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
             debug!(elapsed_ms = step_start.elapsed().as_millis() as u64, remote_url = %url, "git remote get-url origin completed");
@@ -306,7 +324,9 @@ pub async fn get_project_github_status(project_path: String) -> ProjectGitHubSta
         .args(["repo", "view", &github_repo, "--json", "url"])
         .current_dir(&project);
 
-    let result = match run_command_with_timeout(gh_cmd, GITHUB_CLI_TIMEOUT_SECS).await {
+    let result = match run_command_with_timeout(gh_cmd, "gh repo view", GITHUB_CLI_TIMEOUT_SECS)
+        .await
+    {
         Ok(output) if output.status.success() => {
             debug!(elapsed_ms = step_start.elapsed().as_millis() as u64, github_repo = %github_repo, "gh repo view completed successfully");
             // Parse the URL from JSON response
@@ -485,7 +505,7 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
         ])
         .current_dir(&validated_path);
     // Longer timeout: create+push can take a while for bigger repos.
-    let output = run_command_with_timeout(gh_cmd, 60).await?;
+    let output = run_command_with_timeout(gh_cmd, "gh repo create --push", 60).await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -660,7 +680,7 @@ pub async fn list_github_repos(owner: String) -> Result<Vec<GitHubRepo>, Command
         "--limit",
         "100",
     ]);
-    let output = run_command_with_timeout(cmd, GITHUB_CLI_TIMEOUT_SECS).await?;
+    let output = run_command_with_timeout(cmd, "gh repo list", GITHUB_CLI_TIMEOUT_SECS).await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -718,7 +738,8 @@ pub async fn list_collaborator_repos() -> Result<Vec<GitHubRepo>, CommandError> 
         "/user/repos?affiliation=collaborator&per_page=100&sort=updated",
         "--paginate",
     ]);
-    let output = run_command_with_timeout(cmd, GITHUB_CLI_TIMEOUT_SECS).await?;
+    let output =
+        run_command_with_timeout(cmd, "gh api user/repos", GITHUB_CLI_TIMEOUT_SECS).await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src-tauri/src/commands/publishing.rs
+++ b/src-tauri/src/commands/publishing.rs
@@ -171,10 +171,13 @@ pub async fn publish_to_staging(
         if stderr.contains("rejected") || stderr.contains("non-fast-forward") {
             warn!(error = %stderr, "Push rejected - staging branch has diverged");
             // Retain the legacy PUSH_REJECTED sentinel so the frontend can
-            // still discriminate this case via substring match.
-            return Err(CommandError::Other { message: format!(
+            // still discriminate this case via substring match. A concurrent
+            // push landing first is a benign race with dedicated UI, not a
+            // malfunction — Expected keeps it out of telemetry (issue #617,
+            // same class as #312/#521/#609).
+            return Err(CommandError::expected(format!(
                 "PUSH_REJECTED: Staging branch has diverged. Pull changes first or resolve conflicts.\n{stderr}"
-            ) });
+            )));
         }
         if let Some(err) = push_auth_error(&stderr) {
             error!(error = %stderr, "Authentication error");
@@ -289,9 +292,11 @@ pub async fn publish_branch(
         // Check for common errors
         if stderr.contains("rejected") || stderr.contains("non-fast-forward") {
             warn!(error = %stderr, branch = %branch, "Push rejected");
-            return Err(CommandError::Other {
-                message: format!("PUSH_REJECTED:{stderr}"),
-            });
+            // Someone else pushed first — an anticipated race the frontend
+            // already handles via the PUSH_REJECTED sentinel (GitErrorHandler's
+            // push_rejected case). Expected serializes identically to Other on
+            // the wire, so the substring match keeps working (issue #617).
+            return Err(CommandError::expected(format!("PUSH_REJECTED:{stderr}")));
         }
         if let Some(err) = push_auth_error(&stderr) {
             error!(error = %stderr, branch = %branch, "Authentication error");

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -34,7 +34,30 @@ pub async fn run_with_timeout(
     let label = cmd_label.into();
     debug!(cmd = %label, timeout_secs, "spawning external command");
 
-    let result = tokio::time::timeout(Duration::from_secs(timeout_secs), cmd.output()).await;
+    // Retry transient EAGAIN spawn failures in place (issue #616): the
+    // process-table pressure that produces them usually clears within
+    // milliseconds, and background polling callers (e.g. `gh pr list`) would
+    // otherwise surface a scary one-off error for a self-healing condition.
+    // The retries run inside the caller's timeout budget.
+    let run = async {
+        const ATTEMPTS: u64 = 3;
+        for attempt in 1..=ATTEMPTS {
+            match cmd.output().await {
+                Err(e) if attempt < ATTEMPTS && is_spawn_resource_pressure(&e.to_string()) => {
+                    warn!(
+                        cmd = %label,
+                        attempt,
+                        error = %e,
+                        "spawn hit transient resource pressure (EAGAIN); retrying"
+                    );
+                    tokio::time::sleep(Duration::from_millis(100 * attempt)).await;
+                }
+                other => return other,
+            }
+        }
+        unreachable!("loop returns on the final attempt")
+    };
+    let result = tokio::time::timeout(Duration::from_secs(timeout_secs), run).await;
 
     match result {
         Ok(Ok(output)) => {
@@ -47,23 +70,7 @@ pub async fn run_with_timeout(
         }
         Ok(Err(io_err)) => {
             warn!(cmd = %label, error = %io_err, "external command spawn failed");
-            // Name the command: Windows renders a PATH miss as the bare
-            // "program not found", which is useless without knowing WHICH
-            // program (issue #296) — Timeout/Process already carry the label.
-            let message = format!("`{label}`: {io_err}");
-            // A missing binary is an environment gap ("install X first"),
-            // not an app malfunction — Expected keeps it out of telemetry.
-            if io_err.kind() == std::io::ErrorKind::NotFound {
-                Err(CommandError::expected(message))
-            } else if let Some(oom) =
-                crate::errors::windows_out_of_memory(&io_err, Some(label.as_str()))
-            {
-                // Pagefile exhaustion is likewise the environment, not us
-                // (issue #356).
-                Err(oom)
-            } else {
-                Err(CommandError::Io { message })
-            }
+            Err(map_spawn_io_error(&label, &io_err))
         }
         Err(_) => {
             warn!(cmd = %label, timeout_secs, "external command timed out");
@@ -72,6 +79,29 @@ pub async fn run_with_timeout(
                 secs: timeout_secs,
             })
         }
+    }
+}
+
+/// Shared mapping of a spawn-time `io::Error` into a `CommandError`, used by
+/// both timeout runners:
+/// - The error names the command: Windows renders a PATH miss as the bare
+///   "program not found", which is useless without knowing WHICH program
+///   (issue #296) — Timeout/Process already carry the label.
+/// - A missing binary is an environment gap ("install X first"), not an app
+///   malfunction — Expected keeps it out of telemetry.
+/// - Windows pagefile exhaustion is likewise the environment (issue #356).
+/// - Persistent EAGAIN after the in-place retries is process-table pressure —
+///   an environment state with a user-side fix (issue #616).
+fn map_spawn_io_error(label: &str, io_err: &std::io::Error) -> CommandError {
+    let message = format!("`{label}`: {io_err}");
+    if io_err.kind() == std::io::ErrorKind::NotFound {
+        CommandError::expected(message)
+    } else if let Some(oom) = crate::errors::windows_out_of_memory(io_err, Some(label)) {
+        oom
+    } else if is_spawn_resource_pressure(&io_err.to_string()) {
+        spawn_resource_pressure_error(label)
+    } else {
+        CommandError::Io { message }
     }
 }
 
@@ -132,21 +162,10 @@ pub async fn run_with_timeout_stdin(
             );
             Ok(output)
         }
-        // Same io-error mapping as run_with_timeout: missing binary and
-        // Windows pagefile exhaustion are environment states, not
-        // malfunctions (issues #296, #356).
+        // Same io-error mapping as run_with_timeout (issues #296, #356, #616).
         Ok(Err(io_err)) => {
             warn!(cmd = %label, error = %io_err, "external command spawn failed");
-            let message = format!("`{label}`: {io_err}");
-            if io_err.kind() == std::io::ErrorKind::NotFound {
-                Err(CommandError::expected(message))
-            } else if let Some(oom) =
-                crate::errors::windows_out_of_memory(&io_err, Some(label.as_str()))
-            {
-                Err(oom)
-            } else {
-                Err(CommandError::Io { message })
-            }
+            Err(map_spawn_io_error(&label, &io_err))
         }
         Err(_) => {
             warn!(cmd = %label, timeout_secs, "external command timed out");
@@ -362,6 +381,40 @@ mod tests {
         // Don't match a larger error code that merely contains "35"/"11".
         assert!(!is_spawn_resource_pressure("something (os error 110)"));
         assert!(!is_spawn_resource_pressure("something (os error 355)"));
+    }
+
+    // The #616 shape: `I/O error: `gh pr list`: Resource temporarily
+    // unavailable (os error 35)` from run_with_timeout-backed polling must
+    // classify Expected (with the human message), not a reported Io.
+    #[test]
+    fn map_spawn_io_error_covers_all_families() {
+        let eagain = std::io::Error::other("Resource temporarily unavailable (os error 35)");
+        match map_spawn_io_error("gh pr list", &eagain) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("`gh pr list`"), "got: {message}");
+                assert!(
+                    message.contains("low on process resources"),
+                    "got: {message}"
+                );
+                assert!(!message.contains("os error 35"), "got: {message}");
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+
+        let missing = std::io::Error::new(std::io::ErrorKind::NotFound, "not found");
+        assert!(matches!(
+            map_spawn_io_error("gh", &missing),
+            CommandError::Expected { .. }
+        ));
+
+        let plain = std::io::Error::other("boom");
+        match map_spawn_io_error("gh api user", &plain) {
+            CommandError::Io { message } => {
+                assert!(message.contains("`gh api user`"), "got: {message}");
+                assert!(message.contains("boom"), "got: {message}");
+            }
+            other => panic!("expected Io, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Three small fixes for the reports that arrived since round 14 (#613):

- **#611** — `run_command_with_timeout` in github.rs now takes a per-call-site label ("gh auth status", "gh repo create --push", "gh api user/repos", …) instead of hardcoding "gh", so timeout messages and their telemetry fingerprints identify which invocation actually hung — matching what `run_net` in pull_requests.rs already does.
- **#617** — the push-rejected arms in `publish_branch` and `publish_to_staging` return `CommandError::expected` instead of `Other`. The "someone pushed first" race already has dedicated friendly UI (`GitErrorHandler`'s `push_rejected` case); the backend just stops paging telemetry for it. The `PUSH_REJECTED:` sentinel strings are preserved byte-for-byte, and Expected serializes identically to Other on the wire, so frontend substring matching is untouched.
- **#616** — `run_with_timeout` (the runner behind `gh pr list` status polling and most CLI calls) now retries EAGAIN spawn failures in place (3 attempts, 100/200ms backoff, inside the caller's timeout budget) and classifies persistent pressure as the same Expected "system temporarily low on process resources" message round 14 introduced for direct spawn sites. The io-error mapping shared by `run_with_timeout` and `run_with_timeout_stdin` is factored into one `map_spawn_io_error` helper with a test covering the EAGAIN/NotFound/plain-Io families. Note: #616's issue body analyzes a `Canopy/*.swift` codebase — that analysis is misattributed (wrong project; likely an agent hallucination in the auto-filer), but the reported fingerprint is real Ship Studio output from this exact call path.

Verification: `cargo test` 844 passed / 0 failed, `cargo fmt` clean, no new clippy warnings in touched code.

Closes #611, #616, #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when running GitHub and Git operations during temporary system resource pressure.
  * Added clearer error messages for missing command-line tools and persistent execution failures.
  * Improved handling of branch push and staging rejections when branches have diverged.
  * Timeout and failure messages now identify the specific operation involved, making troubleshooting easier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->