### PR TITLE
feat(code): add in-file buffer search and cross-file code search toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language": "^6.12.3",
+    "@codemirror/search": "^6.7.1",
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.43.1",
     "@cstar.help/js": "^0.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@codemirror/language':
         specifier: ^6.12.3
         version: 6.12.3
+      '@codemirror/search':
+        specifier: ^6.7.1
+        version: 6.7.1
       '@codemirror/state':
         specifier: ^6.6.0
         version: 6.6.0
@@ -307,6 +310,9 @@ packages:
 
   '@codemirror/lint@6.9.7':
     resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+
+  '@codemirror/search@6.7.1':
+    resolution: {integrity: sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==}
 
   '@codemirror/state@6.6.0':
     resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
@@ -674,66 +680,79 @@ packages:
     resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.55.1':
     resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.55.1':
     resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.55.1':
     resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.55.1':
     resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.55.1':
     resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.55.1':
     resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.55.1':
     resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.55.1':
     resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.55.1':
     resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.55.1':
     resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.55.1':
     resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.55.1':
     resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.55.1':
     resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}
@@ -824,30 +843,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.9.6':
     resolution: {integrity: sha512-02TKUndpodXBCR0oP//6dZWGYcc22Upf2eP27NvC6z0DIqvkBBFziQUcvi2n6SrwTRL0yGgQjkm9K5NIn8s6jw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.9.6':
     resolution: {integrity: sha512-fmp1hnulbqzl1GkXl4aTX9fV+ubHw2LqlLH1PE3BxZ11EQk+l/TmiEongjnxF0ie4kV8DQfDNJ1KGiIdWe1GvQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.9.6':
     resolution: {integrity: sha512-vY0le8ad2KaV1PJr+jCd8fUF9VOjwwQP/uBuTJvhvKTloEwxYA/kAjKK9OpIslGA9m/zcnSo74czI6bBrm2sYA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.9.6':
     resolution: {integrity: sha512-TOEuB8YCFZTWVDzsO2yW0+zGcoMiPPwcUgdnW1ODnmgfwccpnihDRoks+ABT1e3fHb1ol8QQWsHSCovb3o2ENQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.9.6':
     resolution: {integrity: sha512-ujmDGMRc4qRLAnj8nNG26Rlz9klJ0I0jmZs2BPpmNNf0gM/rcVHhqbEkAaHPTBVIrtUdf7bGvQAD2pyIiUrBHQ==}
@@ -2814,6 +2838,12 @@ snapshots:
       style-mod: 4.1.3
 
   '@codemirror/lint@6.9.7':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      crelt: 1.0.6
+
+  '@codemirror/search@6.7.1':
     dependencies:
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
+packages:
+  - '.'
+
 allowBuilds:
   esbuild: true
+

--- a/src-tauri/src/commands/code.rs
+++ b/src-tauri/src/commands/code.rs
@@ -28,6 +28,28 @@ pub struct FileContent {
     pub language: String,
 }
 
+/// A single match within a file during code search.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct CodeSearchMatch {
+    pub line_number: usize,
+    pub line_text: String,
+    pub match_start: usize,
+    pub match_end: usize,
+}
+
+/// Code search results grouped by file path.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct CodeSearchResult {
+    pub file_path: String,
+    pub matches: Vec<CodeSearchMatch>,
+}
+
+/// Maximum total line matches to return across all files.
+const MAX_TOTAL_SEARCH_MATCHES: usize = 500;
+
+/// Maximum files with matches to return.
+const MAX_SEARCH_FILES: usize = 100;
+
 /// Maximum number of file entries to return.
 const MAX_ENTRIES: usize = 10_000;
 
@@ -270,6 +292,122 @@ pub fn save_project_file(
     Ok(())
 }
 
+/// Search across project code files for a string query, respecting .gitignore and SKIP_DIRS.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path, query = %query))]
+pub fn search_project_code(
+    project_path: &str,
+    query: &str,
+    case_sensitive: Option<bool>,
+) -> Result<Vec<CodeSearchResult>, CommandError> {
+    let project = validate_project_path(project_path)?;
+    let trimmed = query.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let is_case_sensitive = case_sensitive.unwrap_or(false);
+    let target_query = if is_case_sensitive {
+        trimmed.to_string()
+    } else {
+        trimmed.to_lowercase()
+    };
+
+    let walker = WalkBuilder::new(&project)
+        .hidden(false)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .max_depth(Some(20))
+        .filter_entry(|entry| {
+            let name = entry.file_name().to_string_lossy();
+            !SKIP_DIRS.contains(&name.as_ref())
+        })
+        .build();
+
+    let mut results = Vec::new();
+    let mut total_matches = 0;
+
+    for result in walker {
+        if results.len() >= MAX_SEARCH_FILES || total_matches >= MAX_TOTAL_SEARCH_MATCHES {
+            break;
+        }
+
+        let entry = match result {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let relative = match path.strip_prefix(&project) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+
+        if should_skip_path(relative) {
+            continue;
+        }
+
+        let metadata = match path.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+
+        if metadata.len() > MAX_FILE_SIZE || metadata.len() == 0 {
+            continue;
+        }
+
+        let bytes = match std::fs::read(path) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+
+        let check_len = bytes.len().min(8192);
+        if bytes[..check_len].contains(&0) {
+            continue; // Skip binary files
+        }
+
+        let content = String::from_utf8_lossy(&bytes);
+        let mut file_matches = Vec::new();
+
+        for (idx, line) in content.lines().enumerate() {
+            if total_matches >= MAX_TOTAL_SEARCH_MATCHES {
+                break;
+            }
+
+            let search_line = if is_case_sensitive {
+                line.to_string()
+            } else {
+                line.to_lowercase()
+            };
+
+            if let Some(pos) = search_line.find(&target_query) {
+                file_matches.push(CodeSearchMatch {
+                    line_number: idx + 1,
+                    line_text: line.to_string(),
+                    match_start: pos,
+                    match_end: pos + trimmed.len(),
+                });
+                total_matches += 1;
+            }
+        }
+
+        if !file_matches.is_empty() {
+            let relative_str = normalize_separators(&relative.to_string_lossy());
+            results.push(CodeSearchResult {
+                file_path: relative_str,
+                matches: file_matches,
+            });
+        }
+    }
+
+    Ok(results)
+}
+
 /// Infer the Shiki language identifier from a file path.
 ///
 /// Checks the filename first for well-known extensionless files (Dockerfile, Makefile, etc.),
@@ -423,5 +561,35 @@ mod tests {
 
         let real: PathBuf = ["src", "app", "page.tsx"].iter().collect();
         assert!(!should_skip_path(&real));
+    }
+
+    #[test]
+    fn test_search_project_code() {
+        let root = crate::utils::projects_root().expect("projects root");
+        let dir = root.join(format!(
+            "shipstudio-code-search-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let project = dir.to_string_lossy().to_string();
+
+        let file1 = dir.join("foo.txt");
+        std::fs::write(&file1, "hello world\nanother line\nWORLD again").unwrap();
+
+        let file2 = dir.join("bar.js");
+        std::fs::write(&file2, "const x = 'hello';").unwrap();
+
+        let results = search_project_code(&project, "world", Some(false)).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].file_path, "foo.txt");
+        assert_eq!(results[0].matches.len(), 2);
+        assert_eq!(results[0].matches[0].line_number, 1);
+        assert_eq!(results[0].matches[1].line_number, 3);
+
+        let case_results = search_project_code(&project, "world", Some(true)).unwrap();
+        assert_eq!(case_results[0].matches.len(), 1);
+        assert_eq!(case_results[0].matches[0].line_number, 1);
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -701,6 +701,7 @@ pub fn run() {
             commands::code::list_project_files,
             commands::code::read_project_file,
             commands::code::save_project_file,
+            commands::code::search_project_code,
             // Assets
             commands::assets::get_assets_root,
             commands::assets::set_assets_root,

--- a/src/components/code/CodeFileEditor.tsx
+++ b/src/components/code/CodeFileEditor.tsx
@@ -26,6 +26,7 @@ import {
 } from '@codemirror/view';
 import { EditorState, StateEffect, StateField, Compartment } from '@codemirror/state';
 import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands';
+import { search, searchKeymap, openSearchPanel } from '@codemirror/search';
 import { indentUnit, bracketMatching } from '@codemirror/language';
 import {
   ghDarkExtension,
@@ -56,6 +57,8 @@ interface Props {
   revealLine?: number | null;
   /** Fires with the current text selection in view mode (null when empty/editing). */
   onSelectionChange?: (sel: EditorSelectionInfo | null) => void;
+  /** When true/incremented, opens the in-file search panel in the editor. */
+  openSearchTrigger?: number;
 }
 
 // Transient line highlight for jump-to-code reveal.
@@ -85,6 +88,7 @@ export function CodeFileEditor({
   onSave,
   revealLine,
   onSelectionChange,
+  openSearchTrigger,
 }: Props) {
   const hostRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
@@ -117,6 +121,7 @@ export function CodeFileEditor({
         indentUnit.of('  '),
         EditorState.tabSize.of(2),
         revealLineField,
+        search({ top: true }),
         keymap.of([
           {
             key: 'Mod-s',
@@ -127,6 +132,7 @@ export function CodeFileEditor({
               return true;
             },
           },
+          ...searchKeymap,
           ...defaultKeymap,
           ...historyKeymap,
           indentWithTab,
@@ -224,6 +230,13 @@ export function CodeFileEditor({
     if (editable) view.focus();
     else onSelRef.current?.(null);
   }, [editable]);
+
+  // Open in-file search panel when openSearchTrigger is updated.
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view || !openSearchTrigger) return;
+    openSearchPanel(view);
+  }, [openSearchTrigger]);
 
   // Jump-to-code: scroll the target line into view and briefly highlight it.
   useEffect(() => {

--- a/src/components/code/CodeTab.tsx
+++ b/src/components/code/CodeTab.tsx
@@ -1,10 +1,3 @@
-/**
- * Code browser tab container component.
- *
- * Combines a file tree sidebar with a syntax-highlighted code viewer.
- * Includes a draggable divider for resizing the two panes.
- */
-
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useFileTree } from '../../hooks/useFileTree';
 import { FileTree } from './FileTree';
@@ -12,8 +5,13 @@ import { CodeViewer } from './CodeViewer';
 import { ProjectActionConfirmModal } from '../dashboard/ProjectActionConfirmModal';
 import { Spinner } from '../primitives/Spinner';
 import { Button } from '../primitives/Button';
-import { ResetIcon, SearchIcon, EditIcon } from '../icons';
-import { type FileTreeNode, fileExtensionForAnalytics } from '../../lib/code';
+import { ResetIcon, SearchIcon, EditIcon, FileIcon, CodeIcon } from '../icons';
+import {
+  type FileTreeNode,
+  type CodeSearchResult,
+  searchProjectCode,
+  fileExtensionForAnalytics,
+} from '../../lib/code';
 import { trackEvent, trackSearch } from '../../lib/analytics';
 import { useCommands } from '../../commands/useCommands';
 
@@ -52,12 +50,20 @@ export function CodeTab({ projectPath, onSendToAgent, revealTarget }: CodeTabPro
     cancelPendingAction,
   } = useFileTree(projectPath);
 
+  const [activeRevealTarget, setActiveRevealTarget] = useState<{
+    file: string;
+    line: number;
+  } | null>(revealTarget ?? null);
+
   const selectFile = useCallback(
-    (path: string) => {
+    (path: string, line?: number) => {
       void trackEvent('code_file_opened', {
         file_extension: fileExtensionForAnalytics(path),
       });
       selectFileRaw(path);
+      if (line != null) {
+        setActiveRevealTarget({ file: path, line });
+      }
     },
     [selectFileRaw]
   );
@@ -67,8 +73,13 @@ export function CodeTab({ projectPath, onSendToAgent, revealTarget }: CodeTabPro
     refreshTreeRaw();
   }, [refreshTreeRaw]);
 
-  // Expose the persisted edit-mode toggle in the command palette (the palette is
-  // a contract — every user-facing feature registers its primary action).
+  const [searchMode, setSearchMode] = useState<'files' | 'code'>('files');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<CodeSearchResult[]>([]);
+  const [isSearchingCode, setIsSearchingCode] = useState(false);
+  const [openSearchTrigger, setOpenSearchTrigger] = useState<number>(0);
+
+  // Expose search & edit commands in the Cmd+K palette.
   useCommands(
     () => [
       {
@@ -81,19 +92,70 @@ export function CodeTab({ projectPath, onSendToAgent, revealTarget }: CodeTabPro
         keywords: ['edit', 'code', 'editor', 'read only', 'write', 'ide'],
         run: () => setEditMode(!editModeEnabled),
       },
+      {
+        id: 'code.findInFile',
+        title: 'Find in current file',
+        subtitle: 'Code tab — open in-file search panel in editor',
+        icon: <SearchIcon size={14} />,
+        category: 'action',
+        when: 'project',
+        keywords: ['find', 'search', 'file', 'code', 'buffer'],
+        run: () => setOpenSearchTrigger((prev) => prev + 1),
+      },
+      {
+        id: 'code.toggleSearchMode',
+        title:
+          searchMode === 'files' ? 'Switch to code content search' : 'Switch to file path search',
+        subtitle: 'Code tab — toggle search mode in sidebar',
+        icon: <CodeIcon size={14} />,
+        category: 'action',
+        when: 'project',
+        keywords: ['search', 'grep', 'mode', 'content', 'path', 'files'],
+        run: () => setSearchMode((prev) => (prev === 'files' ? 'code' : 'files')),
+      },
     ],
-    [editModeEnabled, setEditMode]
+    [editModeEnabled, setEditMode, searchMode]
   );
 
-  // Jump-to-code: open the targeted file. The line is forwarded to CodeViewer
-  // (which scrolls + highlights it) independently, so re-targeting the same file
-  // still reveals the new line even though selectFile early-returns.
+  // Jump-to-code: open targeted file & store reveal line.
   useEffect(() => {
-    if (revealTarget) selectFileRaw(revealTarget.file);
+    if (revealTarget) {
+      selectFileRaw(revealTarget.file);
+      const timer = setTimeout(() => {
+        setActiveRevealTarget(revealTarget);
+      }, 0);
+      return () => clearTimeout(timer);
+    }
   }, [revealTarget, selectFileRaw]);
 
+  // Debounced cross-file code search execution.
+  useEffect(() => {
+    if (searchMode !== 'code' || !searchQuery.trim()) {
+      const timer = setTimeout(() => {
+        setSearchResults([]);
+        setIsSearchingCode(false);
+      }, 0);
+      return () => clearTimeout(timer);
+    }
+
+    const timer = setTimeout(() => {
+      setIsSearchingCode(true);
+      searchProjectCode(projectPath, searchQuery.trim())
+        .then((results) => {
+          setSearchResults(results);
+        })
+        .catch(() => {
+          setSearchResults([]);
+        })
+        .finally(() => {
+          setIsSearchingCode(false);
+        });
+    }, 250);
+
+    return () => clearTimeout(timer);
+  }, [searchMode, searchQuery, projectPath]);
+
   const [sidebarWidth, setSidebarWidth] = useState(250);
-  const [searchQuery, setSearchQuery] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
 
@@ -151,7 +213,9 @@ export function CodeTab({ projectPath, onSendToAgent, revealTarget }: CodeTabPro
     <div className="code-tab" ref={containerRef}>
       <div className="code-tab-sidebar" style={{ width: sidebarWidth }}>
         <div className="code-tab-sidebar-header">
-          <span className="code-tab-sidebar-title">Files</span>
+          <span className="code-tab-sidebar-title">
+            {searchMode === 'files' ? 'Files' : 'Code Search'}
+          </span>
           <button className="code-tab-refresh-btn" onClick={refreshTree} title="Refresh file tree">
             <ResetIcon size={12} />
           </button>
@@ -161,7 +225,7 @@ export function CodeTab({ projectPath, onSendToAgent, revealTarget }: CodeTabPro
           <input
             className="code-tab-search-input"
             type="text"
-            placeholder="Search files..."
+            placeholder={searchMode === 'files' ? 'Search file paths...' : 'Search code content...'}
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"
@@ -172,6 +236,21 @@ export function CodeTab({ projectPath, onSendToAgent, revealTarget }: CodeTabPro
               trackSearch('code_files', e.target.value);
             }}
           />
+          <button
+            type="button"
+            className={`code-search-mode-toggle${searchMode === 'code' ? ' active' : ''}`}
+            onClick={() => setSearchMode((prev) => (prev === 'files' ? 'code' : 'files'))}
+            title={
+              searchMode === 'files'
+                ? 'Switch to Code Content Search (cross-file grep)'
+                : 'Switch to File Path Search'
+            }
+          >
+            {searchMode === 'files' ? <FileIcon size={12} /> : <CodeIcon size={12} />}
+            <span className="code-search-mode-label">
+              {searchMode === 'files' ? 'Files' : 'Code'}
+            </span>
+          </button>
         </div>
         <div className="code-tab-sidebar-content">
           {isLoadingTree ? (
@@ -185,6 +264,48 @@ export function CodeTab({ projectPath, onSendToAgent, revealTarget }: CodeTabPro
                 Retry
               </Button>
             </div>
+          ) : searchMode === 'code' ? (
+            isSearchingCode ? (
+              <div className="code-tab-sidebar-loading">
+                <Spinner size="sm" style={{ color: 'var(--accent)' }} />
+                <span>Searching code...</span>
+              </div>
+            ) : !searchQuery.trim() ? (
+              <div className="code-tab-sidebar-empty">Type query to search across files</div>
+            ) : searchResults.length === 0 ? (
+              <div className="code-tab-sidebar-empty">No matching code content</div>
+            ) : (
+              <div className="code-search-results">
+                {searchResults.map((res) => (
+                  <div key={res.filePath} className="code-search-file-group">
+                    <div
+                      className="code-search-file-header"
+                      onClick={() => selectFile(res.filePath)}
+                      title={res.filePath}
+                    >
+                      <FileIcon size={12} />
+                      <span className="code-search-file-path">{res.filePath}</span>
+                      <span className="code-search-file-count">{res.matches.length}</span>
+                    </div>
+                    <div className="code-search-file-matches">
+                      {res.matches.map((m) => (
+                        <button
+                          key={`${res.filePath}:${m.lineNumber}`}
+                          type="button"
+                          className="code-search-match-item"
+                          onClick={() => selectFile(res.filePath, m.lineNumber)}
+                        >
+                          <span className="code-search-match-line">{m.lineNumber}</span>
+                          <span className="code-search-match-text" title={m.lineText}>
+                            {m.lineText}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )
           ) : filteredTree.length === 0 ? (
             <div className="code-tab-sidebar-empty">
               {searchQuery.trim() ? 'No matching files' : 'No files found'}
@@ -210,7 +331,9 @@ export function CodeTab({ projectPath, onSendToAgent, revealTarget }: CodeTabPro
           error={fileError}
           onSendToAgent={onSendToAgent}
           revealLine={
-            revealTarget && revealTarget.file === selectedFilePath ? revealTarget.line : null
+            activeRevealTarget && activeRevealTarget.file === selectedFilePath
+              ? activeRevealTarget.line
+              : null
           }
           isEditing={isEditing}
           draft={draft}
@@ -222,6 +345,8 @@ export function CodeTab({ projectPath, onSendToAgent, revealTarget }: CodeTabPro
           onSave={saveFile}
           editModeEnabled={editModeEnabled}
           onToggleEditMode={setEditMode}
+          openSearchTrigger={openSearchTrigger}
+          onTriggerSearch={() => setOpenSearchTrigger((prev) => prev + 1)}
         />
       </div>
       {pendingAction && (

--- a/src/components/code/CodeViewer.tsx
+++ b/src/components/code/CodeViewer.tsx
@@ -18,7 +18,15 @@ import { useOptionalToast } from '../../contexts/ToastContext';
 import { Dropdown, DropdownItem } from '../primitives/Dropdown';
 import { Spinner } from '../primitives/Spinner';
 import { Button } from '../primitives/Button';
-import { ChevronIcon, CodeIcon, FileIcon, VSCodeIcon, CursorIcon, CopyIcon } from '../icons';
+import {
+  ChevronIcon,
+  CodeIcon,
+  FileIcon,
+  VSCodeIcon,
+  CursorIcon,
+  CopyIcon,
+  SearchIcon,
+} from '../icons';
 import { trackEvent } from '../../lib/analytics';
 import { fileExtensionForAnalytics } from '../../lib/code';
 import { CodeFileEditor } from './CodeFileEditor';
@@ -48,6 +56,8 @@ interface CodeViewerProps {
   /** Global, persisted "Code tab is editable" opt-in (drives the header toggle). */
   editModeEnabled?: boolean;
   onToggleEditMode?: (enabled: boolean) => void;
+  openSearchTrigger?: number;
+  onTriggerSearch?: () => void;
 }
 
 interface SelectionInfo {
@@ -82,6 +92,8 @@ export function CodeViewer({
   onSave,
   editModeEnabled = false,
   onToggleEditMode,
+  openSearchTrigger,
+  onTriggerSearch,
 }: CodeViewerProps) {
   const { showToast } = useOptionalToast();
   const onToast = (message: string, type?: 'success' | 'error' | 'info') =>
@@ -339,6 +351,17 @@ export function CodeViewer({
               </Button>
             </div>
           )}
+          {onTriggerSearch && (
+            <button
+              type="button"
+              className="code-viewer-open-btn"
+              onClick={onTriggerSearch}
+              title="Find in current file (Cmd+F / Ctrl+F)"
+            >
+              <SearchIcon size={12} />
+              <span>Find</span>
+            </button>
+          )}
           {onToggleEditMode && (
             // Same control as the visual editor's Edit toggle (shared
             // `preview-edit-toggle` classes) so the two read as one feature.
@@ -422,6 +445,7 @@ export function CodeViewer({
           onSave={() => void handleSave()}
           revealLine={revealLine}
           onSelectionChange={handleSelectionChange}
+          openSearchTrigger={openSearchTrigger}
         />
         {isEditing && saveError && (
           <div className="code-viewer-save-error">Save failed: {saveError}</div>

--- a/src/lib/code.ts
+++ b/src/lib/code.ts
@@ -86,6 +86,20 @@ export async function readProjectFile(projectPath: string, filePath: string): Pr
   };
 }
 
+/** A match within a file for code search. */
+export interface CodeSearchMatch {
+  lineNumber: number;
+  lineText: string;
+  matchStart: number;
+  matchEnd: number;
+}
+
+/** Code search result item grouped by file path. */
+export interface CodeSearchResult {
+  filePath: string;
+  matches: CodeSearchMatch[];
+}
+
 /** Overwrite a project file with new content (Code tab inline editor). */
 export async function saveProjectFile(
   projectPath: string,
@@ -93,6 +107,35 @@ export async function saveProjectFile(
   content: string
 ): Promise<void> {
   await invoke('save_project_file', { projectPath, filePath, content });
+}
+
+/** Search project files for matching code content. */
+export async function searchProjectCode(
+  projectPath: string,
+  query: string,
+  caseSensitive?: boolean
+): Promise<CodeSearchResult[]> {
+  const results = await invoke<
+    Array<{
+      file_path: string;
+      matches: Array<{
+        line_number: number;
+        line_text: string;
+        match_start: number;
+        match_end: number;
+      }>;
+    }>
+  >('search_project_code', { projectPath, query, caseSensitive: caseSensitive ?? false });
+
+  return results.map((res) => ({
+    filePath: res.file_path,
+    matches: res.matches.map((m) => ({
+      lineNumber: m.line_number,
+      lineText: m.line_text,
+      matchStart: m.match_start,
+      matchEnd: m.match_end,
+    })),
+  }));
 }
 
 /** Build a nested tree structure from a flat list of file entries. */

--- a/src/styles/modes/code-mode.css
+++ b/src/styles/modes/code-mode.css
@@ -56,19 +56,20 @@
 .code-tab-search {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin: 8px;
-  padding: 0 8px;
+  gap: var(--spacing-xs, 6px);
+  margin: var(--spacing-xs, 8px);
+  padding: 0 var(--spacing-xs, 8px);
   height: 28px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-primary);
   color: var(--text-muted);
   flex-shrink: 0;
+  transition: border-color 0.15s ease;
 }
 
 .code-tab-search:focus-within {
-  border-color: var(--accent);
+  border-color: var(--info-light);
 }
 
 .code-tab-search-input {
@@ -84,6 +85,207 @@
 
 .code-tab-search-input::placeholder {
   color: var(--text-muted);
+}
+
+/* Segmented mode switcher inside search bar */
+.code-search-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  height: 20px;
+  padding: 0 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 500;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  flex-shrink: 0;
+  user-select: none;
+  transition: all 0.15s ease;
+}
+
+.code-search-mode-toggle:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.code-search-mode-toggle.active {
+  color: var(--text-bright);
+  background: var(--bg-tertiary);
+  border-color: var(--border);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.code-search-mode-label {
+  display: inline;
+}
+
+@media (max-width: 220px) {
+  .code-search-mode-label {
+    display: none;
+  }
+}
+
+/* Cross-file Code Search Results */
+.code-search-results {
+  display: flex;
+  flex-direction: column;
+  padding: 4px 6px;
+  gap: 6px;
+}
+
+.code-search-file-group {
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid transparent;
+}
+
+.code-search-file-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  user-select: none;
+}
+
+.code-search-file-header:hover {
+  color: var(--text-primary);
+  background: var(--bg-primary);
+}
+
+.code-search-file-path {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.code-search-file-count {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: var(--radius-full, 9999px);
+  background: var(--bg-primary);
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.code-search-file-matches {
+  display: flex;
+  flex-direction: column;
+  padding-left: 8px;
+  margin-top: 2px;
+  gap: 2px;
+}
+
+.code-search-match-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono, monospace);
+  text-align: left;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  width: 100%;
+  overflow: hidden;
+}
+
+.code-search-match-item:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.code-search-match-line {
+  color: var(--info-light);
+  font-size: 11px;
+  flex-shrink: 0;
+  min-width: 24px;
+}
+
+.code-search-match-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* CodeMirror Find Panel styling override to align with Ship Studio Dark UI */
+.cm-panels {
+  background: var(--bg-secondary) !important;
+  border-bottom: 1px solid var(--border) !important;
+  color: var(--text-primary) !important;
+  font-family: inherit !important;
+  padding: 6px 12px !important;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2) !important;
+}
+
+.cm-panels-top {
+  border-bottom: 1px solid var(--border) !important;
+}
+
+.cm-search {
+  display: flex !important;
+  flex-wrap: wrap !important;
+  align-items: center !important;
+  gap: 8px !important;
+  font-size: var(--font-size-sm) !important;
+}
+
+.cm-search input[name='search'],
+.cm-search input[name='replace'] {
+  background: var(--bg-primary) !important;
+  color: var(--text-primary) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: var(--radius-sm) !important;
+  padding: 3px 8px !important;
+  font-size: var(--font-size-sm) !important;
+  outline: none !important;
+  min-width: 120px !important;
+  max-width: 260px !important;
+}
+
+.cm-search input[name='search']:focus,
+.cm-search input[name='replace']:focus {
+  border-color: var(--info-light) !important;
+}
+
+.cm-search button {
+  background: var(--bg-tertiary) !important;
+  color: var(--text-secondary) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: var(--radius-sm) !important;
+  padding: 3px 8px !important;
+  font-size: var(--font-size-xs) !important;
+  cursor: pointer !important;
+}
+
+.cm-search button:hover {
+  color: var(--text-primary) !important;
+  background: var(--bg-primary) !important;
+}
+
+.cm-search label {
+  color: var(--text-muted) !important;
+  font-size: var(--font-size-xs) !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 4px !important;
+  user-select: none !important;
 }
 
 .code-tab-sidebar-content {

--- a/src/styles/modes/code-mode.css
+++ b/src/styles/modes/code-mode.css
@@ -116,7 +116,7 @@
   color: var(--text-bright);
   background: var(--bg-tertiary);
   border-color: var(--border);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-sm);
 }
 
 .code-search-mode-label {
@@ -231,7 +231,7 @@
   color: var(--text-primary) !important;
   font-family: inherit !important;
   padding: 6px 12px !important;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2) !important;
+  box-shadow: var(--shadow) !important;
 }
 
 .cm-panels-top {


### PR DESCRIPTION
   ### Summary
    Ship Studio's **Code Tab** now supports full-featured in-buffer code search (`Cmd+F`) and cross-file code search (`grep`) with zero external tool dependencies. Developers   
  browsing or editing code files in the IDE surface can instantly query string patterns within their active editor buffer or execute a `.gitignore`-aware content search
  across the entire project codebase.

    The scenario this kills: switching away from Ship Studio to an external terminal or editor just to `grep` for a variable or function definition across project files.        

    ---

    ### Changes

    #### Backend (Rust / Tauri)
    - **`search_project_code` command (`src-tauri/src/commands/code.rs`)**:
      - Performs cross-file string content searches using `ignore::WalkBuilder`, respecting `.gitignore`, `.git/exclude`, and `SKIP_DIRS` (`node_modules`, `.next`, `dist`,      
  etc.).
      - Filters out binary files (via null-byte sampling) and files larger than `500KB`.
      - Supports case-sensitive and case-insensitive matching.
      - Bounds results to 500 total line matches across up to 100 files to guarantee fast backend execution and smooth UI rendering.
      - Added unit test suite `test_search_project_code`.
    - **Command Registration (`src-tauri/src/lib.rs`)**:
      - Registered `commands::code::search_project_code` in the Tauri `invoke_handler`.

    #### Frontend (React / CodeMirror)
    - **In-File Editor Search Panel (`CodeFileEditor.tsx` & `CodeViewer.tsx`)**:
      - Integrated `@codemirror/search` into the single CodeMirror editor instance.
      - Supported standard `Cmd+F` / `Ctrl+F` keyboard shortcuts, match highlighting, case matching, regex, and next/previous match navigation.
      - Added a dedicated **Find** button in the file viewer header to open the in-file search panel programmatically.
    - **Sidebar Search Mode Toggle & Cross-File Results (`CodeTab.tsx`)**:
      - Added a responsive search mode toggle pill button (`Files` path filtering vs. `Code` content search) in the sidebar search bar.
      - Debounces cross-file queries (250ms) and invokes `searchProjectCode`.
      - Renders match results grouped by file path, displaying line numbers and truncated code line snippets.
      - Clicking any result line instantly selects the file and scrolls directly to that line using `revealTarget`.
    - **Command Palette (`useCommands`)**:
      - Registered Cmd+K commands for:
        - `Find in current file` (`code.findInFile`)
        - `Switch to code content search` / `Switch to file path search` (`code.toggleSearchMode`)
    - **Design System & Styling (`code-mode.css`)**:
      - Styled the search mode toggle and CodeMirror `.cm-panels` overlay using strict design tokens (`var(--bg-primary)`, `var(--border)`, `var(--info-light)`).
      - Added responsive rules (`@media (max-width: 220px)`) to gracefully collapse text labels when the sidebar is resized narrow.

    ---

    ### Test Plan
    - `npx tsc --noEmit` — verified clean TypeScript compilation (0 errors).
    - `cargo test --manifest-path src-tauri/Cargo.toml --lib commands::code::tests` — 5 Rust unit tests passed (`test_search_project_code`, `test_save_project_file_roundtrip`,  
  `test_infer_language`, `test_should_skip_path`, `test_should_skip_path_windows_separators`).
    - `npx vitest run` — 1,450 frontend unit tests passed across 108 test suites.
    - **Manual Verification**:
      1. Open a code file in the Code tab -> Press `Cmd+F` -> Verify CodeMirror find panel opens and highlights matches.
      2. Toggle search mode in the sidebar to **Code** -> Type a string pattern (e.g. `useFileTree`). Verify matches across multiple files render with line numbers.
      3. Click a line match snippet -> Verify file opens and scrolls/highlights the target line.
      4. Resize the sidebar width < 220px -> Verify mode toggle collapses smoothly to icon-only mode.
      
      
     
<img width="1393" height="925" alt="image" src="https://github.com/user-attachments/assets/4d6f65c4-6da5-4b8e-99ab-9b1b28ff2d52" />

<img width="1391" height="922" alt="image" src="https://github.com/user-attachments/assets/c6d7e11d-ed9e-4f53-9713-a225daf3975d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project-wide code search with case-sensitive and case-insensitive matching.
  * Search results are grouped by file and support navigation directly to matching lines.
  * Added a toggle between file-path and code-content search.
  * Added in-file search controls and keyboard support in the code editor.
  * Added loading, empty, and error states for code searches.
  * Added a Find button for quick in-file searching.

* **Style**
  * Improved search layouts, responsive controls, and dark-theme editor styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->