### PR TITLE
Detect all installed browsers instead of a fixed list of six

### DIFF
--- a/src-tauri/src/commands/ide/browsers.rs
+++ b/src-tauri/src/commands/ide/browsers.rs
@@ -1,0 +1,531 @@
+//! # Browser discovery
+//!
+//! Finds installed browsers by reading what each app declares in its
+//! `Contents/Info.plist`, the same source Launch Services builds the system's
+//! "Open With" menu from. Replaces a hardcoded list that made every browser
+//! outside {Safari, Chrome, Firefox, Arc, Brave, Edge} invisible.
+//!
+//! Windows has no equivalent per-app manifest and keeps a curated list.
+
+use crate::errors::CommandError;
+use crate::external_command::run_with_timeout;
+use crate::types::BrowserInfo;
+use crate::utils::create_command;
+use std::path::PathBuf;
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+use tracing::{debug, warn};
+
+#[cfg(target_os = "macos")]
+use base64::Engine;
+#[cfg(target_os = "macos")]
+use std::path::Path;
+
+/// Short enough that a browser installed mid-session still shows up.
+const DISCOVERY_TTL: Duration = Duration::from_secs(300);
+
+#[cfg(target_os = "macos")]
+const PLUTIL_TIMEOUT_SECS: u64 = 5;
+
+/// The dropdown's 14px slot at 4x, for Retina, at ~5-7KB per icon.
+#[cfg(target_os = "macos")]
+const ICON_PX: u32 = 64;
+
+/// The path stays backend-side: `open_url_in_browser` re-resolves it from the
+/// discovered set, so a frontend-supplied id can't become an arbitrary launch.
+#[derive(Clone)]
+struct Browser {
+    id: String,
+    name: String,
+    icon: Option<String>,
+    path: PathBuf,
+}
+
+impl Browser {
+    fn to_info(&self) -> BrowserInfo {
+        BrowserInfo {
+            id: self.id.clone(),
+            name: self.name.clone(),
+            icon: self.icon.clone(),
+        }
+    }
+}
+
+static CACHE: LazyLock<Mutex<Option<(Instant, Vec<Browser>)>>> = LazyLock::new(|| Mutex::new(None));
+
+fn cached() -> Option<Vec<Browser>> {
+    let guard = CACHE.lock().ok()?;
+    let (stored_at, browsers) = guard.as_ref()?;
+    if stored_at.elapsed() >= DISCOVERY_TTL {
+        return None;
+    }
+    debug!(count = browsers.len(), "browser discovery cache hit");
+    Some(browsers.clone())
+}
+
+fn store(browsers: &[Browser]) {
+    if let Ok(mut guard) = CACHE.lock() {
+        *guard = Some((Instant::now(), browsers.to_vec()));
+    }
+}
+
+async fn discover() -> Vec<Browser> {
+    if let Some(hit) = cached() {
+        return hit;
+    }
+    let found = scan().await;
+    debug!(count = found.len(), "browser discovery completed");
+    store(&found);
+    found
+}
+
+// ============ macOS ============
+
+/// Per-user and Setapp installs live outside `/Applications`. Missing roots are
+/// skipped silently.
+#[cfg(target_os = "macos")]
+fn app_roots() -> Vec<PathBuf> {
+    let mut roots = vec![
+        PathBuf::from("/Applications"),
+        PathBuf::from("/Applications/Utilities"),
+        PathBuf::from("/Applications/Setapp"),
+        PathBuf::from("/System/Applications"),
+        PathBuf::from("/System/Applications/Utilities"),
+    ];
+    if let Some(home) = dirs::home_dir() {
+        roots.push(home.join("Applications"));
+    }
+    roots
+}
+
+#[cfg(target_os = "macos")]
+async fn scan() -> Vec<Browser> {
+    let mut bundles: Vec<PathBuf> = Vec::new();
+    for root in app_roots() {
+        let Ok(entries) = std::fs::read_dir(&root) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "app") {
+                bundles.push(path);
+            }
+        }
+    }
+    bundles.sort();
+    bundles.dedup();
+
+    // Sequential on purpose: spawning one `plutil` per app all at once is the
+    // process-table pressure behind the EAGAIN spawn failures in #585/#616.
+    let mut browsers: Vec<Browser> = Vec::new();
+    for bundle in bundles {
+        if let Some(browser) = inspect_bundle(&bundle).await {
+            browsers.push(browser);
+        }
+    }
+
+    browsers.sort_by_key(|b| b.name.to_lowercase());
+    browsers.dedup_by(|a, b| a.id == b.id);
+    browsers
+}
+
+#[cfg(target_os = "macos")]
+async fn inspect_bundle(bundle: &Path) -> Option<Browser> {
+    let plist_path = bundle.join("Contents/Info.plist");
+    let raw = std::fs::read(&plist_path).ok()?;
+
+    // A browser's plist necessarily contains the literal "https", and binary
+    // plists store short ASCII strings as ASCII, so this drops no real browser
+    // while sparing a subprocess for most apps.
+    if !raw.windows(5).any(|w| w == b"https") {
+        return None;
+    }
+
+    let plist = plist_to_json(&plist_path).await?;
+    if !declares_web_browsing(&plist) {
+        return None;
+    }
+
+    let name = display_name(&plist, bundle);
+    let id = plist
+        .get("CFBundleIdentifier")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| bundle.to_string_lossy().into_owned());
+
+    Some(Browser {
+        icon: extract_icon(bundle, &plist).await,
+        id,
+        name,
+        path: bundle.to_path_buf(),
+    })
+}
+
+/// Info.plist is usually a binary plist; `plutil` is the converter macOS ships,
+/// which avoids taking on a plist-parsing dependency.
+#[cfg(target_os = "macos")]
+async fn plist_to_json(path: &Path) -> Option<serde_json::Value> {
+    let mut cmd = create_command("/usr/bin/plutil");
+    cmd.args(["-convert", "json", "-o", "-", "--"]);
+    cmd.arg(path);
+
+    let output = run_with_timeout(
+        tokio::process::Command::from(cmd),
+        "plutil Info.plist",
+        PLUTIL_TIMEOUT_SECS,
+    )
+    .await
+    .map_err(|e| debug!(plist = %path.display(), error = %e, "plutil failed"))
+    .ok()?;
+
+    if !output.status.success() {
+        debug!(plist = %path.display(), "plutil reported a malformed plist");
+        return None;
+    }
+    serde_json::from_slice(&output.stdout).ok()
+}
+
+/// Every lowercased URL scheme the bundle claims.
+#[cfg(target_os = "macos")]
+fn url_schemes(plist: &serde_json::Value) -> Vec<String> {
+    plist
+        .get("CFBundleURLTypes")
+        .and_then(|v| v.as_array())
+        .map(|types| {
+            types
+                .iter()
+                .filter_map(|t| t.get("CFBundleURLSchemes")?.as_array())
+                .flatten()
+                .filter_map(|s| s.as_str())
+                .map(str::to_lowercase)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Browsers split between the modern UTI (Chrome) and the legacy extension list
+/// (Safari, Zen), so both count.
+#[cfg(target_os = "macos")]
+fn opens_html(plist: &serde_json::Value) -> bool {
+    let Some(types) = plist
+        .get("CFBundleDocumentTypes")
+        .and_then(|v| v.as_array())
+    else {
+        return false;
+    };
+    types.iter().any(|t| {
+        let by_uti = t
+            .get("LSItemContentTypes")
+            .and_then(|v| v.as_array())
+            .is_some_and(|utis| {
+                utis.iter()
+                    .filter_map(|u| u.as_str())
+                    .any(|u| u.eq_ignore_ascii_case("public.html"))
+            });
+        let by_extension = t
+            .get("CFBundleTypeExtensions")
+            .and_then(|v| v.as_array())
+            .is_some_and(|exts| {
+                exts.iter()
+                    .filter_map(|e| e.as_str())
+                    .any(|e| e.eq_ignore_ascii_case("html") || e.eq_ignore_ascii_case("htm"))
+            });
+        by_uti || by_extension
+    })
+}
+
+/// Both signals are required: apps that speak http without rendering HTML are
+/// not browsers (Cyberduck registers `http` for WebDAV).
+#[cfg(target_os = "macos")]
+fn declares_web_browsing(plist: &serde_json::Value) -> bool {
+    let schemes = url_schemes(plist);
+    let claims_web = schemes.iter().any(|s| s == "http") && schemes.iter().any(|s| s == "https");
+    claims_web && opens_html(plist)
+}
+
+/// The name the user sees in Finder.
+#[cfg(target_os = "macos")]
+fn display_name(plist: &serde_json::Value, bundle: &Path) -> String {
+    for key in ["CFBundleDisplayName", "CFBundleName"] {
+        if let Some(name) = plist.get(key).and_then(|v| v.as_str()) {
+            let trimmed = name.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+    }
+    bundle
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "Browser".to_string())
+}
+
+/// `CFBundleIconFile` may omit the extension (Safari) and may not be named
+/// AppIcon (Zen ships `firefox.icns`), hence the fallbacks.
+#[cfg(target_os = "macos")]
+fn resolve_icns(bundle: &Path, plist: &serde_json::Value) -> Option<PathBuf> {
+    let resources = bundle.join("Contents/Resources");
+
+    if let Some(declared) = plist.get("CFBundleIconFile").and_then(|v| v.as_str()) {
+        let name = if declared.to_lowercase().ends_with(".icns") {
+            declared.to_string()
+        } else {
+            format!("{declared}.icns")
+        };
+        let candidate = resources.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    let default = resources.join("AppIcon.icns");
+    if default.is_file() {
+        return Some(default);
+    }
+
+    std::fs::read_dir(&resources)
+        .ok()?
+        .flatten()
+        .map(|e| e.path())
+        .find(|p| {
+            p.extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("icns"))
+        })
+}
+
+/// `sips` writes to a file rather than stdout, so the PNG round-trips through a
+/// temp file that is removed either way.
+#[cfg(target_os = "macos")]
+async fn extract_icon(bundle: &Path, plist: &serde_json::Value) -> Option<String> {
+    let icns = resolve_icns(bundle, plist)?;
+    let png = std::env::temp_dir().join(format!(
+        "shipstudio-browser-icon-{}.png",
+        uuid::Uuid::new_v4()
+    ));
+
+    let mut cmd = create_command("/usr/bin/sips");
+    cmd.args(["-s", "format", "png", "-Z", &ICON_PX.to_string()]);
+    cmd.arg(&icns).arg("--out").arg(&png);
+
+    let result = run_with_timeout(
+        tokio::process::Command::from(cmd),
+        "sips app icon",
+        PLUTIL_TIMEOUT_SECS,
+    )
+    .await;
+
+    let encoded = match result {
+        Ok(output) if output.status.success() => std::fs::read(&png)
+            .ok()
+            .map(|bytes| base64::engine::general_purpose::STANDARD.encode(bytes)),
+        Ok(_) => {
+            debug!(icon = %icns.display(), "sips could not convert this icon");
+            None
+        }
+        Err(e) => {
+            debug!(icon = %icns.display(), error = %e, "sips failed");
+            None
+        }
+    };
+
+    let _ = std::fs::remove_file(&png);
+    encoded.map(|data| format!("data:image/png;base64,{data}"))
+}
+
+// ============ Windows ============
+
+/// Curated list, since Windows has no per-app manifest to interrogate.
+/// Tuple: (display name, path relative to Program Files / LocalAppData).
+#[cfg(target_os = "windows")]
+const WINDOWS_BROWSERS: &[(&str, &str)] = &[
+    ("Google Chrome", r"Google\Chrome\Application\chrome.exe"),
+    ("Microsoft Edge", r"Microsoft\Edge\Application\msedge.exe"),
+    (
+        "Brave",
+        r"BraveSoftware\Brave-Browser\Application\brave.exe",
+    ),
+    ("Firefox", r"Mozilla Firefox\firefox.exe"),
+    (
+        "Firefox Developer Edition",
+        r"Firefox Developer Edition\firefox.exe",
+    ),
+    ("Zen", r"Zen Browser\zen.exe"),
+    ("Helium", r"Helium\Application\helium.exe"),
+    ("Opera", r"Opera\opera.exe"),
+    ("Opera GX", r"Opera GX\opera.exe"),
+    ("Vivaldi", r"Vivaldi\Application\vivaldi.exe"),
+    ("Arc", r"Arc\Application\arc.exe"),
+    ("Chromium", r"Chromium\Application\chrome.exe"),
+    ("LibreWolf", r"LibreWolf\librewolf.exe"),
+    ("Waterfox", r"Waterfox\waterfox.exe"),
+    ("Floorp", r"Floorp\floorp.exe"),
+    ("Tor Browser", r"Tor Browser\Browser\firefox.exe"),
+    ("Yandex", r"Yandex\YandexBrowser\Application\browser.exe"),
+];
+
+#[cfg(target_os = "windows")]
+async fn scan() -> Vec<Browser> {
+    let mut browsers: Vec<Browser> = WINDOWS_BROWSERS
+        .iter()
+        .filter_map(|(name, relative_path)| {
+            let path = super::find_windows_browser(relative_path)?;
+            Some(Browser {
+                id: path.to_string_lossy().into_owned(),
+                name: (*name).to_string(),
+                icon: None,
+                path,
+            })
+        })
+        .collect();
+
+    browsers.sort_by_key(|b| b.name.to_lowercase());
+    browsers.dedup_by(|a, b| a.id == b.id);
+    browsers
+}
+
+// ============ Other platforms ============
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+async fn scan() -> Vec<Browser> {
+    Vec::new()
+}
+
+// ============ Commands ============
+
+/// Check which browsers are available on the system. Returns an empty list
+/// rather than an error, so the dropdown degrades to a plain "Open" button.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn check_browser_availability() -> Vec<BrowserInfo> {
+    discover().await.iter().map(Browser::to_info).collect()
+}
+
+/// Open a URL in a specific browser. The id is resolved against the discovered
+/// set, so the path always originates here rather than with the caller.
+#[tauri::command]
+#[tracing::instrument]
+pub async fn open_url_in_browser(url: String, browser_id: String) -> Result<(), CommandError> {
+    let parsed: url::Url = url
+        .parse()
+        .map_err(|_| CommandError::expected(format!("Not a valid URL: {url}")))?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(CommandError::expected(format!(
+            "Only http and https URLs can be opened in a browser (got \"{}\")",
+            parsed.scheme()
+        )));
+    }
+
+    let browsers = discover().await;
+    let Some(browser) = browsers.iter().find(|b| b.id == browser_id) else {
+        warn!(browser_id, "requested browser is no longer installed");
+        return Err(CommandError::expected(format!(
+            "That browser isn't available anymore ({browser_id}). It may have been moved or uninstalled."
+        )));
+    };
+
+    #[cfg(target_os = "macos")]
+    let mut cmd = {
+        // Launch Services reuses a running instance instead of starting a second.
+        let mut cmd = create_command("open");
+        cmd.arg("-a").arg(&browser.path).arg(&url);
+        cmd
+    };
+
+    #[cfg(not(target_os = "macos"))]
+    let mut cmd = {
+        let mut cmd = create_command(&browser.path);
+        cmd.arg(&url);
+        cmd
+    };
+
+    // Retried on transient EAGAIN (process-table pressure) and classified
+    // Expected when it persists — a bare "Resource temporarily unavailable
+    // (os error 35)" was reaching telemetry as an app malfunction (issue #585).
+    crate::external_command::spawn_with_pressure_retry(&format!("open {}", browser.name), || {
+        cmd.spawn()
+    })?;
+
+    Ok(())
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn browser_claiming_http_https_and_html_uti_is_detected() {
+        // Shape of Chrome's and Helium's declarations.
+        let plist = json!({
+            "CFBundleURLTypes": [{ "CFBundleURLSchemes": ["http", "https"] }],
+            "CFBundleDocumentTypes": [{ "LSItemContentTypes": ["public.html", "public.xhtml"] }],
+        });
+        assert!(declares_web_browsing(&plist));
+    }
+
+    #[test]
+    fn browser_declaring_html_by_extension_is_detected() {
+        // Shape of Safari's and Zen's declarations — legacy extension list, no UTI.
+        let plist = json!({
+            "CFBundleURLTypes": [{ "CFBundleURLSchemes": ["http", "https", "ftp"] }],
+            "CFBundleDocumentTypes": [{ "CFBundleTypeExtensions": ["html", "htm", "shtml"] }],
+        });
+        assert!(declares_web_browsing(&plist));
+    }
+
+    #[test]
+    fn http_only_utility_without_html_is_rejected() {
+        // Shape of Cyberduck: registers http for WebDAV but renders no HTML.
+        let plist = json!({
+            "CFBundleURLTypes": [{ "CFBundleURLSchemes": ["http", "ftp", "sftp"] }],
+            "CFBundleDocumentTypes": [{ "CFBundleTypeExtensions": ["duck"] }],
+        });
+        assert!(!declares_web_browsing(&plist));
+    }
+
+    #[test]
+    fn html_viewer_without_web_schemes_is_rejected() {
+        // An editor that opens .html files is not somewhere to send a dev server URL.
+        let plist = json!({
+            "CFBundleURLTypes": [{ "CFBundleURLSchemes": ["vscode"] }],
+            "CFBundleDocumentTypes": [{ "CFBundleTypeExtensions": ["html", "css", "js"] }],
+        });
+        assert!(!declares_web_browsing(&plist));
+    }
+
+    #[test]
+    fn schemes_are_matched_case_insensitively() {
+        let plist = json!({
+            "CFBundleURLTypes": [{ "CFBundleURLSchemes": ["HTTP", "HTTPS"] }],
+            "CFBundleDocumentTypes": [{ "LSItemContentTypes": ["public.html"] }],
+        });
+        assert!(declares_web_browsing(&plist));
+    }
+
+    #[test]
+    fn plist_without_declarations_is_rejected() {
+        assert!(!declares_web_browsing(&json!({})));
+    }
+
+    #[test]
+    fn display_name_prefers_declared_name_over_folder() {
+        let bundle = Path::new("/Applications/Brave Browser.app");
+        let plist = json!({ "CFBundleDisplayName": "Brave" });
+        assert_eq!(display_name(&plist, bundle), "Brave");
+    }
+
+    #[test]
+    fn display_name_falls_back_to_bundle_name_then_folder() {
+        let bundle = Path::new("/Applications/Zen.app");
+        assert_eq!(
+            display_name(&json!({ "CFBundleName": "Zen" }), bundle),
+            "Zen"
+        );
+        assert_eq!(display_name(&json!({}), bundle), "Zen");
+        // A blank declared name must not win over the folder name.
+        assert_eq!(
+            display_name(&json!({ "CFBundleDisplayName": "  " }), bundle),
+            "Zen"
+        );
+    }
+}

--- a/src-tauri/src/commands/ide/mod.rs
+++ b/src-tauri/src/commands/ide/mod.rs
@@ -3,54 +3,23 @@
 //! Commands for IDE integration, browser selection, preview webviews, and screenshots.
 //!
 //! Organized into submodules:
+//! - `browsers` — discovery of installed browsers and opening URLs in a chosen one
 //! - `preview` — preview webview creation, navigation, resize, scroll, and JS evaluation
 //! - `screenshots` — project thumbnails, Playwright captures, image comparison, cropping, and stitching
 
+mod browsers;
 mod preview;
 mod screenshots;
 
+pub use browsers::*;
 pub use preview::*;
 pub use screenshots::*;
 
 use crate::errors::CommandError;
-use crate::types::{BrowserInfo, IdeAvailability};
+use crate::types::IdeAvailability;
 use crate::utils::{create_command, validate_project_path};
 use std::path::{Path, PathBuf};
 use tauri::{Manager, WebviewUrl};
-
-/// Browser configurations for macOS
-/// Tuple: (id, display_name, app_path)
-#[cfg(target_os = "macos")]
-const MACOS_BROWSERS: &[(&str, &str, &str)] = &[
-    ("safari", "Safari", "/Applications/Safari.app"),
-    ("chrome", "Google Chrome", "/Applications/Google Chrome.app"),
-    ("firefox", "Firefox", "/Applications/Firefox.app"),
-    ("arc", "Arc", "/Applications/Arc.app"),
-    ("brave", "Brave", "/Applications/Brave Browser.app"),
-    ("edge", "Microsoft Edge", "/Applications/Microsoft Edge.app"),
-];
-
-/// Browser configurations for Windows
-/// Tuple: (id, display_name, registry_or_path_hint)
-#[cfg(target_os = "windows")]
-const WINDOWS_BROWSERS: &[(&str, &str, &str)] = &[
-    (
-        "chrome",
-        "Google Chrome",
-        r"Google\Chrome\Application\chrome.exe",
-    ),
-    (
-        "edge",
-        "Microsoft Edge",
-        r"Microsoft\Edge\Application\msedge.exe",
-    ),
-    (
-        "brave",
-        "Brave",
-        r"BraveSoftware\Brave-Browser\Application\brave.exe",
-    ),
-    ("firefox", "Firefox", r"Mozilla Firefox\firefox.exe"),
-];
 
 /// Find a browser executable on Windows by checking common install locations.
 #[cfg(target_os = "windows")]
@@ -222,102 +191,6 @@ pub async fn open_in_ide(
     }
 
     Ok(())
-}
-
-/// Check which browsers are available on the system
-#[tauri::command]
-#[tracing::instrument]
-pub async fn check_browser_availability() -> Vec<BrowserInfo> {
-    #[cfg(target_os = "macos")]
-    {
-        MACOS_BROWSERS
-            .iter()
-            .filter_map(|(id, name, path)| {
-                if std::path::Path::new(path).exists() {
-                    Some(BrowserInfo {
-                        id: id.to_string(),
-                        name: name.to_string(),
-                    })
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        WINDOWS_BROWSERS
-            .iter()
-            .filter_map(|(id, name, relative_path)| {
-                if find_windows_browser(relative_path).is_some() {
-                    Some(BrowserInfo {
-                        id: id.to_string(),
-                        name: name.to_string(),
-                    })
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    {
-        vec![]
-    }
-}
-
-/// Open a URL in a specific browser
-#[tauri::command]
-#[tracing::instrument]
-pub async fn open_url_in_browser(url: String, browser_id: String) -> Result<(), CommandError> {
-    #[cfg(target_os = "macos")]
-    {
-        let app_name = MACOS_BROWSERS
-            .iter()
-            .find(|(id, _, _)| *id == browser_id)
-            .map(|(_, name, _)| *name)
-            .ok_or_else(|| format!("Unknown browser: {browser_id}"))?;
-
-        // Retried on transient EAGAIN (process-table pressure) and classified
-        // Expected when it persists — a bare "Failed to open in safari:
-        // Resource temporarily unavailable (os error 35)" was reaching
-        // telemetry as an app malfunction (issue #585).
-        let mut cmd = create_command("open");
-        cmd.args(["-a", app_name, &url]);
-        crate::external_command::spawn_with_pressure_retry(&format!("open {browser_id}"), || {
-            cmd.spawn()
-        })?;
-
-        Ok(())
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        let relative_path = WINDOWS_BROWSERS
-            .iter()
-            .find(|(id, _, _)| *id == browser_id)
-            .map(|(_, _, path)| *path)
-            .ok_or_else(|| format!("Unknown browser: {}", browser_id))?;
-
-        let browser_exe = find_windows_browser(relative_path)
-            .ok_or_else(|| format!("Browser not found: {}", browser_id))?;
-
-        let mut cmd = create_command(browser_exe);
-        cmd.arg(&url);
-        crate::external_command::spawn_with_pressure_retry(&format!("open {browser_id}"), || {
-            cmd.spawn()
-        })?;
-
-        Ok(())
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    {
-        let _ = (url, browser_id);
-        Err(("Browser selection not supported on this platform".to_string()).into())
-    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -336,10 +336,14 @@ pub struct IdeAvailability {
 /// Information about an available browser
 #[derive(Serialize)]
 pub struct BrowserInfo {
-    /// Unique identifier (e.g., "chrome", "safari")
+    /// Opaque identifier used to launch it again (macOS: bundle identifier,
+    /// e.g. "com.google.Chrome"; Windows: the resolved executable path)
     pub id: String,
-    /// Display name (e.g., "Google Chrome", "Safari")
+    /// Display name (e.g., "Google Chrome", "Zen")
     pub name: String,
+    /// The app's own icon as a PNG data URI, when one could be extracted.
+    /// `None` leaves the frontend on its generic fallback icon.
+    pub icon: Option<String>,
 }
 
 // ============ Agent CLI Integration ============

--- a/src/components/preview/BrowserDropdown.test.tsx
+++ b/src/components/preview/BrowserDropdown.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserDropdown } from './BrowserDropdown';
+import { checkBrowserAvailability, openUrlInBrowser, type BrowserInfo } from '../../lib/browser';
+
+vi.mock('../../lib/browser', () => ({
+  checkBrowserAvailability: vi.fn(),
+  openUrlInBrowser: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockedAvailability = vi.mocked(checkBrowserAvailability);
+const mockedOpen = vi.mocked(openUrlInBrowser);
+
+// Shape the backend returns after discovery: a real icon per browser on macOS,
+// opaque bundle identifiers as ids.
+const DISCOVERED: BrowserInfo[] = [
+  { id: 'com.google.Chrome', name: 'Google Chrome', icon: 'data:image/png;base64,QUFB' },
+  { id: 'net.imput.helium', name: 'Helium', icon: 'data:image/png;base64,QkJC' },
+  { id: 'com.apple.Safari', name: 'Safari', icon: 'data:image/png;base64,Q0ND' },
+  { id: 'app.zen-browser.zen', name: 'Zen', icon: 'data:image/png;base64,RERE' },
+];
+
+const openDropdown = async (browsers: BrowserInfo[]) => {
+  mockedAvailability.mockResolvedValue(browsers);
+  const { container } = render(<BrowserDropdown url="http://localhost:3000" />);
+  // The trigger only grows a dropdown once discovery has returned something.
+  await waitFor(() => expect(screen.getByText('Open')).toBeInTheDocument());
+  fireEvent.mouseEnter(container.querySelector('.browser-dropdown-container')!);
+  return container;
+};
+
+describe('BrowserDropdown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists every discovered browser, not just the well-known ones', async () => {
+    await openDropdown(DISCOVERED);
+
+    for (const { name } of DISCOVERED) {
+      expect(await screen.findByRole('button', { name })).toBeInTheDocument();
+    }
+  });
+
+  it("shows each browser's own icon when the backend extracted one", async () => {
+    const container = await openDropdown(DISCOVERED);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Zen' })).toBeInTheDocument());
+    const icons = container.querySelectorAll('.browser-dropdown-inner img.browser-dropdown-icon');
+    expect(icons).toHaveLength(DISCOVERED.length);
+    expect(icons[1]).toHaveAttribute('src', 'data:image/png;base64,QkJC');
+    // Decorative — the name label right beside it already announces the browser.
+    expect(icons[1]).toHaveAttribute('alt', '');
+  });
+
+  it('falls back to a drawn mark when no icon could be extracted (Windows)', async () => {
+    const container = await openDropdown([
+      { id: 'C:\\Program Files\\Mozilla Firefox\\firefox.exe', name: 'Firefox', icon: null },
+    ]);
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Firefox' })).toBeInTheDocument()
+    );
+    expect(container.querySelector('.browser-dropdown-icon')).toBeNull();
+    expect(container.querySelector('.browser-dropdown-inner svg')).toBeInTheDocument();
+  });
+
+  it('opens the clicked browser by its opaque id', async () => {
+    await openDropdown(DISCOVERED);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Helium' }));
+
+    await waitFor(() =>
+      expect(mockedOpen).toHaveBeenCalledWith('http://localhost:3000', 'net.imput.helium')
+    );
+  });
+
+  it('degrades to a plain button when nothing could be discovered', async () => {
+    mockedAvailability.mockResolvedValue([]);
+    const { container } = render(<BrowserDropdown url="http://localhost:3000" />);
+
+    await waitFor(() => expect(screen.getByText('Open')).toBeInTheDocument());
+    expect(container.querySelector('.browser-dropdown-container')).toBeNull();
+  });
+});

--- a/src/components/preview/BrowserDropdown.tsx
+++ b/src/components/preview/BrowserDropdown.tsx
@@ -31,14 +31,18 @@ interface BrowserDropdownProps {
   iconOnly?: boolean;
 }
 
-const BROWSER_ICONS: Record<string, React.ComponentType<{ size?: number }>> = {
-  safari: SafariIcon,
-  chrome: ChromeIcon,
-  firefox: FirefoxIcon,
-  arc: ArcIcon,
-  brave: BraveIcon,
-  edge: EdgeIcon,
-};
+/**
+ * Fallback marks for platforms where the backend can't extract the app's own
+ * icon (Windows). Matched on the display name, since the ids are opaque.
+ */
+const BRAND_ICONS: [RegExp, React.ComponentType<{ size?: number }>][] = [
+  [/safari/i, SafariIcon],
+  [/chrome|chromium/i, ChromeIcon],
+  [/firefox|librewolf|waterfox|floorp|tor browser/i, FirefoxIcon],
+  [/\barc\b/i, ArcIcon],
+  [/brave/i, BraveIcon],
+  [/edge/i, EdgeIcon],
+];
 
 export function BrowserDropdown({
   url,
@@ -132,9 +136,14 @@ export function BrowserDropdown({
     }
   };
 
-  const getBrowserIcon = (browserId: string) => {
-    const IconComponent = BROWSER_ICONS[browserId] || GlobeIcon;
-    return <IconComponent size={14} />;
+  const getBrowserIcon = (browser: BrowserInfo) => {
+    if (browser.icon) {
+      // Decorative: the browser name sits right next to it as the label.
+      return <img src={browser.icon} alt="" className="browser-dropdown-icon" />;
+    }
+    const [, IconComponent] = BRAND_ICONS.find(([pattern]) => pattern.test(browser.name)) ?? [];
+    const Fallback = IconComponent ?? GlobeIcon;
+    return <Fallback size={14} />;
   };
 
   const iconSize = iconOnly ? 12 : 14;
@@ -183,7 +192,7 @@ export function BrowserDropdown({
                 onClick={() => void handleBrowserOpen(browser.id)}
                 disabled={openingBrowser !== null}
               >
-                {getBrowserIcon(browser.id)}
+                {getBrowserIcon(browser)}
                 {openingBrowser === browser.id ? 'Opening...' : browser.name}
               </button>
             ))}

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -12,10 +12,15 @@ import { invoke } from '@tauri-apps/api/core';
 
 /** Information about an available browser */
 export interface BrowserInfo {
-  /** Unique identifier (e.g., "chrome", "safari") */
+  /**
+   * Opaque launch identifier (macOS: bundle identifier, e.g. "com.google.Chrome";
+   * Windows: the resolved executable path). The backend resolves it to a path.
+   */
   id: string;
-  /** Display name (e.g., "Google Chrome", "Safari") */
+  /** Display name (e.g., "Google Chrome", "Zen") */
   name: string;
+  /** The app's own icon as a PNG data URI, when the backend could extract one */
+  icon?: string | null;
 }
 
 /**

--- a/src/styles/features/browser-dropdown.css
+++ b/src/styles/features/browser-dropdown.css
@@ -67,6 +67,15 @@
   opacity: 1;
 }
 
+/* The browser's own app icon, extracted from its bundle. Sized to match the
+   14px SVG marks so rows line up whichever kind of icon a browser resolves to. */
+.browser-dropdown-icon {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  object-fit: contain;
+}
+
 .browser-dropdown-inner button:disabled {
   opacity: 0.6;
   cursor: wait;


### PR DESCRIPTION
## Summary

The "Open" dropdown found browsers by matching a hardcoded list of six (Safari, Chrome,
Firefox, Arc, Brave, Edge) against fixed `/Applications` paths, so every other browser was
invisible. On my machine, with Chrome, Helium, Safari and Zen installed, only Safari and
Chrome showed up. A listed browser also disappeared when installed to `~/Applications` or
via Setapp, since only the one hardcoded path was checked.

This replaces the list with detection. An app counts as a browser when its
`Contents/Info.plist` claims **both** the `http` and `https` URL schemes **and** declares it
can open HTML (the `public.html` UTI, or an `html`/`htm` extension). That is the same
declaration Launch Services builds the system's own "Open With" menu from. Requiring both
signals is what keeps http-speaking utilities out: Cyberduck registers `http` for WebDAV and
is correctly excluded.

Alongside that:

- Scans `/Applications`, `~/Applications`, Setapp and the system app folders, so per-user and
  Setapp installs are found too.
- Shows each browser's own icon, extracted from its bundle with `sips`, instead of a generic
  globe for anything off the known list.
- Caches a discovery pass for 5 minutes, so a newly installed browser still appears without
  restarting the app.
- `open_url_in_browser` now resolves the browser id to a path backend-side rather than
  trusting a frontend-supplied one, and accepts only http(s) URLs.
- Windows has no per-app manifest to interrogate, so it keeps a curated list, extended from 4
  to 17 entries.

This is the same failure class as #262/#263, where the thumbnail fallback missed Brave and
Arc and was fixed by appending to a list. Detecting rather than listing ends that cycle.

**Cost**, since it is the obvious question: two short subprocesses per candidate app
(`plutil`, then `sips` only for confirmed browsers). Measured 0.21s for a full pass over a
25-app `/Applications`, then cached for 5 minutes. A byte-level prefilter on `Info.plist`
skips the subprocess for apps that cannot be browsers, which keeps the candidate set in
single digits on a real machine. The scan is sequential on purpose rather than fanning out,
to avoid the process-table pressure that produced the EAGAIN spawn failures handled in
`external_command` (#585/#616).

`src-tauri/src/commands/ide/mod.rs` shrinks by 135 lines; the new logic lives in a
self-contained `browsers.rs`.

## Test plan

- [x] Ran the discovery against a real `/Applications`: finds Google Chrome, Helium, Safari
      and Zen with their own icons, and excludes Cyberduck, which registers `http` but is not
      a browser
- [x] Verified in `pnpm tauri dev` that the dropdown shows the browsers with their own icons,
      and that picking Helium opens Helium
- [x] 8 new Rust tests covering the classification rules, including the Cyberduck case and an
      HTML-capable editor that is not a browser
- [x] 5 new frontend tests for `BrowserDropdown`, which previously had none
- [ ] Not verified on Windows: no machine available. That path keeps the existing mechanism
      and only gains list entries, so the risk is limited to those entries being wrong.

## CI gates

- [x] `pnpm check:all && pnpm test:run && pnpm rust:test` passes locally, plus
      `pnpm lint:strict`

<details>
<summary><strong>Patterns checklist</strong></summary>

**Frontend** — not applicable: no new modals, buttons, async state, polling or modal state.
The frontend change is confined to how an existing component renders its icon.

**CSS**
- [x] No raw hex colors, z-index numbers or transition durations. The icon sets
      `width`/`height: 14px` to match the 14px SVG marks it sits beside; there is no
      icon-size token, and the `--spacing-*` tokens describe spacing rather than element
      dimensions.
- [x] Styles went into the existing `src/styles/features/browser-dropdown.css`

**Rust**
- [x] `#[tauri::command]`s keep their signatures: `open_url_in_browser` returns
      `Result<T, CommandError>`, `check_browser_availability` keeps returning a plain `Vec`
      so an unreadable system degrades to the plain "open in default browser" button rather
      than an error. Both have `#[tracing::instrument]`.
- [x] No user-supplied paths reach the filesystem: the frontend sends an opaque id, and the
      path is resolved from the discovered set backend-side.
- [x] External CLI calls go through `run_with_timeout`

**Tests**
- [x] Added tests for the classification logic and the dropdown rendering

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Detects installed browsers and displays their names and icons in the browser selection menu.
  * Opens links in the selected browser with support for valid HTTP and HTTPS URLs.
  * Supports browser discovery on macOS and expanded browser options on Windows.
  * Provides a fallback icon when browser artwork is unavailable.

* **Bug Fixes**
  * Improved handling of missing browsers, unavailable icons, and temporary launch failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->