### PR TITLE
Quick sweep: 11 new auto-reported issues (classification, capture, logic)

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -106,6 +106,56 @@ fn headless_invocation(agent: &AgentConfig, prompt: &str) -> Option<HeadlessInvo
     None
 }
 
+/// Known "environment, not our bug" failure states from the agent CLI itself,
+/// matched against the failure detail (stderr, or the exit-code + stdout
+/// snippet when stderr is empty — the session-limit refusal arrives on
+/// stdout). These are conditions Ship Studio can't fix and shouldn't
+/// telemetry-report as bugs; `Expected` keeps them out (same precedent as the
+/// missing-binary case above, issue #548).
+///
+/// - Subscription session/usage/rate limits — "You've hit your session limit
+///   · resets 4:40pm (Asia/Dubai)", usage-limit and rate-limit wordings
+///   (issue #653). The raw detail is appended so the CLI's reset time
+///   survives into the message.
+/// - Expired/missing sign-in — "OAuth token has expired · Please run /login"
+///   family (issue #653's session-expired sibling).
+/// - Untrusted workspace — Claude Code refusing headless runs in a folder the
+///   user never opened interactively: "this workspace has not been trusted.
+///   Run Claude Code interactively here once and accept the trust dialog, or
+///   set projects[…].hasTrustDialogAccepted: true in ~/.claude.json". The raw
+///   compound error (trust warning + stdin race + "--print needs input") is a
+///   confusing wall of text, so it gets a plain remedy instead (issue #660).
+fn classify_agent_cli_failure(agent_name: &str, detail: &str) -> Option<CommandError> {
+    let lower = detail.to_lowercase();
+    if lower.contains("session limit")
+        || lower.contains("usage limit")
+        || lower.contains("rate limit")
+        || lower.contains("quota exceeded")
+    {
+        return Some(CommandError::expected(format!(
+            "{agent_name} hit its usage limit, so AI generation isn't available right now. \
+             The limit resets automatically — try again later. ({detail})"
+        )));
+    }
+    if lower.contains("please run /login")
+        || lower.contains("oauth token has expired")
+        || lower.contains("session expired")
+    {
+        return Some(CommandError::expected(format!(
+            "{agent_name} isn't signed in anymore (its session expired). Open an agent \
+             terminal and sign in again — for Claude Code, run /login — then try again."
+        )));
+    }
+    if lower.contains("has not been trusted") || lower.contains("hastrustdialogaccepted") {
+        return Some(CommandError::expected(format!(
+            "{agent_name} hasn't trusted this project's folder yet, so it won't run \
+             non-interactively here. Open an agent terminal in this project once and accept \
+             the trust prompt, then try again."
+        )));
+    }
+    None
+}
+
 /// Run the active agent headlessly with `prompt` in `cwd` and return its final
 /// answer text. `extra_envs` is injected on top of the extended PATH.
 async fn run_agent_headless(
@@ -190,6 +240,16 @@ async fn run_agent_headless(
             // The head carries the actual error (issue #578).
             crate::external_command::truncate_output(&stderr)
         };
+        // Known environment states (usage limit, expired sign-in, untrusted
+        // workspace) are the CLI working as designed — warn, not error, and
+        // Expected so they stay out of telemetry (issues #653/#660).
+        if let Some(err) = classify_agent_cli_failure(&agent.display_name, &detail) {
+            warn!(
+                "{} CLI failed with an expected condition: {}",
+                agent.display_name, detail
+            );
+            return Err(err);
+        }
         error!("{} CLI failed: {}", agent.display_name, detail);
         return Err(format!("{} CLI failed: {}", agent.display_name, detail).into());
     }
@@ -698,6 +758,66 @@ mod tests {
             }
             HeadlessInvocation::PrintMode { .. } => panic!("Codex should use exec mode"),
         }
+    }
+
+    // The CLI's subscription session/usage-limit refusal is the environment,
+    // not a bug — Expected, with the reset time preserved (issue #653).
+    #[test]
+    fn classify_agent_cli_failure_session_limit_is_expected() {
+        let detail =
+            "exit code Some(1): You've hit your session limit · resets 4:40pm (Asia/Dubai)";
+        let err = classify_agent_cli_failure("Claude Code", detail).expect("must classify");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        let msg = format!("{err}");
+        assert!(msg.contains("usage limit"), "got: {msg}");
+        // The CLI's own reset time must survive into the message.
+        assert!(msg.contains("resets 4:40pm"), "got: {msg}");
+    }
+
+    #[test]
+    fn classify_agent_cli_failure_usage_and_rate_limit_wordings() {
+        assert!(
+            classify_agent_cli_failure("Claude Code", "Claude AI usage limit reached").is_some()
+        );
+        assert!(classify_agent_cli_failure("Codex", "Rate limit exceeded, retry later").is_some());
+    }
+
+    // Expired sign-in ("run /login") is user-fixable, not a malfunction.
+    #[test]
+    fn classify_agent_cli_failure_expired_login_is_expected() {
+        let err = classify_agent_cli_failure(
+            "Claude Code",
+            "OAuth token has expired · Please obtain a new token or run /login",
+        )
+        .expect("must classify");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        assert!(format!("{err}").contains("sign in again"));
+    }
+
+    // The untrusted-workspace compound error (trust warning + stdin race +
+    // "--print needs input") must become one plain remedy (issue #660).
+    #[test]
+    fn classify_agent_cli_failure_untrusted_workspace_is_expected() {
+        let detail = "Ignoring 16 permissions.allow entries from .claude/settings.local.json: \
+                      this workspace has not been trusted. Run Claude Code interactively here once \
+                      and accept the trust dialog, or set projects[\"<project>\"].hasTrustDialogAccepted: \
+                      true in ~/.claude.json.\nError: Input must be provided either through stdin or \
+                      as a prompt argument when using --print";
+        let err = classify_agent_cli_failure("Claude Code", detail).expect("must classify");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        let msg = format!("{err}");
+        assert!(msg.contains("trust"), "got: {msg}");
+        assert!(msg.contains("Open an agent terminal"), "got: {msg}");
+    }
+
+    // Genuine unexplained failures must keep flowing to telemetry.
+    #[test]
+    fn classify_agent_cli_failure_ignores_unknown_failures() {
+        assert!(
+            classify_agent_cli_failure("Claude Code", "exit code Some(1), no output").is_none()
+        );
+        assert!(classify_agent_cli_failure("Claude Code", "segmentation fault").is_none());
+        assert!(classify_agent_cli_failure("Claude Code", "").is_none());
     }
 
     #[test]

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -50,10 +50,17 @@ enum HeadlessInvocation {
     },
     /// Codex `exec`: stdout is a session transcript (which echoes the prompt —
     /// unsafe to parse), so the final message is captured via
-    /// `--output-last-message` into a temp file instead.
+    /// `--output-last-message` into a temp file instead. The prompt travels
+    /// via stdin (the positional argument is `-`, which `codex exec` documents
+    /// as "read instructions from stdin"): besides the E2BIG ceiling, on
+    /// Windows Codex resolves to a `.cmd` shim, and Rust's std refuses to
+    /// spawn a `.cmd` when an argument can't be safely cmd.exe-escaped —
+    /// a prompt embedding a raw git diff (quotes, newlines) failed the whole
+    /// generation with "batch file arguments are invalid" (issue #663).
     CodexExec {
         args: Vec<String>,
         output_file: PathBuf,
+        stdin_prompt: String,
     },
 }
 
@@ -91,7 +98,9 @@ fn headless_invocation(agent: &AgentConfig, prompt: &str) -> Option<HeadlessInvo
         ));
         // --skip-git-repo-check: worktrees/external folders can trip Codex's
         // trusted-directory heuristic even though we always run in a validated
-        // project path.
+        // project path. The trailing `-` makes Codex read the prompt from
+        // stdin — never argv (issues #595's E2BIG class and #663's Windows
+        // .cmd escaping failure).
         let args = vec![
             "exec".to_string(),
             "--skip-git-repo-check".to_string(),
@@ -99,9 +108,13 @@ fn headless_invocation(agent: &AgentConfig, prompt: &str) -> Option<HeadlessInvo
             "never".to_string(),
             "--output-last-message".to_string(),
             output_file.to_string_lossy().to_string(),
-            prompt.to_string(),
+            "-".to_string(),
         ];
