### PR TITLE
Kill timed-out CLI children in run_with_timeout; 180s budget for PR-description diffs

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -25,10 +25,17 @@ const COMMIT_MSG_CLI_TIMEOUT_SECS: u64 = 30;
 /// Fallback commit message used when AI generation is unavailable or fails.
 pub const DEFAULT_COMMIT_MESSAGE: &str = "Update from Ship Studio";
 
-/// Timeout for the local git context-gathering ops (branch/log/diff). Bounds a
-/// pathological repo (a huge diff) and keeps the work off the blocking path —
-/// these run via async tokio process, not std `.output()` on the executor.
+/// Timeout for the fast local git context-gathering ops (branch name, commit
+/// log) — always cheap regardless of repo size.
 const GIT_TIMEOUT_SECS: u64 = 60;
+
+/// Timeout for the diff-shaped ops (`git diff`, `git diff --stat`), whose cost
+/// scales with repo and diff size: a three-dot diff computes the merge-base
+/// and diffs the whole range, which can legitimately exceed 60s on a big repo
+/// on Windows (slower filesystem, antivirus scanning — issue #608, same theme
+/// as #421/#461/#527). The timed-out child is killed by run_with_timeout's
+/// kill_on_drop, so a slow diff can no longer leak a running git process.
+const GIT_DIFF_TIMEOUT_SECS: u64 = 180;
 
 /// How the active agent can answer a one-shot prompt without a TTY.
 enum HeadlessInvocation {
@@ -307,7 +314,7 @@ async fn get_diff_stat(path: &std::path::Path, base: &str) -> Result<String, Com
     let output = run_with_timeout(
         tokio::process::Command::from(cmd),
         "git diff --stat",
-        GIT_TIMEOUT_SECS,
+        GIT_DIFF_TIMEOUT_SECS,
     )
     .await?;
 
@@ -320,7 +327,7 @@ async fn get_diff(path: &std::path::Path, base: &str) -> Result<String, CommandE
     let output = run_with_timeout(
         tokio::process::Command::from(cmd),
         "git diff",
-        GIT_TIMEOUT_SECS,
+        GIT_DIFF_TIMEOUT_SECS,
     )
     .await?;
 

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -34,6 +34,12 @@ pub async fn run_with_timeout(
     let label = cmd_label.into();
     debug!(cmd = %label, timeout_secs, "spawning external command");
 
+    // When the timeout fires, the output() future is dropped — without
+    // kill_on_drop the child would keep running (and e.g. a timed-out
+    // `git diff` keeps grinding a big repo in the background, issue #608;
+    // same class as run_git_net's #556).
+    cmd.kill_on_drop(true);
+
     // Retry transient EAGAIN spawn failures in place (issue #616): the
     // process-table pressure that produces them usually clears within
     // milliseconds, and background polling callers (e.g. `gh pr list`) would
@@ -128,7 +134,9 @@ pub async fn run_with_timeout_stdin(
 
     cmd.stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped());
+        .stderr(std::process::Stdio::piped())
+        // Reap the child if the timeout drops the future mid-run (#608).
+        .kill_on_drop(true);
 
     let data = stdin_data.as_bytes().to_vec();
     let run = async move {
@@ -330,6 +338,33 @@ mod tests {
             }
             other => panic!("expected Expected, got {other:?}"),
         }
+    }
+
+    /// The #608/#556 leak shape: when the timeout fires, the child must be
+    /// killed, not left running. `sh` would touch the marker after 2s if it
+    /// survived; kill_on_drop must prevent that.
+    #[tokio::test]
+    async fn timed_out_child_is_killed_not_orphaned() {
+        let dir = std::env::temp_dir().join(format!("ss-kill-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let marker = dir.join("survived-marker");
+        let _ = std::fs::remove_file(&marker);
+
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c")
+            .arg(format!("sleep 2; touch {}", marker.display()));
+        let err = run_with_timeout(cmd, "sh sleep-touch", 1)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CommandError::Timeout { .. }));
+
+        // Give a hypothetical surviving child ample time to reach the touch.
+        tokio::time::sleep(Duration::from_millis(2500)).await;
+        assert!(
+            !marker.exists(),
+            "timed-out child survived and wrote its marker — kill_on_drop regressed"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes the report behind fingerprint `cmderr-timeout-git diff` (#608), which had two halves:

- **Timed-out children leaked.** `run_with_timeout` (and `run_with_timeout_stdin`) now set `kill_on_drop(true)`, so when the timeout drops the `output()` future the child is reaped instead of grinding on in the background. This covers every CLI call site that uses the shared runners — the reported `git diff`, but also gh, vercel, agent CLIs, etc. Same class as round 14's `run_git_net` fix (#556). Marker-file test proves a timed-out child never completes its work.
- **No headroom for legitimate large diffs.** `get_diff`/`get_diff_stat` in ai.rs (the PR-description context gathering) move from the shared 60s ceiling to a diff-specific 180s: a three-dot diff computes the merge-base and diffs the whole range, which can honestly exceed 60s on a big repo on Windows (same theme as #421/#461/#527). Branch-name/commit-log keep 60s — they're always cheap.

`cargo test`: 845 passed / 0 failed (one new test), fmt clean.

Note for the reviewer: the held draft PR #529 contains the same one-line `kill_on_drop` for `run_with_timeout` among its capture fixes — when #529 lands it will merge trivially (identical change); nothing capture-related ships here.

Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of long-running Git diff operations by allowing additional time for completion.
  * Ensured timed-out commands are terminated cleanly instead of continuing in the background.
  * Reduced the risk of delayed side effects from commands that exceed their timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->