### PR TITLE
Bug Bash Round 15: 44 auto-reported issues across git errors, telemetry, capture, Windows, and misc

### DIFF
--- a/src-tauri/plugins/tauri-plugin-pty/src/lib.rs
+++ b/src-tauri/plugins/tauri-plugin-pty/src/lib.rs
@@ -134,13 +134,7 @@ async fn read(pid: PtyHandler, state: tauri::State<'_, PluginState>) -> Result<V
     // promise on every iteration during teardown, flooding the Tauri
     // IPC bridge and (on macOS WebKit) eventually crashing the network
     // process.
-    let session = state
-        .sessions
-        .read()
-        .await
-        .get(&pid)
-        .ok_or("EOF")?
-        .clone();
+    let session = state.sessions.read().await.get(&pid).ok_or("EOF")?.clone();
     tokio::task::spawn_blocking(move || {
         let mut buf = vec![0u8; 4096];
         let mut reader = session.reader.blocking_lock();
@@ -209,12 +203,7 @@ async fn kill(pid: PtyHandler, state: tauri::State<'_, PluginState>) -> Result<(
     // the top of `read`. Without the removal, the frontend's read loop
     // keeps polling an Arc<Session> whose child is dead, generating a
     // cascade of rejected invoke() calls during project switches.
-    let session = state
-        .sessions
-        .write()
-        .await
-        .remove(&pid)
-        .ok_or("EOF")?;
+    let session = state.sessions.write().await.remove(&pid).ok_or("EOF")?;
     session
         .child_killer
         .lock()
@@ -225,7 +214,7 @@ async fn kill(pid: PtyHandler, state: tauri::State<'_, PluginState>) -> Result<(
 }
 
 #[tauri::command]
-async fn exitstatus(pid: PtyHandler, state: tauri::State<'_, PluginState>) -> Result<u32, String> {
+async fn exitstatus(pid: PtyHandler, state: tauri::State<'_, PluginState>) -> Result<i32, String> {
     let session = state
         .sessions
         .read()
@@ -242,7 +231,13 @@ async fn exitstatus(pid: PtyHandler, state: tauri::State<'_, PluginState>) -> Re
             .wait()
             .map_err(|e| e.to_string())?
             .exit_code();
-        Ok::<u32, String>(exitstatus)
+        // portable_pty reports the raw Windows exit DWORD as a u32. Abnormal
+        // terminations carry a *signed* 32-bit status (an NTSTATUS, or node's
+        // negative libuv errno — e.g. -4058/UV_ENOENT), which as a bare u32
+        // renders as a nonsense huge number like 4294963238 in the frontend's
+        // failure toast (issue #622). Reinterpret as i32 so those arrive as
+        // their small negative selves; normal small exit codes are unchanged.
+        Ok::<i32, String>(exitstatus as i32)
     })
     .await
     .map_err(|e: tokio::task::JoinError| e.to_string())?

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -1432,7 +1432,10 @@ pub fn claude_connect_write(session_id: String, data: Vec<u8>) -> Result<(), Com
         map.get(&session_id).cloned()
     };
     let Some(session) = session else {
-        return Err("unknown connect session".to_string().into());
+        // A keystroke/resize can land after the connect PTY exited (the waiter
+        // thread pruned the registry) or after the modal was closed — a benign,
+        // expected race the frontend already ignores, not a bug (issue #563).
+        return Err(CommandError::expected("unknown connect session"));
     };
     let mut w = session
         .writer
@@ -1453,7 +1456,10 @@ pub fn claude_connect_resize(session_id: String, cols: u16, rows: u16) -> Result
         map.get(&session_id).cloned()
     };
     let Some(session) = session else {
-        return Err("unknown connect session".to_string().into());
+        // A keystroke/resize can land after the connect PTY exited (the waiter
+        // thread pruned the registry) or after the modal was closed — a benign,
+        // expected race the frontend already ignores, not a bug (issue #563).
+        return Err(CommandError::expected("unknown connect session"));
     };
     let master = session
         .master
@@ -1763,7 +1769,10 @@ pub fn workspace_connect_write(session_id: String, data: Vec<u8>) -> Result<(), 
         map.get(&session_id).cloned()
     };
     let Some(session) = session else {
-        return Err("unknown connect session".to_string().into());
+        // A keystroke/resize can land after the connect PTY exited (the waiter
+        // thread pruned the registry) or after the modal was closed — a benign,
+        // expected race the frontend already ignores, not a bug (issue #563).
+        return Err(CommandError::expected("unknown connect session"));
     };
     let mut w = session
         .writer
@@ -1788,7 +1797,10 @@ pub fn workspace_connect_resize(
         map.get(&session_id).cloned()
     };
     let Some(session) = session else {
-        return Err("unknown connect session".to_string().into());
+        // A keystroke/resize can land after the connect PTY exited (the waiter
+        // thread pruned the registry) or after the modal was closed — a benign,
+        // expected race the frontend already ignores, not a bug (issue #563).
+        return Err(CommandError::expected("unknown connect session"));
     };
     let master = session
         .master

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -43,7 +43,12 @@ pub async fn read_env_file(file_path: String) -> Result<Vec<EnvVar>, CommandErro
     // Constrain reads to files inside ShipStudio/registered projects so this
     // can't be used to exfiltrate arbitrary files (~/.aws/credentials, etc.).
     let safe_path = validate_project_file_path(&file_path)?;
-    let contents = std::fs::read_to_string(&safe_path).map_err(|e| e.to_string())?;
+    // classify_fs_error: labels the op/path and turns environment denials —
+    // macOS TCC EPERM, Windows access-denied (a .env briefly locked by an
+    // editor/antivirus/OneDrive) — into Expected instead of a bare
+    // unattributable OS string in telemetry (issue #596).
+    let contents = std::fs::read_to_string(&safe_path)
+        .map_err(|e| crate::utils::classify_fs_error("read this .env file", &safe_path, &e))?;
     let mut vars = Vec::new();
 
     for line in contents.lines() {
@@ -137,7 +142,9 @@ pub async fn write_env_file(file_path: String, vars: Vec<EnvVar>) -> Result<(), 
         contents.push_str(&format!("{}={}\n", var.key, value));
     }
 
-    std::fs::write(&safe_path, contents).map_err(|e| e.to_string())?;
+    // classify_fs_error: see read_env_file (issue #596).
+    std::fs::write(&safe_path, contents)
+        .map_err(|e| crate::utils::classify_fs_error("write this .env file", &safe_path, &e))?;
     Ok(())
 }
 
@@ -173,7 +180,9 @@ pub async fn create_env_file(
         return Err((format!("{file_name} already exists")).into());
     }
 
-    std::fs::write(&env_path, "").map_err(|e| e.to_string())?;
+    // classify_fs_error: see read_env_file (issue #596).
+    std::fs::write(&env_path, "")
+        .map_err(|e| crate::utils::classify_fs_error("create this .env file", &env_path, &e))?;
     Ok(env_path.to_string_lossy().to_string())
 }
 
@@ -183,6 +192,8 @@ pub async fn delete_env_file(file_path: String) -> Result<(), CommandError> {
     // Validate the file is inside ShipStudio (or a registered external project)
     // and operate on the canonicalized path to avoid `..`/symlink escapes.
     let safe_path = validate_project_file_path(&file_path)?;
-    std::fs::remove_file(&safe_path).map_err(|e| e.to_string())?;
+    // classify_fs_error: see read_env_file (issue #596).
+    std::fs::remove_file(&safe_path)
+        .map_err(|e| crate::utils::classify_fs_error("delete this .env file", &safe_path, &e))?;
     Ok(())
 }

--- a/src-tauri/src/commands/external_projects.rs
+++ b/src-tauri/src/commands/external_projects.rs
@@ -371,11 +371,14 @@ pub async fn ensure_external_project_registered(
     // only auto-register paths that actually look like a project root. The
     // picker flow remains the way to add anything that doesn't.
     if !looks_like_project_root(&canonical) {
-        return Err(format!(
+        // A by-design security refusal, not a malfunction — Expected keeps it
+        // out of bug telemetry (issue #598, same classification #416 applied
+        // to the folder-picker guidance branches in this file). Serializes
+        // identically to Other, so the frontend sees the same message.
+        return Err(CommandError::expected(format!(
             "Refusing to auto-register '{}': it does not look like a project directory. Add it via the folder picker instead.",
             canonical.display()
-        )
-        .into());
+        )));
     }
 
     // Register it

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -93,6 +93,42 @@ pub(crate) async fn run_git_net(
     run_with_timeout(tokio_cmd, format!("git {label}"), GIT_NETWORK_TIMEOUT_SECS).await
 }
 
+/// [`run_git_net`] plus a bounded retry when git loses the `.git/index.lock`
+/// race — the async counterpart of `utils::output_retrying_index_lock`
+/// (which wraps a synchronous closure and can't be reused here).
+///
+/// Pull/merge mutate the index just like add/commit/checkout, so they can
+/// collide with the background snapshot watcher's debounced `git stash
+/// create` (or any agent CLI running git) exactly like the already-covered
+/// call sites (#377/#567/#597) — `git_pull`/`pull_and_merge` were the
+/// remaining gap (issue #639). Non-contention failures and successes return
+/// immediately; contention is retried with a short backoff, then returned
+/// as-is so the caller's normal error path reports it.
+pub(crate) async fn run_git_net_retrying_index_lock(
+    args: &[&str],
+    cwd: &std::path::Path,
+    label: &str,
+) -> Result<std::process::Output, CommandError> {
+    const ATTEMPTS: u64 = 3;
+    for attempt in 1..=ATTEMPTS {
+        let output = run_git_net(args, cwd, label).await?;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if output.status.success()
+            || !crate::utils::is_index_lock_contention(&stderr)
+            || attempt == ATTEMPTS
+        {
+            return Ok(output);
+        }
+        tracing::warn!(
+            attempt,
+            label,
+            "git lost the index.lock race; retrying after backoff"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(200 * attempt)).await;
+    }
+    unreachable!("loop always returns on the final attempt")
+}
+
 /// Classify a failed [`run_git_net`] invocation's stderr into the expected
 /// gh/git environment states: auth not configured, a connectivity blip,
 /// GitHub's transient HTTP 400, or gh itself crashing. `run_git_net` routes
@@ -181,16 +217,52 @@ fn ensure_shipstudio_excluded(path: &std::path::Path) {
     );
 }
 
+/// Marker strings that identify a failed `git commit` as the project's own
+/// commit-hook chain refusing the commit (husky / lint-staged / the pre-commit
+/// framework), rather than git itself failing. Git contributes no wording of
+/// its own when a hook exits non-zero — the output IS the hook runner's — so
+/// these are the runners' stable banner/marker literals (issue #604).
+fn is_hook_failure_output(output: &str) -> bool {
+    output.contains("husky")
+        || output.contains("lint-staged")
+        || output.contains("pre-commit")
+        || output.contains("[STARTED]")
+        || output.contains("[FAILED]")
+        || output.contains("hook exited with code")
+}
+
+/// Last `max_bytes` of hook output, cut at a line boundary — the failure
+/// reason (a failing test, a type error) is almost always at the tail, and
+/// the full dump is unreadable in a toast (issue #604).
+fn tail_of_output(output: &str, max_bytes: usize) -> &str {
+    let trimmed = output.trim_end();
+    if trimmed.len() <= max_bytes {
+        return trimmed;
+    }
+    let start = trimmed.len() - max_bytes;
+    // Snap forward to the next line start so we never cut mid-line (or mid
+    // UTF-8 sequence).
+    match trimmed[start..].find('\n') {
+        Some(nl) => &trimmed[start + nl + 1..],
+        None => trimmed
+            .char_indices()
+            .find(|(i, _)| *i >= start)
+            .map(|(i, _)| &trimmed[i..])
+            .unwrap_or(""),
+    }
+}
+
 /// Stages all changes and commits with the given message.
 /// Returns true if a commit was made, false if nothing to commit.
-pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<bool, String> {
+pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<bool, CommandError> {
     // Defense-in-depth backstop for #345: even if a too-broad path slipped past
     // registration, never run `git add -A` across the home tree.
     if crate::utils::is_forbidden_project_root(path) {
         return Err(format!(
             "Refusing to stage changes in '{}': it is the home directory or wider, not a project folder",
             path.display()
-        ));
+        )
+        .into());
     }
     // Make sure .shipstudio/ is excluded BEFORE `git add -A` walks the tree:
     // the frontend's ensure-gitignore calls are best-effort and can be skipped
@@ -208,8 +280,7 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
         let mut cmd = crate::utils::git_command_in(path)?;
         cmd.args(["add", "-A"]);
         crate::external_command::spawn_with_pressure_retry("git add", || cmd.output())
-    })
-    .map_err(String::from)?;
+    })?;
 
     if !add_output.status.success() {
         let add_stderr = String::from_utf8_lossy(&add_output.stderr).to_string();
@@ -224,13 +295,14 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
             let sparse_output =
                 crate::external_command::spawn_with_pressure_retry("git add --sparse", || {
                     sparse_cmd.output()
-                })
-                .map_err(String::from)?;
+                })?;
             if !sparse_output.status.success() {
-                return Err(String::from_utf8_lossy(&sparse_output.stderr).to_string());
+                return Err(String::from_utf8_lossy(&sparse_output.stderr)
+                    .to_string()
+                    .into());
             }
         } else {
-            return Err(add_stderr);
+            return Err(add_stderr.into());
         }
     }
 
@@ -246,8 +318,7 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
         let mut cmd = crate::utils::git_command_in(path)?;
         cmd.args(["commit", "-m", message]);
         crate::external_command::spawn_with_pressure_retry("git commit", || cmd.output())
-    })
-    .map_err(String::from)?;
+    })?;
 
     if !commit_output.status.success() {
         // `status --porcelain` can report entries `add -A` couldn't stage (e.g.
@@ -259,12 +330,28 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
             return Ok(false);
         }
         let stderr = String::from_utf8_lossy(&commit_output.stderr);
+        // The project's own pre-commit hook chain (husky → lint-staged →
+        // tsc/tests) refusing the commit is the project working as configured,
+        // not an app malfunction — the raw dump (hundreds of lines of runner
+        // logs) was surfaced verbatim as a "generic" publish error (issue
+        // #604). Say what happened, keep only the tail where the actual
+        // failure lives, and classify Expected so it stays out of telemetry.
+        // Hook output lands on either stream depending on the runner.
+        let combined = format!("{stdout}{stderr}");
+        if is_hook_failure_output(&combined) {
+            let tail = tail_of_output(&combined, 1000);
+            return Err(CommandError::expected(format!(
+                "This project's pre-commit checks blocked the commit — they run the project's \
+                 own lint/tests before every commit. Fix what they reported (the end of their \
+                 output is below), then try again.\n\n{tail}"
+            )));
+        }
         let detail = if stderr.trim().is_empty() {
             stdout.to_string()
         } else {
             stderr.to_string()
         };
-        return Err(detail);
+        return Err(detail.into());
     }
 
     Ok(true)
@@ -524,6 +611,60 @@ mod tests {
         assert!(classify_git_net_error("").is_none());
     }
 