-        return Some(HeadlessInvocation::CodexExec { args, output_file });
+        return Some(HeadlessInvocation::CodexExec {
+            args,
+            output_file,
+            stdin_prompt: prompt.to_string(),
+        });
     }
     None
 }
@@ -126,9 +139,15 @@ async fn run_agent_headless(
         HeadlessInvocation::PrintMode { args, stdin_prompt } => {
             (args.clone(), None, stdin_prompt.clone())
         }
-        HeadlessInvocation::CodexExec { args, output_file } => {
-            (args.clone(), Some(output_file.clone()), None)
-        }
+        HeadlessInvocation::CodexExec {
+            args,
+            output_file,
+            stdin_prompt,
+        } => (
+            args.clone(),
+            Some(output_file.clone()),
+            Some(stdin_prompt.clone()),
+        ),
     };
 
     let mut cmd = create_command(agent_path);
@@ -140,13 +159,13 @@ async fn run_agent_headless(
     let output = if let Some(prompt_data) = &stdin_prompt {
         // The prompt travels via stdin (piped, written in full, then closed so
         // the CLI sees EOF) instead of argv — see HeadlessInvocation::PrintMode
-        // (issue #595).
+        // (issue #595) and HeadlessInvocation::CodexExec (issue #663).
         let tokio_cmd = tokio::process::Command::from(cmd);
         crate::external_command::run_with_timeout_stdin(tokio_cmd, prompt_data, label, timeout_secs)
             .await
     } else {
-        // No TTY here: an EOF'd stdin keeps agents that read it (Codex exec)
-        // from waiting on input that will never come.
+        // No TTY here: an EOF'd stdin keeps agents that read it from waiting
+        // on input that will never come.
         cmd.stdin(std::process::Stdio::null());
         let tokio_cmd = tokio::process::Command::from(cmd);
         run_with_timeout(tokio_cmd, label, timeout_secs).await
@@ -682,9 +701,18 @@ mod tests {
 
     #[test]
     fn headless_invocation_codex_captures_last_message_to_file() {
-        let inv = headless_invocation(&crate::agent::CODEX, "hello").unwrap();
+        // The prompt must NOT be an argv element: on Windows Codex is a .cmd
+        // shim, and Rust refuses to spawn a .cmd when an argument (a prompt
+        // embedding a raw diff) can't be safely cmd.exe-escaped — "batch file
+        // arguments are invalid" (issue #663). `-` tells `codex exec` to read
+        // the prompt from stdin instead.
+        let inv = headless_invocation(&crate::agent::CODEX, "hello \"quoted\"\nmultiline").unwrap();
         match inv {
-            HeadlessInvocation::CodexExec { args, output_file } => {
+            HeadlessInvocation::CodexExec {
+                args,
+                output_file,
+                stdin_prompt,
+            } => {
                 assert_eq!(args[0], "exec");
                 assert!(args.contains(&"--skip-git-repo-check".to_string()));
                 let file_arg = args
@@ -693,8 +721,10 @@ mod tests {
                     .map(|i| &args[i + 1])
                     .expect("has --output-last-message");
                 assert_eq!(file_arg, &output_file.to_string_lossy().to_string());
-                // Prompt is the final argument.
-                assert_eq!(args.last().unwrap(), "hello");
+                // The final argument is the stdin sentinel, never the prompt.
+                assert_eq!(args.last().unwrap(), "-");
+                assert!(!args.iter().any(|a| a.contains("hello")));
+                assert_eq!(stdin_prompt, "hello \"quoted\"\nmultiline");
             }
             HeadlessInvocation::PrintMode { .. } => panic!("Codex should use exec mode"),
         }

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -606,6 +606,31 @@ pub(crate) fn gh_network_error(stderr: &str) -> Option<CommandError> {
     })
 }
 
+/// Go's `crypto/tls`/`crypto/x509` error when gh can reach a server but can't
+/// verify the certificate chain it presents — "tls: failed to verify
+/// certificate: x509: certificate signed by unknown authority". Almost always
+/// a corporate proxy or antivirus doing TLS interception with a private CA
+/// the system doesn't trust, or a broken/outdated certificate store — the
+/// environment, not an app malfunction (issue #658). Deliberately NOT folded
+/// into gh_network_error's "check your internet connection" message: retrying
+/// or checking connectivity can't fix a trust chain — the user needs to
+/// install the intercepting proxy's CA cert or repair their trust store.
+pub(crate) fn gh_tls_error(stderr: &str) -> Option<CommandError> {
+    let s = stderr.to_lowercase();
+    // "x509:" prefixes every Go certificate-verification failure variant
+    // (unknown authority, expired, hostname mismatch, …) and appears nowhere
+    // in ordinary gh/GraphQL output.
+    let cert_unverifiable = s.contains("failed to verify certificate") || s.contains("x509:");
+    cert_unverifiable.then(|| {
+        CommandError::expected(
+            "GitHub's secure connection couldn't be verified. This usually means a corporate \
+             proxy, VPN, or antivirus is inspecting HTTPS traffic on this computer (its \
+             certificate isn't trusted yet), or the system's certificate store is out of date. \
+             Install your proxy's certificate or update your system, then try again.",
+        )
+    })
+}
+
 /// gh's passthrough of GitHub's generic HTTP 400 GraphQL response — "HTTP 400:
 /// We received a malformed request from your client. Sorry about that. Please
 /// try resubmitting your request…". GitHub emits this when the API can't parse
@@ -708,7 +733,10 @@ pub(crate) fn gh_crash_error(stderr: &str) -> Option<CommandError> {
 /// classification for the shared cases — call sites still layer their own
 /// auth / subcommand-specific checks on top.
 pub(crate) fn gh_common_error(stderr: &str) -> Option<CommandError> {
-    gh_network_error(stderr)
+    // TLS first: a cert-verification failure needs its trust-store guidance,
+    // not the generic "check your internet connection" message (issue #658).
+    gh_tls_error(stderr)
+        .or_else(|| gh_network_error(stderr))
         .or_else(|| gh_malformed_request_error(stderr))
         .or_else(|| gh_server_error(stderr))
         .or_else(|| gh_config_error(stderr))
@@ -1242,6 +1270,32 @@ mod tests {
 
     // The #627 shape: GitHub's API answering a transient 5xx (504 from the
     // GraphQL endpoint) — server-side, retryable, not an app malfunction.
+    // TLS cert-verification failures (corporate proxy / AV interception,
+    // broken trust store) get their own trust-store guidance, kept out of
+    // telemetry (issue #658).
+    #[test]
+    fn gh_tls_error_classifies_cert_verification_failure_as_expected() {
+        let stderr = r#"Post "https://api.github.com/graphql": tls: failed to verify certificate: x509: certificate signed by unknown authority"#;
+        let err = gh_tls_error(stderr).expect("should classify as TLS trust failure");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        let msg = format!("{err}");
+        assert!(msg.contains("couldn't be verified"), "got: {msg}");
+        // Must NOT be the generic connectivity advice — retrying can't fix a
+        // trust chain.
+        assert!(!msg.to_lowercase().contains("internet connection"));
+        // gh_common_error routes it to the TLS message, not the network one.
+        let common = gh_common_error(stderr).expect("common classifier must cover TLS");
+        assert!(format!("{common}").contains("couldn't be verified"));
+    }
+
+    #[test]
+    fn gh_tls_error_ignores_unrelated_stderr() {
+        assert!(gh_tls_error("GraphQL: name already exists on this account").is_none());
+        assert!(gh_tls_error("dial tcp 1.2.3.4:443: connect: connection refused").is_none());
+        assert!(gh_tls_error("tls handshake timeout").is_none());
+        assert!(gh_tls_error("").is_none());
+    }
+
     #[test]
     fn gh_server_error_classifies_github_5xx_as_expected() {
         let terse = "HTTP 504: 504 Gateway Timeout (https://api.github.com/graphql)";

--- a/src-tauri/src/commands/ide/screenshots/playwright.rs
+++ b/src-tauri/src/commands/ide/screenshots/playwright.rs
@@ -7,11 +7,12 @@ use crate::utils::validate_project_path;
 
 /// Ceiling for one capture-script run (page load + scroll + shot). Must cover
 /// the script's own worst-case inner budgets — a 60s first goto attempt plus
-/// the 120s retry (issue #606), the capped scroll pass, and the 120s
-/// screenshot/stitch — or we kill captures that were progressing legitimately
-/// and would have failed (or succeeded) with a far better error on their own
-/// (issue #527).
-const CAPTURE_TIMEOUT_SECS: u64 = 360;
+/// the 120s retry (issue #606), the capped scroll pass, the 120s
+/// screenshot/stitch, and the short-budget CDP screenshot retries
+/// (issue #657: up to 2 × (2s beat + 30s attempt) ≈ 64s) — or we kill
+/// captures that were progressing legitimately and would have failed (or
+/// succeeded) with a far better error on their own (issue #527).
+const CAPTURE_TIMEOUT_SECS: u64 = 420;
 /// Ceiling for downloading Chromium during self-heal (~130MB).
 const BROWSER_INSTALL_TIMEOUT_SECS: u64 = 600;
 
@@ -111,6 +112,19 @@ fn capture_script_error(what: &str, url: &str, output: &std::process::Output) ->
             "The screenshot browser crashed while starting up. This is usually a one-off \
              (graphics driver or security software interfering with the headless browser) — \
              try again, and if it keeps happening, restarting your machine often clears it.",
+        );
+    }
+    // Chromium's CDP refusing the screenshot outright ("Page.captureScreenshot:
+    // Unable to capture screenshot") is a known transient renderer failure —
+    // GPU/memory pressure or backing-store limits (puppeteer#5341). The
+    // capture script already retries it in place; one that persists through
+    // those retries is still an environment-level condition, not an app bug
+    // (issue #657, same signature as #569 on the full-page path).
+    if stderr.contains("Unable to capture screenshot") {
+        return CommandError::expected(
+            "The screenshot browser couldn't render the capture (a transient graphics/memory \
+             hiccup in headless Chromium). Try again in a moment — if it keeps happening, \
+             closing other applications or restarting your machine usually clears it.",
         );
     }
     // Both goto attempts exhausting their navigation timeout is a recurring,
@@ -431,12 +445,32 @@ const {{ chromium }} = require('playwright');
         }}).catch(() => {{}});
         await page.waitForTimeout(500);
 
+        // Chromium's CDP can refuse a screenshot outright ("Protocol error
+        // (Page.captureScreenshot): Unable to capture screenshot") under
+        // transient GPU/memory pressure — a known flaky Chromium failure,
+        // not a page problem. Retry that exact error up to twice after a
+        // short beat; anything else propagates unchanged (issue #657).
+        // Retries get a short budget: this failure mode errors out quickly,
+        // and the outer capture ceiling has already paid for one
+        // full-length attempt.
+        const screenshotWithRetry = async (options) => {{
+            for (let attempt = 0; ; attempt++) {{
+                try {{
+                    return await page.screenshot(attempt === 0 ? options : {{ ...options, timeout: 30000 }});
+                }} catch (err) {{
+                    const msg = String((err && err.message) || err);
+                    if (attempt >= 2 || !msg.includes('Unable to capture screenshot')) throw err;
+                    await new Promise((resolve) => setTimeout(resolve, 2000));
+                }}
+            }}
+        }};
+
         // Take full-page screenshot
         // fullPage stitches the entire scrollable height — on tall pages
         // that can exceed Playwright's default 30s action timeout, and the
         // overall script budget leaves room for it, so give it real headroom
         // (issue #461).
-        await page.screenshot({{ path: '{}', fullPage: true, timeout: 120000 }});
+        await screenshotWithRetry({{ path: '{}', fullPage: true, timeout: 120000 }});
         console.log('Screenshot saved successfully');
     }} finally {{
         if (browser) await browser.close();
@@ -600,11 +634,31 @@ const {{ chromium }} = require('playwright');
         // Wait for animations to complete
         await page.waitForTimeout(3000);
 
+        // Chromium's CDP can refuse a screenshot outright ("Protocol error
+        // (Page.captureScreenshot): Unable to capture screenshot") under
+        // transient GPU/memory pressure — a known flaky Chromium failure,
+        // not a page problem. Retry that exact error up to twice after a
+        // short beat; anything else propagates unchanged (issue #657).
+        // Retries get a short budget: this failure mode errors out quickly,
+        // and the outer capture ceiling has already paid for one
+        // full-length attempt.
+        const screenshotWithRetry = async (options) => {{
+            for (let attempt = 0; ; attempt++) {{
+                try {{
+                    return await page.screenshot(attempt === 0 ? options : {{ ...options, timeout: 30000 }});
+                }} catch (err) {{
+                    const msg = String((err && err.message) || err);
+                    if (attempt >= 2 || !msg.includes('Unable to capture screenshot')) throw err;
+                    await new Promise((resolve) => setTimeout(resolve, 2000));
+                }}
+            }}
+        }};
+
         // Take viewport screenshot (not full page). Explicit timeout replaces
         // Playwright's 30s action default, which slow machines exceeded — the
         // full-page capture already has this, the viewport one was missed
         // (issue #568).
-        await page.screenshot({{ path: '{}', timeout: 120000 }});
+        await screenshotWithRetry({{ path: '{}', timeout: 120000 }});
     }} finally {{
         if (browser) await browser.close();
     }}
@@ -744,6 +798,29 @@ mod capture_error_tests {
         ) {
             CommandError::Expected { message } => {
                 assert!(message.contains("browser crashed"), "got: {message}")
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cdp_unable_to_capture_screenshot_is_expected_not_telemetry() {
+        // Issue #657 (same signature as #569 on the full-page path): CDP
+        // refusing Page.captureScreenshot is a known transient Chromium
+        // failure. The script retries it in place; one that persists is an
+        // environment-level condition, not an app bug.
+        let output = failed_output(
+            "page.screenshot: Protocol error (Page.captureScreenshot): Unable to capture screenshot\n\
+             Call log:\n  - taking page screenshot\n  - waiting for fonts to load...\n  - fonts loaded",
+        );
+        match capture_script_error(
+            "Playwright viewport screenshot",
+            "http://localhost:3000",
+            &output,
+        ) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("couldn't render"), "got: {message}");
+                assert!(message.contains("Try again"), "got: {message}");
             }
             other => panic!("expected Expected, got {other:?}"),
         }

--- a/src-tauri/src/commands/ide/screenshots/webview_snapshot.rs
+++ b/src-tauri/src/commands/ide/screenshots/webview_snapshot.rs
@@ -106,6 +106,26 @@ pub async fn capture_thumbnail_from_webview(
     Ok(thumbnail_path.to_string_lossy().to_string())
 }
 
+/// Ceiling for the snapshot completion handler to fire. WebKit renders
+/// snapshots in-process off the live layer tree — normally milliseconds —
+/// so this only guards a wedged web process / blocked main thread.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+const WEBVIEW_SNAPSHOT_TIMEOUT_SECS: u64 = 10;
+
+/// Error for a snapshot whose completion handler never fired within the
+/// ceiling: the web process (or the app's main thread) was wedged at capture
+/// time. Classified Expected — a transient environmental state, not an app
+/// malfunction; the frontend falls back to the headless capture path whenever
+/// this command fails (issue #652).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn snapshot_timeout_error() -> CommandError {
+    CommandError::expected(format!(
+        "The app's preview didn't respond to the snapshot request within \
+         {WEBVIEW_SNAPSHOT_TIMEOUT_SECS}s — the webview may be busy rendering. The thumbnail \
+         will be captured with the standard fallback path instead."
+    ))
+}
+
 /// Max per-channel spread within a row/column for it to count as a uniform
 /// sliver (tolerates anti-aliased boundary pixels; real content spreads far
 /// wider — the observed background sliver measured spread ≤ 12).