+    /// The #639 shape: a pull/merge losing the `.git/index.lock` race against
+    /// the background snapshot watcher must retry instead of failing outright.
+    /// Simulated with a real repo whose index.lock is held at first and
+    /// released while the retry backoff is in flight (`git add` exercises the
+    /// same lock path without needing a remote).
+    #[tokio::test]
+    async fn run_git_net_retrying_index_lock_recovers_when_lock_released() {
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        std::fs::write(tmp.path().join("a.txt"), "hello").unwrap();
+        let lock = tmp.path().join(".git").join("index.lock");
+        std::fs::write(&lock, "").unwrap();
+
+        // Release the lock while the helper is backing off (attempt 1 fails
+        // immediately; attempt 3 runs at ~600ms).
+        let lock_clone = lock.clone();
+        let releaser = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            let _ = std::fs::remove_file(&lock_clone);
+        });
+
+        let out = run_git_net_retrying_index_lock(&["add", "-A"], tmp.path(), "add")
+            .await
+            .expect("git add should run");
+        releaser.await.unwrap();
+        assert!(
+            out.status.success(),
+            "must succeed once the lock is released: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    /// Non-contention failures must pass through immediately, un-retried.
+    #[tokio::test]
+    async fn run_git_net_retrying_index_lock_passes_other_failures_through() {
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let started = std::time::Instant::now();
+        let out = run_git_net_retrying_index_lock(
+            &["checkout", "no-such-branch-xyz"],
+            tmp.path(),
+            "checkout",
+        )
+        .await
+        .expect("git should run");
+        assert!(!out.status.success());
+        // A retried run would take ≥ 600ms of backoff sleeps alone — a single
+        // un-retried git spawn stays well under that even on a slow machine.
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(500),
+            "non-contention failures must not be retried"
+        );
+    }
+
     /// Initialize a fresh git repo in `dir` with a local user identity so
     /// commits work in CI environments without global git config.
     fn init_repo(dir: &std::path::Path) {
@@ -655,6 +796,68 @@ mod tests {
             ".shipstudio must not be staged, got: {listing}"
         );
         assert!(listing.contains("a.txt"));
+    }
+
+    // The #604 shape: husky → lint-staged → tsc/vitest output dumped verbatim
+    // as a "generic" publish error when the hook refused the commit.
+    #[test]
+    fn hook_failure_output_matches_hook_runner_markers() {
+        let lint_staged = "Already up to date\nDone in 252ms using pnpm v11.9.0\n[STARTED] Backing up original state...\n[COMPLETED] Backed up original state in git stash\n[STARTED] Running tasks for staged files...\n[FAILED] tsc --noEmit\nsrc/App.tsx(10,3): error TS2322: Type 'string' is not assignable to type 'number'.";
+        assert!(is_hook_failure_output(lint_staged));
+        assert!(is_hook_failure_output(
+            "husky - pre-commit script failed (code 1)"
+        ));
+        assert!(is_hook_failure_output(
+            ".git/hooks/pre-commit: line 3: pnpm: command not found"
+        ));
+        // Ordinary git commit failures must NOT classify as hook failures.
+        assert!(!is_hook_failure_output(
+            "fatal: unable to auto-detect email address"
+        ));
+        assert!(!is_hook_failure_output(
+            "error: gpg failed to sign the data"
+        ));
+        assert!(!is_hook_failure_output(""));
+    }
+
+    #[test]
+    fn tail_of_output_keeps_the_end_at_a_line_boundary() {
+        let long: String = (0..200).map(|i| format!("line {i}\n")).collect();
+        let tail = tail_of_output(&long, 100);
+        assert!(tail.len() <= 100);
+        assert!(tail.starts_with("line "), "must start at a line boundary");
+        assert!(tail.ends_with("line 199"), "must keep the very end");
+        // Short output passes through whole.
+        assert_eq!(tail_of_output("short\n", 100), "short");
+    }
+
+    /// End-to-end: a repo with a failing pre-commit hook must produce the
+    /// short Expected explanation, not the raw hook dump as an Other error.
+    #[cfg(unix)]
+    #[test]
+    fn stage_and_commit_classifies_hook_refusal_as_expected() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let hooks = tmp.path().join(".git").join("hooks");
+        std::fs::create_dir_all(&hooks).unwrap();
+        let hook = hooks.join("pre-commit");
+        std::fs::write(
+            &hook,
+            "#!/bin/sh\necho '[STARTED] Running tasks for staged files...'\necho '[FAILED] tsc --noEmit'\nexit 1\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::write(tmp.path().join("a.txt"), "hello").unwrap();
+
+        let err = git_stage_and_commit(tmp.path(), "blocked").expect_err("hook must block commit");
+        assert!(
+            matches!(err, crate::errors::CommandError::Expected { .. }),
+            "hook refusal must classify Expected, got: {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("pre-commit checks blocked"), "got: {msg}");
+        assert!(msg.contains("[FAILED] tsc --noEmit"), "must keep the tail");
     }
 
     #[test]

--- a/src-tauri/src/commands/git/sync.rs
+++ b/src-tauri/src/commands/git/sync.rs
@@ -7,7 +7,9 @@ use crate::utils::validate_project_path;
 use super::git_stage_and_commit;
 // Network git ops (fetch, pull, merge) go through the workspace-scoped helper in
 // the parent module so they authenticate as the project's workspace login.
-use super::run_git_net;
+// Pull/merge mutate the index, so they additionally retry on .git/index.lock
+// contention like the commit/snapshot/discard paths (issue #639).
+use super::{run_git_net, run_git_net_retrying_index_lock};
 use tracing::warn;
 
 /// Git's normal refusal to pull a branch that has never been pushed (no
@@ -112,7 +114,9 @@ pub async fn fetch_all_branches(project_path: String) -> Result<(), CommandError
 pub async fn git_pull(project_path: String) -> Result<(), CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let output = run_git_net(&["pull", "--ff-only"], &validated_path, "pull --ff-only").await?;
+    let output =
+        run_git_net_retrying_index_lock(&["pull", "--ff-only"], &validated_path, "pull --ff-only")
+            .await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -146,9 +150,9 @@ pub async fn pull_and_merge(
 
     let output = if let Some(branch) = merge_branch {
         let merge_ref = format!("origin/{branch}");
-        run_git_net(&["merge", &merge_ref], &validated_path, "merge").await?
+        run_git_net_retrying_index_lock(&["merge", &merge_ref], &validated_path, "merge").await?
     } else {
-        run_git_net(
+        run_git_net_retrying_index_lock(
             &["pull", "--no-rebase"],
             &validated_path,
             "pull --no-rebase",

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -540,14 +540,21 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
 /// telemetry, and the frontend shows its connect-GitHub UI) instead of
 /// surfacing the raw CLI text (issue #326).
 pub(crate) fn gh_auth_error(stderr: &str) -> Option<CommandError> {
+    let lower = stderr.to_lowercase();
     // "gh auth login"/GH_TOKEN = no credential at all (issue #326);
     // "gh auth refresh"/"Requires authentication" = a credential exists but
     // GitHub rejected it (expired/revoked token, HTTP 401) — same reconnect
-    // UX applies (issue #470).
+    // UX applies (issue #470). "could not read Username/Password" = git fell
+    // back to an interactive credential prompt because no usable credential
+    // helper answered — no tty in a GUI-spawned process, so it dies with
+    // "Device not configured"/"terminal prompts disabled"; the same reconnect
+    // UX fixes it (issue #638, mirroring publishing.rs's push_auth_error).
     if stderr.contains("gh auth login")
         || stderr.contains("GH_TOKEN")
         || stderr.contains("gh auth refresh")
-        || stderr.to_lowercase().contains("requires authentication")
+        || lower.contains("requires authentication")
+        || lower.contains("could not read username")
+        || lower.contains("could not read password")
     {
         return Some(CommandError::NotAuthenticated {
             service: "github".to_string(),
@@ -585,7 +592,13 @@ pub(crate) fn gh_network_error(stderr: &str) -> Option<CommandError> {
         // and prints only "error connecting to <host>\ncheck your internet
         // connection or https://githubstatus.com" (issue #473).
         || s.contains("check your internet connection")
-        || s.contains("error connecting to ");
+        || s.contains("error connecting to ")
+        // Go's bare net/http `EOF` — the connection closed before any response
+        // byte, without the "unexpected" prefix #434 covered. A naked "eof"
+        // substring would false-positive on ordinary words ("thereof"), so
+        // match the error-position shape `…: EOF` at the end of a line
+        // (issue #642).
+        || s.lines().any(|l| l.trim_end().ends_with(": eof"));
     unreachable.then(|| {
         CommandError::expected(
             "Couldn't reach GitHub. Check your internet connection and try again.",
@@ -610,6 +623,55 @@ pub(crate) fn gh_malformed_request_error(stderr: &str) -> Option<CommandError> {
                  Try again in a moment.",
             )
         })
+}
+
+/// GitHub's API answering with a transient server-side 5xx — gh passes the
+/// response text through ("HTTP 504: We couldn't respond to your request in
+/// time…", "HTTP 502: Bad Gateway", …). The request reached GitHub and
+/// GitHub fell over; nothing the app did wrong and nothing the user can do
+/// but retry — the sibling of the HTTP 400 case below (issues #627/#602).
+/// `Expected` keeps it out of telemetry.
+pub(crate) fn gh_server_error(stderr: &str) -> Option<CommandError> {
+    let s = stderr.to_lowercase();
+    let is_5xx = s.contains("http 500")
+        || s.contains("http 502")
+        || s.contains("http 503")
+        || s.contains("http 504")
+        || s.contains("bad gateway")
+        || s.contains("service unavailable")
+        || s.contains("gateway timeout")
+        // The prose GitHub uses for its GraphQL 504s ("We couldn't respond to
+        // your request in time. Sorry about that. Please try resubmitting…").
+        || s.contains("respond to your request in time");
+    is_5xx.then(|| {
+        CommandError::expected(
+            "GitHub's API is temporarily unavailable (a GitHub server error). \
+             Try again in a moment.",
+        )
+    })
+}
+
+/// gh failing before it even runs a subcommand because it can't read its own
+/// config file — "failed to load config: open …/.config/gh/config.yml:
+/// permission denied" / "failed to create root command: failed to read
+/// configuration: …". A local file-permissions problem (typically a prior
+/// sudo run left the directory root-owned), not a Ship Studio bug and not a
+/// GitHub sign-in failure — reconnecting can't fix a file the OS won't let gh
+/// read (issue #631). Recurs on every gh call for the affected user, so
+/// `Expected` keeps it from flooding telemetry, and the message names the
+/// real fix (same precedent as the ~/.npm chown guidance in errors.ts).
+pub(crate) fn gh_config_error(stderr: &str) -> Option<CommandError> {
+    let s = stderr.to_lowercase();
+    let config_unreadable = (s.contains("failed to read configuration")
+        || s.contains("failed to load config"))
+        && s.contains("permission denied");
+    config_unreadable.then(|| {
+        CommandError::expected(
+            "The GitHub CLI (gh) can't read its own settings because of a file-permissions \
+             problem on this computer — this isn't a GitHub sign-in issue. Open a terminal and \
+             run `sudo chown -R $(whoami) ~/.config/gh`, then try again.",
+        )
+    })
 }
 
 /// gh (a Go binary) crashing with a Go runtime panic/fatal error — stderr is
@@ -641,12 +703,15 @@ pub(crate) fn gh_crash_error(stderr: &str) -> Option<CommandError> {
 }
 
 /// A `gh` invocation that hits GitHub can fail these ways regardless of which
-/// subcommand ran: a connectivity blip, GitHub's transient HTTP 400, or gh
-/// itself crashing. One-stop classification for the shared cases — call sites
-/// still layer their own auth / subcommand-specific checks on top.
+/// subcommand ran: a connectivity blip, GitHub's transient HTTP 400 or 5xx,
+/// an unreadable gh config file, or gh itself crashing. One-stop
+/// classification for the shared cases — call sites still layer their own
+/// auth / subcommand-specific checks on top.
 pub(crate) fn gh_common_error(stderr: &str) -> Option<CommandError> {
     gh_network_error(stderr)
         .or_else(|| gh_malformed_request_error(stderr))
+        .or_else(|| gh_server_error(stderr))
+        .or_else(|| gh_config_error(stderr))
         .or_else(|| gh_crash_error(stderr))
 }
 
@@ -1158,5 +1223,84 @@ mod tests {
         let err = gh_network_error(stderr).expect("should classify as network error");
         assert!(matches!(err, CommandError::Expected { .. }));
         assert!(err.to_string().contains("Couldn't reach GitHub"));
+    }
+
+    // The #642 shape: Go's bare "EOF" (no "unexpected" prefix, which #434
+    // already covered) — the connection closed before any response byte.
+    #[test]
+    fn gh_network_error_classifies_bare_eof() {
+        let stderr = r#"Post "https://api.github.com/graphql": EOF"#;
+        let err = gh_network_error(stderr).expect("should classify as network error");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        // The "unexpected EOF" variant keeps matching too.
+        assert!(
+            gh_network_error(r#"Post "https://api.github.com/graphql": unexpected EOF"#).is_some()
+        );
+        // Bare "eof" inside an ordinary word must NOT match.
+        assert!(gh_network_error("GraphQL: field thereof is deprecated").is_none());
+    }
+
+    // The #627 shape: GitHub's API answering a transient 5xx (504 from the
+    // GraphQL endpoint) — server-side, retryable, not an app malfunction.
+    #[test]
+    fn gh_server_error_classifies_github_5xx_as_expected() {
+        let terse = "HTTP 504: 504 Gateway Timeout (https://api.github.com/graphql)";
+        let err = gh_server_error(terse).expect("should classify as expected");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        assert!(err.to_string().contains("Try again"), "got: {err}");
+        // The prose 504 variant GitHub sends for GraphQL timeouts.
+        let prose = "HTTP 504: We couldn't respond to your request in time. Sorry about that. Please try resubmitting your request and contact us if the problem persists. (https://api.github.com/graphql)";
+        assert!(gh_server_error(prose).is_some());
+        assert!(
+            gh_server_error("HTTP 502: Bad Gateway (https://api.github.com/graphql)").is_some()
+        );
+        assert!(gh_server_error("HTTP 503: Service Unavailable").is_some());
+    }
+
+    #[test]
+    fn gh_server_error_ignores_non_5xx_stderr() {
+        assert!(gh_server_error("HTTP 404: Not Found (https://api.github.com/graphql)").is_none());
+        assert!(gh_server_error("HTTP 400: We received a malformed request").is_none());
+        assert!(gh_server_error("GraphQL: name already exists on this account").is_none());
+        assert!(gh_server_error("").is_none());
+    }
+
+    // The #631 shape: gh dying at startup because its own config file is
+    // unreadable — a local file-permissions problem, not a sign-in failure.
+    #[test]
+    fn gh_config_error_classifies_unreadable_config_as_expected() {
+        let stderr = "warning: failed to load config: open /Users/x/.config/gh/config.yml: permission denied\nfailed to create root command: failed to read configuration: open /Users/x/.config/gh/config.yml: permission denied";
+        let err = gh_config_error(stderr).expect("should classify as expected");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        let msg = err.to_string();
+        assert!(msg.contains("chown"), "must name the real fix, got: {msg}");
+        assert!(
+            msg.contains("isn't a GitHub sign-in issue"),
+            "must steer away from the reconnect flow, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn gh_config_error_ignores_other_permission_or_config_errors() {
+        // A repo-access permission denial is auth, not a config-file problem.
+        assert!(gh_config_error("remote: Permission denied (publickey)").is_none());
+        // A config parse error without a permissions component stays unclassified.
+        assert!(gh_config_error("failed to read configuration: invalid yaml").is_none());
+        assert!(gh_config_error("").is_none());
+    }
+
+    // The #638 shape: git falling back to an interactive credential prompt in
+    // a tty-less GUI process — an auth-setup state, not an app bug.
+    #[test]
+    fn gh_auth_error_classifies_credential_prompt_failure() {
+        let stderr =
+            "fatal: could not read Username for 'https://github.com': Device not configured";
+        let err = gh_auth_error(stderr).expect("should classify as auth error");
+        assert!(matches!(err, CommandError::NotAuthenticated { .. }));
+        assert!(gh_auth_error(
+            "fatal: could not read Password for 'https://user@github.com': terminal prompts disabled"
+        )
+        .is_some());
+        assert!(gh_auth_error("fatal: not a git repository").is_none());
     }
 }

--- a/src-tauri/src/commands/ide/screenshots/playwright.rs
+++ b/src-tauri/src/commands/ide/screenshots/playwright.rs
@@ -6,11 +6,12 @@ use crate::external_command::run_with_timeout;
 use crate::utils::validate_project_path;
 
 /// Ceiling for one capture-script run (page load + scroll + shot). Must cover
-/// the script's own worst-case inner budgets — two 60s goto attempts, the
-/// capped scroll pass, and the 120s full-page stitch — or we kill captures
-/// that were progressing legitimately and would have failed (or succeeded)
-/// with a far better error on their own (issue #527).
-const CAPTURE_TIMEOUT_SECS: u64 = 300;
+/// the script's own worst-case inner budgets — a 60s first goto attempt plus
+/// the 120s retry (issue #606), the capped scroll pass, and the 120s
+/// screenshot/stitch — or we kill captures that were progressing legitimately
+/// and would have failed (or succeeded) with a far better error on their own
+/// (issue #527).
+const CAPTURE_TIMEOUT_SECS: u64 = 360;
 /// Ceiling for downloading Chromium during self-heal (~130MB).
 const BROWSER_INSTALL_TIMEOUT_SECS: u64 = 600;
 
@@ -66,6 +67,19 @@ async fn run_capture_script(
     Ok(output)
 }
 
+/// True when stderr shows the process (Node itself, or a child) failing at
+/// the dynamic-linker level — the binary can spawn but can't resolve a shared
+/// library it was linked against. Classic case: Homebrew upgrades `icu4c` out
+/// from under a `node` that wasn't relinked, and every `node` invocation dies
+/// with a raw `dyld[...]: Library not loaded` dump (issue #645). A broken
+/// local toolchain, not an app malfunction.
+fn is_broken_loader_error(stderr: &str) -> bool {
+    stderr.contains("Library not loaded")
+        || stderr.contains("dyld[")
+        || stderr.contains("dyld: ")
+        || stderr.contains("error while loading shared libraries")
+}
+
 /// Map a failed capture-script run to a `CommandError`. A connection refused
 /// that survived the in-script retry means the dev server went away mid-flight
 /// (crashed, restarted on another port) — an expected state exactly like the
@@ -75,6 +89,39 @@ fn capture_script_error(what: &str, url: &str, output: &std::process::Output) ->
     if stderr.contains("ERR_CONNECTION_REFUSED") {
         return CommandError::expected(format!(
             "The dev server at {url} stopped responding while the screenshot was being captured. Wait for the preview to finish reloading, then try again."
+        ));
+    }
+    // Node itself failing to start (dyld can't resolve a linked library) is a
+    // broken local Node install — e.g. Homebrew upgraded icu4c without node
+    // being relinked. Actionable for the user, not an app bug (issue #645).
+    if is_broken_loader_error(&stderr) {
+        return CommandError::expected(
+            "Your system Node.js installation appears broken (it failed to start because a \
+             library it depends on is missing). Reinstall Node.js — e.g. `brew reinstall node` \
+             — then try again.",
+        );
+    }
+    // The headless browser process dying at startup ("Target crashed" before
+    // any navigation) is an environment-level failure — GPU/driver quirks or
+    // security software killing the fresh Chromium process — that a retry
+    // usually clears. Persistent occurrences are still not app bugs
+    // (issue #558).
+    if stderr.contains("Target crashed") {
+        return CommandError::expected(
+            "The screenshot browser crashed while starting up. This is usually a one-off \
+             (graphics driver or security software interfering with the headless browser) — \
+             try again, and if it keeps happening, restarting your machine often clears it.",
+        );
+    }
+    // Both goto attempts exhausting their navigation timeout is a recurring,
+    // environmental condition on slow dev servers (Windows first-compile +
+    // antivirus overhead — issues #385/#606), not a malfunction: the route
+    // simply didn't finish loading inside the budget.
+    if stderr.contains("page.goto") && stderr.contains("Timeout") {
+        return CommandError::expected(format!(
+            "The page at {url} didn't finish loading in time for the screenshot — the dev \
+             server is probably still compiling this route. Wait for the preview to load \
+             fully, then try again."
         ));
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -105,6 +152,20 @@ async fn ensure_node_supports_playwright() -> Result<(), CommandError> {
         return Ok(());
     };
     if !output.status.success() {
+        // Even `node --version` failing means node itself can't run. When the
+        // stderr shows a dynamic-linker failure (Homebrew library upgraded out
+        // from under node), stop here with an actionable message instead of
+        // letting the capture re-hit the identical dyld dump and surface it
+        // raw (issue #645). Any other probe failure stays tolerated — the
+        // capture proceeds and reports its own, more specific error.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if is_broken_loader_error(&stderr) {
+            return Err(CommandError::expected(
+                "Your system Node.js installation appears broken (it failed to start because \
+                 a library it depends on is missing). Reinstall Node.js — e.g. `brew reinstall \
+                 node` — then try again.",
+            ));
+        }
         return Ok(());
     }
     let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -275,8 +336,22 @@ const {{ chromium }} = require('playwright');
 (async () => {{
     let browser;
     try {{
-        browser = await chromium.launch();
-        const page = await browser.newPage({{ viewport: {{ width: {viewport_width}, height: 800 }} }});
+        // Headless Chromium can crash at startup on some Windows GPU/driver
+        // combos ("Target crashed" on newPage, before any navigation) —
+        // disable the GPU like the Chrome CLI thumbnail fallback already
+        // does, and relaunch once if the fresh browser process still dies
+        // (issue #558).
+        const newPageOptions = {{ viewport: {{ width: {viewport_width}, height: 800 }} }};
+        browser = await chromium.launch({{ args: ['--disable-gpu'] }});
+        let page;
+        try {{
+            page = await browser.newPage(newPageOptions);
+        }} catch (err) {{
+            if (!String((err && err.message) || err).includes('Target crashed')) throw err;
+            await browser.close().catch(() => {{}});
+            browser = await chromium.launch({{ args: ['--disable-gpu'] }});
+            page = await browser.newPage(newPageOptions);
+        }}
 
         // Dev servers keep HMR/live-reload connections open forever, so
         // 'networkidle' may never arrive — wait for 'load', then settle
@@ -285,6 +360,8 @@ const {{ chromium }} = require('playwright');
         // server compiles the route on first request (issue #385): give the
         // navigation a longer budget, and retry once on timeout — the compile
         // keeps progressing server-side, so a warmed route answers quickly.
+        // The retry gets double the budget: 60s twice was still not enough on
+        // slow Windows dev servers (issue #606).
         try {{
             await page.goto('{}', {{ waitUntil: 'load', timeout: 60000 }});
         }} catch (err) {{
@@ -298,7 +375,7 @@ const {{ chromium }} = require('playwright');
             }} else if (!msg.includes('Timeout')) {{
                 throw err;
             }}
-            await page.goto('{}', {{ waitUntil: 'load', timeout: 60000 }});
+            await page.goto('{}', {{ waitUntil: 'load', timeout: 120000 }});
         }}
         await page.waitForLoadState('networkidle', {{ timeout: 5000 }}).catch(() => {{}});
 
@@ -357,7 +434,8 @@ const {{ chromium }} = require('playwright');
         // Take full-page screenshot
         // fullPage stitches the entire scrollable height — on tall pages
         // that can exceed Playwright's default 30s action timeout, and the
-        // overall script budget is 180s, so give it real headroom (issue #461).
+        // overall script budget leaves room for it, so give it real headroom
+        // (issue #461).
         await page.screenshot({{ path: '{}', fullPage: true, timeout: 120000 }});
         console.log('Screenshot saved successfully');
     }} finally {{
@@ -455,13 +533,31 @@ const {{ chromium }} = require('playwright');
 (async () => {{
     let browser;
     try {{
-        browser = await chromium.launch();
-        const page = await browser.newPage({{ viewport: {{ width: {viewport_width}, height: 800 }} }});
+        // Headless Chromium can crash at startup on some Windows GPU/driver
+        // combos ("Target crashed" on newPage, before any navigation) —
+        // disable the GPU like the Chrome CLI thumbnail fallback already
+        // does, and relaunch once if the fresh browser process still dies
+        // (issue #558).
+        const newPageOptions = {{ viewport: {{ width: {viewport_width}, height: 800 }} }};
+        browser = await chromium.launch({{ args: ['--disable-gpu'] }});
+        let page;
+        try {{
+            page = await browser.newPage(newPageOptions);
+        }} catch (err) {{
+            if (!String((err && err.message) || err).includes('Target crashed')) throw err;
+            await browser.close().catch(() => {{}});
+            browser = await chromium.launch({{ args: ['--disable-gpu'] }});
+            page = await browser.newPage(newPageOptions);
+        }}
 
         // Same wait strategy as the full-page capture: 'networkidle' may never
         // arrive on dev servers with persistent connections (issues #309/#310),
         // and a cold route compiling on first request can need >30s to reach
-        // `load` — long budget plus one retry on timeout (issue #385).
+        // `load` — long budget plus one retry on timeout (issue #385). The
+        // retry gets double the budget: on slow Windows dev servers (first
+        // compile + antivirus overhead) 60s twice was still not enough, and
+        // the compile keeps progressing server-side while we wait
+        // (issue #606).
         try {{
             await page.goto('{}', {{ waitUntil: 'load', timeout: 60000 }});
         }} catch (err) {{
@@ -475,7 +571,7 @@ const {{ chromium }} = require('playwright');
             }} else if (!msg.includes('Timeout')) {{
                 throw err;
             }}
-            await page.goto('{}', {{ waitUntil: 'load', timeout: 60000 }});
+            await page.goto('{}', {{ waitUntil: 'load', timeout: 120000 }});
         }}
         await page.waitForLoadState('networkidle', {{ timeout: 5000 }}).catch(() => {{}});
 
@@ -601,6 +697,89 @@ mod capture_error_tests {
         let err = capture_script_error("Playwright screenshot", "http://localhost:3000", &output);
         assert!(!matches!(err, CommandError::Expected { .. }));
         assert!(format!("{err}").contains("something broke"));
+    }
+
+    #[test]
+    fn broken_node_dyld_error_is_expected_with_reinstall_guidance() {
+        // Issue #645: Homebrew upgraded icu4c without relinking node — node
+        // itself can't start. A broken local toolchain, not an app bug.
+        let output = failed_output(
+            "dyld[54199]: Library not loaded: /opt/homebrew/opt/icu4c/lib/libicui18n.74.dylib\n\
+             Referenced from: /opt/homebrew/Cellar/node/22.9.0/bin/node\n\
+             Reason: tried: '/opt/homebrew/opt/icu4c/lib/libicui18n.74.dylib' (no such file)",
+        );
+        match capture_script_error(
+            "Playwright viewport screenshot",
+            "http://localhost:3000",
+            &output,
+        ) {
+            CommandError::Expected { message } => {
+                assert!(
+                    message.contains("Node.js installation appears broken"),
+                    "got: {message}"
+                );
+                assert!(message.contains("Reinstall Node.js"), "got: {message}");
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn linux_loader_error_is_also_classified_broken_node() {
+        assert!(is_broken_loader_error(
+            "node: error while loading shared libraries: libicui18n.so.74: cannot open shared object file"
+        ));
+        assert!(!is_broken_loader_error("SyntaxError: unexpected token"));
+    }
+
+    #[test]
+    fn target_crashed_is_expected_not_telemetry() {
+        // Issue #558: the headless browser process dying at startup is a
+        // GPU-driver / security-software environment failure.
+        let output = failed_output("browser.newPage: Target crashed");
+        match capture_script_error(
+            "Playwright viewport screenshot",
+            "http://localhost:3000",
+            &output,
+        ) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("browser crashed"), "got: {message}")
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn goto_timeout_after_both_attempts_is_expected() {
+        // Issue #606: both navigation attempts exhausting their budget on a
+        // slow first compile is a recurring environmental condition.
+        let output = failed_output(
+            "page.goto: Timeout 120000ms exceeded.\nCall log:\n  - navigating to \"http://localhost:59973/\", waiting until \"load\"",
+        );
+        match capture_script_error(
+            "Playwright viewport screenshot",
+            "http://localhost:59973",
+            &output,
+        ) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("didn't finish loading"), "got: {message}");
+                assert!(message.contains("http://localhost:59973"), "got: {message}");
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_goto_timeouts_are_not_swallowed_as_expected() {
+        // A timeout elsewhere (e.g. the screenshot action) isn't the
+        // slow-compile navigation shape — keep it a real, detailed error.
+        let output = failed_output("page.screenshot: Timeout 120000ms exceeded.");
+        let err = capture_script_error(
+            "Playwright viewport screenshot",
+            "http://localhost:3000",
+            &output,
+        );
+        assert!(!matches!(err, CommandError::Expected { .. }));
     }
 }
 

--- a/src-tauri/src/commands/ide/screenshots/thumbnail.rs
+++ b/src-tauri/src/commands/ide/screenshots/thumbnail.rs
@@ -19,8 +19,9 @@ use crate::commands::ide::{find_chromium_browser, resize_thumbnail_image};
 /// Playwright runs) starved the runtime and froze every IPC call in the app
 /// (issue #387).
 const PLAYWRIGHT_THUMBNAIL_TIMEOUT_SECS: u64 = 120;
-/// Ceiling for the Chrome/Edge CLI fallback. Its virtual-time budget is 3s;
-/// the rest is browser startup + page load headroom.
+/// Per-attempt ceiling for the Chrome/Edge CLI fallback. The virtual-time
+/// budget is 3s (15s on the one retry — issue #647); the rest is browser
+/// startup + page load headroom.
 const BROWSER_THUMBNAIL_TIMEOUT_SECS: u64 = 60;
 
 /// Projects with a thumbnail capture currently in flight. The 5-minute timer,
@@ -123,6 +124,39 @@ fn browser_failure_detail(stderr: &str) -> Option<String> {
         Some(format!("{capped}…"))
     } else {
         Some(joined)
+    }
+}
+
+/// True for Chromium's ProcessSingleton failure: it couldn't lock the profile
+/// directory it was told to use ("Failed to create ... SingletonLock: File
+/// exists", "Failed to create a ProcessSingleton for your profile directory").
+/// With per-capture profile dirs plus the stale sweep this should be rare —
+/// but when it does happen (e.g. a crashed capture's lock surviving inside a
+/// dirty profile) it's a transient environment state the next capture clears,
+/// not an app malfunction (issue #644).
+fn is_profile_singleton_error(stderr: &str) -> bool {
+    stderr.contains("ProcessSingleton") || stderr.contains("SingletonLock")
+}
+
+/// Map an `image` crate failure decoding user-uploaded thumbnail bytes to an
+/// actionable error. "The image format could not be determined" means the
+/// magic bytes matched no decoder we ship — commonly HEIC, the default photo
+/// format on macOS/iOS, plus BMP/TIFF/AVIF/ICO — a fact about the user's
+/// file, not an app malfunction (issue #649). A decode failure mid-stream
+/// means the file is corrupt or truncated. Both are expected user-input
+/// states; only genuinely unexplained failures stay reportable.
+fn humanize_image_decode_error(err: image::ImageError) -> CommandError {
+    match err {
+        image::ImageError::Unsupported(_) => CommandError::expected(
+            "That file isn't a recognized image format. Please upload a PNG, JPEG, GIF, or \
+             WEBP image — HEIC photos (the iPhone/macOS default) need converting to one of \
+             those first.",
+        ),
+        image::ImageError::Decoding(_) => CommandError::expected(
+            "That image couldn't be read — the file appears to be corrupted or truncated. \
+             Try re-exporting it as PNG or JPEG, then upload again.",
+        ),
+        other => format!("Could not read uploaded image: {other}").into(),
     }
 }
 
@@ -238,64 +272,90 @@ pub async fn capture_project_thumbnail(
         // both concurrent captures and app restarts into a dirty .shipstudio.
         static PROFILE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         sweep_stale_thumbnail_profiles(&shipstudio_dir);
-        let profile_dir = shipstudio_dir.join(format!(
-            "thumbnail_profile_{}_{}",
-            std::process::id(),
-            PROFILE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        ));
-        let user_data_arg = format!("--user-data-dir={}", profile_dir.to_string_lossy());
 
-        // Use new headless mode with explicit viewport control
-        // Set background to white so any extra captured area isn't black
-        let mut browser_cmd = create_command(&browser);
-        browser_cmd.args([
-            "--headless=new",
-            &user_data_arg,
-            "--no-first-run",
-            "--disable-gpu",
-            "--no-sandbox",
-            // A one-shot throwaway capture gains nothing from Chromium's
-            // crash reporter, and spinning up a crashpad_handler per capture
-            // added a whole extra failure mode: its named-pipe handshake can
-            // lose a race with process teardown/AV and kill the capture with
-            // "TransactNamedPipe: The pipe has been ended" (issue #421).
-            "--disable-crash-reporter",
-            "--disable-breakpad",
-            // A disposable one-shot capture has no business phoning home:
-            // background networking spins up GoogleUpdater/GCM machinery
-            // whose log spew drowned real failure signals (issues #498–#500).
-            "--disable-background-networking",
-            "--disable-component-update",
-            "--disable-sync",
-            "--hide-scrollbars",
-            "--force-device-scale-factor=1",
-            "--default-background-color=FFFFFFFF",
-            "--window-position=0,0",
-            "--window-size=1280,800",
-            "--virtual-time-budget=3000",
-            &screenshot_arg,
-            &url,
-        ]);
-        let result = run_with_timeout(
-            tokio::process::Command::from(browser_cmd),
-            "headless browser thumbnail",
-            BROWSER_THUMBNAIL_TIMEOUT_SECS,
-        )
-        .await;
+        // Two attempts with an escalating virtual-time budget. 3s of virtual
+        // time covers a warmed dev server; a route compiling on first request
+        // (slow Windows machines especially) can exhaust it before the page
+        // ever paints — the browser then exits 0 without writing any file
+        // (issue #526). That shape is detectable, so retry it once with a
+        // much longer budget before giving up (issue #647).
+        let mut capture_written;
+        let budgets = [3000u32, 15000u32];
+        let last_attempt = budgets.len() - 1;
+        let mut attempt = 0;
+        let output = loop {
+            let budget_ms = budgets[attempt];
+            let profile_dir = shipstudio_dir.join(format!(
+                "thumbnail_profile_{}_{}",
+                std::process::id(),
+                PROFILE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            ));
+            let user_data_arg = format!("--user-data-dir={}", profile_dir.to_string_lossy());
+            let virtual_time_arg = format!("--virtual-time-budget={budget_ms}");
 
-        // The throwaway profile has served its purpose; don't let it grow.
-        // On timeout the killed browser can leave it half-written — the stale
-        // sweep above mops those up on later captures.
-        let _ = std::fs::remove_dir_all(&profile_dir);
-        let output = result?;
+            // Use new headless mode with explicit viewport control
+            // Set background to white so any extra captured area isn't black
+            let mut browser_cmd = create_command(&browser);
+            browser_cmd.args([
+                "--headless=new",
+                &user_data_arg,
+                "--no-first-run",
+                "--disable-gpu",
+                "--no-sandbox",
+                // A one-shot throwaway capture gains nothing from Chromium's
+                // crash reporter, and spinning up a crashpad_handler per capture
+                // added a whole extra failure mode: its named-pipe handshake can
+                // lose a race with process teardown/AV and kill the capture with
+                // "TransactNamedPipe: The pipe has been ended" (issue #421).
+                "--disable-crash-reporter",
+                "--disable-breakpad",
+                // A disposable one-shot capture has no business phoning home:
+                // background networking spins up GoogleUpdater/GCM machinery
+                // whose log spew drowned real failure signals (issues #498–#500).
+                "--disable-background-networking",
+                "--disable-component-update",
+                "--disable-sync",
+                "--hide-scrollbars",
+                "--force-device-scale-factor=1",
+                "--default-background-color=FFFFFFFF",
+                "--window-position=0,0",
+                "--window-size=1280,800",
+                &virtual_time_arg,
+                &screenshot_arg,
+                &url,
+            ]);
+            let result = run_with_timeout(
+                tokio::process::Command::from(browser_cmd),
+                "headless browser thumbnail",
+                BROWSER_THUMBNAIL_TIMEOUT_SECS,
+            )
+            .await;
 
-        // Success is "the screenshot file exists", not "the exit code was 0":
-        // headless Chromium on Windows can write the PNG and still exit
-        // non-zero over unrelated internal warnings, and failing on the exit
-        // code alone throws away a perfectly good capture (issue #374).
-        let capture_written = std::fs::metadata(&temp_path)
-            .map(|m| m.len() > 0)
-            .unwrap_or(false);
+            // The throwaway profile has served its purpose; don't let it grow.
+            // On timeout the killed browser can leave it half-written — the
+            // stale sweep above mops those up on later captures.
+            let _ = std::fs::remove_dir_all(&profile_dir);
+            let out = result?;
+
+            // Success is "the screenshot file exists", not "the exit code was
+            // 0": headless Chromium on Windows can write the PNG and still
+            // exit non-zero over unrelated internal warnings, and failing on
+            // the exit code alone throws away a perfectly good capture
+            // (issue #374).
+            capture_written = std::fs::metadata(&temp_path)
+                .map(|m| m.len() > 0)
+                .unwrap_or(false);
+
+            let silent_success_without_file = out.status.success() && !capture_written;
+            if !silent_success_without_file || attempt == last_attempt {
+                break out;
+            }
+            attempt += 1;
+            tracing::warn!(
+                "Browser exited 0 without writing {} — retrying with a longer virtual-time budget (issue #647)",
+                temp_path.display()
+            );
+        };
 
         if capture_written && !output.status.success() {
             tracing::warn!(
@@ -306,6 +366,18 @@ pub async fn capture_project_thumbnail(
 
         if !capture_written {
             let stderr = String::from_utf8_lossy(&output.stderr);
+            // Chrome refusing to start because it couldn't lock the profile
+            // dir (stale SingletonLock from a crashed capture, or an
+            // overlapping capture racing on the same profile) is a transient
+            // environment state the per-capture dirs + stale sweep clear on
+            // the next run — expected, not telemetry (issue #644).
+            if is_profile_singleton_error(&stderr) {
+                return Err(CommandError::expected(
+                    "The capture browser couldn't lock its temporary profile directory \
+                     (a leftover lock from an interrupted capture). Stale profiles are \
+                     cleaned up automatically — the next capture attempt should succeed.",
+                ));
+            }
             // Headless Chromium can die with EMPTY stderr (crash, killed by
             // AV/security software) — fall back to the exit code plus a
             // stdout snippet so the report says something (issue #291).
@@ -337,16 +409,20 @@ pub async fn capture_project_thumbnail(
                         .map(|c| c.to_string())
                         .unwrap_or_else(|| "killed by signal".to_string());
                     if output.status.success() && stdout.is_empty() {
-                        // Exit 0 + silence + no file: the browser thinks it
-                        // succeeded but nothing landed on disk — seen on
-                        // Windows when rendering fails internally or security
-                        // software intercepts the write (issue #526). Name the
-                        // shape so reports are diagnosable, instead of the
-                        // meaningless "exit code 0, no output".
-                        format!(
-                            "browser exited successfully but wrote no screenshot file at {} — page render failed silently or the file write was blocked",
+                        // Exit 0 + silence + no file, even after the
+                        // longer-budget retry above: the page didn't render in
+                        // time (dev server still compiling the route) or
+                        // security software blocked the file write
+                        // (issues #526/#647). A recurring environment
+                        // condition, not an app malfunction — the capture
+                        // timer will simply try again later.
+                        return Err(CommandError::expected(format!(
+                            "The capture browser finished without writing a screenshot at {} — \
+                             the page probably didn't render in time (the dev server may still \
+                             be compiling), or security software blocked the file write. The \
+                             thumbnail will be retried automatically.",
                             temp_path.display()
-                        )
+                        )));
                     } else if stdout.is_empty() {
                         format!("exit code {code}, no output")
                     } else {
@@ -432,9 +508,10 @@ pub async fn upload_project_thumbnail(
     // Decode through the `image` crate — gives us format detection + a
     // hard reject for non-image input. Then re-encode as PNG at the same
     // 640px width as the auto-capture path so the dashboard renders
-    // consistently regardless of source.
-    let img = image::load_from_memory(&image_data)
-        .map_err(|e| format!("Could not read uploaded image: {e}"))?;
+    // consistently regardless of source. Unrecognized/corrupt input gets a
+    // human message naming the supported formats instead of the crate's raw
+    // "format could not be determined" (issue #649).
+    let img = image::load_from_memory(&image_data).map_err(humanize_image_decode_error)?;
     let resized = img.resize(640, 400, image::imageops::FilterType::Lanczos3);
 
     let thumbnail_path = shipstudio_dir.join("thumbnail.png");
@@ -512,6 +589,62 @@ mod browser_stderr_tests {
         let detail = browser_failure_detail(&stderr).unwrap();
         assert!(detail.chars().count() <= 601);
         assert!(detail.ends_with('…'));
+    }
+}
+
+#[cfg(test)]
+mod singleton_classification_tests {
+    use super::*;
+
+    #[test]
+    fn stale_singleton_lock_stderr_is_recognized() {
+        // Condensed from the real report behind issue #644.
+        let stderr = "[0810/163833.123:ERROR:chrome/browser/process_singleton_posix.cc:347] Failed to create /Users/x/ShipStudio/p/.shipstudio/thumbnail_profile/SingletonLock: File exists (17)\n\
+            [0810/163833.456:ERROR:chrome/app/chrome_main_delegate.cc:520] Failed to create a ProcessSingleton for your profile directory.";
+        assert!(is_profile_singleton_error(stderr));
+    }
+
+    #[test]
+    fn unrelated_stderr_is_not_a_singleton_error() {
+        assert!(!is_profile_singleton_error(""));
+        assert!(!is_profile_singleton_error(
+            "ERROR:gpu_init.cc(523)] Passthrough is not supported"
+        ));
+    }
+}
+
+#[cfg(test)]
+mod upload_decode_error_tests {
+    use super::*;
+
+    #[test]
+    fn unrecognized_format_is_expected_and_names_supported_formats() {
+        // Bytes matching no decoder's magic signature — the shape a HEIC
+        // upload produces (issue #649).
+        let err = image::load_from_memory(&[0u8; 32]).expect_err("garbage must not decode");
+        match humanize_image_decode_error(err) {
+            CommandError::Expected { message } => {
+                for fmt in ["PNG", "JPEG", "GIF", "WEBP"] {
+                    assert!(message.contains(fmt), "missing {fmt} in: {message}");
+                }
+                assert!(message.contains("HEIC"), "got: {message}");
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn truncated_png_is_expected_corruption_message() {
+        // Valid PNG magic, garbage after — recognized format, broken file.
+        let mut bytes = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+        bytes.extend_from_slice(&[0u8; 16]);
+        let err = image::load_from_memory(&bytes).expect_err("truncated png must not decode");
+        match humanize_image_decode_error(err) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("corrupted or truncated"), "got: {message}");
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
     }
 }
 

--- a/src-tauri/src/commands/ide/screenshots/thumbnail.rs
+++ b/src-tauri/src/commands/ide/screenshots/thumbnail.rs
@@ -398,7 +398,11 @@ pub async fn get_project_thumbnail(project_path: String) -> Result<Option<String
     if thumbnail_path.exists() {
         // Return as base64 data URL for easy display
         use base64::Engine;
-        let data = std::fs::read(&thumbnail_path).map_err(|e| e.to_string())?;
+        // classify_fs_error: labels the op/path and turns environment denials
+        // (TCC, Windows access-denied) into Expected (issues #596, #625).
+        let data = std::fs::read(&thumbnail_path).map_err(|e| {
+            crate::utils::classify_fs_error("read this project's thumbnail", &thumbnail_path, &e)
+        })?;
         let base64_data = base64::engine::general_purpose::STANDARD.encode(&data);
         Ok(Some(format!("data:image/png;base64,{base64_data}")))
     } else {
@@ -425,8 +429,13 @@ pub async fn upload_project_thumbnail(
     let project = validate_project_path(&project_path)?;
     let shipstudio_dir = project.join(".shipstudio");
     if !shipstudio_dir.exists() {
-        std::fs::create_dir_all(&shipstudio_dir)
-            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
+        std::fs::create_dir_all(&shipstudio_dir).map_err(|e| {
+            crate::utils::classify_fs_error(
+                "create this project's .shipstudio folder",
+                &shipstudio_dir,
+                &e,
+            )
+        })?;
     }
 
     // Decode through the `image` crate — gives us format detection + a
@@ -447,8 +456,9 @@ pub async fn upload_project_thumbnail(
     // sibling tauri command directly so we stay synchronous on disk.
     let metadata_path = shipstudio_dir.join("project.json");
     let mut metadata: ProjectMetadata = if metadata_path.exists() {
-        let contents = std::fs::read_to_string(&metadata_path)
-            .map_err(|e| format!("Failed to read project metadata: {e}"))?;
+        let contents = std::fs::read_to_string(&metadata_path).map_err(|e| {
+            crate::utils::classify_fs_error("read project metadata", &metadata_path, &e)
+        })?;
         let mut existing: ProjectMetadata = serde_json::from_str(&contents)
             .map_err(|e| format!("Failed to parse project metadata: {e}"))?;
         existing.migrate();
@@ -458,12 +468,13 @@ pub async fn upload_project_thumbnail(
     };
     metadata.custom_thumbnail = Some(true);
     metadata.schema_version = PROJECT_METADATA_SCHEMA_VERSION;
-    let serialized = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize project metadata: {e}"))?;
-    std::fs::write(&metadata_path, serialized)
-        .map_err(|e| format!("Failed to write project metadata: {e}"))?;
+    // classify_fs_error routing: TCC/access-denied/read-only failures
+    // classify Expected instead of paging telemetry (issue #625).
+    crate::commands::projects::save_project_metadata(&project, &metadata)?;
 
-    let bytes = std::fs::read(&thumbnail_path).map_err(|e| e.to_string())?;
+    let bytes = std::fs::read(&thumbnail_path).map_err(|e| {
+        crate::utils::classify_fs_error("read this project's thumbnail", &thumbnail_path, &e)
+    })?;
     let base64_data = base64::engine::general_purpose::STANDARD.encode(&bytes);
     Ok(format!("data:image/png;base64,{base64_data}"))
 }

--- a/src-tauri/src/commands/mobile.rs
+++ b/src-tauri/src/commands/mobile.rs
@@ -273,12 +273,37 @@ async fn simctl_stdout(
 #[tracing::instrument]
 pub async fn list_booted_simulators() -> Result<Vec<MobileSimulator>, CommandError> {
     tracing::info!("list_booted_simulators: invoked");
-    let stdout = simctl_stdout(
-        &["list", "devices", "booted", "--json"],
-        "xcrun simctl list booted",
-        SIMCTL_TIMEOUT_SECS,
-    )
-    .await?;
+    // CoreSimulator can be transiently slow to answer (same flakiness class as
+    // #311/#411's `launchctl list` call), and this lookup sits on the critical
+    // path of every preview connect — so retry a hung call once, and if it
+    // still times out classify it as Expected: a wedged CoreSimulator is a
+    // machine state with a user-side fix, not an app malfunction (issue #554).
+    let mut stdout = None;
+    for attempt in 0..2 {
+        match simctl_stdout(
+            &["list", "devices", "booted", "--json"],
+            "xcrun simctl list booted",
+            SIMCTL_TIMEOUT_SECS,
+        )
+        .await
+        {
+            Ok(out) => {
+                stdout = Some(out);
+                break;
+            }
+            Err(CommandError::Timeout { .. }) if attempt == 0 => {
+                tracing::warn!("xcrun simctl list booted timed out; retrying once");
+            }
+            Err(CommandError::Timeout { .. }) => {
+                return Err(CommandError::expected(
+                    "The iOS Simulator took too long to respond. Try again — and if it \
+                     keeps happening, quit and reopen Simulator.app.",
+                ));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    let stdout = stdout.expect("loop either sets stdout or returns");
     let sims = parse_booted_simulators(&stdout)?;
     tracing::info!("list_booted_simulators: {} booted", sims.len());
     Ok(sims)
@@ -565,10 +590,27 @@ async fn ensure_emulator(preferred: Option<String>) -> Result<(AndroidDevice, bo
         .ok_or("No Android Virtual Device found. Create an emulator (AVD) to preview on.")?;
 
     // Boot detached — the emulator runs for the session; teardown uses `adb emu kill`.
+    // Its stdout/stderr go to a log file (not /dev/null) so a boot timeout can
+    // say WHY — missing acceleration, corrupted AVD, wrong-arch system image —
+    // instead of a bare one-liner (issue #583).
     let mut emu = emulator_command();
     emu.args(["-avd", &avd, "-no-snapshot-save", "-no-boot-anim"]);
-    emu.stdout(std::process::Stdio::null());
-    emu.stderr(std::process::Stdio::null());
+    let log_path = emulator_log_path(&avd);
+    match std::fs::File::create(&log_path).and_then(|out| out.try_clone().map(|err| (out, err))) {
+        Ok((out, err)) => {
+            emu.stdout(out);
+            emu.stderr(err);
+        }
+        Err(e) => {
+            tracing::warn!(
+                log = %log_path.display(),
+                error = %e,
+                "couldn't create emulator log file; boot output will be discarded"
+            );
+            emu.stdout(std::process::Stdio::null());
+            emu.stderr(std::process::Stdio::null());
+        }
+    }
     emu.spawn()
         .map_err(|e| format!("Failed to launch the Android emulator: {e}"))?;
 
@@ -585,11 +627,51 @@ async fn ensure_emulator(preferred: Option<String>) -> Result<(AndroidDevice, bo
             }
         }
         if waited >= ANDROID_BOOT_WAIT_TIMEOUT_SECS {
-            return Err("The Android emulator did not finish booting in time.".into());
+            return Err(match read_log_tail(&log_path, EMULATOR_LOG_TAIL_LINES) {
+                Some(tail) => format!(
+                    "The Android emulator did not finish booting in time. Emulator output:\n{tail}"
+                )
+                .into(),
+                None => "The Android emulator did not finish booting in time.".into(),
+            });
         }
         tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
         waited += 2;
     }
+}
+
+/// Lines of emulator output to keep when reporting a boot failure — the error
+/// (bad acceleration, corrupted image) is almost always at the end.
+const EMULATOR_LOG_TAIL_LINES: usize = 15;
+
+/// Where the emulator's boot output for `avd` is written. In the OS temp dir
+/// (best-effort diagnostics, not user data); the AVD name is sanitized since
+/// it becomes a filename component.
+fn emulator_log_path(avd: &str) -> std::path::PathBuf {
+    let safe: String = avd
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    std::env::temp_dir().join(format!("shipstudio-emulator-{safe}.log"))
+}
+
+/// Read the last `max_lines` lines of a log file, capped for embedding in an
+/// error message. `None` when the file is missing or empty.
+fn read_log_tail(path: &std::path::Path, max_lines: usize) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let mut tail: Vec<&str> = trimmed.lines().rev().take(max_lines).collect();
+    tail.reverse();
+    Some(crate::external_command::truncate_output(&tail.join("\n")))
 }
 
 /// Whether the emulator's OS has finished booting (`getprop sys.boot_completed`).
@@ -2509,6 +2591,45 @@ async fn start_android_preview(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Issue #583: the boot-timeout error must carry the emulator's own
+    /// output tail — the last lines are where the actual failure is.
+    #[test]
+    fn read_log_tail_returns_last_lines() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let log = tmp.path().join("emu.log");
+        let lines: Vec<String> = (1..=30).map(|i| format!("line {i}")).collect();
+        std::fs::write(&log, lines.join("\n")).unwrap();
+        let tail = read_log_tail(&log, 15).unwrap();
+        assert!(tail.starts_with("line 16"), "got: {tail}");
+        assert!(tail.ends_with("line 30"), "got: {tail}");
+        assert!(!tail.contains("line 15\n"), "got: {tail}");
+    }
+
+    #[test]
+    fn read_log_tail_none_for_missing_or_empty() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        assert!(read_log_tail(&tmp.path().join("nope.log"), 15).is_none());
+        let empty = tmp.path().join("empty.log");
+        std::fs::write(&empty, "  \n").unwrap();
+        assert!(read_log_tail(&empty, 15).is_none());
+    }
+
+    #[test]
+    fn read_log_tail_caps_oversized_output() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let log = tmp.path().join("big.log");
+        std::fs::write(&log, "x".repeat(10_000)).unwrap();
+        let tail = read_log_tail(&log, 15).unwrap();
+        assert!(tail.ends_with("(truncated)"), "got tail len {}", tail.len());
+    }
+
+    #[test]
+    fn emulator_log_path_sanitizes_avd_name() {
+        let path = emulator_log_path("Pixel 8 / API 35");
+        let name = path.file_name().unwrap().to_string_lossy().into_owned();
+        assert_eq!(name, "shipstudio-emulator-Pixel_8___API_35.log");
+    }
 
     #[test]
     fn friendly_runtime_formats_ios_version() {

--- a/src-tauri/src/commands/plugins/plugin_lifecycle.rs
+++ b/src-tauri/src/commands/plugins/plugin_lifecycle.rs
@@ -488,6 +488,18 @@ pub async fn update_plugin(
         return Err((format!("Git clone failed: {stderr}")).into());
     }
 
+    // Validate the built bundle exists — same guard as install_plugin (issue
+    // #381). Without it an update from a repo whose dist/ was removed would
+    // leave a registered-but-unloadable plugin, exactly the broken state the
+    // self-heal path (issue #624) exists to repair.
+    if !plugin_dir.join("dist").join("index.js").exists() {
+        let _ = remove_dir_all_relaxed(&plugin_dir);
+        return Err(CommandError::expected(
+            "This plugin can't be updated: its repository has no built bundle (dist/index.js). \
+             The plugin author needs to build it and commit the dist folder.",
+        ));
+    }
+
     // Read commit hash before removing .git
     let commit_hash = read_git_head(&plugin_dir);
 

--- a/src-tauri/src/commands/plugins/plugin_storage.rs
+++ b/src-tauri/src/commands/plugins/plugin_storage.rs
@@ -193,6 +193,29 @@ pub async fn exec_plugin_shell(
                         &command,
                     ));
                 }
+                // Windows ERROR_FILENAME_EXCED_RANGE (os error 206): the
+                // resolved absolute path (#475) plus args can exceed the
+                // legacy MAX_PATH limit on long profiles (OneDrive-redirected
+                // homes, fnm multishell dirs). Environment limit with a
+                // user-side fix, so Expected (issue #549).
+                if crate::external_command::is_windows_path_too_long(&rendered) {
+                    return Err(CommandError::expected(format!(
+                        "Plugin '{plugin_id}' couldn't run '{command}' — Windows rejected the \
+                         command because its path or arguments exceed the path-length limit \
+                         (os error 206). Enable Windows long-path support, or move the \
+                         tool/project to a shorter path, then try again."
+                    )));
+                }
+                // Access denied (Windows os error 5 — localized text — or Unix
+                // EACCES/EPERM): typically antivirus briefly locking the
+                // binary. Environment, not an app malfunction (issue #596).
+                if e.kind() == std::io::ErrorKind::PermissionDenied {
+                    return Err(CommandError::expected(format!(
+                        "Plugin '{plugin_id}' couldn't run '{command}' — the operating system \
+                         denied access. This is usually security/antivirus software briefly \
+                         locking the program, or missing file permissions. Try again in a moment."
+                    )));
+                }
                 // Name the plugin and command here too — this final branch
                 // used to drop both, leaving a bare unattributable OS error
                 // as the only telemetry signal (issue #573).

--- a/src-tauri/src/commands/projects/dev_server.rs
+++ b/src-tauri/src/commands/projects/dev_server.rs
@@ -50,17 +50,9 @@ pub async fn set_custom_dev_command(
 
     metadata.custom_dev_command = command;
 
-    if !shipstudio_dir.exists() {
-        std::fs::create_dir_all(&shipstudio_dir)
-            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
-    }
-
-    let contents = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize project metadata: {e}"))?;
-    std::fs::write(&metadata_path, contents)
-        .map_err(|e| format!("Failed to write project metadata: {e}"))?;
-
-    Ok(())
+    // classify_fs_error routing: TCC/access-denied/read-only failures
+    // classify Expected instead of paging telemetry (issue #625).
+    super::metadata::save_project_metadata(&project, &metadata)
 }
 
 /// Gets whether this project is forced to serve as a static site, overriding
@@ -104,17 +96,9 @@ pub async fn set_force_static_serve(project_path: String, force: bool) -> Result
 
     metadata.force_static_serve = if force { Some(true) } else { None };
 
-    if !shipstudio_dir.exists() {
-        std::fs::create_dir_all(&shipstudio_dir)
-            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
-    }
-
-    let contents = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize project metadata: {e}"))?;
-    std::fs::write(&metadata_path, contents)
-        .map_err(|e| format!("Failed to write project metadata: {e}"))?;
-
-    Ok(())
+    // classify_fs_error routing: TCC/access-denied/read-only failures
+    // classify Expected instead of paging telemetry (issue #625).
+    super::metadata::save_project_metadata(&project, &metadata)
 }
 
 /// Gets the dev server port for a project (returns None if not configured, meaning use default 3000)
@@ -159,17 +143,9 @@ pub async fn set_dev_server_port(project_path: String, port: u16) -> Result<(), 
 
     metadata.dev_server_port = Some(port);
 
-    if !shipstudio_dir.exists() {
-        std::fs::create_dir_all(&shipstudio_dir)
-            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
-    }
-
-    let contents = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize project metadata: {e}"))?;
-    std::fs::write(&metadata_path, contents)
-        .map_err(|e| format!("Failed to write project metadata: {e}"))?;
-
-    Ok(())
+    // classify_fs_error routing: TCC/access-denied/read-only failures
+    // classify Expected instead of paging telemetry (issue #625).
+    super::metadata::save_project_metadata(&project, &metadata)
 }
 
 /// Gets the active workspace subpath for a monorepo project, or None if the
@@ -237,17 +213,9 @@ pub async fn set_workspace_subpath(
 
     metadata.workspace_subpath = subpath;
 
-    if !shipstudio_dir.exists() {
-        std::fs::create_dir_all(&shipstudio_dir)
-            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
-    }
-
-    let contents = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize project metadata: {e}"))?;
-    std::fs::write(&metadata_path, contents)
-        .map_err(|e| format!("Failed to write project metadata: {e}"))?;
-
-    Ok(())
+    // classify_fs_error routing: TCC/access-denied/read-only failures
+    // classify Expected instead of paging telemetry (issue #625).
+    super::metadata::save_project_metadata(&project, &metadata)
 }
 
 /// Result of checking whether a project's npm/pnpm/yarn dependencies are installed.

--- a/src-tauri/src/commands/projects/metadata.rs
+++ b/src-tauri/src/commands/projects/metadata.rs
@@ -8,6 +8,36 @@ use crate::errors::CommandError;
 use crate::types::{ProjectMetadata, PROJECT_METADATA_SCHEMA_VERSION};
 use crate::utils::validate_project_path;
 
+/// Persist `metadata` to `<project>/.shipstudio/project.json`, creating the
+/// `.shipstudio` directory as needed.
+///
+/// Shared by every project.json writer (metadata, ui_state, dev_server,
+/// shopify, thumbnail) so filesystem failures classify identically through
+/// `classify_fs_error`: macOS TCC EPERM, Windows access-denied, and read-only
+/// volumes become actionable `Expected` errors instead of a bare "Operation
+/// not permitted (os error 1)" reaching telemetry (issue #625).
+pub(crate) fn save_project_metadata(
+    project: &std::path::Path,
+    metadata: &ProjectMetadata,
+) -> Result<(), CommandError> {
+    let shipstudio_dir = project.join(".shipstudio");
+    if !shipstudio_dir.exists() {
+        std::fs::create_dir_all(&shipstudio_dir).map_err(|e| {
+            crate::utils::classify_fs_error(
+                "create this project's .shipstudio folder",
+                &shipstudio_dir,
+                &e,
+            )
+        })?;
+    }
+
+    let metadata_path = shipstudio_dir.join("project.json");
+    let contents = serde_json::to_string_pretty(metadata)
+        .map_err(|e| format!("Failed to serialize project metadata: {e}"))?;
+    std::fs::write(&metadata_path, contents)
+        .map_err(|e| crate::utils::classify_fs_error("write project metadata", &metadata_path, &e))
+}
+
 /// Reads project metadata from .shipstudio/project.json with automatic schema migration
 #[tauri::command]
 #[tracing::instrument(fields(project = %project_path))]
@@ -21,18 +51,16 @@ pub async fn read_project_metadata(
         return Ok(None);
     }
 
-    let contents = std::fs::read_to_string(&metadata_path)
-        .map_err(|e| format!("Failed to read project metadata: {e}"))?;
+    let contents = std::fs::read_to_string(&metadata_path).map_err(|e| {
+        crate::utils::classify_fs_error("read project metadata", &metadata_path, &e)
+    })?;
 
     let mut metadata: ProjectMetadata = serde_json::from_str(&contents)
         .map_err(|e| format!("Failed to parse project metadata: {e}"))?;
 
     // Apply migrations if needed and save the updated metadata
     if metadata.migrate() {
-        let updated_contents = serde_json::to_string_pretty(&metadata)
-            .map_err(|e| format!("Failed to serialize migrated metadata: {e}"))?;
-        std::fs::write(&metadata_path, updated_contents)
-            .map_err(|e| format!("Failed to save migrated metadata: {e}"))?;
+        save_project_metadata(&project, &metadata)?;
     }
 
     Ok(Some(metadata))
@@ -47,24 +75,11 @@ pub async fn write_project_metadata(
     mut metadata: ProjectMetadata,
 ) -> Result<(), CommandError> {
     let project = validate_project_path(&project_path)?;
-    let shipstudio_dir = project.join(".shipstudio");
-
-    if !shipstudio_dir.exists() {
-        std::fs::create_dir_all(&shipstudio_dir)
-            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
-    }
 
     // Ensure schema_version is current when writing
     metadata.schema_version = PROJECT_METADATA_SCHEMA_VERSION;
 
-    let metadata_path = shipstudio_dir.join("project.json");
-    let contents = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize project metadata: {e}"))?;
-
-    std::fs::write(&metadata_path, contents)
-        .map_err(|e| format!("Failed to write project metadata: {e}"))?;
-
-    Ok(())
+    save_project_metadata(&project, &metadata)
 }
 
 /// Checks whether a project has a `.vercel/project.json` config file.
@@ -73,4 +88,45 @@ pub async fn write_project_metadata(
 pub async fn has_vercel_config(project_path: String) -> Result<bool, CommandError> {
     let project = validate_project_path(&project_path)?;
     Ok(project.join(".vercel").join("project.json").exists())
+}
+
+#[cfg(test)]
+mod save_project_metadata_tests {
+    use super::*;
+
+    #[test]
+    fn roundtrips_metadata_and_creates_shipstudio_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let metadata = ProjectMetadata {
+            custom_dev_command: Some("bun dev".to_string()),
+            ..Default::default()
+        };
+        save_project_metadata(tmp.path(), &metadata).unwrap();
+
+        let written = tmp.path().join(".shipstudio").join("project.json");
+        let parsed: ProjectMetadata =
+            serde_json::from_str(&std::fs::read_to_string(&written).unwrap()).unwrap();
+        assert_eq!(parsed.custom_dev_command.as_deref(), Some("bun dev"));
+    }
+
+    // The #625 shape: a write failure must route through classify_fs_error
+    // (labeled with action + path), never a bare OS string.
+    #[test]
+    #[cfg(unix)]
+    fn write_failure_is_labeled() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Pre-create .shipstudio, then make it unwritable so fs::write fails.
+        let dir = tmp.path().join(".shipstudio");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let err = save_project_metadata(tmp.path(), &ProjectMetadata::default()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("project metadata"), "got: {msg}");
+        assert!(msg.contains("project.json"), "got: {msg}");
+
+        // Restore so TempDir cleanup can delete it.
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
 }

--- a/src-tauri/src/commands/projects/templates.rs
+++ b/src-tauri/src/commands/projects/templates.rs
@@ -3,7 +3,7 @@
 //! Handles creating new projects from zip templates and exporting
 //! existing projects as zip template files.
 
-use super::detection::static_site_dir;
+use super::detection::has_html_files;
 use crate::errors::CommandError;
 use tauri::AppHandle;
 use tauri_plugin_dialog::DialogExt;
@@ -69,20 +69,88 @@ pub async fn extract_template_zip(
         return Err(e);
     }
 
-    // Verify it's a valid project (has package.json, HTML files at the root
-    // or in public/, or a Shopify theme layout)
-    if !project_path.join("package.json").exists()
-        && static_site_dir(&project_path).is_none()
-        && !project_path.join("layout").join("theme.liquid").exists()
-    {
+    // Verify it's a valid project (has package.json, HTML files, or a Shopify
+    // theme layout — searched a few levels deep, since templates routinely
+    // nest these under src/, dist/, or a wrapper directory; issue #641).
+    if !contains_project_markers(&project_path, TEMPLATE_MARKER_SEARCH_DEPTH) {
+        // Log what was actually extracted so a report can distinguish "the
+        // template really is invalid" from "extraction produced an unexpected
+        // layout" (issue #641).
+        let top_entries: Vec<String> = std::fs::read_dir(&project_path)
+            .map(|entries| {
+                entries
+                    .flatten()
+                    .map(|e| e.file_name().to_string_lossy().into_owned())
+                    .collect()
+            })
+            .unwrap_or_default();
+        tracing::warn!(
+            entries = ?top_entries,
+            "template validation failed; extracted top-level entries"
+        );
         // Clean up invalid project
         std::fs::remove_dir_all(&project_path).ok();
-        return Err("Invalid template: no package.json, .html files, or Shopify theme layout found. Please use a valid project template."
-            .to_string()
-            .into());
+        // The zip's content is the user's input, not an app malfunction.
+        return Err(CommandError::expected(
+            "Invalid template: no package.json, .html files, or Shopify theme layout found. Please use a valid project template.",
+        ));
     }
 
     Ok(project_path.to_string_lossy().to_string())
+}
+
+/// How many directory levels below the extraction root to search for project
+/// markers. Covers an unstripped wrapper dir plus common nesting like
+/// `src/index.html` or `wrapper/dist/index.html`.
+const TEMPLATE_MARKER_SEARCH_DEPTH: usize = 3;
+
+/// Whether `dir` (or any subdirectory up to `depth` levels down) contains a
+/// recognizable project marker: a `package.json`, any `.html` file, or a
+/// Shopify theme's `layout/theme.liquid`.
+///
+/// Root-only checks used to reject legitimately-structured templates whose
+/// project files sit one level deeper — e.g. when root-stripping didn't kick
+/// in, or when the site lives in `src/`/`dist/` (issue #641). Heavy and
+/// hidden directories are skipped.
+fn contains_project_markers(dir: &std::path::Path, depth: usize) -> bool {
+    if dir.join("package.json").exists()
+        || dir.join("layout").join("theme.liquid").exists()
+        || has_html_files(dir)
+    {
+        return true;
+    }
+    if depth == 0 {
+        return false;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        // `file_type()` doesn't follow symlinks, so a symlinked dir can't
+        // recurse out of the extracted tree (or loop).
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with('.') || name == "node_modules" {
+            continue;
+        }
+        if contains_project_markers(&entry.path(), depth - 1) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Zip entries that are packaging junk, not template content: macOS resource
+/// forks (`__MACOSX/`), Finder metadata (`.DS_Store`), and AppleDouble
+/// sidecar files (`._*`). Finder's "Compress" adds these next to the real
+/// root directory, which used to defeat the shared-root detection below and
+/// leave every file nested one level too deep (issue #641).
+fn is_junk_zip_entry(name: &str) -> bool {
+    name.split('/')
+        .any(|segment| segment == "__MACOSX" || segment == ".DS_Store" || segment.starts_with("._"))
 }
 
 /// Extract a zip archive into `project_path`, streaming each entry to disk
@@ -99,38 +167,44 @@ fn extract_archive_to<R: std::io::Read + std::io::Seek>(
         return Err(("Zip file is empty".to_string()).into());
     }
 
-    // Detect if zip has a single root directory (GitHub-style download)
-    // by checking the first entry
-    let first_entry_name = archive
-        .by_index(0)
-        .map_err(|e| format!("Failed to read zip entry: {e}"))?
-        .name()
-        .to_string();
-
-    let root_prefix = if first_entry_name.contains('/') {
-        // Get the root directory name (e.g., "repo-main/")
-        let parts: Vec<&str> = first_entry_name.split('/').collect();
-        if parts.len() > 1 && !parts[0].is_empty() {
-            Some(format!("{}/", parts[0]))
-        } else {
-            None
+    // Detect whether every real entry shares a single root directory
+    // (GitHub-style download). Packaging junk (__MACOSX/, .DS_Store, ._*)
+    // is ignored here — macOS zips add it at top level next to the real
+    // root, and counting it used to silently disable root-stripping, which
+    // then failed validation on a perfectly valid template (issue #641).
+    let mut shared_root: Option<String> = None;
+    let mut single_root = true;
+    for i in 0..archive.len() {
+        let name = archive
+            .by_index(i)
+            .map_err(|e| format!("Failed to read zip entry #{i}: {e}"))?
+            .name()
+            .to_string();
+        if is_junk_zip_entry(&name) {
+            continue;
         }
+        match name.split_once('/') {
+            Some((top, _)) if !top.is_empty() => match &shared_root {
+                None => shared_root = Some(top.to_string()),
+                Some(root) if root == top => {}
+                Some(_) => {
+                    single_root = false;
+                    break;
+                }
+            },
+            // A top-level file (or a weird leading-slash name): no single root.
+            _ => {
+                single_root = false;
+                break;
+            }
+        }
+    }
+    let root_prefix = if single_root {
+        shared_root.map(|root| format!("{root}/"))
     } else {
         None
     };
-
-    // Verify all entries have the same root prefix if we detected one
-    let strip_root = if let Some(ref prefix) = root_prefix {
-        let all_have_prefix = (0..archive.len()).all(|i| {
-            archive
-                .by_index(i)
-                .map(|f| f.name().starts_with(prefix))
-                .unwrap_or(false)
-        });
-        all_have_prefix
-    } else {
-        false
-    };
+    let strip_root = root_prefix.is_some();
 
     // Create project directory
     std::fs::create_dir_all(project_path).map_err(|e| {
@@ -147,6 +221,11 @@ fn extract_archive_to<R: std::io::Read + std::io::Seek>(
             .map_err(|e| format!("Failed to read zip entry #{i}: {e}"))?;
 
         let mut outpath = file.name().to_string();
+
+        // Never materialize packaging junk (issue #641).
+        if is_junk_zip_entry(&outpath) {
+            continue;
+        }
 
         // Strip root directory if present
         if strip_root {
@@ -352,4 +431,144 @@ pub async fn export_project_as_template(
         .map_err(|e| format!("Failed to finalize zip file: {e}"))?;
 
     Ok(Some(save_path.to_string_lossy().to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{contains_project_markers, extract_archive_to, is_junk_zip_entry};
+    use std::io::Write;
+    use tempfile::TempDir;
+    use zip::write::SimpleFileOptions;
+
+    /// Build an in-memory zip with the given (name, content) entries.
+    /// Directory entries are names ending in '/'.
+    fn make_zip(entries: &[(&str, &str)]) -> std::io::Cursor<Vec<u8>> {
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut cursor);
+            let options = SimpleFileOptions::default();
+            for (name, content) in entries {
+                if name.ends_with('/') {
+                    writer.add_directory(name.to_string(), options).unwrap();
+                } else {
+                    writer.start_file(name.to_string(), options).unwrap();
+                    writer.write_all(content.as_bytes()).unwrap();
+                }
+            }
+            writer.finish().unwrap();
+        }
+        cursor.set_position(0);
+        cursor
+    }
+
+    #[test]
+    fn strips_shared_root_directory() {
+        let tmp = TempDir::new().unwrap();
+        let dest = tmp.path().join("proj");
+        let zip = make_zip(&[
+            ("repo-main/", ""),
+            ("repo-main/package.json", "{}"),
+            ("repo-main/src/app.js", "x"),
+        ]);
+        extract_archive_to(zip, &dest).unwrap();
+        assert!(dest.join("package.json").exists());
+        assert!(dest.join("src/app.js").exists());
+    }
+
+    /// Issue #641: macOS Finder zips carry __MACOSX/, .DS_Store, and ._*
+    /// sidecar entries at top level next to the real root. These must not
+    /// defeat root-stripping (which then made a valid template fail
+    /// validation), and must not be extracted.
+    #[test]
+    fn junk_entries_do_not_defeat_root_stripping() {
+        let tmp = TempDir::new().unwrap();
+        let dest = tmp.path().join("proj");
+        let zip = make_zip(&[
+            ("repo-main/", ""),
+            ("repo-main/package.json", "{}"),
+            ("__MACOSX/repo-main/._package.json", "junk"),
+            (".DS_Store", "junk"),
+            ("repo-main/.DS_Store", "junk"),
+        ]);
+        extract_archive_to(zip, &dest).unwrap();
+        assert!(
+            dest.join("package.json").exists(),
+            "root must be stripped despite junk siblings"
+        );
+        assert!(!dest.join("__MACOSX").exists());
+        assert!(!dest.join(".DS_Store").exists());
+    }
+
+    #[test]
+    fn mixed_roots_are_not_stripped() {
+        let tmp = TempDir::new().unwrap();
+        let dest = tmp.path().join("proj");
+        let zip = make_zip(&[
+            ("repo-main/package.json", "{}"),
+            ("README.txt", "top-level stray file"),
+        ]);
+        extract_archive_to(zip, &dest).unwrap();
+        // No single shared root → files land where the zip put them.
+        assert!(dest.join("repo-main/package.json").exists());
+        assert!(dest.join("README.txt").exists());
+    }
+
+    #[test]
+    fn junk_entry_detection() {
+        assert!(is_junk_zip_entry("__MACOSX/repo/._file"));
+        assert!(is_junk_zip_entry(".DS_Store"));
+        assert!(is_junk_zip_entry("repo/.DS_Store"));
+        assert!(is_junk_zip_entry("repo/._index.html"));
+        assert!(!is_junk_zip_entry("repo/index.html"));
+        assert!(!is_junk_zip_entry("repo/_private/file.js"));
+    }
+
+    #[test]
+    fn markers_found_at_root() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("package.json"), "{}").unwrap();
+        assert!(contains_project_markers(tmp.path(), 3));
+    }
+
+    /// Issue #641: html nested under src/ or dist/ (or a wrapper dir that
+    /// wasn't stripped) must still count as a valid template.
+    #[test]
+    fn markers_found_in_nested_directories() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        std::fs::write(tmp.path().join("src/index.html"), "<html></html>").unwrap();
+        assert!(contains_project_markers(tmp.path(), 3));
+
+        let tmp2 = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp2.path().join("wrapper/dist")).unwrap();
+        std::fs::write(tmp2.path().join("wrapper/dist/index.html"), "x").unwrap();
+        assert!(contains_project_markers(tmp2.path(), 3));
+
+        let tmp3 = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp3.path().join("theme/layout")).unwrap();
+        std::fs::write(tmp3.path().join("theme/layout/theme.liquid"), "x").unwrap();
+        assert!(contains_project_markers(tmp3.path(), 3));
+    }
+
+    #[test]
+    fn markers_respect_depth_limit_and_skip_heavy_dirs() {
+        let tmp = TempDir::new().unwrap();
+        // Beyond the depth limit → not found.
+        let deep = tmp.path().join("a/b/c/d");
+        std::fs::create_dir_all(&deep).unwrap();
+        std::fs::write(deep.join("index.html"), "x").unwrap();
+        assert!(!contains_project_markers(tmp.path(), 3));
+
+        // node_modules must never make a template "valid".
+        let tmp2 = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp2.path().join("node_modules/pkg")).unwrap();
+        std::fs::write(tmp2.path().join("node_modules/pkg/package.json"), "{}").unwrap();
+        assert!(!contains_project_markers(tmp2.path(), 3));
+    }
+
+    #[test]
+    fn empty_dir_has_no_markers() {
+        let tmp = TempDir::new().unwrap();
+        assert!(!contains_project_markers(tmp.path(), 3));
+    }
 }

--- a/src-tauri/src/commands/projects/ui_state.rs
+++ b/src-tauri/src/commands/projects/ui_state.rs
@@ -42,17 +42,9 @@ pub async fn mark_project_opened(project_path: String) -> Result<(), CommandErro
     // Workspace happened to be active when you opened them — a data-integrity
     // bug. Do not reintroduce it.
 
-    if !shipstudio_dir.exists() {
-        std::fs::create_dir_all(&shipstudio_dir)
-            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
-    }
-
-    let contents = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize project metadata: {e}"))?;
-    std::fs::write(&metadata_path, contents)
-        .map_err(|e| format!("Failed to write project metadata: {e}"))?;
-
-    Ok(())
+    // classify_fs_error routing: TCC/access-denied/read-only failures
+    // classify Expected instead of paging telemetry (issue #625).
+    super::metadata::save_project_metadata(&project, &metadata)
 }
 
 /// Gets the branch prefix username preference (defaults to true if not set)
@@ -96,17 +88,9 @@ pub async fn set_branch_prefix_preference(
 
     metadata.branch_prefix_username = Some(prefix);
 
-    if !shipstudio_dir.exists() {
-        std::fs::create_dir_all(&shipstudio_dir)
-            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
-    }
-
-    let contents = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize project metadata: {e}"))?;
-    std::fs::write(&metadata_path, contents)
-        .map_err(|e| format!("Failed to write project metadata: {e}"))?;
-
-    Ok(())
+    // classify_fs_error routing: TCC/access-denied/read-only failures
+    // classify Expected instead of paging telemetry (issue #625).
+    super::metadata::save_project_metadata(&project, &metadata)
 }
 
 /// Gets whether the main branch warning banner should be hidden for this project
@@ -150,17 +134,9 @@ pub async fn set_hide_main_branch_warning(
 
     metadata.hide_main_branch_warning = Some(hidden);
 
-    if !shipstudio_dir.exists() {
-        std::fs::create_dir_all(&shipstudio_dir)
-            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
-    }
-
-    let contents = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize project metadata: {e}"))?;
-    std::fs::write(&metadata_path, contents)
-        .map_err(|e| format!("Failed to write project metadata: {e}"))?;
-
-    Ok(())
+    // classify_fs_error routing: TCC/access-denied/read-only failures
+    // classify Expected instead of paging telemetry (issue #625).
+    super::metadata::save_project_metadata(&project, &metadata)
 }
 
 /// Gets the auto-accept mode preference for a project
@@ -202,17 +178,9 @@ pub async fn set_auto_accept_mode(project_path: String, enabled: bool) -> Result
 
     metadata.auto_accept_mode = Some(enabled);
 
-    if !shipstudio_dir.exists() {
-        std::fs::create_dir_all(&shipstudio_dir)
-            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
-    }
-
-    let contents = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize project metadata: {e}"))?;
-    std::fs::write(&metadata_path, contents)
-        .map_err(|e| format!("Failed to write project metadata: {e}"))?;
-
-    Ok(())
+    // classify_fs_error routing: TCC/access-denied/read-only failures
+    // classify Expected instead of paging telemetry (issue #625).
+    super::metadata::save_project_metadata(&project, &metadata)
 }
 
 /// Gets the saved terminal tab state for a project
@@ -228,8 +196,9 @@ pub async fn get_terminal_state(
         return Ok(None);
     }
 
-    let contents = std::fs::read_to_string(&metadata_path)
-        .map_err(|e| format!("Failed to read project metadata: {e}"))?;
+    let contents = std::fs::read_to_string(&metadata_path).map_err(|e| {
+        crate::utils::classify_fs_error("read project metadata", &metadata_path, &e)
+    })?;
     let metadata: ProjectMetadata = serde_json::from_str(&contents)
         .map_err(|e| format!("Failed to parse project metadata: {e}"))?;
 
@@ -258,17 +227,9 @@ pub async fn set_terminal_state(
 
     metadata.terminal_state = Some(state);
 
-    if !shipstudio_dir.exists() {
-        std::fs::create_dir_all(&shipstudio_dir)
-            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
-    }
-
-    let contents_str = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize project metadata: {e}"))?;
-    std::fs::write(&metadata_path, contents_str)
-        .map_err(|e| format!("Failed to write project metadata: {e}"))?;
-
-    Ok(())
+    // classify_fs_error routing: TCC/access-denied/read-only failures
+    // classify Expected instead of paging telemetry (issue #625).
+    super::metadata::save_project_metadata(&project, &metadata)
 }
 
 /// Reassigns a project to a different Workspace (Account) by updating
@@ -376,17 +337,9 @@ fn write_project_account_id(
         Some(account_id.to_string())
     };
 
-    if !shipstudio_dir.exists() {
-        std::fs::create_dir_all(&shipstudio_dir)
-            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
-    }
-
-    let contents = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize project metadata: {e}"))?;
-    std::fs::write(&metadata_path, contents)
-        .map_err(|e| format!("Failed to write project metadata: {e}"))?;
-
-    Ok(())
+    // classify_fs_error routing: TCC/access-denied/read-only failures
+    // classify Expected instead of paging telemetry (issue #625).
+    super::metadata::save_project_metadata(&project, &metadata)
 }
 
 /// The Workspace (Account) a project effectively belongs to, given the set of

--- a/src-tauri/src/commands/publishing.rs
+++ b/src-tauri/src/commands/publishing.rs
@@ -35,6 +35,57 @@ fn push_auth_error(stderr: &str) -> Option<CommandError> {
     None
 }
 
+/// GitHub pre-receive rejections that contain the literal word "rejected" but
+/// are NOT the benign "someone else pushed first" race: the broad
+/// `stderr.contains("rejected")` arms below matched them and told the user to
+/// "pull changes first" — advice that can't fix either condition. Both are
+/// user-fixable states with one specific remedy, so they get their own
+/// message and stay out of telemetry (`Expected`).
+///
+/// - `GH001` / "exceeds GitHub's file size limit": a file over 100 MB — the
+///   fix is removing the file or switching to Git LFS (issue #626).
+/// - `GH005` / "refs longer than 255 bytes": the branch name itself is too
+///   long for GitHub — the fix is renaming the branch (issue #636; the
+///   frontend's `sanitizeBranchName` now caps generated names too).
+///
+/// Must run BEFORE any generic "rejected"/"non-fast-forward" check.
+fn push_pre_receive_error(stderr: &str) -> Option<CommandError> {
+    let lower = stderr.to_lowercase();
+    if lower.contains("exceeds github's file size limit") || lower.contains("gh001") {
+        // Best-effort: name the offending file(s) from lines like
+        // "remote: error: File Archiv.zip is 120.17 MB; this exceeds GitHub's
+        // file size limit of 100.00 MB".
+        let files: Vec<&str> = stderr
+            .lines()
+            .filter(|l| l.to_lowercase().contains("file size limit"))
+            .filter_map(|l| l.split("File ").nth(1))
+            .filter_map(|rest| rest.split(" is ").next())
+            .filter(|name| !name.is_empty())
+            .collect();
+        let detail = if files.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", files.join(", "))
+        };
+        return Some(CommandError::expected(format!(
+            "GitHub rejected this push because a file is larger than its 100 MB limit{detail}. \
+             Remove the file from the branch (or use Git LFS for large files) and push again — \
+             pulling changes won't help."
+        )));
+    }
+    if lower.contains("gh005")
+        || lower.contains("refs longer than")
+        || lower.contains("ref too long")
+    {
+        return Some(CommandError::expected(
+            "GitHub rejected this push because the branch name is too long (GitHub limits refs \
+             to 255 bytes). Rename the branch to something shorter and push again — pulling \
+             changes won't help.",
+        ));
+    }
+    None
+}
+
 /// Push-time "the remote repo doesn't exist" rejections — the linked repo was
 /// deleted, renamed, transferred, or made inaccessible outside the app.
 /// Environment, not malfunction: telemetry-flooding this on every publish
@@ -118,6 +169,13 @@ pub async fn publish_to_github(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        // Large-file / ref-too-long pre-receive declines carry a specific fix
+        // of their own (issues #626/#636) — and without this arm they'd fall
+        // through to the auto-reported generic Process error below.
+        if let Some(err) = push_pre_receive_error(&stderr) {
+            warn!(error = %stderr, branch = %branch, "Push declined by GitHub pre-receive check");
+            return Err(err);
+        }
         if let Some(err) = push_auth_error(&stderr) {
             error!(error = %stderr, branch = %branch, "Authentication error");
             return Err(err);
@@ -168,6 +226,14 @@ pub async fn publish_to_staging(
 
     if !push_output.status.success() {
         let stderr = String::from_utf8_lossy(&push_output.stderr);
+        // Pre-receive declines (GH001 large file, GH005 ref too long) contain
+        // the word "rejected" but are NOT the diverged-branch race — check
+        // them first or the user gets "pull changes first" advice that can't
+        // fix anything (issues #626/#636).
+        if let Some(err) = push_pre_receive_error(&stderr) {
+            warn!(error = %stderr, "Push declined by GitHub pre-receive check");
+            return Err(err);
+        }
         if stderr.contains("rejected") || stderr.contains("non-fast-forward") {
             warn!(error = %stderr, "Push rejected - staging branch has diverged");
             // Retain the legacy PUSH_REJECTED sentinel so the frontend can
@@ -229,6 +295,12 @@ pub async fn publish_to_production(
 
     if !push_output.status.success() {
         let stderr = String::from_utf8_lossy(&push_output.stderr);
+        // Pre-receive declines have their own fix and would otherwise be
+        // auto-reported as a generic Process error (issues #626/#636).
+        if let Some(err) = push_pre_receive_error(&stderr) {
+            warn!(error = %stderr, "Push declined by GitHub pre-receive check");
+            return Err(err);
+        }
         if let Some(err) = push_auth_error(&stderr) {
             error!(error = %stderr, "Authentication error");
             return Err(err);
@@ -289,6 +361,14 @@ pub async fn publish_branch(
 
     if !push_output.status.success() {
         let stderr = String::from_utf8_lossy(&push_output.stderr);
+        // Pre-receive declines (GH001 large file, GH005 ref too long) contain
+        // the word "rejected" but are NOT the concurrent-push race — check
+        // them first or the frontend shows the "someone else pushed, pull
+        // first" modal for a problem pulling can't fix (issues #626/#636).
+        if let Some(err) = push_pre_receive_error(&stderr) {
+            warn!(error = %stderr, branch = %branch, "Push declined by GitHub pre-receive check");
+            return Err(err);
+        }
         // Check for common errors
         if stderr.contains("rejected") || stderr.contains("non-fast-forward") {
             warn!(error = %stderr, branch = %branch, "Push rejected");
@@ -324,8 +404,55 @@ pub async fn publish_branch(
 
 #[cfg(test)]
 mod tests {
+    use super::push_pre_receive_error;
     use crate::commands::git::run_git_net;
+    use crate::errors::CommandError;
     use std::path::Path;
+
+    // The #626 shape: GH001 large-file decline contains "rejected" but is not
+    // the concurrent-push race — it must classify Expected with LFS guidance
+    // and name the offending file.
+    #[test]
+    fn pre_receive_error_classifies_gh001_large_file() {
+        let stderr = "remote: error: Trace: 3539f6eaf2da6d14bbb65f8b9db2f684f713c6d5732665c678bdc1bb29d18696\nremote: error: See https://gh.io/lfs for more information.\nremote: error: File Archiv.zip is 120.17 MB; this exceeds GitHub's file size limit of 100.00 MB\nremote: error: GH001: Large files detected. You may want to try Git Large File Storage - https://git-lfs.github.com.\n ! [remote rejected] feat/x -> feat/x (pre-receive hook declined)\nerror: failed to push some refs to 'https://github.com/o/r.git'";
+        let err = push_pre_receive_error(stderr).expect("must classify GH001");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        let msg = err.to_string();
+        assert!(msg.contains("100 MB"), "got: {msg}");
+        assert!(msg.contains("Archiv.zip"), "must name the file, got: {msg}");
+        assert!(msg.contains("LFS"), "must point at Git LFS, got: {msg}");
+        assert!(
+            !msg.contains("PUSH_REJECTED"),
+            "must not trigger the pull-first modal"
+        );
+    }
+
+    // The #636 shape: GH005 ref-too-long decline — the only fix is renaming
+    // the branch, not pulling.
+    #[test]
+    fn pre_receive_error_classifies_gh005_ref_too_long() {
+        let stderr = "remote: error: GH005: Sorry, refs longer than 255 bytes are not allowed.\nremote: ref too long: \"refs/heads/user/some-extremely-long-generated-branch-name\"\n ! [remote rejected] x -> x (pre-receive hook declined)\nerror: failed to push some refs to 'https://github.com/o/r.git'";
+        let err = push_pre_receive_error(stderr).expect("must classify GH005");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        let msg = err.to_string();
+        assert!(msg.contains("branch name is too long"), "got: {msg}");
+        assert!(msg.contains("Rename"), "must suggest renaming, got: {msg}");
+    }
+
+    // An ordinary non-fast-forward race must NOT classify — it stays on the
+    // existing PUSH_REJECTED path with its dedicated pull-first UI.
+    #[test]
+    fn pre_receive_error_ignores_ordinary_push_race() {
+        let stderr = " ! [rejected] main -> main (non-fast-forward)\nerror: failed to push some refs to 'https://github.com/o/r.git'\nhint: Updates were rejected because the tip of your current branch is behind";
+        assert!(push_pre_receive_error(stderr).is_none());
+        assert!(push_pre_receive_error("").is_none());
+        // Other pre-receive declines (branch protection etc.) fall through to
+        // the existing arms too.
+        assert!(push_pre_receive_error(
+            "remote: error: GH006: Protected branch update failed for refs/heads/main"
+        )
+        .is_none());
+    }
 
     /// The network git helper must actually execute git through the timeout path
     /// (the whole point of A8 — replacing blocking `.output()` so a hung remote

--- a/src-tauri/src/commands/pull_requests.rs
+++ b/src-tauri/src/commands/pull_requests.rs
@@ -114,12 +114,19 @@ pub async fn create_pull_request(
 ) -> Result<String, CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    // Push the branch to the remote first (gh pr create requires this)
-    let mut push_cmd = crate::utils::git_command_in(&validated_path)?;
-    push_cmd.args(["push", "-u", "origin", "HEAD"]).envs(
-        crate::commands::accounts::get_env_vars_for_project(&validated_path),
-    );
-    let push_output = run_net(push_cmd, "git push").await?;
+    // Push the branch to the remote first (gh pr create requires this).
+    // Through run_git_net — not a hand-built command — so HTTPS credentials
+    // resolve via `gh auth git-credential` and GIT_TERMINAL_PROMPT=0 is set,
+    // exactly like push_branch. The hand-built version inherited whatever
+    // credential helper the machine had (often none usable in a GUI-spawned
+    // process), and git's interactive fallback died with "could not read
+    // Username for 'https://github.com': Device not configured" (issue #638).
+    let push_output = crate::commands::git::run_git_net(
+        &["push", "-u", "origin", "HEAD"],
+        &validated_path,
+        "push",
+    )
+    .await?;
 
     if !push_output.status.success() {
         let stderr = String::from_utf8_lossy(&push_output.stderr);

--- a/src-tauri/src/commands/setup/install.rs
+++ b/src-tauri/src/commands/setup/install.rs
@@ -73,7 +73,7 @@ pub async fn install_node_via_brew(app: tauri::AppHandle) -> Result<(), CommandE
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err((format!("Failed to install Node.js: {stderr}")).into());
+        return Err(humanize_brew_failure("Failed to install Node.js", &stderr));
     }
 
     Ok(())
@@ -109,7 +109,7 @@ pub async fn install_git_via_brew(app: tauri::AppHandle) -> Result<(), CommandEr
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err((format!("Failed to install Git: {stderr}")).into());
+        return Err(humanize_brew_failure("Failed to install Git", &stderr));
     }
 
     Ok(())
@@ -145,7 +145,10 @@ pub async fn install_gh_via_brew(app: tauri::AppHandle) -> Result<(), CommandErr
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err((format!("Failed to install GitHub CLI: {stderr}")).into());
+        return Err(humanize_brew_failure(
+            "Failed to install GitHub CLI",
+            &stderr,
+        ));
     }
 
     Ok(())
@@ -203,17 +206,76 @@ pub async fn install_brew_packages(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        if let Some(err) = brew_permission_error(&stderr) {
-            return Err(err);
-        }
-        return Err((format!(
-            "Failed to install packages: {}",
-            stderr.lines().next().unwrap_or("Unknown error")
-        ))
-        .into());
+        return Err(humanize_brew_failure("Failed to install packages", &stderr));
     }
 
     Ok(())
+}
+
+/// Turn a failed `brew` run's stderr into an actionable `CommandError`.
+///
+/// Homebrew failures fall into a few recurring machine-state buckets that the
+/// generic "first stderr line" fallback used to mangle (issues #448, #571,
+/// #580, #581). Known-bad-environment states become `Expected` (they're not
+/// app malfunctions, so they stay out of telemetry) with Homebrew's own
+/// remediation; everything else surfaces the *actual* error line instead of
+/// whatever progress banner happened to be printed first.
+fn humanize_brew_failure(context: &str, stderr: &str) -> crate::errors::CommandError {
+    // "prefix isn't writable" — left behind by a prior sudo/multi-user
+    // install (issue #448).
+    if let Some(err) = brew_permission_error(stderr) {
+        return err;
+    }
+
+    // "A legacy DSL was used" — Homebrew rejecting a pre-1.0 formula file,
+    // which means a very stale or corrupted local formula database, not a
+    // problem with the package itself (issue #581).
+    if stderr.contains("legacy DSL") {
+        return crate::errors::CommandError::expected(format!(
+            "{context}: your Homebrew formula database is stale or corrupted \
+             (Homebrew reported a \"legacy DSL\" formula error). Open Terminal and run: \
+             brew update-reset — then retry this step."
+        ));
+    }
+
+    // version.rb TypeError ("Version value must be a string; got a NilClass")
+    // — Homebrew's own Ruby crashing because it can't read the macOS version;
+    // a broken/mixed Homebrew install, not something the app did (issue #571).
+    if stderr.contains("Version value must be a string") {
+        return crate::errors::CommandError::expected(format!(
+            "{context}: your Homebrew installation is in a broken state (it crashed while \
+             reading your macOS version). Open Terminal and run: brew update-reset — and if \
+             that doesn't help, reinstall the Xcode Command Line Tools with: \
+             xcode-select --install — then retry this step."
+        ));
+    }
+
+    // Generic failure: surface the real error, not brew's auto-update banner.
+    (format!("{context}: {}", brew_error_line(stderr))).into()
+}
+
+/// Pick the most meaningful line out of brew's stderr.
+///
+/// The batch installer allows brew's auto-update to run, so stderr routinely
+/// *starts* with progress banners ("Updating Homebrew...", "==> Downloading
+/// ...") before the actual failure appears further down — naively taking the
+/// first line surfaces the banner and swallows the error (issue #580).
+/// Prefer the first `Error:` line (brew prefixes real errors with it); fall
+/// back to the last non-banner line.
+fn brew_error_line(stderr: &str) -> &str {
+    let is_banner = |l: &str| {
+        l.is_empty()
+            || l.starts_with("==>")
+            || l.starts_with("Updating Homebrew")
+            || l.starts_with("Warning:")
+            || l.chars()
+                .all(|c| matches!(c, '#' | '%' | '.' | ' ' | '-' | '=') || c.is_ascii_digit())
+    };
+    let mut lines = stderr.lines().map(str::trim);
+    if let Some(err) = lines.clone().find(|l| l.starts_with("Error:")) {
+        return err;
+    }
+    lines.rfind(|l| !is_banner(l)).unwrap_or("Unknown error")
 }
 
 /// Homebrew's "prefix isn't writable" failure — a machine state left behind by
@@ -392,5 +454,83 @@ pub async fn check_npm_cache_permissions() -> String {
         }
     } else {
         "ok".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{brew_error_line, humanize_brew_failure};
+    use crate::errors::CommandError;
+
+    /// Issue #580: brew's auto-update banner must never be surfaced as *the*
+    /// error — the real failure appears further down stderr.
+    #[test]
+    fn skips_updating_homebrew_banner_and_finds_real_error() {
+        let stderr = "Updating Homebrew...\n\
+                      ==> Downloading https://formulae.brew.sh/api/formula.jws.json\n\
+                      Error: node: no bottle available!\n\
+                      You can try to install from source with:\n  brew install --build-from-source node";
+        let err = humanize_brew_failure("Failed to install packages", stderr);
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Error: node: no bottle available!"),
+            "got: {msg}"
+        );
+        assert!(!msg.contains("Updating Homebrew"), "got: {msg}");
+        // An unknown brew failure stays reportable (not Expected).
+        assert!(!matches!(err, CommandError::Expected { .. }));
+    }
+
+    #[test]
+    fn falls_back_to_last_meaningful_line_without_error_prefix() {
+        let stderr = "Updating Homebrew...\n\
+                      ==> Fetching node\n\
+                      ########## 45.0%\n\
+                      curl: (28) Operation timed out\n";
+        assert_eq!(brew_error_line(stderr), "curl: (28) Operation timed out");
+    }
+
+    #[test]
+    fn all_banner_stderr_falls_back_to_unknown() {
+        assert_eq!(
+            brew_error_line("Updating Homebrew...\n==> Fetching\n"),
+            "Unknown error"
+        );
+        assert_eq!(brew_error_line(""), "Unknown error");
+    }
+
+    /// Issue #581: a "legacy DSL" formula error means the local formula
+    /// database is stale/corrupted — Expected, with `brew update-reset` advice.
+    #[test]
+    fn legacy_dsl_is_expected_with_update_reset_advice() {
+        let stderr = "Updating Homebrew...\n\
+                      Error: A legacy DSL was used: sha256 ({\"d7f992eb\" => :catalina})";
+        let err = humanize_brew_failure("Failed to install packages", stderr);
+        assert!(matches!(err, CommandError::Expected { .. }), "got: {err:?}");
+        let msg = err.to_string();
+        assert!(msg.contains("brew update-reset"), "got: {msg}");
+    }
+
+    /// Issue #571: Homebrew's version.rb TypeError is a broken Homebrew
+    /// environment — Expected, advising update-reset / reinstalling CLT.
+    #[test]
+    fn version_rb_crash_is_expected_with_guidance() {
+        let stderr = "/usr/local/Homebrew/Library/Homebrew/version.rb:368:in `initialize': \
+                      Version value must be a string; got a NilClass () (TypeError)";
+        let err = humanize_brew_failure("Failed to install packages", stderr);
+        assert!(matches!(err, CommandError::Expected { .. }), "got: {err:?}");
+        let msg = err.to_string();
+        assert!(msg.contains("brew update-reset"), "got: {msg}");
+        assert!(msg.contains("xcode-select --install"), "got: {msg}");
+    }
+
+    /// Issue #448 regression guard: the permission classification still wins.
+    #[test]
+    fn permission_error_still_classified() {
+        let stderr = "Error: The following directories are not writable by your user:\n\
+                      /opt/homebrew/lib is not writable";
+        let err = humanize_brew_failure("Failed to install packages", stderr);
+        assert!(matches!(err, CommandError::Expected { .. }), "got: {err:?}");
+        assert!(err.to_string().contains("sudo chown"), "got: {err}");
     }
 }

--- a/src-tauri/src/commands/shopify.rs
+++ b/src-tauri/src/commands/shopify.rs
@@ -139,17 +139,9 @@ pub async fn set_shopify_store(
 
     metadata.shopify_store = store;
 
-    if !shipstudio_dir.exists() {
-        std::fs::create_dir_all(&shipstudio_dir)
-            .map_err(|e| format!("Failed to create .shipstudio directory: {e}"))?;
-    }
-
-    let contents = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize project metadata: {e}"))?;
-    std::fs::write(&metadata_path, contents)
-        .map_err(|e| format!("Failed to write project metadata: {e}"))?;
-
-    Ok(())
+    // classify_fs_error routing: TCC/access-denied/read-only failures
+    // classify Expected instead of paging telemetry (issue #625).
+    crate::commands::projects::save_project_metadata(&project, &metadata)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -107,6 +107,14 @@ fn map_spawn_io_error(label: &str, io_err: &std::io::Error) -> CommandError {
         oom
     } else if is_spawn_resource_pressure(&io_err.to_string()) {
         spawn_resource_pressure_error(label)
+    } else if io_err.kind() == std::io::ErrorKind::PermissionDenied {
+        // Windows ERROR_ACCESS_DENIED (os error 5, localized text — e.g.
+        // "Acceso denegado.") and Unix EACCES/EPERM: an AV scanner or file
+        // lock blocking the spawn is the user's environment, not an app
+        // malfunction (issue #596).
+        spawn_access_denied_error(label)
+    } else if is_windows_path_too_long(&io_err.to_string()) {
+        windows_path_too_long_error(label)
     } else {
         CommandError::Io { message }
     }
@@ -206,35 +214,82 @@ pub async fn run_to_stdout(
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-// ===== Transient spawn resource pressure (EAGAIN) =====
+// ===== Transient spawn resource pressure (EAGAIN / EMFILE / ENFILE) =====
 //
 // Under macOS process/thread-table pressure, `fork()`/`posix_spawn()` can
 // transiently fail with EAGAIN ("Resource temporarily unavailable", os error
 // 35 on macOS/BSD, 11 on Linux). This surfaced as bare, unlabeled OS error
 // strings from many independent spawn sites (issues #555, #573, #585, #586,
-// #587). The helpers below give every spawn site one shared treatment:
-// a couple of short-backoff retries, and — if the pressure persists — a
-// human-readable `Expected` error instead of telemetry noise.
+// #587). File-descriptor exhaustion is the same condition wearing a different
+// errno: EMFILE ("Too many open files", os error 24) when this process hits
+// its fd budget, ENFILE ("Too many open files in system", os error 23) when
+// the whole machine does — both transient, both self-healing, both previously
+// reaching telemetry raw (issue #574). The helpers below give every spawn
+// site one shared treatment: a couple of short-backoff retries, and — if the
+// pressure persists — a human-readable `Expected` error instead of telemetry
+// noise.
 
-/// True when a rendered error message is the transient EAGAIN spawn failure.
+/// True when a rendered error message is a transient resource-pressure spawn
+/// failure: EAGAIN (process-table pressure) or EMFILE/ENFILE (fd exhaustion,
+/// issue #574).
 ///
 /// Message-based (rather than `raw_os_error`-based) so it works uniformly for
 /// `std::io::Error` and for portable_pty's `anyhow`-shaped errors, which only
 /// expose the underlying OS error through their `Display` text. The raw-code
-/// fallbacks are Unix-gated: on Windows os error 35/11 mean unrelated things.
+/// fallbacks are Unix-gated: on Windows os errors 35/11/23/24 mean unrelated
+/// things (ERROR_CRC, ERROR_BAD_LENGTH, …).
 pub fn is_spawn_resource_pressure(message: &str) -> bool {
     message.contains("Resource temporarily unavailable")
-        || (cfg!(unix) && (message.contains("(os error 35)") || message.contains("(os error 11)")))
+        || message.contains("Too many open files")
+        || (cfg!(unix)
+            && (message.contains("(os error 35)")
+                || message.contains("(os error 11)")
+                || message.contains("(os error 23)")
+                || message.contains("(os error 24)")))
 }
 
-/// The persistent-EAGAIN error: process-table/resource pressure is an
+/// The persistent resource-pressure error: process-table/fd pressure is an
 /// environment condition with a user-side fix, not an app malfunction —
 /// `Expected` keeps it out of telemetry and swaps the raw OS string for
 /// actionable guidance.
 pub fn spawn_resource_pressure_error(label: &str) -> CommandError {
     CommandError::expected(format!(
-        "Couldn't start `{label}` — your system is temporarily low on process resources. \
-         Close some apps or terminal tabs and try again."
+        "Couldn't start `{label}` — your system is temporarily low on process resources \
+         or open files. Close some apps or terminal tabs and try again."
+    ))
+}
+
+/// The access-denied spawn error (issue #596): the OS refused to run the
+/// program. On Windows this is `ERROR_ACCESS_DENIED` (os error 5, whose text
+/// is localized — "Acceso denegado." on a Spanish install); on Unix,
+/// EACCES/EPERM. Typically antivirus/security software briefly locking the
+/// binary, or missing file permissions — the user's environment, so
+/// `Expected` keeps it out of telemetry.
+pub fn spawn_access_denied_error(label: &str) -> CommandError {
+    CommandError::expected(format!(
+        "Couldn't start `{label}` — the operating system denied access. This is usually \
+         security/antivirus software briefly locking the program, or missing file \
+         permissions. Try again in a moment."
+    ))
+}
+
+/// True when a rendered error message is Windows `ERROR_FILENAME_EXCED_RANGE`
+/// (os error 206, "The filename or extension is too long") — `CreateProcess`
+/// rejecting an over-long resolved executable path or command line (issue
+/// #549). The text is localized on non-English Windows, so match the os-error
+/// code, and only on Windows: 206 means something unrelated elsewhere.
+pub fn is_windows_path_too_long(message: &str) -> bool {
+    cfg!(windows) && message.contains("(os error 206)")
+}
+
+/// The Windows path-too-long error (issue #549): an environment limit
+/// (legacy MAX_PATH without the long-path opt-in) with user-side fixes, so
+/// `Expected` swaps the raw OS string for actionable guidance.
+pub fn windows_path_too_long_error(label: &str) -> CommandError {
+    CommandError::expected(format!(
+        "Couldn't start `{label}` — Windows rejected the command because its path or \
+         arguments exceed the path-length limit (os error 206). Enable Windows \
+         long-path support, or move the tool/project to a shorter path, then try again."
     ))
 }
 
@@ -274,8 +329,9 @@ pub fn retry_spawn_on_pressure<T, E: std::fmt::Display>(
 /// retry, then map any failure into a labeled `CommandError` — persistent
 /// EAGAIN becomes the human `Expected` message, a missing binary stays
 /// `Expected` (mirroring [`run_with_timeout`], #296), Windows pagefile
-/// exhaustion keeps its typed guidance (#356), and anything else is a
-/// labeled `Io` so telemetry can attribute the call site.
+/// exhaustion keeps its typed guidance (#356), access-denied and path-too-long
+/// spawns classify Expected (#596, #549), and anything else is a labeled `Io`
+/// so telemetry can attribute the call site.
 pub fn spawn_with_pressure_retry<T>(
     label: &str,
     spawn: impl FnMut() -> std::io::Result<T>,
@@ -284,14 +340,7 @@ pub fn spawn_with_pressure_retry<T>(
         if is_spawn_resource_pressure(&io_err.to_string()) {
             return spawn_resource_pressure_error(label);
         }
-        let message = format!("`{label}`: {io_err}");
-        if io_err.kind() == std::io::ErrorKind::NotFound {
-            CommandError::expected(message)
-        } else if let Some(oom) = crate::errors::windows_out_of_memory(&io_err, Some(label)) {
-            oom
-        } else {
-            CommandError::Io { message }
-        }
+        map_spawn_io_error(label, &io_err)
     })
 }
 
@@ -417,6 +466,101 @@ mod tests {
         // Don't match a larger error code that merely contains "35"/"11".
         assert!(!is_spawn_resource_pressure("something (os error 110)"));
         assert!(!is_spawn_resource_pressure("something (os error 355)"));
+        assert!(!is_spawn_resource_pressure("something (os error 230)"));
+        assert!(!is_spawn_resource_pressure("something (os error 240)"));
+    }
+
+    // The #574 shape: fd exhaustion is the same transient resource pressure
+    // as EAGAIN and must get the same retry+classify treatment.
+    #[test]
+    fn spawn_pressure_matches_fd_exhaustion_shapes() {
+        // EMFILE — per-process fd budget exhausted.
+        assert!(is_spawn_resource_pressure(
+            "Too many open files (os error 24)"
+        ));
+        // ENFILE — system-wide open-file table exhausted.
+        assert!(is_spawn_resource_pressure(
+            "Too many open files in system (os error 23)"
+        ));
+        assert!(is_spawn_resource_pressure(
+            "Failed to execute command: Too many open files in system (os error 23)"
+        ));
+        // Localized strerror text still matches via the Unix-gated os codes.
+        #[cfg(unix)]
+        {
+            assert!(is_spawn_resource_pressure("¡demasiados! (os error 23)"));
+            assert!(is_spawn_resource_pressure("¡demasiados! (os error 24)"));
+        }
+    }
+
+    // On Windows, os errors 23/24 are ERROR_CRC / ERROR_BAD_LENGTH — the raw
+    // code fallbacks must not classify them as fd pressure there.
+    #[test]
+    #[cfg(windows)]
+    fn spawn_pressure_ignores_windows_crc_codes() {
+        assert!(!is_spawn_resource_pressure("Data error (os error 23)"));
+        assert!(!is_spawn_resource_pressure("Bad length (os error 24)"));
+    }
+
+    // The #596 shape: a localized Windows "Acceso denegado. (os error 5)"
+    // spawn failure must classify Expected (kind-based, so the localized
+    // Display text doesn't matter), with the label preserved.
+    #[test]
+    fn map_spawn_io_error_classifies_access_denied_as_expected() {
+        let denied = std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "Acceso denegado. (os error 5)",
+        );
+        match map_spawn_io_error("git status", &denied) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("`git status`"), "got: {message}");
+                assert!(message.contains("denied access"), "got: {message}");
+                assert!(!message.contains("Acceso denegado"), "got: {message}");
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn spawn_with_pressure_retry_classifies_access_denied_as_expected() {
+        let err = spawn_with_pressure_retry::<()>("npm install", || {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "Access is denied. (os error 5)",
+            ))
+        })
+        .unwrap_err();
+        assert!(matches!(err, CommandError::Expected { .. }), "got: {err:?}");
+        assert!(err.to_string().contains("`npm install`"));
+    }
+
+    // The #549 shape: ERROR_FILENAME_EXCED_RANGE is Windows-only; elsewhere
+    // os error 206 means something unrelated and must stay unclassified.
+    #[test]
+    #[cfg(not(windows))]
+    fn path_too_long_never_matches_off_windows() {
+        assert!(!is_windows_path_too_long(
+            "The filename or extension is too long. (os error 206)"
+        ));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn path_too_long_matches_error_206_on_windows() {
+        // Localized text still matches — the check is on the os-error code.
+        assert!(is_windows_path_too_long(
+            "El nombre de archivo o la extensión es demasiado largo. (os error 206)"
+        ));
+        assert!(!is_windows_path_too_long("some other failure (os error 2)"));
+
+        let e = std::io::Error::from_raw_os_error(206);
+        match map_spawn_io_error("npx tool", &e) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("`npx tool`"), "got: {message}");
+                assert!(message.contains("long-path"), "got: {message}");
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
     }
 
     // The #616 shape: `I/O error: `gh pr list`: Resource temporarily

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -33,6 +33,17 @@ const MAX_BODY_SIZE: usize = 50 * 1024 * 1024;
 /// wedged port and should fail fast instead of holding the request forever.
 const UPSTREAM_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// Overall connect budget for the WebSocket (HMR) upgrade's retry loop.
+/// Windows gets a longer budget: dev-server cold starts and restarts are
+/// measurably slower there (filesystem/AV overhead), and recurring reports
+/// showed the shared 5s budget being fully exhausted mid-restart even after
+/// the #353 per-attempt fix (issue #623). Waiting longer only delays the 502
+/// on a genuinely-down server — the browser-side HMR client retries after the
+/// 502 either way — while riding out a slow restart avoids the failure
+/// entirely.
+const WS_UPSTREAM_CONNECT_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(if cfg!(windows) { 12 } else { 5 });
+
 /// Timeout for the upstream response headers. Must be generous: dev servers
 /// compile routes on demand and hold the request open until the compile
 /// finishes — tens of seconds on a real dependency tree (the frontend's
@@ -847,7 +858,7 @@ async fn handle_websocket_upgrade(
         select_ok([v4, v6]).await.map(|(stream, _)| stream)
     }
 
-    let connect_deadline = tokio::time::Instant::now() + UPSTREAM_CONNECT_TIMEOUT;
+    let connect_deadline = tokio::time::Instant::now() + WS_UPSTREAM_CONNECT_TIMEOUT;
     // Each attempt gets its own short timeout (capped to what's left of the
     // overall budget) rather than racing the whole deadline: an unready port
     // doesn't always refuse the connection — on Windows especially, the SYN
@@ -888,7 +899,7 @@ async fn handle_websocket_upgrade(
                         "[Proxy] WebSocket target localhost:{} unavailable after {} connect attempts over {:?}: {}",
                         target_port,
                         attempts,
-                        UPSTREAM_CONNECT_TIMEOUT,
+                        WS_UPSTREAM_CONNECT_TIMEOUT,
                         e
                     );
                 } else {

--- a/src-tauri/src/static_server.rs
+++ b/src-tauri/src/static_server.rs
@@ -445,9 +445,46 @@ fn resolve_file_path(project_root: &Path, url_path: &str) -> Option<PathBuf> {
     None
 }
 
+/// Transient file-descriptor pressure: EMFILE (os error 24, this process's fd
+/// budget) or ENFILE (os error 23, the system-wide open-file table). Both are
+/// usually momentary — another process releases descriptors within
+/// milliseconds — so a read that fails with them deserves a retry, not an
+/// instant 500 (issue #575). The raw-code fallbacks are Unix-gated: on
+/// Windows os errors 23/24 mean unrelated things.
+fn is_fd_pressure(e: &std::io::Error) -> bool {
+    let rendered = e.to_string();
+    rendered.contains("Too many open files")
+        || (cfg!(unix) && matches!(e.raw_os_error(), Some(23) | Some(24)))
+}
+
+/// Run `op`, retrying a couple of times with a short backoff when it fails
+/// with transient fd pressure (see [`is_fd_pressure`]). Any other failure —
+/// and fd pressure that survives every retry — is returned unchanged.
+async fn with_fd_pressure_retry<T, F, Fut>(mut op: F) -> std::io::Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = std::io::Result<T>>,
+{
+    const ATTEMPTS: u64 = 3;
+    for attempt in 1..=ATTEMPTS {
+        match op().await {
+            Err(e) if attempt < ATTEMPTS && is_fd_pressure(&e) => {
+                tracing::warn!(
+                    attempt,
+                    error = %e,
+                    "[StaticServer] read hit transient fd pressure (EMFILE/ENFILE); retrying"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(75 * attempt)).await;
+            }
+            other => return other,
+        }
+    }
+    unreachable!("loop returns on the final attempt")
+}
+
 /// Read a file from disk and return it as an HTTP response with the correct MIME type.
 async fn serve_file(file_path: &Path) -> Result<Response<ServerBody>, hyper::Error> {
-    match tokio::fs::read(file_path).await {
+    match with_fd_pressure_retry(|| tokio::fs::read(file_path)).await {
         Ok(contents) => {
             let mime = file_path
                 .extension()
@@ -464,11 +501,26 @@ async fn serve_file(file_path: &Path) -> Result<Response<ServerBody>, hyper::Err
                 .unwrap())
         }
         Err(e) => {
-            tracing::error!(
-                "[StaticServer] Failed to read file {}: {}",
-                file_path.display(),
-                e
-            );
+            // Log the raw os error code distinctly so fd-pressure failures
+            // (23/24) are easy to filter from other read failures (#575).
+            // Pressure that survived every retry is machine-wide fd
+            // exhaustion — an environment condition, not a server bug — so
+            // it logs at warn instead of auto-filing an error report.
+            if is_fd_pressure(&e) {
+                tracing::warn!(
+                    "[StaticServer] Failed to read file {} after fd-pressure retries (os error {:?}): {}",
+                    file_path.display(),
+                    e.raw_os_error(),
+                    e
+                );
+            } else {
+                tracing::error!(
+                    "[StaticServer] Failed to read file {} (os error {:?}): {}",
+                    file_path.display(),
+                    e.raw_os_error(),
+                    e
+                );
+            }
             let body = "<html><body><h1>500 - Internal Server Error</h1></body></html>";
             Ok(Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
@@ -484,6 +536,87 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    // ===== #575: fd-pressure classification + bounded read retry =====
+
+    #[test]
+    fn fd_pressure_matches_emfile_and_enfile_shapes() {
+        // ENFILE — the reported #575 shape (system-wide table exhausted).
+        assert!(is_fd_pressure(&std::io::Error::other(
+            "Too many open files in system (os error 23)"
+        )));
+        // EMFILE — per-process budget exhausted.
+        assert!(is_fd_pressure(&std::io::Error::other(
+            "Too many open files (os error 24)"
+        )));
+        // Raw-code fallback for localized strerror text (Unix only).
+        #[cfg(unix)]
+        {
+            assert!(is_fd_pressure(&std::io::Error::from_raw_os_error(23)));
+            assert!(is_fd_pressure(&std::io::Error::from_raw_os_error(24)));
+        }
+    }
+
+    #[test]
+    fn fd_pressure_rejects_other_errors() {
+        assert!(!is_fd_pressure(&std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "No such file or directory (os error 2)"
+        )));
+        assert!(!is_fd_pressure(&std::io::Error::other(
+            "Operation not permitted (os error 1)"
+        )));
+    }
+
+    #[tokio::test]
+    async fn fd_retry_recovers_after_transient_pressure() {
+        let calls = std::cell::Cell::new(0u32);
+        let result = with_fd_pressure_retry(|| {
+            calls.set(calls.get() + 1);
+            let n = calls.get();
+            async move {
+                if n < 3 {
+                    Err(std::io::Error::other(
+                        "Too many open files in system (os error 23)",
+                    ))
+                } else {
+                    Ok(vec![1u8, 2, 3])
+                }
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), vec![1, 2, 3]);
+        assert_eq!(calls.get(), 3);
+    }
+
+    #[tokio::test]
+    async fn fd_retry_gives_up_after_bounded_attempts() {
+        let calls = std::cell::Cell::new(0u32);
+        let result: std::io::Result<Vec<u8>> = with_fd_pressure_retry(|| {
+            calls.set(calls.get() + 1);
+            async { Err(std::io::Error::other("Too many open files (os error 24)")) }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(calls.get(), 3, "must be bounded, not infinite");
+    }
+
+    #[tokio::test]
+    async fn fd_retry_does_not_retry_other_errors() {
+        let calls = std::cell::Cell::new(0u32);
+        let result: std::io::Result<Vec<u8>> = with_fd_pressure_retry(|| {
+            calls.set(calls.get() + 1);
+            async {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "No such file or directory (os error 2)",
+                ))
+            }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(calls.get(), 1);
+    }
 
     #[test]
     fn test_get_mime_type() {

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -160,6 +160,31 @@ fn most_recent_subdir(dir: &std::path::Path) -> Option<std::path::PathBuf> {
         .map(|entry| entry.path())
 }
 
+/// pnpm's self-managed global bin directories (issue #570): `$PNPM_HOME` when
+/// set (pnpm's own bin dir is configurable), plus the per-platform defaults
+/// its standalone installer / `pnpm setup` uses — macOS `~/Library/pnpm`,
+/// Linux `~/.local/share/pnpm`, Windows `%LOCALAPPDATA%\pnpm`. Mirrors
+/// `claude.rs::candidate_paths_for`. Pure on its inputs so it's testable;
+/// existence isn't checked — a nonexistent PATH entry is harmless, matching
+/// the other entries here.
+fn pnpm_home_dirs(home: &std::path::Path, pnpm_home: Option<&str>) -> Vec<String> {
+    let mut dirs: Vec<String> = Vec::new();
+    if let Some(ph) = pnpm_home {
+        let ph = ph.trim();
+        if !ph.is_empty() {
+            dirs.push(ph.to_string());
+        }
+    }
+    let home_str = home.to_string_lossy();
+    if cfg!(windows) {
+        dirs.push(format!("{home_str}\\AppData\\Local\\pnpm"));
+    } else {
+        dirs.push(format!("{home_str}/Library/pnpm")); // macOS default
+        dirs.push(format!("{home_str}/.local/share/pnpm")); // Linux default
+    }
+    dirs
+}
+
 /// Computes the extended PATH (uncached). Called by `get_extended_path()`.
 fn build_extended_path() -> String {
     let current_path = std::env::var("PATH").unwrap_or_default();
@@ -243,6 +268,11 @@ fn build_extended_path() -> String {
             windows_paths.push(format!("{}\\AppData\\Local\\Programs\\Git\\bin", home_str));
             windows_paths.push(format!("{}\\AppData\\Roaming\\npm", home_str));
             windows_paths.push(format!(r"{}\.local\bin", home_str));
+            // pnpm's self-managed install dir ($PNPM_HOME, default
+            // %LOCALAPPDATA%\pnpm) — see the Unix branch (issue #570).
+            for dir in pnpm_home_dirs(&home, std::env::var("PNPM_HOME").ok().as_deref()) {
+                windows_paths.push(dir);
+            }
         }
 
         windows_paths
@@ -265,6 +295,15 @@ fn build_extended_path() -> String {
         paths.push(format!("{home_str}/.opencode/bin")); // Opencode installer location
         paths.push(format!("{home_str}/.bun/bin")); // Bun-installed tools
         paths.push(format!("{home_str}/n/bin"));
+        // pnpm's self-managed install dirs (standalone installer / `pnpm
+        // setup`): $PNPM_HOME when set, else the platform defaults. Without
+        // these, a repo's husky/lefthook hook that shells out to pnpm fails
+        // with "command not found" under git_command()'s PATH (issue #570) —
+        // the same gap claude.rs::candidate_paths_for already closed for
+        // agent-CLI detection.
+        for dir in pnpm_home_dirs(&home, std::env::var("PNPM_HOME").ok().as_deref()) {
+            paths.push(dir);
+        }
 
         // Add NVM current/default version if it exists
         // First try the default alias, then fall back to finding the latest version
@@ -520,7 +559,18 @@ pub fn git_environment_gap(stderr: &str) -> Option<crate::errors::CommandError> 
 /// with the Files & Folders remediation instead of a bare "Operation not
 /// permitted" telemetry bug — the same treatment `read_projects_dir` got in
 /// #307, shared here so every fs call site classifies identically (issues
-/// #545, #605). Anything else stays a labeled `Io` for diagnosability.
+/// #545, #605, #625).
+///
+/// Two more environment shapes classify Expected here:
+/// - Windows `ERROR_ACCESS_DENIED` (os error 5, localized text — "Acceso
+///   denegado." on a Spanish install): typically the file being briefly
+///   locked by antivirus, another program, or cloud sync (issue #596).
+/// - A read-only filesystem (Unix EROFS os error 30 / Windows
+///   ERROR_WRITE_PROTECT os error 19): the volume itself refuses writes —
+///   e.g. a project opened off a read-only disk image or locked SD card
+///   (issue #625).
+///
+/// Anything else stays a labeled `Io` for diagnosability.
 pub fn classify_fs_error(
     action: &str,
     path: &std::path::Path,
@@ -530,6 +580,21 @@ pub fn classify_fs_error(
         crate::errors::CommandError::expected(format!(
             "Ship Studio isn't allowed to {action} ({}). Grant access in System Settings → \
              Privacy & Security → Files & Folders (or Full Disk Access), then try again.",
+            path.display()
+        ))
+    } else if cfg!(windows) && e.raw_os_error() == Some(5) {
+        crate::errors::CommandError::expected(format!(
+            "Ship Studio couldn't {action} ({}) — Windows denied access. The file may be \
+             briefly locked by antivirus, another program, or cloud sync (e.g. OneDrive). \
+             Try again in a moment.",
+            path.display()
+        ))
+    } else if (cfg!(unix) && e.raw_os_error() == Some(30))
+        || (cfg!(windows) && e.raw_os_error() == Some(19))
+    {
+        crate::errors::CommandError::expected(format!(
+            "Ship Studio couldn't {action} ({}) — the disk or volume is read-only. Move \
+             the project to a writable location, then try again.",
             path.display()
         ))
     } else {
@@ -1354,6 +1419,134 @@ mod tests {
                 }
                 other => panic!("expected Io, got {other:?}"),
             }
+        }
+
+        // The #596 shape: localized Windows ERROR_ACCESS_DENIED on an fs op
+        // ("Acceso denegado. (os error 5)") — matched by code, not text.
+        #[test]
+        #[cfg(windows)]
+        fn windows_access_denied_becomes_expected() {
+            let e = std::io::Error::from_raw_os_error(5);
+            let err = classify_fs_error(
+                "write project metadata",
+                std::path::Path::new("C:\\p\\.shipstudio\\project.json"),
+                &e,
+            );
+            assert!(
+                matches!(err, crate::errors::CommandError::Expected { .. }),
+                "got: {err:?}"
+            );
+            let msg = err.to_string();
+            assert!(msg.contains("denied access"), "got: {msg}");
+            assert!(msg.contains("project.json"), "got: {msg}");
+        }
+
+        // The #625 shape: EROFS on a project.json write (read-only volume).
+        #[test]
+        #[cfg(unix)]
+        fn read_only_filesystem_becomes_expected() {
+            let e = std::io::Error::from_raw_os_error(30);
+            let err = classify_fs_error(
+                "write project metadata",
+                std::path::Path::new("/p/.shipstudio/project.json"),
+                &e,
+            );
+            assert!(
+                matches!(err, crate::errors::CommandError::Expected { .. }),
+                "got: {err:?}"
+            );
+            let msg = err.to_string();
+            assert!(msg.contains("read-only"), "got: {msg}");
+            assert!(msg.contains("project.json"), "got: {msg}");
+        }
+
+        // Unix EPERM outside macOS (and any other permission error not
+        // covered by a specific branch) must stay a labeled Io — the TCC
+        // guidance would be wrong on Linux.
+        #[test]
+        #[cfg(all(unix, not(target_os = "macos")))]
+        fn linux_eperm_stays_labeled_io() {
+            let e = std::io::Error::from_raw_os_error(1);
+            let err = classify_fs_error(
+                "write project metadata",
+                std::path::Path::new("/p/.shipstudio/project.json"),
+                &e,
+            );
+            assert!(
+                matches!(err, crate::errors::CommandError::Io { .. }),
+                "got: {err:?}"
+            );
+        }
+    }
+
+    mod pnpm_home_dirs_tests {
+        use super::*;
+
+        #[test]
+        fn includes_pnpm_home_when_set() {
+            let home = std::path::Path::new(if cfg!(windows) {
+                "C:\\Users\\x"
+            } else {
+                "/Users/x"
+            });
+            let dirs = pnpm_home_dirs(home, Some("/custom/pnpm-home"));
+            assert_eq!(dirs.first().map(String::as_str), Some("/custom/pnpm-home"));
+            // Defaults still follow so a stale/empty PNPM_HOME doesn't hide them.
+            assert!(dirs.len() > 1);
+        }
+
+        #[test]
+        fn blank_pnpm_home_is_ignored() {
+            let home = std::path::Path::new(if cfg!(windows) {
+                "C:\\Users\\x"
+            } else {
+                "/Users/x"
+            });
+            let with_blank = pnpm_home_dirs(home, Some("  "));
+            let without = pnpm_home_dirs(home, None);
+            assert_eq!(with_blank, without);
+        }
+
+        #[test]
+        #[cfg(not(windows))]
+        fn unix_defaults_cover_macos_and_linux_locations() {
+            let dirs = pnpm_home_dirs(std::path::Path::new("/Users/x"), None);
+            assert!(
+                dirs.contains(&"/Users/x/Library/pnpm".to_string()),
+                "{dirs:?}"
+            );
+            assert!(
+                dirs.contains(&"/Users/x/.local/share/pnpm".to_string()),
+                "{dirs:?}"
+            );
+        }
+
+        #[test]
+        #[cfg(windows)]
+        fn windows_default_is_local_app_data_pnpm() {
+            let dirs = pnpm_home_dirs(std::path::Path::new("C:\\Users\\x"), None);
+            assert!(
+                dirs.contains(&"C:\\Users\\x\\AppData\\Local\\pnpm".to_string()),
+                "{dirs:?}"
+            );
+        }
+
+        // The #570 regression guard: the extended PATH handed to git (and thus
+        // to pre-commit hooks) must contain pnpm's self-managed install dirs.
+        #[test]
+        fn build_extended_path_includes_pnpm_dirs() {
+            let path = build_extended_path();
+            let expected = if cfg!(windows) {
+                "\\AppData\\Local\\pnpm"
+            } else if cfg!(target_os = "macos") {
+                "/Library/pnpm"
+            } else {
+                "/.local/share/pnpm"
+            };
+            assert!(
+                path.contains(expected),
+                "extended PATH missing pnpm dir: {path}"
+            );
         }
     }
 

--- a/src/components/branches/PublishBranchDropdown.tsx
+++ b/src/components/branches/PublishBranchDropdown.tsx
@@ -85,7 +85,8 @@ export function PublishBranchDropdown({
   excludeClickOutsideSelector,
 }: PublishBranchDropdownProps) {
   const { showToast } = useOptionalToast();
-  const onToast = (message: string, type?: 'success' | 'error') => showToast(message, type);
+  const onToast = (message: string, type?: 'success' | 'error' | 'info') =>
+    showToast(message, type);
   const [isOpen, setIsOpen] = useState(false);
   const [publishState, setPublishState] = useState<PublishState>({ status: 'idle' });
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -181,10 +182,25 @@ export function PublishBranchDropdown({
         errorType = 'auth_error';
       }
 
-      logger.error('Publish failed', { branch: currentBranch, errorType, message });
-      trackError('git_push', e, 'Workspace');
+      // push_rejected ("someone else pushed first") and merge_conflict are
+      // fully anticipated states with dedicated recovery UI (GitErrorHandler +
+      // the dropdown's own error panel) — the backend already classifies them
+      // Expected (#617). Keep them out of the reporting channels: logger.error
+      // and error toasts both auto-file bug reports (issue #643); mirror
+      // handlePullLatest's warn/info treatment of the pull-side equivalents.
+      const expectedFailure = errorType === 'push_rejected' || errorType === 'merge_conflict';
+      if (expectedFailure) {
+        logger.warn('Publish refused (expected state)', {
+          branch: currentBranch,
+          errorType,
+          message,
+        });
+      } else {
+        logger.error('Publish failed', { branch: currentBranch, errorType, message });
+        trackError('git_push', e, 'Workspace');
+      }
       setPublishState({ status: 'error', message, errorType });
-      onToast?.(`Push failed: ${message}`, 'error');
+      onToast?.(`Push failed: ${message}`, expectedFailure ? 'info' : 'error');
 
       // Notify parent about the error for GitErrorHandler
       if (onPublishError) {

--- a/src/components/branches/PullRequestsTab.tsx
+++ b/src/components/branches/PullRequestsTab.tsx
@@ -53,7 +53,8 @@ export function PullRequestsTab({
   onResolveConflicts,
 }: PullRequestsTabProps) {
   const { showToast } = useOptionalToast();
-  const onToast = (message: string, type?: 'success' | 'error') => showToast(message, type);
+  const onToast = (message: string, type?: 'success' | 'error' | 'info') =>
+    showToast(message, type);
 
   const fetchPrsFn = useCallback(async (path: string) => {
     try {
@@ -132,7 +133,10 @@ export function PullRequestsTab({
       // button does, instead of dumping gh's raw multi-line stderr into a
       // toast (issue #278).
       if (isMergeConflictError(e) && onResolveConflicts) {
-        onToast?.('This pull request has merge conflicts', 'error');
+        // Expected, by-design state with dedicated follow-up UI (the conflict
+        // resolver opens right below) — info toast, NOT 'error': error toasts
+        // auto-file bug reports and this isn't a bug (issue #632).
+        onToast?.('This pull request has merge conflicts', 'info');
         onResolveConflicts(headRef, baseRef);
       } else {
         onToast?.(`Failed to merge: ${formatCommandError(asCommandError(e))}`, 'error');

--- a/src/components/branches/WorktreeCreateModal.tsx
+++ b/src/components/branches/WorktreeCreateModal.tsx
@@ -16,7 +16,7 @@ import { Spinner } from '../primitives/Spinner';
 import { useModal } from '../../contexts/ModalContext';
 import { sanitizeBranchName, type BranchInfo } from '../../lib/branches';
 import { addWorktree, worktreeFolderName, type WorktreeInfo } from '../../lib/worktrees';
-import { asCommandError, formatCommandError } from '../../lib/errors';
+import { humanizeGitError } from '../../lib/errors';
 import { trackEvent, trackError } from '../../lib/analytics';
 import { basename } from '../../lib/paths';
 
@@ -95,7 +95,12 @@ function WorktreeCreateForm({
       onCreated(result.path);
     } catch (err) {
       void trackError('worktree_create_failed', err);
-      setError(formatCommandError(asCommandError(err)));
+      // Humanize known git refusals — most importantly "already used by
+      // worktree"/"already checked out", which slips past the stale-list
+      // guard above when the branch got checked out elsewhere after the
+      // worktree list was loaded (issue #635, same condition as #406).
+      // Falls back to the formatted raw error when nothing matches.
+      setError(humanizeGitError(err, { branch: effectiveBranch }));
       setIsCreating(false);
     }
   };

--- a/src/components/plugins/PluginManager.tsx
+++ b/src/components/plugins/PluginManager.tsx
@@ -107,6 +107,51 @@ export function PluginManager({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isOpen, onClose]);
 
+  // Plugins already background-checked for updates this modal-open, so a
+  // refetch (toggle, uninstall, …) doesn't re-hit the network per plugin.
+  const autoCheckedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (!isOpen) autoCheckedRef.current = new Set();
+  }, [isOpen]);
+
+  // Proactively check installed plugins for updates in the background
+  // (issue #572): fixed plugin releases otherwise never reach users who
+  // don't think to click "Check for update" on each plugin — a stale broken
+  // bundle (e.g. the Vercel plugin's POSIX-only `cat` on Windows) kept
+  // failing indefinitely. Failures are silent: this is a nicety, and an
+  // offline machine shouldn't toast or file reports over it.
+  const autoCheckUpdates = useCallback(
+    async (installed: PluginInfo[]) => {
+      if (!projectPath) return;
+      const candidates = installed.filter(
+        (p) => !p.is_dev && p.source_url && !autoCheckedRef.current.has(p.manifest.id)
+      );
+      await Promise.allSettled(
+        candidates.map(async (p) => {
+          autoCheckedRef.current.add(p.manifest.id);
+          try {
+            const result = await checkPluginUpdate(projectPath, p.manifest.id);
+            setUpdateStates((prev) => {
+              // Never clobber an in-flight manual action.
+              const current = prev[p.manifest.id];
+              if (current === 'updating' || current === 'checking') return prev;
+              return {
+                ...prev,
+                [p.manifest.id]: result.has_update ? 'available' : 'up_to_date',
+              };
+            });
+          } catch (err) {
+            logger.warn('Background plugin update check failed', {
+              plugin: p.manifest.id,
+              error: formatCommandError(asCommandError(err)),
+            });
+          }
+        })
+      );
+    },
+    [projectPath]
+  );
+
   // Fetch installed plugins when modal opens
   const fetchPlugins = useCallback(async () => {
     if (!projectPath) {
@@ -117,6 +162,7 @@ export function PluginManager({
     try {
       const result = await listPlugins(projectPath);
       setPlugins(result);
+      void autoCheckUpdates(result);
     } catch (err) {
       trackError('plugin_list_load', err, 'Plugin Manager');
       logger.error('Failed to load plugins', {
@@ -126,7 +172,7 @@ export function PluginManager({
     } finally {
       setIsLoading(false);
     }
-  }, [projectPath]);
+  }, [projectPath, autoCheckUpdates]);
 
   useEffect(() => {
     if (!isOpen) return;

--- a/src/components/plugins/PluginSlot.test.tsx
+++ b/src/components/plugins/PluginSlot.test.tsx
@@ -110,6 +110,32 @@ describe('buildContext failure reporting', () => {
     expect(showToast).not.toHaveBeenCalled();
   });
 
+  it('one-shots the project-folder-gone toast as info instead of erroring every poll (#629)', async () => {
+    mockIPC(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- deliberately a plain CommandError object, the shape under test
+      throw {
+        type: 'Other',
+        message:
+          "The folder '/p/gone' no longer exists — it may have been moved, renamed, or deleted outside Ship Studio",
+      };
+    });
+    const { actions, showToast } = makeActions();
+    const gone = { ...project, path: '/p/gone' };
+    const ctx = buildContext('vercel', 'Vercel', gone, actions, theme, []);
+
+    // First background call: one friendly info toast (Expected condition —
+    // must not go through the error-toast telemetry pipeline).
+    await expect(ctx.shell.exec('vercel', ['ls'])).rejects.toBeTruthy();
+    expect(showToast).toHaveBeenCalledTimes(1);
+    expect(showToast.mock.calls[0][0]).toContain('no longer exists');
+    expect(showToast.mock.calls[0][1]).toBe('info');
+
+    // Subsequent polls for the same project: suppressed entirely.
+    await expect(ctx.storage.read()).rejects.toBeTruthy();
+    await expect(ctx.shell.exec('vercel', ['ls'])).rejects.toBeTruthy();
+    expect(showToast).toHaveBeenCalledTimes(1);
+  });
+
   it('does not toast when the call succeeds', async () => {
     mockIPC((cmd) => {
       if (cmd === 'read_plugin_storage') return { key: 'value' };

--- a/src/components/plugins/PluginSlot.tsx
+++ b/src/components/plugins/PluginSlot.tsx
@@ -25,11 +25,21 @@ import {
   wasPluginUnloaded,
   unloadPluginModule,
 } from '../../lib/plugin-loader';
-import { asCommandError, formatCommandError } from '../../lib/errors';
+import { asCommandError, formatCommandError, isProjectFolderGoneError } from '../../lib/errors';
 import { logger } from '../../lib/logger';
 import { invoke } from '@tauri-apps/api/core';
 import { WarningIcon } from '../icons';
 import type { LoadedPlugin } from '../../hooks/usePlugins';
+
+/**
+ * Project paths whose root folder was detected missing mid-session (deleted,
+ * renamed, or moved outside Ship Studio). Session-scoped one-shot guard: the
+ * first plugin rejection for that project shows one info toast; a plugin that
+ * keeps polling in the background is then only warn-logged instead of
+ * toasting on every tick (issue #629 — same repeated-toast shape #315 fixed
+ * for a plugin's own folder disappearing).
+ */
+const projectGoneNotified = new Set<string>();
 
 interface PluginSlotProps {
   /** Slot name (e.g., "toolbar", "sidebar") */
@@ -195,6 +205,23 @@ export function buildContext(
         `Plugin "${pluginName}" was deactivated because its files are no longer on disk. Unlink or reinstall it from the Plugins menu.`,
         'error'
       );
+      throw e;
+    }
+    // The *project's* folder is gone (deleted/renamed/moved outside the app
+    // while its session stayed open) — an Expected environment change the
+    // backend deliberately keeps out of telemetry, and permanent for this
+    // path. One info toast per project, then only a local warn log, so a
+    // plugin polling on its own interval can't toast every tick (issue #629).
+    if (isProjectFolderGoneError(e)) {
+      if (projectGoneNotified.has(projectPath)) {
+        logger.warn(
+          `Plugin "${pluginId}" call rejected — project folder is gone; toast suppressed`,
+          { projectPath, error: message }
+        );
+      } else {
+        projectGoneNotified.add(projectPath);
+        actions.showToast(`Plugin "${pluginName}": ${message}`, 'info');
+      }
       throw e;
     }
     actions.showToast(`Plugin "${pluginName}": ${message}`, 'error');

--- a/src/components/terminal/BuildTerminal.tsx
+++ b/src/components/terminal/BuildTerminal.tsx
@@ -21,13 +21,13 @@ import { useEffect, useRef } from 'react';
 import { Terminal as XTerm } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
-import { WebglAddon } from '@xterm/addon-webgl';
+import { attachWebglRenderer } from '../../lib/terminalWebgl';
 import { createWebLinksAddon } from '../../lib/terminalLinks';
 import {
   openPtySession,
   attachPtySession,
   writePtySessionLogged,
-  resizePtySession,
+  resizePtySessionLogged,
   detachPtySession,
   onPtySessionData,
   onPtySessionExit,
@@ -136,17 +136,14 @@ export function BuildTerminal({
     });
 
     // GPU renderer, gated by the same user setting Terminal honors.
+    // attachWebglRenderer keeps the addon loaded only while the pane has
+    // layout — a zero-size/hidden pane made the glyph atlas throw from
+    // getImageData (issue #383).
     void (async () => {
       if (cancelled) return;
       const gpuEnabled = await getTerminalGpuEnabled();
       if (cancelled || !gpuEnabled) return;
-      try {
-        const webgl = new WebglAddon();
-        webgl.onContextLoss(() => webgl.dispose());
-        term.loadAddon(webgl);
-      } catch {
-        /* canvas fallback */
-      }
+      disposers.push(attachWebglRenderer(term, container));
     })();
 
     // Initial fit after layout settles; focus is owned by the isActive effect.
@@ -193,7 +190,7 @@ export function BuildTerminal({
         if (cancelled) return;
         // Layout may have settled while the open was in flight (those resize
         // callbacks were skipped) — sync the PTY to the current size once.
-        void resizePtySession(sessionId, Math.max(term.cols, 2), Math.max(term.rows, 2));
+        resizePtySessionLogged(sessionId, Math.max(term.cols, 2), Math.max(term.rows, 2));
 
         const gate = createAttachGate((bytes) => {
           term.write(bytes);
@@ -255,7 +252,7 @@ export function BuildTerminal({
       if (cancelled) return;
       safeFit();
       if (sessionOpened) {
-        void resizePtySession(sessionId, term.cols, term.rows);
+        resizePtySessionLogged(sessionId, term.cols, term.rows);
       }
     });
     resizeObserver.observe(container);

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -17,12 +17,12 @@ import { Terminal as XTerm } from '@xterm/xterm';
 import { createWebLinksAddon } from '../../lib/terminalLinks';
 import { FitAddon } from '@xterm/addon-fit';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
-import { WebglAddon } from '@xterm/addon-webgl';
+import { attachWebglRenderer } from '../../lib/terminalWebgl';
 import {
   openPtySession,
   attachPtySession,
   writePtySessionLogged,
-  resizePtySession,
+  resizePtySessionLogged,
   killPtySession,
   detachPtySession,
   onPtySessionData,
@@ -447,20 +447,20 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     // Use WebGL renderer for GPU-accelerated rendering (reduces flickering).
     // Gated by a user setting — some macOS beta / GPU-driver combinations render corrupted
     // glyphs through WebGL, so users can opt out via Settings → Preferences.
+    // attachWebglRenderer only keeps the addon loaded while the pane has
+    // layout — background panes stay mounted (and streaming) while zero-sized,
+    // which made the glyph atlas throw from getImageData (issue #383).
+    let disposeWebgl: (() => void) | null = null;
+    let webglTornDown = false;
     void (async () => {
       const gpuEnabled = await getTerminalGpuEnabled();
       if (!gpuEnabled) {
         logger.info('[Terminal] GPU rendering disabled by user, using canvas renderer');
         return;
       }
-      try {
-        const webglAddon = new WebglAddon();
-        webglAddon.onContextLoss(() => {
-          webglAddon.dispose();
-        });
-        term.loadAddon(webglAddon);
-      } catch {
-        logger.warn('[Terminal] WebGL not available, using canvas renderer');
+      // The effect can tear down while the settings read is in flight.
+      if (!webglTornDown) {
+        disposeWebgl = attachWebglRenderer(term, container);
       }
     })();
 
@@ -1225,7 +1225,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         if (fitAddonRef.current && terminalRef.current && ptyRef.current) {
           fitAddonRef.current.fit();
           const { sessionId } = ptyRef.current;
-          void resizePtySession(sessionId, terminalRef.current.cols, terminalRef.current.rows);
+          resizePtySessionLogged(sessionId, terminalRef.current.cols, terminalRef.current.rows);
         }
       });
     });
@@ -1233,6 +1233,8 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
 
     return () => {
       mounted = false;
+      webglTornDown = true;
+      disposeWebgl?.();
       resizeObserver.disconnect();
       if (resizeRaf) cancelAnimationFrame(resizeRaf);
       if (startupTimer) clearTimeout(startupTimer);
@@ -1300,7 +1302,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         if (fitAddonRef.current && terminalRef.current && ptyRef.current) {
           fitAddonRef.current.fit();
           const { sessionId } = ptyRef.current;
-          void resizePtySession(sessionId, terminalRef.current.cols, terminalRef.current.rows);
+          resizePtySessionLogged(sessionId, terminalRef.current.cols, terminalRef.current.rows);
         }
       },
     }),

--- a/src/contexts/PluginContext.tsx
+++ b/src/contexts/PluginContext.tsx
@@ -22,7 +22,7 @@ export interface PluginProjectData {
 
 /** App actions plugins can trigger */
 export interface PluginAppActions {
-  showToast: (message: string, type?: 'success' | 'error') => void;
+  showToast: (message: string, type?: 'success' | 'error' | 'info') => void;
   refreshGitStatus: () => void;
   refreshBranches: () => void;
   focusTerminal: () => void;

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -614,6 +614,10 @@ export function useDevServer(currentProjectPath: string | null) {
       // Shopify themes are exempt: `shopify theme dev` needs no npm install,
       // and a theme's optional package.json (Tailwind tooling, or one an
       // agent added) must not block the preview behind an install gate.
+      // Whether the project has a package.json at all — a framework detected
+      // via its config file alone can't run a dev script (issue #593).
+      // null = unknown (dependency check failed or was exempt).
+      let hasPackageJson: boolean | null = null;
       try {
         // Shopify themes and force-static projects don't need an npm install to
         // preview: the theme runs via `shopify theme dev`, and a force-static
@@ -622,6 +626,9 @@ export function useDevServer(currentProjectPath: string | null) {
           detectedType === 'shopifytheme' || forceStatic
             ? { installed: true, hasPackageJson: false }
             : await checkDependenciesInstalled(projectPath);
+        if (detectedType !== 'shopifytheme' && !forceStatic) {
+          hasPackageJson = depStatus.hasPackageJson;
+        }
         if (!depStatus.installed && depStatus.hasPackageJson) {
           const packageManager = await detectPackageManager(projectPath).catch((err) => {
             logger.warn(
@@ -775,6 +782,18 @@ export function useDevServer(currentProjectPath: string | null) {
         logger.info('[OpenProject] Unknown project type; skipping dev server', {
           projectPath,
         });
+      } else if (hasPackageJson === false && cwd === projectPath) {
+        // A framework detected from its config file alone (next.config.js /
+        // vite.config.ts / …) with no package.json: there's no dev script to
+        // run, so spawning `npm run dev` is doomed and produced a spurious
+        // "File not found: package.json" error in telemetry (issue #593).
+        // Mirrors the `unknown`-type skip above. Monorepo subpaths (cwd !==
+        // projectPath) are exempt: the root check doesn't reflect the
+        // workspace directory the server actually runs in.
+        logger.info(
+          '[OpenProject] Framework config found but no package.json; skipping dev server',
+          { projectPath, projectType: detectedType }
+        );
       } else {
         try {
           s.outputBuffer = '';

--- a/src/hooks/usePlugins.test.tsx
+++ b/src/hooks/usePlugins.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Tests for usePlugins' missing-bundle self-heal (issue #624).
+ *
+ * Plugins registered before the install-time bundle check (issue #381)
+ * can have a valid manifest but no dist/index.js. The hook must repair
+ * those by re-installing from source once, and — when repair isn't
+ * possible — surface an actionable failure instead of the raw path error
+ * (and without re-attempting the heal on every reload).
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { usePlugins } from './usePlugins';
+import type { PluginInfo } from '../lib/plugins';
+import type { PluginModule } from '../lib/plugin-loader';
+
+vi.mock('../lib/plugins', () => ({
+  listPlugins: vi.fn(),
+  updatePlugin: vi.fn(),
+}));
+
+vi.mock('../lib/plugin-loader', () => ({
+  loadPluginModule: vi.fn(),
+  unloadPluginModule: vi.fn(),
+}));
+
+import { listPlugins, updatePlugin } from '../lib/plugins';
+import { loadPluginModule } from '../lib/plugin-loader';
+
+const mockListPlugins = vi.mocked(listPlugins);
+const mockUpdatePlugin = vi.mocked(updatePlugin);
+const mockLoadPluginModule = vi.mocked(loadPluginModule);
+
+function makeInfo(overrides: Partial<PluginInfo> = {}): PluginInfo {
+  return {
+    manifest: {
+      id: 'dependency-checker',
+      name: 'Dependency Checker',
+      version: '1.0.0',
+      description: '',
+      slots: ['toolbar'],
+      author: '',
+      repository: '',
+      setup: [],
+      min_app_version: '',
+      icon: '',
+      required_commands: [],
+      api_version: 1,
+    },
+    enabled: true,
+    installed_at: 0,
+    source_url: 'https://github.com/ship-studio/plugin-dependency-checker',
+    is_dev: false,
+    local_path: '',
+    ...overrides,
+  };
+}
+
+const workingModule: PluginModule = { name: 'Dependency Checker', slots: {} };
+
+const missingBundleError = new Error(
+  'Plugin bundle not found: /p/.shipstudio/plugins/dependency-checker/dist/index.js'
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('usePlugins missing-bundle self-heal', () => {
+  it('re-installs from source and loads the plugin when the bundle is missing', async () => {
+    mockListPlugins.mockResolvedValue([makeInfo()]);
+    mockLoadPluginModule
+      .mockRejectedValueOnce(missingBundleError)
+      .mockResolvedValueOnce(workingModule);
+    mockUpdatePlugin.mockResolvedValue(makeInfo());
+
+    const { result } = renderHook(() => usePlugins('/projects/heal-success'));
+
+    await waitFor(() => expect(result.current.plugins).toHaveLength(1));
+    expect(mockUpdatePlugin).toHaveBeenCalledWith('/projects/heal-success', 'dependency-checker');
+    expect(result.current.failures).toHaveLength(0);
+  });
+
+  it('surfaces an actionable failure when the re-install also fails', async () => {
+    mockListPlugins.mockResolvedValue([makeInfo()]);
+    mockLoadPluginModule.mockRejectedValue(missingBundleError);
+    mockUpdatePlugin.mockRejectedValue(new Error('Git clone failed: no network'));
+
+    const { result } = renderHook(() => usePlugins('/projects/heal-failure'));
+
+    await waitFor(() => expect(result.current.failures).toHaveLength(1));
+    expect(result.current.plugins).toHaveLength(0);
+    expect(result.current.failures[0].reason).toContain('Uninstall and reinstall');
+    // The raw bundle path must not leak into the user-facing reason.
+    expect(result.current.failures[0].reason).not.toContain('dist/index.js');
+  });
+
+  it('does not retry the heal for the same plugin within a session', async () => {
+    mockListPlugins.mockResolvedValue([makeInfo()]);
+    mockLoadPluginModule.mockRejectedValue(missingBundleError);
+    mockUpdatePlugin.mockRejectedValue(new Error('Git clone failed'));
+
+    const { result } = renderHook(() => usePlugins('/projects/heal-once'));
+    await waitFor(() => expect(result.current.failures).toHaveLength(1));
+    expect(mockUpdatePlugin).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.reloadPlugins();
+    });
+    await waitFor(() => expect(result.current.failures).toHaveLength(1));
+    // Reload re-fails, but no second network re-install is attempted.
+    expect(mockUpdatePlugin).toHaveBeenCalledTimes(1);
+  });
+
+  it('never self-heals dev plugins', async () => {
+    mockListPlugins.mockResolvedValue([
+      makeInfo({ is_dev: true, local_path: '/dev/plugin', source_url: '' }),
+    ]);
+    mockLoadPluginModule.mockRejectedValue(missingBundleError);
+
+    const { result } = renderHook(() => usePlugins('/projects/dev-plugin'));
+
+    await waitFor(() => expect(result.current.failures).toHaveLength(1));
+    expect(mockUpdatePlugin).not.toHaveBeenCalled();
+  });
+
+  it('does not heal unrelated load failures', async () => {
+    mockListPlugins.mockResolvedValue([makeInfo()]);
+    mockLoadPluginModule.mockRejectedValue(new Error('Plugin must export a name'));
+
+    const { result } = renderHook(() => usePlugins('/projects/other-error'));
+
+    await waitFor(() => expect(result.current.failures).toHaveLength(1));
+    expect(mockUpdatePlugin).not.toHaveBeenCalled();
+    expect(result.current.failures[0].reason).toContain('Plugin must export a name');
+  });
+});

--- a/src/hooks/usePlugins.ts
+++ b/src/hooks/usePlugins.ts
@@ -13,13 +13,71 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { listPlugins, PluginInfo } from '../lib/plugins';
+import { listPlugins, updatePlugin, PluginInfo } from '../lib/plugins';
 import { loadPluginModule, unloadPluginModule, PluginModule } from '../lib/plugin-loader';
 import { asCommandError, formatCommandError } from '../lib/errors';
 import { logger } from '../lib/logger';
 
 /** API versions the host supports. Plugins with unsupported versions are skipped. */
 const SUPPORTED_API_VERSIONS = [0, 1];
+
+/**
+ * Plugins we already tried to self-heal this app session, keyed
+ * `projectPath:pluginId` — a failed heal must not retry (and re-clone) on
+ * every reload.
+ */
+const attemptedSelfHeals = new Set<string>();
+
+/** The load failure produced by a registry entry whose built bundle is gone. */
+function isMissingBundleError(message: string): boolean {
+  return message.includes('Plugin bundle not found');
+}
+
+/**
+ * Load a plugin's module, self-healing a missing bundle by re-installing from
+ * the plugin's source repository (issue #624).
+ *
+ * Installs made before the install-time bundle check existed (issue #381)
+ * could register a plugin with a valid manifest but no dist/index.js; nothing
+ * ever repaired those entries, so they failed identically on every session
+ * forever. One re-install from source (which now validates the bundle) fixes
+ * them for good. Tried at most once per plugin per session.
+ */
+async function loadModuleWithSelfHeal(
+  path: string,
+  info: PluginInfo,
+  onLifecycleError: (pluginName: string, error: unknown) => void
+): Promise<PluginModule> {
+  try {
+    return await loadPluginModule(path, info.manifest.id, onLifecycleError);
+  } catch (e) {
+    const message = formatCommandError(asCommandError(e));
+    const healKey = `${path}:${info.manifest.id}`;
+    const canHeal =
+      !info.is_dev &&
+      info.source_url &&
+      isMissingBundleError(message) &&
+      !attemptedSelfHeals.has(healKey);
+    if (!canHeal) {
+      throw e;
+    }
+    attemptedSelfHeals.add(healKey);
+    logger.warn('Plugin bundle missing; re-installing from source to self-heal', {
+      plugin: info.manifest.id,
+    });
+    try {
+      await updatePlugin(path, info.manifest.id);
+    } catch (healError) {
+      logger.warn('Plugin self-heal re-install failed', {
+        plugin: info.manifest.id,
+        error: formatCommandError(asCommandError(healError)),
+      });
+      // Surface the original missing-bundle state, not the update error.
+      throw e;
+    }
+    return await loadPluginModule(path, info.manifest.id, onLifecycleError);
+  }
+}
 
 /** A fully loaded plugin: manifest + JS module */
 export interface LoadedPlugin {
@@ -109,7 +167,7 @@ export function usePlugins(
 
         const results = await Promise.allSettled(
           compatible.map((info) =>
-            loadPluginModule(path, info.manifest.id, handleLifecycleError).then((module) => ({
+            loadModuleWithSelfHeal(path, info, handleLifecycleError).then((module) => ({
               info,
               module,
             }))
@@ -121,16 +179,35 @@ export function usePlugins(
             loaded.push(result.value);
           } else {
             const info = compatible[i];
+            const message = formatCommandError(asCommandError(result.reason));
+            if (isMissingBundleError(message)) {
+              // A missing bundle that survived the self-heal is a broken
+              // install the user has to redo — an expected machine state,
+              // not an app malfunction, so warn (no auto-filed report;
+              // issue #624) and tell them what to do instead of showing
+              // the raw path.
+              logger.warn('Plugin bundle missing after self-heal attempt', {
+                plugin: info.manifest.id,
+                error: message,
+              });
+              failed.push({
+                id: info.manifest.id,
+                name: info.manifest.name,
+                reason:
+                  'This plugin is missing its built files and could not be repaired automatically. Uninstall and reinstall it from the Plugin Manager.',
+              });
+              return;
+            }
             logger.error('Failed to load plugin', {
               plugin: info.manifest.id,
               // Mirror failed.push below — String() on a CommandError object
               // logs "[object Object]" (issue #408).
-              error: formatCommandError(asCommandError(result.reason)),
+              error: message,
             });
             failed.push({
               id: info.manifest.id,
               name: info.manifest.name,
-              reason: formatCommandError(asCommandError(result.reason)),
+              reason: message,
             });
           }
         });

--- a/src/hooks/useProjectLifecycle.test.ts
+++ b/src/hooks/useProjectLifecycle.test.ts
@@ -78,6 +78,7 @@ vi.mock('../lib/session', () => ({
   endProjectSession: vi.fn(() => null),
 }));
 
+import { invoke } from '@tauri-apps/api/core';
 import { registerExternalProject } from '../lib/external-projects';
 import { logger } from '../lib/logger';
 
@@ -174,5 +175,61 @@ describe('handleImportLocalFolder — expected-refusal routing (#518/#535)', () 
     expect(params.showToast).toHaveBeenCalledWith('I/O error: disk exploded', 'error');
     // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
     expect(logger.error as Fn).toHaveBeenCalled();
+  });
+});
+
+describe('handleSelectProject — folder-gone toast routing (#640)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /** Make ensure_external_project_registered reject; everything else resolves. */
+  function rejectRegistration(message: string) {
+    vi.mocked(invoke).mockImplementation((cmd: string) =>
+      cmd === 'ensure_external_project_registered'
+        ? // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- deliberately a plain CommandError object, the shape under test
+          Promise.reject({ type: 'Other', message })
+        : Promise.resolve(undefined)
+    );
+  }
+
+  it('shows the Expected "folder no longer exists" case as an info toast', async () => {
+    rejectRegistration(
+      "The folder '/x/legal-invoice' no longer exists — it may have been moved, renamed, or deleted outside Ship Studio"
+    );
+    const params = createParams();
+    const { result } = renderHook(() => useProjectLifecycle(params));
+
+    await act(async () => {
+      await result.current.handleSelectProject({
+        name: 'legal-invoice',
+        path: '/x/legal-invoice',
+        thumbnail: null,
+      });
+    });
+
+    const [message, type] = vi.mocked(params.showToast).mock.calls[0];
+    expect(message).toContain('its folder no longer exists');
+    expect(type).toBe('info');
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
+  });
+
+  it('keeps the unrecognized-location refusal as an error toast', async () => {
+    rejectRegistration('Invalid path in validate_project_path: /x/elsewhere');
+    const params = createParams();
+    const { result } = renderHook(() => useProjectLifecycle(params));
+
+    await act(async () => {
+      await result.current.handleSelectProject({
+        name: 'elsewhere',
+        path: '/x/elsewhere',
+        thumbnail: null,
+      });
+    });
+
+    const [message, type] = vi.mocked(params.showToast).mock.calls[0];
+    expect(message).toContain("isn't a recognized project location");
+    expect(type).toBe('error');
   });
 });

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -68,7 +68,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { logger } from '../lib/logger';
 import { trackEvent, trackError, setActiveProject } from '../lib/analytics';
 import { asCommandError, formatCommandError, isExpectedProjectImportRefusal } from '../lib/errors';
-import { extractTerminalError } from '../lib/terminalDiagnostics';
+import { describeExitStatus, extractTerminalError } from '../lib/terminalDiagnostics';
 import { getProjectId } from '../lib/projectIdentity';
 import { startProjectSession, endProjectSession } from '../lib/session';
 import { basename } from '../lib/paths';
@@ -806,10 +806,14 @@ export function useProjectLifecycle({
         error_detail: scrubbedDetail,
         $screen_name: 'Workspace',
       });
+      // describeExitStatus: abnormal Windows statuses (negative NTSTATUS /
+      // libuv codes, or their huge u32 wraps from older backends) render as
+      // hex instead of a nonsense number like 4294963238 (issue #622).
+      const exitDesc = describeExitStatus(exitCode);
       showToast(
         detail
-          ? `Install exited with code ${exitCode ?? 'null'}: ${detail} — check the terminal for the full output.`
-          : `Install exited with code ${exitCode ?? 'null'}. Check the terminal for details.`,
+          ? `Install exited with ${exitDesc}: ${detail} — check the terminal for the full output.`
+          : `Install exited with ${exitDesc}. Check the terminal for details.`,
         'error'
       );
       return; // keep overlay open so user can read stderr + close manually

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -321,10 +321,15 @@ export function useProjectLifecycle({
       // Distinguish "the folder is gone" (moved/renamed/deleted outside the
       // app — issue #365) from "the path isn't in an allowed location"; the
       // "re-add via Select Project Folder" advice only fits the latter.
-      const message = formatCommandError(asCommandError(e)).includes('no longer exists')
+      const folderGone = formatCommandError(asCommandError(e)).includes('no longer exists');
+      const message = folderGone
         ? `Can't open "${project.name}" — its folder no longer exists. It may have been moved, renamed, or deleted outside Ship Studio.`
         : `Can't open "${project.name}" — its folder isn't a recognized project location. Re-add it via "Select Project Folder".`;
-      showToast(message, 'error');
+      // A folder deleted/moved outside the app is a user-caused environment
+      // change the backend already classifies Expected — info toast, NOT
+      // 'error': error toasts auto-file bug reports (issue #640, same
+      // pattern as #535's import-refusal gating below).
+      showToast(message, folderGone ? 'info' : 'error');
       return;
     }
 

--- a/src/hooks/useProjectRemovalActions.ts
+++ b/src/hooks/useProjectRemovalActions.ts
@@ -48,7 +48,7 @@ export function useProjectRemovalActions({
     } catch (unpinError) {
       trackError(`project_unpin_after_${action}`, unpinError, 'Dashboard');
       logger.error(`Failed to unpin project after ${action}`, {
-        error: unpinError instanceof Error ? unpinError.message : String(unpinError),
+        error: formatCommandError(asCommandError(unpinError)),
       });
     }
   };
@@ -64,8 +64,11 @@ export function useProjectRemovalActions({
       await loadAll();
     } catch (error) {
       trackError('project_delete', error, 'Dashboard');
+      // CommandError rejections are plain tagged objects, not Error instances —
+      // String(error) renders them as "[object Object]" (issue #633). Format
+      // them the same way the user-facing alert below already does.
       logger.error('Failed to delete project', {
-        error: error instanceof Error ? error.message : String(error),
+        error: formatCommandError(asCommandError(error)),
       });
       alert('Failed to delete project: ' + formatCommandError(asCommandError(error)));
     } finally {
@@ -89,7 +92,7 @@ export function useProjectRemovalActions({
     } catch (error) {
       trackError('project_remove_from_app', error, 'Dashboard');
       logger.error('Failed to remove project from Ship Studio', {
-        error: error instanceof Error ? error.message : String(error),
+        error: formatCommandError(asCommandError(error)),
       });
       showToast(`Failed to remove project: ${formatCommandError(asCommandError(error))}`, 'error');
     } finally {

--- a/src/lib/branches.test.ts
+++ b/src/lib/branches.test.ts
@@ -71,4 +71,35 @@ describe('sanitizeBranchName', () => {
   it('handles the issue #166 repro', () => {
     expect(sanitizeBranchName('adjust h2')).toBe('adjust-h2');
   });
+
+  // Issue #636: free-text-derived names blew past GitHub's 255-byte ref limit
+  // (GH005) and the push failure was misreported as a push race.
+  describe('length cap', () => {
+    it('caps long names at 120 bytes without leaving trailing junk', () => {
+      const longInput =
+        'Facebook did not provide video data. Open Facebook in the selected browser (chrome), ' +
+        'sign in, and confirm this video plays there, then retry. The video may also be private, ' +
+        'age restricted, deleted, or unavailable in this account/region';
+      const result = sanitizeBranchName(longInput);
+      expect(new TextEncoder().encode(result).length).toBeLessThanOrEqual(120);
+      expect(result.length).toBeGreaterThan(0);
+      // No trailing separator left at the cut point.
+      expect(result).not.toMatch(/[-/.]$/);
+    });
+
+    it('leaves names at or under the cap untouched', () => {
+      const exact = 'a'.repeat(120);
+      expect(sanitizeBranchName(exact)).toBe(exact);
+    });
+
+    it('counts bytes, not characters, and never splits a multi-byte character', () => {
+      // é is 2 bytes in UTF-8 → 100 chars = 200 bytes, over the cap.
+      const result = sanitizeBranchName('é'.repeat(100));
+      const bytes = new TextEncoder().encode(result).length;
+      expect(bytes).toBeLessThanOrEqual(120);
+      // Round-trips cleanly — no U+FFFD from a half-cut sequence.
+      expect(result).not.toContain('�');
+      expect(result).toBe('é'.repeat(result.length));
+    });
+  });
 });

--- a/src/lib/branches.ts
+++ b/src/lib/branches.ts
@@ -139,6 +139,17 @@ export async function discardChanges(projectPath: string): Promise<void> {
 }
 
 /**
+ * Byte cap for sanitized branch names. GitHub rejects refs longer than 255
+ * bytes (`GH005: Sorry, refs longer than 255 bytes are not allowed.`), and the
+ * limit applies to the full `refs/heads/<name>` string — auto-generated names
+ * derived from free text (task/issue descriptions) blew past it and the push
+ * failure was misreported as a push race (issue #636). 120 leaves generous
+ * headroom for the `refs/heads/` prefix and any `user/`-style namespacing a
+ * caller prepends.
+ */
+const MAX_BRANCH_NAME_BYTES = 120;
+
+/**
  * Sanitize user input into a valid git branch name.
  *
  * Rather than rejecting names like "adjust h2", we normalize them into
@@ -148,6 +159,8 @@ export async function discardChanges(projectPath: string): Promise<void> {
  * - collapses `..` runs into a single `.`
  * - collapses repeated `-` / `/`
  * - strips leading `-`, `/` and `.`, trailing `/` and `.`, and a trailing `.lock`
+ * - caps the result at {@link MAX_BRANCH_NAME_BYTES} bytes (GitHub's ref limit
+ *   is 255 bytes; free-text-derived names could exceed it — issue #636)
  *
  * An input with nothing salvageable returns an empty string — callers must
  * treat that the same as an empty input.
@@ -166,12 +179,21 @@ export function sanitizeBranchName(name: string): string {
     .replace(/-+/g, '-') // collapse repeated dashes
     .replace(/\/+/g, '/'); // collapse repeated slashes
 
+  // Cap the byte length (git ref limits are in bytes, not characters).
+  // Truncate on the encoded bytes, then drop any replacement character left
+  // by cutting a multi-byte sequence in half.
+  if (new TextEncoder().encode(sanitized).length > MAX_BRANCH_NAME_BYTES) {
+    const bytes = new TextEncoder().encode(sanitized).slice(0, MAX_BRANCH_NAME_BYTES);
+    sanitized = new TextDecoder().decode(bytes).replace(/�+$/, '');
+  }
+
   // Stripping one thing can expose another (e.g. "name..lock" → "name.lock"
-  // → "name"), so repeat until stable.
+  // → "name"), so repeat until stable. Also tidies whatever the byte cap cut
+  // mid-word (a trailing `-`/`/`/`.` left at the cut point).
   for (;;) {
     const next = sanitized
       .replace(/^[-/.]+/, '') // leading dashes/slashes/dots (git rejects leading "-")
-      .replace(/[/.]+$/, '') // trailing slashes/dots
+      .replace(/[-/.]+$/, '') // trailing dashes/slashes/dots
       .replace(/\.lock$/, ''); // git refuses refs ending in ".lock"
     if (next === sanitized) break;
     sanitized = next;

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -131,6 +131,37 @@ describe('friendlyProcessError', () => {
     expect(describeProcessError('npm ERR! code E401').expected).toBe(true);
   });
 
+  it('maps HTTPS credential-prompt failures to gh auth guidance (issue #637)', () => {
+    const raw =
+      "Process exited with code 1\n\nCloning into 'ogeh-ai-website'...\nfatal: could not read Password for 'https://user@github.com': Device not configured\nfailed to run git: exit status 128";
+    const info = describeProcessError(raw);
+    expect(info.expected).toBe(true);
+    expect(info.message).toContain('gh auth login');
+    expect(info.message).not.toContain('Cloning into');
+    // The Username variant (and GIT_TERMINAL_PROMPT=0's wording) match too.
+    expect(
+      describeProcessError(
+        "fatal: could not read Username for 'https://github.com': terminal prompts disabled"
+      ).expected
+    ).toBe(true);
+  });
+
+  it('maps GitHub API 5xx responses to a friendly retry message (issue #620)', () => {
+    const raw =
+      'Process exited with code 1\n\nHTTP 504: We couldn’t respond to your request in time. Sorry about that. Please try resubmitting your request and contact us if the problem persists. (https://api.github.com/graphql)';
+    const info = describeProcessError(raw);
+    expect(info.expected).toBe(true);
+    expect(info.message).toMatch(/temporarily unavailable/i);
+    // The terse variant classifies too.
+    expect(
+      describeProcessError('HTTP 504: 504 Gateway Timeout (https://api.github.com/graphql)')
+        .expected
+    ).toBe(true);
+    expect(describeProcessError('HTTP 502: Bad Gateway (https://api.github.com)').expected).toBe(
+      true
+    );
+  });
+
   it('classifies recognized shapes as expected and unknown ones as not', () => {
     expect(describeProcessError('sh: pnpm: command not found').expected).toBe(true);
     expect(describeProcessError('Process exited with code 128').expected).toBe(true);
@@ -225,6 +256,24 @@ describe('humanizeGitError', () => {
       // Newer git wording for the same refusal.
       raw: "fatal: 'feat/x' is already checked out at '/Users/x/proj/.claude/worktrees/feat-x'",
       expect: /already checked out in another worktree/i,
+    },
+    {
+      // gh failing before any subcommand because its own config file is
+      // unreadable — a local file-permissions problem, NOT a sign-in failure;
+      // must not fall into the generic "permission denied" auth branch
+      // (issue #631).
+      raw: 'warning: failed to load config: open /Users/x/.config/gh/config.yml: permission denied\nfailed to create root command: failed to read configuration: open /Users/x/.config/gh/config.yml: permission denied',
+      expect: /can't read its own settings.*chown/is,
+    },
+    {
+      // Go's bare net/http "EOF" — connection closed before any response byte
+      // (issue #642; the "unexpected EOF" variant was #434).
+      raw: 'Post "https://api.github.com/graphql": EOF',
+      expect: /couldn't reach GitHub/i,
+    },
+    {
+      raw: 'Post "https://api.github.com/graphql": unexpected EOF',
+      expect: /couldn't reach GitHub/i,
     },
     {
       raw: "error: pathspec 'feat/gone' did not match any file(s) known to git",

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -8,6 +8,7 @@ import {
   isAgentNotInstalledError,
   isExpectedProjectImportRefusal,
   isMergeConflictError,
+  isProjectFolderGoneError,
   isRecognizedGitFailure,
   type CommandError,
 } from './errors';
@@ -319,5 +320,32 @@ describe('isAgentNotInstalledError', () => {
   it('does not match other failures', () => {
     expect(isAgentNotInstalledError('Failed to add MCP server: connection refused')).toBe(false);
     expect(isAgentNotInstalledError(new Error('spawn ENOENT'))).toBe(false);
+  });
+});
+
+describe('isProjectFolderGoneError', () => {
+  it("matches canonicalize_tagged's folder-gone message (#365/#629)", () => {
+    expect(
+      isProjectFolderGoneError({
+        type: 'Other',
+        message:
+          "The folder '/Users/me/ShipStudio/demo' no longer exists — it may have been moved, renamed, or deleted outside Ship Studio",
+      })
+    ).toBe(true);
+  });
+
+  it("matches validate_project_path's invalid-path rejection", () => {
+    expect(
+      isProjectFolderGoneError('Invalid path in validate_project_path: /Users/me/ShipStudio/demo')
+    ).toBe(true);
+  });
+
+  it('does not match a branch-gone message or unrelated failures', () => {
+    // humanizeGitError's missing-ref wording also says "no longer exists" —
+    // the helper must key on the backend's fuller folder-gone phrase.
+    expect(
+      isProjectFolderGoneError('feature/x no longer exists. It may have been deleted or renamed.')
+    ).toBe(false);
+    expect(isProjectFolderGoneError(new Error('connection refused'))).toBe(false);
   });
 });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -222,6 +222,23 @@ export function isAgentNotInstalledError(value: unknown): boolean {
 }
 
 /**
+ * True when a caught backend error means a project's root folder is gone —
+ * deleted, renamed, or moved outside Ship Studio while its session stayed
+ * open. The backend classifies this `CommandError::expected` (see
+ * `canonicalize_tagged` in `src-tauri/src/utils.rs`, issues #365/#372), but
+ * Expected serializes identically to Other across IPC, so callers re-check
+ * the message shape. Permanent for that path — retrying can never succeed,
+ * so callers should stop polling / suppress repeat surfacing (issue #629).
+ */
+export function isProjectFolderGoneError(value: unknown): boolean {
+  const message = formatCommandError(asCommandError(value));
+  return (
+    message.includes('no longer exists — it may have been moved') ||
+    message.includes('Invalid path in validate_project_path')
+  );
+}
+
+/**
  * Exit-code → actionable-message mappings shared by the PTY-driven flows
  * (project creation, GitHub import) that run `git clone` / package installs.
  */

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -101,6 +101,19 @@ export function humanizeGitError(value: unknown, ctx: GitErrorContext = {}): str
     return `There are newer changes on GitHub than you have locally. Pull the latest changes first, then try again.`;
   }
 
+  // The gh CLI can't read its own config file — a local file-permissions
+  // problem (e.g. a prior sudo run left ~/.config/gh root-owned), not a
+  // GitHub sign-in failure. Must be checked BEFORE the generic "permission
+  // denied" auth branch below, which would send the user to "reconnect
+  // GitHub" — advice that can't fix a file the OS won't let gh read
+  // (issue #631).
+  if (
+    (m.includes('failed to read configuration') || m.includes('failed to load config')) &&
+    m.includes('permission denied')
+  ) {
+    return `The GitHub CLI (gh) can't read its own settings because of a file-permissions problem on this computer — this isn't a GitHub sign-in issue. Open a terminal and run \`sudo chown -R $(whoami) ~/.config/gh\`, then try again.`;
+  }
+
   // GitHub wouldn't authenticate. GitHub's no-write-access rejection reads
   // "Permission to <owner>/<repo>.git denied to <user>." — the words are split
   // by the repo name, so it needs the two-part check (issue #321).
@@ -128,7 +141,13 @@ export function humanizeGitError(value: unknown, ctx: GitErrorContext = {}): str
     m.includes('dial tcp') ||
     m.includes('connectex') ||
     m.includes('timed out') ||
-    m.includes('timeout')
+    m.includes('timeout') ||
+    // Go's net/http closing the connection mid-request. The bare `…: EOF`
+    // variant needs the end-of-line anchor — a naked "eof" substring would
+    // false-positive on ordinary words like "thereof" (issues #434/#642,
+    // mirroring gh_network_error in src-tauri/src/commands/github.rs).
+    m.includes('unexpected eof') ||
+    /:\s*eof\s*$/m.test(m)
   ) {
     return `Couldn't reach GitHub. Check your internet connection and try again.`;
   }
@@ -278,6 +297,39 @@ export function describeProcessError(
       expected: true,
       message:
         "GitHub couldn't authenticate this computer over SSH, so the repository couldn't be reached. Either set up an SSH key for your GitHub account (github.com/settings/keys), or switch to HTTPS by running `gh config set git_protocol https` in a terminal, then try again.",
+    };
+  }
+  // Git-over-HTTPS credential failure: no usable credential helper, so git
+  // fell back to an interactive username/password prompt — which a GUI-spawned
+  // process can't answer ("Device not configured" / "terminal prompts
+  // disabled"). The HTTPS counterpart of the SSH branch above: a
+  // user-credential-setup state, not an app bug (issue #637).
+  if (
+    lower.includes('could not read username for') ||
+    lower.includes('could not read password for')
+  ) {
+    return {
+      expected: true,
+      message:
+        "GitHub couldn't authenticate this computer over HTTPS — git needed to ask for a password, and there's no saved credential to use. Open a terminal and run `gh auth login`, then `gh auth setup-git`, and try again.",
+    };
+  }
+  // GitHub's own API returning a transient 5xx (e.g. "HTTP 504: We couldn't
+  // respond to your request in time…" from api.github.com/graphql during
+  // `gh repo clone`). gh exits with the generic code 1, so only the wording
+  // identifies it — a GitHub-side blip with a built-in retry suggestion, not
+  // an app bug (issue #620).
+  if (
+    /http 5\d\d/.test(lower) ||
+    lower.includes('respond to your request in time') ||
+    lower.includes('gateway timeout') ||
+    lower.includes('service unavailable') ||
+    lower.includes('bad gateway')
+  ) {
+    return {
+      expected: true,
+      message:
+        "GitHub's API is temporarily unavailable — this happens during brief GitHub outages. Wait a moment and try again.",
     };
   }
   // npm registry auth failure (E401). npm exits with the generic code 1, so

--- a/src/lib/project.test.ts
+++ b/src/lib/project.test.ts
@@ -477,3 +477,39 @@ describe('lib/project', () => {
     });
   });
 });
+
+// Imported separately: hasMergeConflictMarkers is a pure helper, no IPC.
+import { hasMergeConflictMarkers } from './project';
+
+describe('hasMergeConflictMarkers', () => {
+  // The #577 shape: a merge conflict left in package.json makes it start
+  // with '<' and JSON.parse fails with "Unrecognized token '<'".
+  it('detects a standard conflict block', () => {
+    const conflicted = [
+      '{',
+      '<<<<<<< HEAD',
+      '  "name": "app",',
+      '=======',
+      '  "name": "my-app",',
+      '>>>>>>> feature/rename',
+      '}',
+    ].join('\n');
+    expect(hasMergeConflictMarkers(conflicted)).toBe(true);
+  });
+
+  it('detects a marker with CRLF line endings and a bare marker line', () => {
+    expect(hasMergeConflictMarkers('{\r\n<<<<<<< HEAD\r\n}\r\n')).toBe(true);
+    expect(hasMergeConflictMarkers('{\n<<<<<<<\n}\n')).toBe(true);
+  });
+
+  it('does not fire on valid package.json content', () => {
+    expect(hasMergeConflictMarkers('{ "scripts": { "dev": "vite" } }')).toBe(false);
+    expect(hasMergeConflictMarkers('')).toBe(false);
+  });
+
+  it('does not fire on < characters that are not line-leading markers', () => {
+    // e.g. a description containing arrows, or fewer than seven '<'.
+    expect(hasMergeConflictMarkers('{ "description": "a <<<<<<< b" }')).toBe(false);
+    expect(hasMergeConflictMarkers('<<< not a marker\n')).toBe(false);
+  });
+});

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -306,6 +306,17 @@ export async function getSystemEnv(): Promise<Record<string, string>> {
 }
 
 /**
+ * True when file content contains an unresolved git merge-conflict marker
+ * (a line starting with `<<<<<<<`). Used to explain a package.json that
+ * fails to parse because a merge conflict was left in it (issue #577) —
+ * git's conflict markers are the overwhelmingly common way a JSON file
+ * comes to start with `<`.
+ */
+export function hasMergeConflictMarkers(content: string): boolean {
+  return /^<{7}( |\r?$)/m.test(content);
+}
+
+/**
  * Start the development server for a project.
  * Intelligently handles different frameworks (Vite, Next.js, etc.)
  * by parsing the dev script and ensuring the correct port is used.
@@ -357,44 +368,70 @@ export async function startDevServer(
       // /Applications/XAMPP lost dev-script parsing (issue #264). It also
       // sidesteps Windows mixed-separator concatenation (issue #257).
       const file = await readProjectFile(projectPath, 'package.json');
-      const pkg = JSON.parse(file.content) as { scripts?: { dev?: string } };
-      const devScript = pkg.scripts?.dev;
-
-      if (devScript) {
-        // Parse the dev script and replace any hardcoded port with our desired port
-        // Use npx to run the command so local binaries are found
-        // Returns null if the script contains shell syntax (&&, ||, |, ;, or env vars)
-        const npxArgs = parseDevScriptForNpx(devScript, port);
-        if (npxArgs) {
-          command = 'npx';
-          args = npxArgs;
-          logger.info('[DevServer] Parsed dev script successfully', {
-            original: devScript,
-            command,
-            args: args.join(' '),
-            port,
-          });
-        } else {
-          // Script has shell syntax - use npm run dev which respects the PORT env var
-          logger.info('[DevServer] Using npm run dev for shell script', {
-            original: devScript,
-            port,
-          });
-        }
+      if (hasMergeConflictMarkers(file.content)) {
+        // An unresolved git merge conflict in package.json: JSON.parse would
+        // throw "Unrecognized token '<'" and telemetry recorded an app bug
+        // for what is a user-actionable repo state (issue #577). Surface the
+        // real cause in the dev-server log instead — the npm fallback below
+        // still spawns (and prints npm's own EJSONPARSE), so the user sees
+        // both messages where they're looking.
+        logger.warn(
+          '[DevServer] package.json contains unresolved merge conflict markers; falling back to npm run dev',
+          { projectPath }
+        );
+        onOutput?.(
+          '[Ship Studio] package.json has an unresolved merge conflict — resolve it (Branches → Resolve conflicts) and restart the dev server.\r\n'
+        );
       } else {
-        logger.warn('[DevServer] No dev script found in package.json, using npm run dev');
+        const pkg = JSON.parse(file.content) as { scripts?: { dev?: string } };
+        const devScript = pkg.scripts?.dev;
+
+        if (devScript) {
+          // Parse the dev script and replace any hardcoded port with our desired port
+          // Use npx to run the command so local binaries are found
+          // Returns null if the script contains shell syntax (&&, ||, |, ;, or env vars)
+          const npxArgs = parseDevScriptForNpx(devScript, port);
+          if (npxArgs) {
+            command = 'npx';
+            args = npxArgs;
+            logger.info('[DevServer] Parsed dev script successfully', {
+              original: devScript,
+              command,
+              args: args.join(' '),
+              port,
+            });
+          } else {
+            // Script has shell syntax - use npm run dev which respects the PORT env var
+            logger.info('[DevServer] Using npm run dev for shell script', {
+              original: devScript,
+              port,
+            });
+          }
+        } else {
+          logger.warn('[DevServer] No dev script found in package.json, using npm run dev');
+        }
       }
     } catch (e) {
       // Fall back to npm run dev with port forwarded via -- --port
       // (e.g. package.json genuinely missing, or not valid JSON)
-      trackError('devserver_package_json', e, 'Workspace');
       // CommandError rejections are plain objects — String() renders them as
       // "[object Object]" (issue #332); format them like the toasts do.
       const errorMessage = formatCommandError(asCommandError(e));
-      logger.error('[DevServer] Failed to read/parse package.json, falling back to npm run dev', {
-        error: errorMessage,
-        projectPath,
-      });
+      if (errorMessage.includes('File not found: package.json')) {
+        // A project with no package.json at all (framework detected from its
+        // config file alone) is a known project state, not an app bug —
+        // useDevServer skips the spawn for the common case (issue #593), and
+        // remaining paths (restarts, monorepo cwd) must not page telemetry.
+        logger.warn('[DevServer] No package.json found; falling back to npm run dev', {
+          projectPath,
+        });
+      } else {
+        trackError('devserver_package_json', e, 'Workspace');
+        logger.error('[DevServer] Failed to read/parse package.json, falling back to npm run dev', {
+          error: errorMessage,
+          projectPath,
+        });
+      }
     }
   }
 

--- a/src/lib/ptySession.test.ts
+++ b/src/lib/ptySession.test.ts
@@ -8,7 +8,9 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { createAttachGate } from './ptySession';
+import { mockIPC } from '@tauri-apps/api/mocks';
+import { createAttachGate, resizePtySessionLogged } from './ptySession';
+import { logger } from './logger';
 
 const bytes = (s: string): Uint8Array => new TextEncoder().encode(s);
 const text = (b: Uint8Array): string => new TextDecoder().decode(b);
@@ -91,5 +93,43 @@ describe('createAttachGate', () => {
     expect(delivered).toEqual(['a']);
     gate.push(1, bytes('b'));
     expect(delivered).toEqual(['a', 'b']);
+  });
+});
+
+describe('resizePtySessionLogged (#646)', () => {
+  it('swallows a resize-vs-exit race and warn-logs it instead of rejecting unhandled', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    // The backend's Expected classification for a resize that raced the PTY
+    // exiting — previously became a genuine unhandled promise rejection that
+    // the global handler auto-reported as a bug.
+    mockIPC(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- deliberately a plain CommandError object, the shape under test
+      throw { type: 'Other', message: 'terminal session has ended' };
+    });
+
+    resizePtySessionLogged('sess-1', 80, 24);
+
+    await vi.waitFor(() => {
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+    const [message, context] = warnSpy.mock.calls[0] as [string, Record<string, unknown>];
+    expect(message).toContain('resize failed');
+    expect(context).toMatchObject({
+      sessionId: 'sess-1',
+      cols: 80,
+      rows: 24,
+      error: 'terminal session has ended',
+    });
+  });
+
+  it('does not log when the resize succeeds', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    mockIPC(() => undefined);
+
+    resizePtySessionLogged('sess-2', 100, 40);
+
+    // Flush the fire-and-forget promise chain.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/ptySession.ts
+++ b/src/lib/ptySession.ts
@@ -112,13 +112,32 @@ export function writePtySessionLogged(sessionId: string, data: string): void {
   });
 }
 
-/** Resize the PTY backing a session. */
+/** Resize the PTY backing a session. Rejects on failure — fire-and-forget
+ *  layout paths (ResizeObserver ticks, pane switches) should use
+ *  {@link resizePtySessionLogged} instead. */
 export async function resizePtySession(
   sessionId: string,
   cols: number,
   rows: number
 ): Promise<void> {
   await invoke('pty_session_resize', { sessionId, cols, rows });
+}
+
+/** Fire-and-forget variant of {@link resizePtySession} for paths where
+ *  nothing awaits the resize. A resize can race the PTY exiting ("terminal
+ *  session has ended" — Expected on the backend); a bare `void` call turns
+ *  that benign race into an unhandled rejection that the global handler
+ *  auto-reports as a bug (issue #646). Mirror of writePtySessionLogged:
+ *  log at warn, never toast. */
+export function resizePtySessionLogged(sessionId: string, cols: number, rows: number): void {
+  resizePtySession(sessionId, cols, rows).catch((err: unknown) => {
+    logger.warn('[ptySession] resize failed — ignored', {
+      sessionId,
+      cols,
+      rows,
+      error: formatCommandError(asCommandError(err)),
+    });
+  });
 }
 
 /** Kill a session's PTY and drop its registry entry. Idempotent. */

--- a/src/lib/terminalDiagnostics.test.ts
+++ b/src/lib/terminalDiagnostics.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   createPtyChunkDecoder,
+  describeExitStatus,
   detectAlreadyLoggedIn,
   extractTerminalError,
   isNetworkError,
@@ -224,5 +225,30 @@ describe('detectAlreadyLoggedIn', () => {
     expect(detectAlreadyLoggedIn('You are not logged in. Run /login to sign in.\n')).toBeNull();
     expect(detectAlreadyLoggedIn('error: OAuth token exchange failed\n')).toBeNull();
     expect(detectAlreadyLoggedIn('')).toBeNull();
+  });
+});
+
+describe('describeExitStatus', () => {
+  it('renders ordinary exit codes as "code N"', () => {
+    expect(describeExitStatus(0)).toBe('code 0');
+    expect(describeExitStatus(1)).toBe('code 1');
+    expect(describeExitStatus(127)).toBe('code 127');
+    expect(describeExitStatus(3010)).toBe('code 3010'); // Windows reboot-required
+  });
+
+  it('renders null (killed mid-run) as "code null"', () => {
+    expect(describeExitStatus(null)).toBe('code null');
+  });
+
+  // The #622 shape: a raw u32-wrapped negative status from older backends.
+  it('renders huge u32-wrapped Windows statuses as hex', () => {
+    expect(describeExitStatus(4294963238)).toBe('status 0xFFFFF026'); // -4058 = UV_ENOENT
+    expect(describeExitStatus(3221225477)).toBe('status 0xC0000005'); // ACCESS_VIOLATION
+  });
+
+  // The post-fix backend shape: the same statuses arriving as signed i32.
+  it('renders negative signed statuses as the same hex', () => {
+    expect(describeExitStatus(-4058)).toBe('status 0xFFFFF026');
+    expect(describeExitStatus(-1073741819)).toBe('status 0xC0000005');
   });
 });

--- a/src/lib/terminalDiagnostics.ts
+++ b/src/lib/terminalDiagnostics.ts
@@ -174,3 +174,25 @@ export function detectAlreadyLoggedIn(tail: string): { identity: string | null }
   }
   return ALREADY_LOGGED_IN_PATTERN.test(text) ? { identity: null } : null;
 }
+
+/**
+ * Describe a PTY exit code for a failure message.
+ *
+ * Normal exits stay the familiar "code N". Abnormal Windows terminations
+ * arrive as full 32-bit statuses — a negative NTSTATUS or node's negative
+ * libuv errno (e.g. -4058 = UV_ENOENT), historically wrapped to a huge u32
+ * like 4294963238 by the PTY plugin — and interpolating those raw made the
+ * failure toast look broken (issue #622). Both the negative (current backend)
+ * and wrapped-u32 (older backend) shapes render as the status in hex, which
+ * is how such codes are documented and searchable.
+ */
+export function describeExitStatus(exitCode: number | null): string {
+  if (exitCode === null) return 'code null';
+  // Plausible ordinary exit codes (0-255 everywhere; Windows tools also use
+  // small positive codes like 3221225477's little siblings — anything beyond
+  // 0xFFFF is not a code a CLI returns deliberately).
+  if (exitCode >= 0 && exitCode <= 0xffff) return `code ${exitCode}`;
+  // Reinterpret as an unsigned 32-bit status and render as hex.
+  const u32 = exitCode < 0 ? exitCode + 0x1_0000_0000 : exitCode;
+  return `status 0x${u32.toString(16).toUpperCase().padStart(8, '0')}`;
+}

--- a/src/lib/terminalWebgl.test.ts
+++ b/src/lib/terminalWebgl.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the guarded WebGL renderer loader (issue #383).
+ *
+ * The addon must only be loaded while the container has non-zero layout —
+ * a zero-size/hidden pane makes the addon's glyph atlas throw an uncaught
+ * InvalidStateError from getImageData, which telemetry auto-reports.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Terminal } from '@xterm/xterm';
+
+const { addonInstances } = vi.hoisted(() => ({
+  addonInstances: [] as Array<{
+    dispose: ReturnType<typeof vi.fn>;
+    onContextLoss: ReturnType<typeof vi.fn>;
+  }>,
+}));
+
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: class {
+    dispose = vi.fn();
+    onContextLoss = vi.fn();
+    constructor() {
+      addonInstances.push(this as unknown as (typeof addonInstances)[number]);
+    }
+  },
+}));
+
+import { attachWebglRenderer } from './terminalWebgl';
+
+/** Minimal ResizeObserver stub that lets tests fire the callback manually. */
+let fireResize: () => void = () => {};
+const observeSpy = vi.fn();
+const disconnectSpy = vi.fn();
+
+class ResizeObserverStub {
+  constructor(cb: ResizeObserverCallback) {
+    fireResize = () => cb([], this as unknown as ResizeObserver);
+  }
+  observe = observeSpy;
+  disconnect = disconnectSpy;
+}
+
+interface FakeContainer {
+  offsetWidth: number;
+  offsetHeight: number;
+}
+
+function makeFixture(width: number, height: number) {
+  const container: FakeContainer = { offsetWidth: width, offsetHeight: height };
+  const term = { loadAddon: vi.fn() };
+  const dispose = attachWebglRenderer(
+    term as unknown as Terminal,
+    container as unknown as HTMLElement
+  );
+  return { container, term, dispose };
+}
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+  addonInstances.length = 0;
+});
+
+describe('attachWebglRenderer', () => {
+  it('loads the addon immediately when the container has layout', () => {
+    const { term } = makeFixture(800, 600);
+    expect(term.loadAddon).toHaveBeenCalledTimes(1);
+    expect(addonInstances).toHaveLength(1);
+  });
+
+  it('defers loading while the container is zero-size, then loads when layout arrives', () => {
+    const { container, term } = makeFixture(0, 0);
+    expect(term.loadAddon).not.toHaveBeenCalled();
+
+    container.offsetWidth = 800;
+    container.offsetHeight = 600;
+    fireResize();
+    expect(term.loadAddon).toHaveBeenCalledTimes(1);
+  });
+
+  it('disposes the addon when the pane collapses to zero and reloads when it returns', () => {
+    const { container, term } = makeFixture(800, 600);
+    expect(addonInstances).toHaveLength(1);
+
+    container.offsetWidth = 0;
+    fireResize();
+    expect(addonInstances[0].dispose).toHaveBeenCalledTimes(1);
+
+    container.offsetWidth = 800;
+    fireResize();
+    // A fresh addon instance is loaded — the disposed one is never reused.
+    expect(addonInstances).toHaveLength(2);
+    expect(term.loadAddon).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not reload after a GPU context loss (permanent canvas fallback)', () => {
+    const { container } = makeFixture(800, 600);
+    const [addon] = addonInstances;
+    // Simulate xterm firing the context-loss callback the loader registered.
+    const onLoss = addon.onContextLoss.mock.calls[0][0] as () => void;
+    onLoss();
+    expect(addon.dispose).toHaveBeenCalled();
+    expect(disconnectSpy).toHaveBeenCalled();
+
+    container.offsetWidth = 1000;
+    fireResize();
+    expect(addonInstances).toHaveLength(1);
+  });
+
+  it('cleanup disconnects the observer and disposes the loaded addon', () => {
+    const { dispose } = makeFixture(800, 600);
+    dispose();
+    expect(disconnectSpy).toHaveBeenCalled();
+    expect(addonInstances[0].dispose).toHaveBeenCalledTimes(1);
+
+    // Post-cleanup resize events are inert.
+    fireResize();
+    expect(addonInstances).toHaveLength(1);
+  });
+});

--- a/src/lib/terminalWebgl.ts
+++ b/src/lib/terminalWebgl.ts
@@ -1,0 +1,85 @@
+/**
+ * Guarded loader for xterm's WebGL renderer addon.
+ *
+ * The WebGL glyph atlas calls `getImageData` on canvases sized from the
+ * terminal's layout; when the pane has zero size (collapsed split, hidden
+ * ancestor) the canvas is zero-sized and `getImageData` throws an uncaught
+ * `InvalidStateError` from inside the addon's render path — which the global
+ * error handler then auto-reports as a bug (issue #383). Ship Studio keeps
+ * background terminals mounted (and streaming PTY output) while not laid
+ * out, so this is a reachable state, not an edge case.
+ *
+ * `attachWebglRenderer` therefore only keeps the WebGL addon loaded while
+ * the container actually has layout: it defers loading until the container
+ * has non-zero size, disposes the addon (falling back to xterm's DOM/canvas
+ * renderer) whenever the container collapses to zero, and reloads it when
+ * layout returns. WebGL being unavailable, or a GPU context loss, falls back
+ * to the non-WebGL renderer permanently — same behavior the call sites had
+ * before this guard existed.
+ */
+
+import type { Terminal } from '@xterm/xterm';
+import { WebglAddon } from '@xterm/addon-webgl';
+import { logger } from './logger';
+
+/**
+ * Keep a WebGL renderer attached to `term` only while `container` has
+ * non-zero layout. Returns a dispose function — call it on teardown (before
+ * or after `term.dispose()`, both are safe).
+ */
+export function attachWebglRenderer(term: Terminal, container: HTMLElement): () => void {
+  let addon: WebglAddon | null = null;
+  /** WebGL failed to initialize or lost its context — stop trying. */
+  let unavailable = false;
+  let disposed = false;
+
+  const disposeAddon = () => {
+    const current = addon;
+    addon = null;
+    if (!current) return;
+    try {
+      current.dispose();
+    } catch {
+      /* already disposed (context loss, terminal teardown) */
+    }
+  };
+
+  const sync = () => {
+    if (disposed || unavailable) return;
+    const hasLayout = container.offsetWidth > 0 && container.offsetHeight > 0;
+    if (!hasLayout) {
+      // Zero-size/hidden pane: drop to the DOM renderer so the glyph atlas
+      // never draws against a zero-sized canvas.
+      disposeAddon();
+      return;
+    }
+    if (addon) return;
+    try {
+      const webgl = new WebglAddon();
+      webgl.onContextLoss(() => {
+        // GPU context lost — permanent fallback, matching the pre-guard
+        // behavior at both call sites.
+        unavailable = true;
+        if (addon === webgl) addon = null;
+        webgl.dispose();
+        observer.disconnect();
+      });
+      term.loadAddon(webgl);
+      addon = webgl;
+    } catch {
+      unavailable = true;
+      observer.disconnect();
+      logger.warn('[Terminal] WebGL not available, using canvas renderer');
+    }
+  };
+
+  const observer = new ResizeObserver(sync);
+  observer.observe(container);
+  sync();
+
+  return () => {
+    disposed = true;
+    observer.disconnect();
+    disposeAddon();
+  };
+}


### PR DESCRIPTION
Five parallel themed fix branches merged into one integration branch. All fixes verified by full suites: 910 Rust lib tests, 1484 frontend tests, tsc/eslint/check:patterns/check:loc/cargo fmt clean.

## Git/GitHub errors (12)
#620 #626 #627 #631 #635 #636 #637 #638 #639 #642 #604 #598 — GitHub 5xx classification, GH001 100MB-file and GH005 ref-too-long push declines classified before the push-race arm, gh config permission errors, worktree modal humanization, 120-byte branch-name cap, credential-prompt failures, create_pull_request routed through the gh credential helper, index.lock retry on pull/pull_and_merge, bare ": EOF" network match, pre-commit hook output classified + trimmed, auto-register guard Expected. (#604 is classification-only: no commit timeout added — hooks legitimately run minutes.)

## Frontend telemetry hygiene (8)
#629 #632 #633 #640 #643 #646 #563 #383 — project-folder-gone one-shot info toast in PluginSlot, PR-conflict toast downgraded to info, [object Object] fixed via formatCommandError, folder-gone select toast info, push-rejected/merge-conflict publish failures warn+info (sentinels untouched), resizePtySessionLogged wrapper at all four call sites, connect-session teardown race Expected, WebGL renderer deferred/disposed on zero-size panes.

## Capture/thumbnails (6)
#644 #645 #647 #649 #606 #558 — SingletonLock classification (root cause already fixed by #358), broken-Node dyld probe + classification, Chrome/Edge fallback two-attempt escalating virtual-time budget with file-existence verification, humanized thumbnail-upload decode errors, viewport retry goto 120s + CAPTURE_TIMEOUT_SECS 360 with goto-timeout classified Expected, --disable-gpu + one relaunch on "Target crashed".

## Windows & resource pressure (10)
#622 #623 #549 #574 #575 #596 #593 #577 #625 #570 — real signed exit statuses from the PTY plugin + hex rendering for abnormal codes, 12s WS upstream connect budget on Windows, os error 206 classified, EMFILE/ENFILE joined to the spawn-pressure retry family, static-server fd-pressure retry, kind-based PermissionDenied classification (locale-proof) + fs os-error-5 branch, config-only frameworks skip package.json read, conflict-marker detection before JSON.parse with terminal guidance, shared save_project_metadata routing 12 writer sites through classify_fs_error, pnpm dirs in extended PATH.

## Misc (8)
#641 #624 #572 #554 #583 #580 #581 #571 — Finder-zip junk tolerated + 3-level-deep template validation, plugin bundle self-heal on load + bundle check on update, proactive plugin update check on manager open, simctl retry + Expected classification, emulator boot log tail in errors, shared humanize_brew_failure covering banner/legacy-DSL/Ruby-crash patterns.

Skipped with write-ups: #621 (wry unwrap unfixed upstream — needs an upstream issue), #398 (rfd/tauri panic, no released fix in the chain).

Issue references above are deliberately not closing keywords — issues will be closed manually after merge (GitHub silently drops keyword closes at this volume).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git, GitHub, publishing, and installation error messages with clearer recovery guidance.
  * Added retries for Git index locks, simulator queries, browser captures, static files, and WebSocket connections.
  * Improved handling of missing project folders, merge conflicts, corrupted project files, and plugin bundles.
  * Fixed development server behavior for projects without a `package.json`.

* **New Features**
  * Plugins can check for updates automatically and recover missing bundles.
  * Added clearer terminal exit-status diagnostics and safer WebGL rendering.
  * Improved project template validation and branch-name handling.
  * Added more informative notifications for expected issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->