@@ -232,7 +252,12 @@ async fn snapshot_webview_region(
 
     // WebKit renders snapshots in-process off the live layer tree — normally
     // milliseconds. The ceiling only guards a wedged web process.
-    match tokio::time::timeout(std::time::Duration::from_secs(10), rx.recv()).await {
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(WEBVIEW_SNAPSHOT_TIMEOUT_SECS),
+        rx.recv(),
+    )
+    .await
+    {
         Ok(Some(Ok(bytes))) => Ok(bytes),
         Ok(Some(Err(message))) => Err(CommandError::from(format!(
             "Webview snapshot failed: {message}"
@@ -240,9 +265,14 @@ async fn snapshot_webview_region(
         Ok(None) => Err(CommandError::from(
             "Webview snapshot callback dropped without a result".to_string(),
         )),
-        Err(_) => Err(CommandError::from(
-            "Webview snapshot timed out after 10s".to_string(),
-        )),
+        // Nothing leaks on this path: the snapshot targets the app's own live
+        // webview (no hidden window or capture webview is ever created), the
+        // per-project CaptureClaim releases when this command returns, and
+        // the pending Obj-C completion block only holds the channel sender —
+        // if WebKit eventually finishes, its send lands in this dropped
+        // channel and is discarded, so a late snapshot can never write a
+        // stale thumbnail over the fallback's result.
+        Err(_) => Err(snapshot_timeout_error()),
     }
 }
 
@@ -369,6 +399,25 @@ mod trim_tests {
         let img = RgbImage::from_pixel(30, 30, Rgb([30, 30, 30]));
         let out = trim_uniform_edges(DynamicImage::ImageRgb8(img));
         assert_eq!((out.width(), out.height()), (30, 30));
+    }
+}
+
+#[cfg(test)]
+mod timeout_error_tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_timeout_is_expected_not_telemetry() {
+        // Issue #652: the completion handler never firing means the web
+        // process / main thread was wedged at capture time — a transient
+        // environmental state the frontend falls back from, not an app bug.
+        match snapshot_timeout_error() {
+            CommandError::Expected { message } => {
+                assert!(message.contains("didn't respond"), "got: {message}");
+                assert!(message.contains("10s"), "got: {message}");
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
     }
 }
 

--- a/src-tauri/src/commands/plugins/plugin_storage.rs
+++ b/src-tauri/src/commands/plugins/plugin_storage.rs
@@ -91,6 +91,20 @@ pub fn write_plugin_storage(
     })
 }
 
+/// A plugin's shell command hitting its timeout. `Expected`, not `Other`: the
+/// host can't know whether a timeout is fatal to the plugin — plugins run
+/// background polls (e.g. the Vercel plugin's 3-second `git remote -v` /
+/// `git rev-parse` ticks) that deliberately `.catch(() => null)` a slow tick,
+/// yet `CommandError`'s Serialize hook auto-reported every timeout at the IPC
+/// boundary before any frontend `.catch()` could run (issues #661/#662). The
+/// plugin decides what's fatal; the message is unchanged so plugins that do
+/// surface it keep the same text.
+fn plugin_shell_timeout_error(plugin_id: &str, command: &str, timeout: u64) -> CommandError {
+    CommandError::expected(format!(
+        "Plugin '{plugin_id}' shell command '{command}' timed out after {timeout}s"
+    ))
+}
+
 /// Execute a shell command in a plugin's context
 ///
 /// Security: validates project_path, uses extended PATH, enforces configurable timeout (default 120s).
@@ -168,9 +182,7 @@ pub async fn exec_plugin_shell(
                 // Name the plugin and command — a bare "timed out (120s)" is the
                 // same message for every plugin on every platform, so telemetry
                 // can't tell a slow-but-legit install from a hung plugin (#379).
-                return Err(CommandError::from(format!(
-                    "Plugin '{plugin_id}' shell command '{command}' timed out after {timeout}s"
-                )));
+                return Err(plugin_shell_timeout_error(&plugin_id, &command, timeout));
             }
             Ok(Ok(output)) => break output,
             Ok(Err(e)) => {
@@ -370,4 +382,24 @@ pub fn unlink_dev_plugin(project_path: String, plugin_id: String) -> Result<(), 
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Plugin shell timeouts must be Expected — the reporting hook fires the
+    /// moment the error serializes across IPC, before any plugin-side
+    /// `.catch()` runs, so anything else auto-reports background-poll ticks
+    /// as bugs (issues #661/#662). The message must stay byte-identical to
+    /// the pre-classification one for plugins that surface it.
+    #[test]
+    fn plugin_shell_timeout_error_is_expected_with_same_message() {
+        let err = plugin_shell_timeout_error("vercel", "git", 10);
+        assert!(matches!(err, CommandError::Expected { .. }));
+        assert_eq!(
+            format!("{err}"),
+            "Plugin 'vercel' shell command 'git' timed out after 10s"
+        );
+    }
 }

--- a/src-tauri/src/commands/projects/dev_server.rs
+++ b/src-tauri/src/commands/projects/dev_server.rs
@@ -229,6 +229,14 @@ pub struct DependencyStatus {
     /// Lets the frontend tell "no install needed" (generic / static project)
     /// from "install needed, run pnpm install".
     pub has_package_json: bool,
+    /// True when a `package.json` exists at the resolved dev-server cwd —
+    /// the workspace subpath for monorepo projects, the repo root otherwise.
+    /// `has_package_json` is deliberately root-OR-workspace (right for the
+    /// "is an install needed" question) but wrong for "will `npm run dev` at
+    /// the cwd find a package.json" — a monorepo subpath without its own
+    /// package.json reported `true` and spawned a doomed dev server
+    /// (issue #656).
+    pub workspace_has_package_json: bool,
 }
 
 /// Check whether a project's dependencies are installed.
@@ -248,12 +256,13 @@ pub async fn check_dependencies_installed(
 
     // Workspaces install at the repo root; single-package projects install in
     // place. Either location is enough to consider deps present.
-    let has_package_json =
-        repo_root.join("package.json").exists() || workspace.join("package.json").exists();
+    let workspace_has_package_json = workspace.join("package.json").exists();
+    let has_package_json = repo_root.join("package.json").exists() || workspace_has_package_json;
     if !has_package_json {
         return Ok(DependencyStatus {
             installed: true,
             has_package_json: false,
+            workspace_has_package_json,
         });
     }
 
@@ -262,6 +271,7 @@ pub async fn check_dependencies_installed(
     Ok(DependencyStatus {
         installed,
         has_package_json: true,
+        workspace_has_package_json,
     })
 }
 

--- a/src-tauri/src/commands/publishing.rs
+++ b/src-tauri/src/commands/publishing.rs
@@ -49,7 +49,8 @@ fn push_auth_error(stderr: &str) -> Option<CommandError> {
 ///   frontend's `sanitizeBranchName` now caps generated names too).
 ///
 /// Must run BEFORE any generic "rejected"/"non-fast-forward" check.
-fn push_pre_receive_error(stderr: &str) -> Option<CommandError> {
+/// (`pub(crate)`: also used by `create_pull_request`'s auto-push, issue #654.)
+pub(crate) fn push_pre_receive_error(stderr: &str) -> Option<CommandError> {
     let lower = stderr.to_lowercase();
     if lower.contains("exceeds github's file size limit") || lower.contains("gh001") {
         // Best-effort: name the offending file(s) from lines like

--- a/src-tauri/src/commands/pull_requests.rs
+++ b/src-tauri/src/commands/pull_requests.rs
@@ -102,6 +102,22 @@ pub async fn list_pull_requests(
     Ok(prs)
 }
 
+/// git's stderr for an ordinary push rejection — the remote branch moved ahead
+/// of the local one ("! [rejected] … (non-fast-forward)", "failed to push some
+/// refs … fetch first", "the tip of your current branch is behind"). A benign,
+/// by-design race, not an app malfunction: the user pulls and retries. Same
+/// phrases the publishing paths treat as Expected (issues #617/#560/#654).
+/// `classify_git_net_error` deliberately returns `None` for these, and
+/// `push_pre_receive_error` must run first so GH001/GH005 keep their specific
+/// remedies.
+fn is_push_rejection(stderr: &str) -> bool {
+    let lower = stderr.to_lowercase();
+    lower.contains("non-fast-forward")
+        || lower.contains("rejected")
+        || lower.contains("fetch first")
+        || lower.contains("tip of your current branch is behind")
+}
+
 /// Create a new pull request.
 /// Automatically pushes the branch to the remote first if needed.
 #[tauri::command]
@@ -136,6 +152,26 @@ pub async fn create_pull_request(
             // environment state, same as push_branch (issue #560).
             if let Some(err) = crate::commands::git::classify_git_net_error(&stderr) {
                 return Err(err);
+            }
+            // Pre-receive refusals with their own remedy (file over 100 MB,
+            // ref too long) — must run before the generic rejection check,
+            // same ordering as the publishing paths (issues #626/#636).
+            if let Some(err) = crate::commands::publishing::push_pre_receive_error(&stderr) {
+                return Err(err);
+            }
+            // An ordinary non-fast-forward race ("someone pushed first") is
+            // by-design git behavior, not a malfunction — the same case the
+            // publishing paths already classify as Expected (issue #654).
+            // Keep the exact "Failed to push branch: <stderr>" shape: the
+            // SubmitReviewModal runs it through humanizeGitError, which
+            // matches "rejected"/"non-fast-forward" in the raw text and
+            // renders the pull-first guidance. (No PUSH_REJECTED sentinel
+            // here — only PublishBranchDropdown consumes that.)
+            if is_push_rejection(&stderr) {
+                return Err(CommandError::expected(format!(
+                    "Failed to push branch: {}",
+                    truncate_output(&stderr)
+                )));
             }
             return Err(format!("Failed to push branch: {}", truncate_output(&stderr)).into());
         }
@@ -334,5 +370,28 @@ mod tests {
         assert!(is_conflict_stderr("Pull request is not mergeable"));
         assert!(is_conflict_stderr("merge commit cannot be cleanly created"));
         assert!(!is_conflict_stderr("could not find pull request"));
+    }
+
+    /// An everyday non-fast-forward race on create_pull_request's auto-push is
+    /// by-design git behavior — it must classify as a push rejection so the
+    /// command returns Expected instead of telemetry noise (issue #654).
+    #[test]
+    fn is_push_rejection_matches_non_fast_forward_stderr() {
+        let stderr = "To https://github.com/o/r.git\n ! [rejected]        HEAD -> feat/x (non-fast-forward)\nerror: failed to push some refs to 'https://github.com/o/r.git'\nhint: Updates were rejected because the tip of your current branch is behind\nhint: its remote counterpart.";
+        assert!(is_push_rejection(stderr));
+        assert!(is_push_rejection(
+            "error: failed to push some refs\nhint: (e.g., 'git pull ...') before pushing again. fetch first"
+        ));
+    }
+
+    #[test]
+    fn is_push_rejection_ignores_unrelated_push_failures() {
+        assert!(!is_push_rejection(
+            "remote: Permission denied (publickey).\nfatal: Could not read from remote repository."
+        ));
+        assert!(!is_push_rejection(
+            "fatal: unable to access: could not resolve host"
+        ));
+        assert!(!is_push_rejection(""));
     }
 }

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -115,6 +115,22 @@ fn map_spawn_io_error(label: &str, io_err: &std::io::Error) -> CommandError {
         spawn_access_denied_error(label)
     } else if is_windows_path_too_long(&io_err.to_string()) {
         windows_path_too_long_error(label)
+    } else if io_err.kind() == std::io::ErrorKind::InvalidInput
+        && io_err
+            .to_string()
+            .contains("batch file arguments are invalid")
+    {
+        // Windows-only: Rust's std routes `.bat`/`.cmd` scripts through
+        // `cmd.exe` (the BatBadBut mitigation) and refuses to spawn when an
+        // argument can't be safely cmd-escaped (embedded double quotes,
+        // newlines). npm-installed CLIs resolve to `.cmd` shims on Windows, so
+        // an argument carrying free-form text (an AI prompt embedding a git
+        // diff) hit this as an unactionable raw Io error (issue #663). It's an
+        // input-shape limitation of the environment, not an app malfunction.
+        CommandError::expected(format!(
+            "`{label}` couldn't be launched: one of its arguments contains characters \
+             (quotes or line breaks) that Windows can't pass to a .cmd script."
+        ))
     } else {
         CommandError::Io { message }
     }
@@ -561,6 +577,31 @@ mod tests {
             }
             other => panic!("expected Expected, got {other:?}"),
         }
+    }
+
+    // The #663 shape: Rust's BatBadBut mitigation refuses to spawn a .cmd
+    // with an argument it can't safely cmd-escape — an environment/input
+    // limitation, so Expected with a human message, not a reported raw Io.
+    #[test]
+    fn map_spawn_io_error_classifies_batch_argument_rejection_as_expected() {
+        let e = std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "batch file arguments are invalid",
+        );
+        match map_spawn_io_error("Codex CLI", &e) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("`Codex CLI`"), "got: {message}");
+                assert!(message.contains(".cmd script"), "got: {message}");
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+
+        // Other InvalidInput failures stay unclassified.
+        let unrelated = std::io::Error::new(std::io::ErrorKind::InvalidInput, "bad handle");
+        assert!(matches!(
+            map_spawn_io_error("Codex CLI", &unrelated),
+            CommandError::Io { .. }
+        ));
     }
 
     // The #616 shape: `I/O error: `gh pr list`: Resource temporarily

--- a/src/components/plugins/McpModal.test.tsx
+++ b/src/components/plugins/McpModal.test.tsx
@@ -151,6 +151,48 @@ describe('McpModal error flows', () => {
     expect(logger.error as Fn).not.toHaveBeenCalled();
   });
 
+  it("rejects an OpenCode name-only Add inline via OpenCode's own grammar (#655)", async () => {
+    render(<McpModal agentId="opencode" agentDisplayName="OpenCode" agentBinaryName="opencode" />);
+    const input = await openAddTab();
+
+    // A quoted name is one shell token — the generic whitespace-based
+    // validator saw two tokens and waved it through to the CLI.
+    fireEvent.change(input, { target: { value: '"my server"' } });
+    clickAddSubmit();
+
+    expect(await screen.findByText(/need a command or a --url/i)).toBeInTheDocument();
+    expect(addMcpServer).not.toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.warn as Fn).not.toHaveBeenCalled();
+  });
+
+  it("logs the backend's own input-shape rejection at warn, not error (#655)", async () => {
+    vi.mocked(addMcpServer).mockRejectedValue({
+      type: 'Other',
+      message:
+        'OpenCode MCP servers need a command or a --url, e.g. `my-server -- npx -y @some/mcp-server`',
+    });
+
+    render(<McpModal agentId="opencode" agentDisplayName="OpenCode" agentBinaryName="opencode" />);
+    const input = await openAddTab();
+
+    // Passes frontend validation but (hypothetically) still bounces off the
+    // backend parser — must be classified as user input, not an app bug.
+    fireEvent.change(input, { target: { value: 'my-server -- npx -y @some/mcp-server' } });
+    clickAddSubmit();
+
+    expect(await screen.findByText(/need a command or a --url/i)).toBeInTheDocument();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.warn as Fn).toHaveBeenCalledWith(
+      'Failed to add MCP server: input rejected by agent parser',
+      expect.objectContaining({ error: expect.stringContaining('need a command') as unknown })
+    );
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
+  });
+
   it('keeps logger.error for genuinely unrecognized add failures', async () => {
     vi.mocked(addMcpServer).mockRejectedValue({
       type: 'Other',

--- a/src/components/plugins/McpModal.tsx
+++ b/src/components/plugins/McpModal.tsx
@@ -19,6 +19,7 @@ import {
   removeMcpServer,
   validateMcpAddCommand,
   isMcpUnsupportedCliError,
+  isMcpInvalidInputError,
 } from '../../lib/mcp';
 import { trackEvent, trackSearch } from '../../lib/analytics';
 import { logger } from '../../lib/logger';
@@ -117,8 +118,9 @@ export function McpModal({
     // Validate before shelling out: a name with no command/URL would only
     // fail at the CLI level with a raw "missing required argument
     // 'commandOrUrl'" usage error (issue #588). Inline feedback, no toast,
-    // no log — the user just hasn't finished typing the command.
-    const validationError = validateMcpAddCommand(addCommand.trim(), agentBinaryName);
+    // no log — the user just hasn't finished typing the command. The agentId
+    // selects OpenCode's stricter flag-unaware grammar (issue #655).
+    const validationError = validateMcpAddCommand(addCommand.trim(), agentBinaryName, agentId);
     if (validationError) {
       setAddError(validationError);
       setAddSuccess(false);
@@ -154,6 +156,14 @@ export function McpModal({
         setAddError(
           `${agentDisplayName} doesn't appear to be installed on this computer, so its MCP servers can't be managed. Install ${agentDisplayName} first, then try again.`
         );
+      } else if (isMcpInvalidInputError(err)) {
+        // The backend's own input-shape validation (OpenCode config path) —
+        // a user-input problem the frontend pre-flight didn't catch, not an
+        // app bug. Inline feedback + warn, no auto-filed report (issue #655).
+        logger.warn('Failed to add MCP server: input rejected by agent parser', {
+          error: message,
+        });
+        setAddError(message);
       } else {
         logger.error('Failed to add MCP server', { error: message });
         setAddError(message);

--- a/src/components/plugins/PluginSlot.test.tsx
+++ b/src/components/plugins/PluginSlot.test.tsx
@@ -136,6 +136,35 @@ describe('buildContext failure reporting', () => {
     expect(showToast).toHaveBeenCalledTimes(1);
   });
 
+  it('suppresses the toast for a plugin shell timeout — the plugin decides what is fatal (#661/#662)', async () => {
+    mockIPC(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- deliberately a plain CommandError object, the shape under test
+      throw {
+        type: 'Other',
+        message: "Plugin 'vercel' shell command 'git' timed out after 10s",
+      };
+    });
+    const { actions, showToast } = makeActions();
+    const ctx = buildContext('vercel', 'Vercel', project, actions, theme, []);
+
+    // Still re-throws so the plugin's own `.catch(() => null)` sees it, but
+    // no error toast (which would auto-file a telemetry report).
+    await expect(ctx.shell.exec('git', ['remote', '-v'])).rejects.toBeTruthy();
+    expect(showToast).not.toHaveBeenCalled();
+
+    // A different plugin's timeout message doesn't match this plugin's id —
+    // still toasts (the match is on the host's own message shape, per-plugin).
+    mockIPC(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- plain CommandError shape under test
+      throw {
+        type: 'Other',
+        message: "Plugin 'other' shell command 'git' timed out after 10s",
+      };
+    });
+    await expect(ctx.shell.exec('git', ['remote', '-v'])).rejects.toBeTruthy();
+    expect(showToast).toHaveBeenCalledTimes(1);
+  });
+
   it('does not toast when the call succeeds', async () => {
     mockIPC((cmd) => {
       if (cmd === 'read_plugin_storage') return { key: 'value' };

--- a/src/components/plugins/PluginSlot.tsx
+++ b/src/components/plugins/PluginSlot.tsx
@@ -224,6 +224,21 @@ export function buildContext(
       }
       throw e;
     }
+    // The host's own shell-command timeout (exec_plugin_shell). This catch is
+    // attached at the context level, so it fires BEFORE the plugin's own
+    // `.catch(() => null)` — a background poll the plugin deliberately lets
+    // fail (e.g. the Vercel plugin's 3-second git ticks) used to error-toast
+    // and telemetry-report anyway (issues #661/#662). The plugin decides
+    // what's fatal: warn locally, re-throw, no toast.
+    if (
+      message.includes(`Plugin '${pluginId}' shell command '`) &&
+      message.includes('timed out after')
+    ) {
+      logger.warn(`Plugin "${pluginId}" shell command timed out — plugin handles this itself`, {
+        error: message,
+      });
+      throw e;
+    }
     actions.showToast(`Plugin "${pluginName}": ${message}`, 'error');
     throw e;
   };

--- a/src/hooks/useDevServer.test.ts
+++ b/src/hooks/useDevServer.test.ts
@@ -14,6 +14,11 @@ vi.mock('../lib/project', () => ({
   getWorkspaceSubpath: vi.fn().mockResolvedValue(null),
   resolveWorkspacePath: (path: string, subpath: string | null) =>
     subpath ? `${path}/${subpath}` : path,
+  checkDependenciesInstalled: vi.fn().mockResolvedValue({
+    installed: true,
+    hasPackageJson: true,
+    workspaceHasPackageJson: true,
+  }),
 }));
 
 vi.mock('../lib/static-server', () => ({
@@ -57,6 +62,11 @@ describe('useDevServer', () => {
     vi.mocked(project.getCustomDevCommand).mockResolvedValue(null);
     vi.mocked(project.getForceStaticServe).mockResolvedValue(false);
     vi.mocked(project.getWorkspaceSubpath).mockResolvedValue(null);
+    vi.mocked(project.checkDependenciesInstalled).mockResolvedValue({
+      installed: true,
+      hasPackageJson: true,
+      workspaceHasPackageJson: true,
+    });
   });
 
   it('initializes with default state', () => {
@@ -319,6 +329,97 @@ describe('useDevServer', () => {
         'main',
         expect.any(Function)
       );
+    });
+
+    it('skips the dev server when a framework config exists but no package.json (issue #593)', async () => {
+      const { detectProjectType } = await import('../lib/static-server');
+      const { startDevServer, checkDependenciesInstalled } = await import('../lib/project');
+      vi.mocked(detectProjectType).mockResolvedValue('nextjs');
+      vi.mocked(checkDependenciesInstalled).mockResolvedValue({
+        installed: true,
+        hasPackageJson: false,
+        workspaceHasPackageJson: false,
+      });
+
+      const { result } = renderHook(() => useDevServer('/path/to/project'));
+
+      await act(async () => {
+        await result.current.startServerForProject('/path/to/project', 'my-project', 3000, 'main');
+      });
+
+      expect(result.current.projectType).toBe('nextjs');
+      expect(startDevServer).not.toHaveBeenCalled();
+    });
+
+    it('skips the dev server when the workspace subpath has no package.json even though the repo root does (issue #656)', async () => {
+      const { detectProjectType } = await import('../lib/static-server');
+      const { startDevServer, checkDependenciesInstalled, getWorkspaceSubpath } =
+        await import('../lib/project');
+      vi.mocked(detectProjectType).mockResolvedValue('nextjs');
+      vi.mocked(getWorkspaceSubpath).mockResolvedValue('apps/web');
+      // Root has a package.json (so the OR-based flag is true), but the picked
+      // workspace subpath does not — the spawn at the subpath would be doomed.
+      vi.mocked(checkDependenciesInstalled).mockResolvedValue({
+        installed: true,
+        hasPackageJson: true,
+        workspaceHasPackageJson: false,
+      });
+
+      const { result } = renderHook(() => useDevServer('/path/to/project'));
+
+      await act(async () => {
+        await result.current.startServerForProject('/path/to/project', 'my-project', 3000, 'main');
+      });
+
+      expect(result.current.projectType).toBe('nextjs');
+      expect(startDevServer).not.toHaveBeenCalled();
+    });
+
+    it('starts the dev server at the workspace subpath when it has its own package.json', async () => {
+      const { detectProjectType } = await import('../lib/static-server');
+      const { startDevServer, checkDependenciesInstalled, getWorkspaceSubpath } =
+        await import('../lib/project');
+      vi.mocked(detectProjectType).mockResolvedValue('nextjs');
+      vi.mocked(getWorkspaceSubpath).mockResolvedValue('apps/web');
+      vi.mocked(checkDependenciesInstalled).mockResolvedValue({
+        installed: true,
+        hasPackageJson: true,
+        workspaceHasPackageJson: true,
+      });
+
+      const { result } = renderHook(() => useDevServer('/path/to/project'));
+
+      await act(async () => {
+        await result.current.startServerForProject('/path/to/project', 'my-project', 3000, 'main');
+      });
+
+      expect(startDevServer).toHaveBeenCalledWith(
+        '/path/to/project/apps/web',
+        3000,
+        'main',
+        expect.any(Function)
+      );
+    });
+
+    it('still starts the dev server when the backend predates workspaceHasPackageJson', async () => {
+      const { detectProjectType } = await import('../lib/static-server');
+      const { startDevServer, checkDependenciesInstalled, getWorkspaceSubpath } =
+        await import('../lib/project');
+      vi.mocked(detectProjectType).mockResolvedValue('nextjs');
+      vi.mocked(getWorkspaceSubpath).mockResolvedValue('apps/web');
+      // Older backend: field absent from the payload.
+      vi.mocked(checkDependenciesInstalled).mockResolvedValue({
+        installed: true,
+        hasPackageJson: true,
+      } as never);
+
+      const { result } = renderHook(() => useDevServer('/path/to/project'));
+
+      await act(async () => {
+        await result.current.startServerForProject('/path/to/project', 'my-project', 3000, 'main');
+      });
+
+      expect(startDevServer).toHaveBeenCalled();
     });
 
     it('does not start a web dev server for native mobile projects', async () => {

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -618,16 +618,23 @@ export function useDevServer(currentProjectPath: string | null) {
       // via its config file alone can't run a dev script (issue #593).
       // null = unknown (dependency check failed or was exempt).
       let hasPackageJson: boolean | null = null;
+      // Same, but at the resolved dev-server cwd (workspace subpath for
+      // monorepos). The root-OR-workspace flag above is right for install
+      // gating but wrong for "will the dev spawn at cwd find a package.json"
+      // (issue #656).
+      let cwdHasPackageJson: boolean | null = null;
       try {
         // Shopify themes and force-static projects don't need an npm install to
         // preview: the theme runs via `shopify theme dev`, and a force-static
         // site is served straight off disk regardless of its build tooling.
         const depStatus =
           detectedType === 'shopifytheme' || forceStatic
-            ? { installed: true, hasPackageJson: false }
+            ? { installed: true, hasPackageJson: false, workspaceHasPackageJson: false }
             : await checkDependenciesInstalled(projectPath);
         if (detectedType !== 'shopifytheme' && !forceStatic) {
           hasPackageJson = depStatus.hasPackageJson;
+          // Older backends predate the field; keep null (= unknown) then.
+          cwdHasPackageJson = depStatus.workspaceHasPackageJson ?? null;
         }
         if (!depStatus.installed && depStatus.hasPackageJson) {
           const packageManager = await detectPackageManager(projectPath).catch((err) => {
@@ -787,13 +794,23 @@ export function useDevServer(currentProjectPath: string | null) {
         // vite.config.ts / …) with no package.json: there's no dev script to
         // run, so spawning `npm run dev` is doomed and produced a spurious
         // "File not found: package.json" error in telemetry (issue #593).
-        // Mirrors the `unknown`-type skip above. Monorepo subpaths (cwd !==
-        // projectPath) are exempt: the root check doesn't reflect the
-        // workspace directory the server actually runs in.
+        // Mirrors the `unknown`-type skip above.
         logger.info(
           '[OpenProject] Framework config found but no package.json; skipping dev server',
           { projectPath, projectType: detectedType }
         );
+      } else if (cwdHasPackageJson === false && cwd !== projectPath) {
+        // Monorepo workspace subpath without its own package.json: the
+        // root-OR-workspace hasPackageJson flag can be true (the repo root has
+        // one), but the dev server spawns at the subpath, where the
+        // package.json read is doomed — this produced the same spurious
+        // "File not found: package.json" error plus a doomed `npm run dev` at
+        // the subpath (issue #656, the case #593 intentionally exempted).
+        logger.info('[OpenProject] Workspace subpath has no package.json; skipping dev server', {
+          projectPath,
+          cwd,
+          projectType: detectedType,
+        });
       } else {
         try {
           s.outputBuffer = '';

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -277,6 +277,12 @@ describe('humanizeGitError', () => {
       expect: /couldn't reach GitHub/i,
     },
     {
+      // TLS interception by a corporate proxy/AV — must get trust-store
+      // guidance, not "check your internet connection" (issue #658).
+      raw: 'Post "https://api.github.com/graphql": tls: failed to verify certificate: x509: certificate signed by unknown authority',
+      expect: /secure connection couldn't be verified/i,
+    },
+    {
       raw: "error: pathspec 'feat/gone' did not match any file(s) known to git",
       expect: /no longer exists/i,
     },

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -130,6 +130,15 @@ export function humanizeGitError(value: unknown, ctx: GitErrorContext = {}): str
     return `GitHub didn't accept the connection. Your sign-in may have expired, or your account may not have write access to this repository. Reconnect GitHub (top right) or check your access, then try again.`;
   }
 
+  // TLS certificate verification failed — a corporate proxy/antivirus doing
+  // HTTPS inspection with an untrusted CA, or a broken certificate store.
+  // Must be checked BEFORE the generic network branch: "check your internet
+  // connection" can't fix a trust chain (issue #658, mirroring gh_tls_error
+  // in src-tauri/src/commands/github.rs).
+  if (m.includes('failed to verify certificate') || m.includes('x509:')) {
+    return `GitHub's secure connection couldn't be verified. This usually means a corporate proxy, VPN, or antivirus is inspecting HTTPS traffic on this computer, or the system's certificate store is out of date. Install your proxy's certificate or update your system, then try again.`;
+  }
+
   // Couldn't reach GitHub at all. 'dial tcp'/'connectex' cover Go's dial
   // errors from the gh CLI — the Windows connectex wording contains none of
   // the usual timeout/refused substrings (issue #375).

--- a/src/lib/mcp.test.ts
+++ b/src/lib/mcp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateMcpAddCommand, isMcpUnsupportedCliError } from './mcp';
+import { validateMcpAddCommand, isMcpUnsupportedCliError, isMcpInvalidInputError } from './mcp';
 
 describe('validateMcpAddCommand (#588)', () => {
   const validInputs = [
@@ -35,6 +35,78 @@ describe('validateMcpAddCommand (#588)', () => {
   it('strips the prefix for the configured agent binary', () => {
     expect(validateMcpAddCommand('codex mcp add my-server -- npx pkg', 'codex')).toBeNull();
     expect(validateMcpAddCommand('codex mcp add my-server', 'codex')).not.toBeNull();
+  });
+});
+
+describe('validateMcpAddCommand for OpenCode (#655)', () => {
+  const validate = (input: string) => validateMcpAddCommand(input, 'opencode', 'opencode');
+
+  const validInputs = [
+    'my-server -- npx -y @some/mcp-server', // command after --
+    'my-server npx -y @some/mcp-server', // command without --
+    'my-server --url https://example.com/mcp', // remote via --url
+    'opencode mcp add my-server -- npx -y pkg', // optional CLI prefix
+    // OpenCode's parser has no flag awareness — these tokens are read as the
+    // command, so the backend accepts them. Reject only what it rejects.
+    'my-server --transport http something',
+    'my-server -e FOO=bar npx pkg',
+  ];
+
+  it.each(validInputs)('accepts: %s', (input) => {
+    expect(validate(input)).toBeNull();
+  });
+
+  it.each([
+    'my-server', // name only — exactly what the backend rejects
+    'opencode mcp add my-server', // name only behind the prefix
+    'my-server --', // separator with nothing after it
+    '', // nothing at all
+  ])('rejects with guidance: %s', (input) => {
+    const message = validate(input);
+    expect(message).not.toBeNull();
+    expect(message).toContain('--url');
+    expect(message).toContain('npx');
+  });
+
+  it('rejects --url without a value', () => {
+    expect(validate('my-server --url')).toContain('--url');
+  });
+
+  it('tokenizes quotes like the backend shell_split: a quoted name alone is still just a name', () => {
+    // Whitespace-splitting saw two tokens here and waved it through; the
+    // backend's shell_split sees one token (the name) and rejected it — the
+    // exact frontend/backend disagreement from the report.
+    expect(validate('"my server"')).not.toBeNull();
+    expect(validate('"my server" -- npx -y pkg')).toBeNull();
+  });
+});
+
+describe('isMcpInvalidInputError (#655)', () => {
+  it("matches the backend's OpenCode input-shape validation messages", () => {
+    expect(
+      isMcpInvalidInputError(
+        'OpenCode MCP servers need a command or a --url, e.g. `my-server -- npx -y @some/mcp-server`'
+      )
+    ).toBe(true);
+    expect(
+      isMcpInvalidInputError(
+        'mcp add: --url needs a value, e.g. `my-server --url https://example.com/mcp`'
+      )
+    ).toBe(true);
+    expect(isMcpInvalidInputError('No arguments provided for mcp add')).toBe(true);
+    // CommandError objects work too (Tauri rejections are plain objects;
+    // Expected serializes as Other across IPC).
+    expect(
+      isMcpInvalidInputError({
+        type: 'Other',
+        message: 'OpenCode MCP servers need a command or a --url',
+      })
+    ).toBe(true);
+  });
+
+  it('does not match unrelated failures', () => {
+    expect(isMcpInvalidInputError('Failed to add MCP server: connection refused')).toBe(false);
+    expect(isMcpInvalidInputError('OpenCode binary not found')).toBe(false);
   });
 });
 

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -66,6 +66,57 @@ export function isMcpUnsupportedCliError(value: unknown): boolean {
   );
 }
 
+/**
+ * True when an `mcp add` failure is the backend's own input-shape validation
+ * (OpenCode's config-file path in `opencode_mcp_entry`,
+ * src-tauri/src/commands/mcp.rs) — the user hasn't finished typing the
+ * command, not an app bug. The backend classifies these `Expected`, but the
+ * frontend's generic catch branch still logged them as errors, auto-filing
+ * bug reports for typos (issue #655).
+ */
+export function isMcpInvalidInputError(value: unknown): boolean {
+  const message = formatCommandError(asCommandError(value));
+  return (
+    /need a command or a --url/i.test(message) ||
+    /--url needs a value/i.test(message) ||
+    /No arguments provided for mcp add/i.test(message)
+  );
+}
+
+/**
+ * Split a raw `mcp add` argument string like a shell would — whitespace
+ * separates tokens, single/double quotes group, `\"` and `\\` escape inside
+ * double quotes. Mirrors the backend's `shell_split`
+ * (src-tauri/src/commands/mcp.rs) so frontend validation tokenizes exactly
+ * like the parser that will actually consume the input.
+ */
+function shellSplitArgs(input: string): string[] {
+  const args: string[] = [];
+  let current = '';
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < input.length; i++) {
+    const c = input[i];
+    if (c === "'" && !inDouble) {
+      inSingle = !inSingle;
+    } else if (c === '"' && !inSingle) {
+      inDouble = !inDouble;
+    } else if ((c === ' ' || c === '\t') && !inSingle && !inDouble) {
+      if (current) {
+        args.push(current);
+        current = '';
+      }
+    } else if (c === '\\' && inDouble && (input[i + 1] === '"' || input[i + 1] === '\\')) {
+      current += input[i + 1];
+      i++;
+    } else {
+      current += c;
+    }
+  }
+  if (current) args.push(current);
+  return args;
+}
+
 /** Flags of `mcp add` that consume the next token as their value. */
 const MCP_ADD_VALUE_FLAGS = new Set([
   '--transport',
@@ -88,13 +139,42 @@ const MCP_ADD_VALUE_FLAGS = new Set([
  * (`--transport http name url`), and either a `--url <value>`, a URL token,
  * or a command (bare token / `-- command...`) satisfies the requirement.
  *
+ * For OpenCode (`agentId === 'opencode'`) the generic flag-aware grammar is
+ * wrong: OpenCode's `mcp add` is interactive-only, so the backend writes its
+ * config file directly via `opencode_mcp_entry`, whose parser has no flag
+ * awareness at all — first token is the name, the rest is either
+ * `--url <value>` or the command (optionally after `--`). Mirror that exact
+ * rule so what the frontend waves through matches what the backend accepts,
+ * and only reject what OpenCode definitely rejects (issue #655).
+ *
  * @returns A user-facing error message, or `null` when the input looks valid.
  */
-export function validateMcpAddCommand(rawArgs: string, agentBinaryName = 'claude'): string | null {
+export function validateMcpAddCommand(
+  rawArgs: string,
+  agentBinaryName = 'claude',
+  agentId?: string
+): string | null {
   let text = rawArgs.trim();
   // Strip the optional "<binary> mcp add" prefix exactly like the backend.
   if (text.startsWith(agentBinaryName)) text = text.slice(agentBinaryName.length).trimStart();
   if (text.startsWith('mcp add')) text = text.slice('mcp add'.length).trimStart();
+
+  if (agentId === 'opencode') {
+    // Same tokenization + shape rule as `opencode_mcp_entry`
+    // (src-tauri/src/commands/mcp.rs).
+    const [, ...rest] = shellSplitArgs(text);
+    if (rest[0] === '--url') {
+      if (rest.length < 2) {
+        return 'Give --url a value, e.g. `my-server --url https://example.com/mcp`.';
+      }
+      return null;
+    }
+    const command = rest[0] === '--' ? rest.slice(1) : rest;
+    if (command.length === 0) {
+      return 'OpenCode MCP servers need a command or a --url: add a command after the name (e.g. `my-server -- npx -y @some/mcp-server`) or a URL (e.g. `my-server --url https://example.com/mcp`).';
+    }
+    return null;
+  }
 
   const invalid =
     'Include what the server runs or connects to: a command after the name (e.g. `my-server -- npx -y @some/mcp-server`) or a URL (e.g. `my-server --url https://example.com/mcp`).';

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -793,17 +793,30 @@ export function resolveWorkspacePath(projectPath: string, subpath: string | null
 export interface DependencyStatus {
   /** True when `node_modules` is present (or the project has no package.json). */
   installed: boolean;
-  /** True when the project has a `package.json` at all. */
+  /** True when the project has a `package.json` at all (repo root OR workspace subpath). */
   hasPackageJson: boolean;
+  /**
+   * True when a `package.json` exists at the resolved dev-server cwd — the
+   * workspace subpath for monorepo projects, the repo root otherwise. This is
+   * the flag that answers "will `npm run dev` at the cwd find a package.json";
+   * `hasPackageJson` only answers "does an install make sense somewhere"
+   * (issue #656).
+   */
+  workspaceHasPackageJson: boolean;
 }
 
 /** Check whether dependencies are installed for a project. */
 export async function checkDependenciesInstalled(projectPath: string): Promise<DependencyStatus> {
-  const raw = await invoke<{ installed: boolean; has_package_json: boolean }>(
-    'check_dependencies_installed',
-    { projectPath }
-  );
-  return { installed: raw.installed, hasPackageJson: raw.has_package_json };
+  const raw = await invoke<{
+    installed: boolean;
+    has_package_json: boolean;
+    workspace_has_package_json: boolean;
+  }>('check_dependencies_installed', { projectPath });
+  return {
+    installed: raw.installed,
+    hasPackageJson: raw.has_package_json,
+    workspaceHasPackageJson: raw.workspace_has_package_json,
+  };
 }
 
 /**


### PR DESCRIPTION
Follow-up sweep on the 0.18.5 telemetry wave that arrived after Round 15 (#650). Three themed branches merged; full suites green (923 Rust / 1506 frontend, tsc, check:patterns, fmt).

## Error classification (6)
- #658 TLS certificate verification failures (corporate proxy/AV) classified Expected with trust-store guidance, in gh_common_error + humanizeGitError
- #654 create_pull_request auto-push now classifies GH001/GH005 (shared push_pre_receive_error) and ordinary push rejections as Expected; message text unchanged for SubmitReviewModal's matching
- #653 Claude CLI session/usage/rate-limit failures classified Expected, preserving the CLI's reset-time text
- #660 untrusted-workspace failures classified Expected with open-the-terminal-once guidance
- #661/#662 root cause confirmed HOST-side: plugin shell timeouts auto-reported on both the backend serialize path and PluginSlot's context-level catch, before the plugin's own catch could run. Timeout branch now Expected (byte-identical message) and PluginSlot warn-logs + re-throws instead of toasting — the plugin decides what's fatal.

## Capture (2)
- #652 wedged-WKWebView native snapshot timeout classified Expected; verified no webview leak (captures the live preview, nothing hidden to clean up) and that the headless fallback already engages
- #657 CDP "Unable to capture screenshot" gets in-script retry (2 extra attempts) in BOTH viewport and full-page scripts + Expected classification; CAPTURE_TIMEOUT_SECS 360 → 420 to preserve the outer-timeout invariant

## Logic (3)
- #656 monorepo subpath dev-server dispatch: new workspace_has_package_json in DependencyStatus; subpath without its own package.json now skips the doomed npm run dev (root skip from #593 preserved; tolerant of stale-backend payloads)
- #655 MCP add validation mirrors OpenCode's actual shell-split grammar (frontend port of the Rust shell_split); CLI rejections route to warn + inline error
- #663 Codex headless prompt moved to stdin via `codex exec -` (mirroring the Claude #595 stdin path) so cmd.exe escaping never sees it; residual "batch file arguments are invalid" classified Expected in map_spawn_io_error

Issue references are deliberately not closing keywords — closed manually after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved guidance for AI agent usage limits, authentication, workspace trust, GitHub certificate errors, and command failures.
  - Added retries and clearer handling for screenshot and webview snapshot timeouts.
  - Prevented dev servers from starting in workspaces without their own package manifest.
  - Improved MCP command validation and inline feedback for invalid input.
  - Reduced unnecessary error notifications for expected plugin timeouts.
  - Better handling of rejected pushes and unsupported Windows command arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->