### PR TITLE
Round 17: 20 auto-reported issues — plugin context bleed, telemetry classification, capture/proxy resilience

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -162,7 +162,8 @@ fn classify_agent_cli_failure(agent_name: &str, detail: &str) -> Option<CommandE
              The limit resets automatically — try again later. ({detail})"
         )));
     }
-    if lower.contains("failed to load models cache") || lower.contains("codex_models_manager::cache")
+    if lower.contains("failed to load models cache")
+        || lower.contains("codex_models_manager::cache")
     {
         return Some(CommandError::expected(format!(
             "{agent_name}'s local model cache is stale, so AI generation isn't available \

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -138,6 +138,14 @@ fn headless_invocation(agent: &AgentConfig, prompt: &str) -> Option<HeadlessInvo
 ///   set projects[…].hasTrustDialogAccepted: true in ~/.claude.json". The raw
 ///   compound error (trust warning + stdin race + "--print needs input") is a
 ///   confusing wall of text, so it gets a plain remedy instead (issue #660).
+/// - Codex's stale models cache — "failed to load models cache" (logged by
+///   `codex_models_manager::cache`): a corrupt/outdated local cache file the
+///   user can just delete (issue #689).
+///
+/// Callers must pass the FULL failure detail, never a truncated copy — Codex
+/// dumps a whole session transcript on failure and the matching line can sit
+/// anywhere in it (issues #665/#689). Substring matching handles mid-transcript
+/// hits; only the user-facing message is capped.
 fn classify_agent_cli_failure(agent_name: &str, detail: &str) -> Option<CommandError> {
     let lower = detail.to_lowercase();
     if lower.contains("session limit")
@@ -145,9 +153,20 @@ fn classify_agent_cli_failure(agent_name: &str, detail: &str) -> Option<CommandE
         || lower.contains("rate limit")
         || lower.contains("quota exceeded")
     {
+        // The raw detail carries the CLI's reset time — keep it, but capped
+        // (head+tail, since it may be a full transcript) so a user-facing
+        // message can't balloon.
+        let detail = crate::external_command::truncate_output_head_tail(detail);
         return Some(CommandError::expected(format!(
             "{agent_name} hit its usage limit, so AI generation isn't available right now. \
              The limit resets automatically — try again later. ({detail})"
+        )));
+    }
+    if lower.contains("failed to load models cache") || lower.contains("codex_models_manager::cache")
+    {
+        return Some(CommandError::expected(format!(
+            "{agent_name}'s local model cache is stale, so AI generation isn't available \
+             right now. Delete ~/.codex/models_cache.json and try again."
         )));
     }
     if lower.contains("please run /login")
@@ -167,6 +186,22 @@ fn classify_agent_cli_failure(agent_name: &str, detail: &str) -> Option<CommandE
         )));
     }
     None
+}
+
+/// Remove the echoed prompt from an agent CLI's failure output.
+///
+/// `codex exec` writes a session transcript to stderr, which reproduces the
+/// prompt we fed it — including the user's entire git diff. The app built that
+/// prompt itself, so an exact-substring match is reliable: excise it rather
+/// than forwarding the user's own data back as an "error" (issue #665). The
+/// prompt is matched trimmed (transcripts may re-render it without the exact
+/// leading/trailing whitespace we sent).
+fn strip_prompt_echo(output: &str, prompt: &str) -> String {
+    let prompt = prompt.trim();
+    if prompt.is_empty() || !output.contains(prompt) {
+        return output.to_string();
+    }
+    output.replace(prompt, "[prompt omitted]")
 }
 
 /// Run the active agent headlessly with `prompt` in `cwd` and return its final
@@ -240,29 +275,38 @@ async fn run_agent_headless(
     let final_message = read_and_cleanup(&output_file);
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Codex `exec` fails with a full session transcript on stderr — and
+        // that transcript echoes the prompt we sent, git diff included. Excise
+        // the echo BEFORE any capping or classification: it's the user's own
+        // data reflected back as an "error", and it buries the real failure
+        // line (issue #665).
+        let stderr = strip_prompt_echo(&String::from_utf8_lossy(&output.stderr), prompt);
         // A silent non-zero exit (empty stderr) used to surface as the
         // undiagnosable "Claude Code CLI failed: " — fall back to the exit code
-        // and a stdout snippet so there's something to act on (issue #269).
-        let detail = if stderr.trim().is_empty() {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let snippet: String = stdout.trim().chars().take(300).collect();
-            if snippet.is_empty() {
+        // and stdout so there's something to act on (issue #269).
+        let full_detail = if stderr.trim().is_empty() {
+            let stdout = strip_prompt_echo(&String::from_utf8_lossy(&output.stdout), prompt);
+            let stdout = stdout.trim();
+            if stdout.is_empty() {
                 format!("exit code {:?}, no output", output.status.code())
             } else {
-                format!("exit code {:?}: {snippet}", output.status.code())
+                format!("exit code {:?}: {stdout}", output.status.code())
             }
         } else {
-            // Cap like the stdout branch: an agent CLI can dump a whole
-            // session transcript (prompt, diff, paths) to stderr on failure —
-            // forwarding it unbounded is both noise and a data-exposure risk.
-            // The head carries the actual error (issue #578).
-            crate::external_command::truncate_output(&stderr)
+            stderr
         };
         // Known environment states (usage limit, expired sign-in, untrusted
-        // workspace) are the CLI working as designed — warn, not error, and
-        // Expected so they stay out of telemetry (issues #653/#660).
-        if let Some(err) = classify_agent_cli_failure(&agent.display_name, &detail) {
+        // workspace, stale Codex models cache) are the CLI working as designed
+        // — warn, not error, and Expected so they stay out of telemetry
+        // (issues #653/#660/#689). Classification sees the FULL detail: the
+        // matching line can sit anywhere in a transcript, so classifying a
+        // truncated copy would miss it (issue #689).
+        // What we forward/log stays capped — but head+tail, not head-only: in
+        // transcript-shaped output the actual error is the LAST line, so a
+        // head-only cap kept the banner and cut the one useful line
+        // (issues #578/#665).
+        let detail = crate::external_command::truncate_output_head_tail(&full_detail);
+        if let Some(err) = classify_agent_cli_failure(&agent.display_name, &full_detail) {
             warn!(
                 "{} CLI failed with an expected condition: {}",
                 agent.display_name, detail
@@ -847,6 +891,38 @@ mod tests {
         assert!(msg.contains("Open an agent terminal"), "got: {msg}");
     }
 
+    // The #689 shape: Codex refusing to run because its local models cache is
+    // stale — the environment, user-fixable by deleting the cache file.
+    #[test]
+    fn classify_agent_cli_failure_codex_models_cache_is_expected() {
+        let detail = "ERROR codex_models_manager::cache: failed to load models cache: \
+                      missing field `slug` at line 1 column 2000";
+        let err = classify_agent_cli_failure("Codex", detail).expect("must classify");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        let msg = format!("{err}");
+        assert!(msg.contains("model cache is stale"), "got: {msg}");
+        assert!(msg.contains("~/.codex/models_cache.json"), "got: {msg}");
+
+        // Either marker alone must classify too.
+        assert!(classify_agent_cli_failure("Codex", "failed to load models cache").is_some());
+        assert!(
+            classify_agent_cli_failure("Codex", "WARN codex_models_manager::cache: boom").is_some()
+        );
+    }
+
+    // The matching line arrives as the FIRST stderr line of a transcript that
+    // continues for thousands of chars — classification runs on the full
+    // (untruncated) detail, so it must still fire (interplay with #665's cap).
+    #[test]
+    fn classify_agent_cli_failure_matches_mid_transcript() {
+        let transcript = format!(
+            "OpenAI Codex banner\n{}\nERROR codex_models_manager::cache: failed to load models cache\n{}",
+            "transcript filler\n".repeat(200),
+            "more filler\n".repeat(200)
+        );
+        assert!(classify_agent_cli_failure("Codex", &transcript).is_some());
+    }
+
     // Genuine unexplained failures must keep flowing to telemetry.
     #[test]
     fn classify_agent_cli_failure_ignores_unknown_failures() {
@@ -855,6 +931,35 @@ mod tests {
         );
         assert!(classify_agent_cli_failure("Claude Code", "segmentation fault").is_none());
         assert!(classify_agent_cli_failure("Claude Code", "").is_none());
+    }
+
+    // The #665 data-exposure shape: Codex's failure transcript echoes the
+    // prompt we sent — git diff included — and it must be excised before the
+    // text reaches an error message or telemetry.
+    #[test]
+    fn strip_prompt_echo_excises_echoed_prompt() {
+        let prompt = build_commit_prompt(
+            " M src/secret.rs",
+            "diff --git a/src/secret.rs b/src/secret.rs\n+const API_KEY: &str = \"sk-secret\";",
+        );
+        let stderr = format!(
+            "OpenAI Codex v0.30 banner\n--------\nuser\n{prompt}\n--------\nERROR: stream disconnected"
+        );
+        let cleaned = strip_prompt_echo(&stderr, &prompt);
+        assert!(!cleaned.contains("sk-secret"), "diff leaked: {cleaned}");
+        assert!(cleaned.contains("[prompt omitted]"), "got: {cleaned}");
+        // The surrounding transcript (banner + the actual error) survives.
+        assert!(cleaned.contains("OpenAI Codex v0.30 banner"));
+        assert!(cleaned.contains("ERROR: stream disconnected"));
+    }
+
+    #[test]
+    fn strip_prompt_echo_leaves_unrelated_output_alone() {
+        let stderr = "ERROR: stream disconnected before completion";
+        assert_eq!(strip_prompt_echo(stderr, "some prompt"), stderr);
+        // An empty/whitespace prompt must never trigger a replace.
+        assert_eq!(strip_prompt_echo(stderr, ""), stderr);
+        assert_eq!(strip_prompt_echo(stderr, "  \n "), stderr);
     }
 
     #[test]

--- a/src-tauri/src/commands/assets.rs
+++ b/src-tauri/src/commands/assets.rs
@@ -319,11 +319,23 @@ pub async fn delete_asset(project_path: String, asset_path: String) -> Result<()
         return Err(("Security error: path is outside the assets folder".to_string()).into());
     }
 
-    if full_path.is_dir() {
-        fs::remove_dir_all(&full_path).map_err(|e| format!("Failed to delete directory: {e}"))?;
-    } else {
-        fs::remove_file(&full_path).map_err(|e| format!("Failed to delete file: {e}"))?;
-    }
+    // Robust deletes (read-only clearing + transient-lock retries): on Windows
+    // an antivirus scan or the Search indexer briefly holding the file failed a
+    // bare fs::remove_dir_all/remove_file with "Access is denied (os error 5)"
+    // (issue #696). Blocking work (chmod walk, retry sleeps up to ~8s) — keep
+    // it off the async runtime, mirroring delete_project.
+    let is_dir = full_path.is_dir();
+    tokio::task::spawn_blocking(move || {
+        if is_dir {
+            crate::utils::remove_dir_all_robust(&full_path)
+                .map_err(|e| format!("Failed to delete directory: {e}"))
+        } else {
+            crate::utils::remove_file_robust(&full_path)
+                .map_err(|e| format!("Failed to delete file: {e}"))
+        }
+    })
+    .await
+    .map_err(|e| format!("Asset deletion task failed: {e}"))??;
 
     Ok(())
 }

--- a/src-tauri/src/commands/git/branches.rs
+++ b/src-tauri/src/commands/git/branches.rs
@@ -539,6 +539,20 @@ pub async fn create_branch(
                 // tree files would be overwritten") variants (issue #566).
                 return Err(crate::errors::CommandError::expected(stderr.to_string()));
             }
+            // The base ref didn't resolve: "fatal: 'origin/Y' is not a commit
+            // and a branch 'X' cannot be created from it". The base branch was
+            // deleted or renamed on GitHub after the branch list loaded (or
+            // the fetch above failed) — a stale-state race with a user-side
+            // fix, not a malfunction (issue #692). The message wording is
+            // matched by isRecognizedGitFailure in src/lib/errors.ts — keep
+            // them byte-identical.
+            if is_missing_base_ref_error(&stderr) {
+                warn!(error = %stderr, "Branch creation base ref no longer exists");
+                return Err(crate::errors::CommandError::expected(
+                    "The branch this was based on no longer exists on GitHub. \
+                     Refresh your branches and try again.",
+                ));
+            }
             error!(error = %stderr, "Failed to create branch");
             return Err((stderr.to_string()).into());
         }
@@ -616,6 +630,14 @@ pub async fn push_branch(project_path: String, branch_name: String) -> Result<()
 
     info!("Branch published successfully");
     Ok(())
+}
+
+/// Git refusing `checkout -b <new> <base>` because the base ref doesn't
+/// resolve to a commit — "fatal: 'origin/Y' is not a commit and a branch 'X'
+/// cannot be created from it". Happens when the base branch was deleted or
+/// renamed on the remote after the branch list loaded (issue #692).
+fn is_missing_base_ref_error(stderr: &str) -> bool {
+    stderr.contains("is not a commit and a branch")
 }
 
 /// Git refusing `branch -D` because the branch is checked out in another
@@ -756,7 +778,7 @@ pub async fn delete_branch(
 
 #[cfg(test)]
 mod tests {
-    use super::is_worktree_delete_refusal;
+    use super::{is_missing_base_ref_error, is_worktree_delete_refusal};
 
     // The #562 shape: deleting a branch that another worktree has checked out.
     #[test]
@@ -770,6 +792,24 @@ mod tests {
         let stderr =
             "error: Cannot delete branch 'feature/x' checked out at '/Users/x/ShipStudio/proj'";
         assert!(is_worktree_delete_refusal(stderr));
+    }
+
+    // The #692 shape: creating a branch from a base whose remote ref is gone.
+    #[test]
+    fn missing_base_ref_error_matches_git_wording() {
+        let stderr = "fatal: 'origin/feature-x' is not a commit and a branch 'my-branch' cannot be created from it";
+        assert!(is_missing_base_ref_error(stderr));
+    }
+
+    #[test]
+    fn missing_base_ref_error_ignores_other_checkout_failures() {
+        assert!(!is_missing_base_ref_error(
+            "error: Your local changes to the following files would be overwritten by checkout"
+        ));
+        assert!(!is_missing_base_ref_error(
+            "fatal: a branch named 'my-branch' already exists"
+        ));
+        assert!(!is_missing_base_ref_error(""));
     }
 
     #[test]

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -217,6 +217,19 @@ fn ensure_shipstudio_excluded(path: &std::path::Path) {
     );
 }
 
+/// A failed `git commit` whose stdout says the commit was a no-op. Git has
+/// three wordings for it: "nothing to commit", "…working tree clean", and —
+/// when entries are reported by `status --porcelain` but couldn't be staged —
+/// "no changes added to commit". The third shows up when `git add -A` skips
+/// an unstageable entry such as a nested git repository (issue #702); since
+/// `add -A` always runs immediately before the commit here, that wording can
+/// only mean unstageable entries, never "the user forgot to stage".
+fn is_commit_noop_stdout(stdout: &str) -> bool {
+    stdout.contains("nothing to commit")
+        || stdout.contains("working tree clean")
+        || stdout.contains("no changes added to commit")
+}
+
 /// Marker strings that identify a failed `git commit` as the project's own
 /// commit-hook chain refusing the commit (husky / lint-staged / the pre-commit
 /// framework), rather than git itself failing. Git contributes no wording of
@@ -326,7 +339,7 @@ pub fn git_stage_and_commit(path: &std::path::Path, message: &str) -> Result<boo
         // "nothing to commit" to *stdout* and leaves stderr blank — treat it as
         // the no-op it is instead of surfacing an empty error (issue #274).
         let stdout = String::from_utf8_lossy(&commit_output.stdout);
-        if stdout.contains("nothing to commit") || stdout.contains("working tree clean") {
+        if is_commit_noop_stdout(&stdout) {
             return Ok(false);
         }
         let stderr = String::from_utf8_lossy(&commit_output.stderr);
@@ -803,6 +816,27 @@ mod tests {
             ".shipstudio must not be staged, got: {listing}"
         );
         assert!(listing.contains("a.txt"));
+    }
+
+    // The #702 shape: `git add -A` can't stage a nested git repo, so the
+    // commit refuses with git's third no-op wording — must classify as a
+    // no-op alongside the two wordings #274 already covered.
+    #[test]
+    fn commit_noop_stdout_matches_all_three_git_wordings() {
+        assert!(is_commit_noop_stdout(
+            "On branch main\nnothing to commit, working tree clean"
+        ));
+        assert!(is_commit_noop_stdout(
+            "On branch main\nYour branch is up to date with 'origin/main'.\n\nnothing to commit, working tree clean"
+        ));
+        assert!(is_commit_noop_stdout(
+            "On branch main\nUntracked files:\n\t(use \"git add <file>...\" to include in what will be committed)\n\tnested-repo/\n\nno changes added to commit (use \"git add\" and/or \"git commit -a\")"
+        ));
+        // Genuine commit failures must NOT classify as no-ops.
+        assert!(!is_commit_noop_stdout(""));
+        assert!(!is_commit_noop_stdout(
+            "[main 1a2b3c4] my commit\n 1 file changed"
+        ));
     }
 
     // The #604 shape: husky → lint-staged → tsc/vitest output dumped verbatim

--- a/src-tauri/src/commands/git/status.rs
+++ b/src-tauri/src/commands/git/status.rs
@@ -28,6 +28,27 @@ fn truncate_stderr(stderr: &str) -> String {
     format!("{}…", &stderr[..cut])
 }
 
+/// Failure message for a non-zero `git status` exit. Git can die with a
+/// completely silent stderr (killed by the OS, exec-level failure) — the old
+/// unconditional `: {stderr}` suffix then produced "Failed to get git
+/// status: " with zero diagnostic signal (issue #682). Fall back to the exit
+/// code so telemetry always carries *something*.
+fn git_status_failure_message(stderr_trimmed: &str, exit_code: Option<i32>) -> String {
+    if stderr_trimmed.is_empty() {
+        return match exit_code {
+            Some(code) => format!("Failed to get git status (exit {code})"),
+            None => "Failed to get git status (terminated by signal)".to_string(),
+        };
+    }
+    // Include (truncated) stderr — a bare "Failed to get git status" is
+    // undiagnosable and buckets unrelated root causes under one
+    // fingerprint (issue #547, same class as #252).
+    format!(
+        "Failed to get git status: {}",
+        truncate_stderr(stderr_trimmed)
+    )
+}
+
 #[tauri::command]
 #[tracing::instrument(fields(project = %project_path))]
 pub async fn check_git_has_changes(project_path: String) -> Result<bool, CommandError> {
@@ -111,14 +132,7 @@ pub async fn get_changed_files(project_path: String) -> Result<Vec<ChangedFile>,
             warn!(error = %stderr.trim(), "git blocked by an environment gap while getting status");
             return Err(gap);
         }
-        // Include (truncated) stderr — a bare "Failed to get git status" is
-        // undiagnosable and buckets unrelated root causes under one
-        // fingerprint (issue #547, same class as #252).
-        return Err((format!(
-            "Failed to get git status: {}",
-            truncate_stderr(stderr.trim())
-        ))
-        .into());
+        return Err(git_status_failure_message(stderr.trim(), output.status.code()).into());
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -365,7 +379,7 @@ pub async fn reset_to_branch(project_path: String, branch: String) -> Result<(),
 
 #[cfg(test)]
 mod tests {
-    use super::truncate_stderr;
+    use super::{git_status_failure_message, truncate_stderr};
 
     #[test]
     fn truncate_stderr_passes_short_text_through() {
@@ -388,5 +402,31 @@ mod tests {
         let long = "é".repeat(600);
         let out = truncate_stderr(&long);
         assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn status_failure_keeps_stderr_when_present() {
+        assert_eq!(
+            git_status_failure_message("fatal: bad object HEAD", Some(128)),
+            "Failed to get git status: fatal: bad object HEAD"
+        );
+    }
+
+    // The #682 shape: non-zero exit with a silent stderr must carry the exit
+    // code instead of trailing off after a colon.
+    #[test]
+    fn status_failure_falls_back_to_exit_code_when_stderr_is_empty() {
+        assert_eq!(
+            git_status_failure_message("", Some(128)),
+            "Failed to get git status (exit 128)"
+        );
+    }
+
+    #[test]
+    fn status_failure_names_signal_death_when_no_exit_code() {
+        assert_eq!(
+            git_status_failure_message("", None),
+            "Failed to get git status (terminated by signal)"
+        );
     }
 }

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -189,6 +189,13 @@ fn gh_command_and_account(project_path: Option<&str>) -> Result<(Command, String
     }
 }
 
+/// User-facing message when a `gh api` call blows its time budget — a slow or
+/// flaky network, not an app malfunction (issue #686). `Expected` keeps it out
+/// of telemetry; ImportProject.tsx matches the "took too long" wording to
+/// suggest retrying instead of re-authenticating — keep them in sync.
+const GH_TIMEOUT_MESSAGE: &str =
+    "GitHub took too long to respond. Check your internet connection and try again.";
+
 #[tauri::command]
 #[tracing::instrument]
 pub async fn get_github_username(project_path: Option<String>) -> Result<String, CommandError> {
@@ -199,7 +206,14 @@ pub async fn get_github_username(project_path: Option<String>) -> Result<String,
     }
 
     cmd.args(["api", "user", "--jq", ".login"]);
-    let output = run_command_with_timeout(cmd, "gh api user", GITHUB_CLI_TIMEOUT_SECS).await?;
+    let output = match run_command_with_timeout(cmd, "gh api user", GITHUB_CLI_TIMEOUT_SECS).await {
+        // A blown time budget is the network, not a malfunction — same
+        // mapping pattern as mobile.rs's simctl timeouts (issue #686).
+        Err(CommandError::Timeout { .. }) => {
+            return Err(CommandError::expected(GH_TIMEOUT_MESSAGE))
+        }
+        other => other?,
+    };
 
     if !output.status.success() {
         return Err(CommandError::NotAuthenticated {
@@ -219,7 +233,15 @@ pub async fn get_github_orgs(project_path: Option<String>) -> Result<Vec<String>
     // login so org choices match the account the repo will be created under.
     let (mut cmd, _account_id) = gh_command_and_account(project_path.as_deref())?;
     cmd.args(["api", "user/orgs", "--jq", ".[].login"]);
-    let output = run_command_with_timeout(cmd, "gh api user/orgs", GITHUB_CLI_TIMEOUT_SECS).await?;
+    let output =
+        match run_command_with_timeout(cmd, "gh api user/orgs", GITHUB_CLI_TIMEOUT_SECS).await {
+            // Same network-not-malfunction mapping as get_github_username
+            // (issue #686).
+            Err(CommandError::Timeout { .. }) => {
+                return Err(CommandError::expected(GH_TIMEOUT_MESSAGE))
+            }
+            other => other?,
+        };
 
     if !output.status.success() {
         // Return empty list if we can't get orgs (user might not have any)
@@ -922,6 +944,18 @@ mod tests {
     /// `invalidate_github_username_cache` clears the whole cache, so without this
     /// these tests race under cargo's default multi-threaded runner.
     static CACHE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    // The #686 contract: ImportProject.tsx special-cases the "took too long"
+    // wording to suggest retrying (not re-authenticating), and errors.ts's
+    // isRecognizedGitFailure matches "check your internet connection" — a
+    // rewording here silently breaks both.
+    #[test]
+    fn gh_timeout_message_keeps_the_frontend_matched_wording() {
+        assert!(GH_TIMEOUT_MESSAGE.contains("took too long"));
+        assert!(GH_TIMEOUT_MESSAGE
+            .to_lowercase()
+            .contains("check your internet connection"));
+    }
 
     #[test]
     fn parse_github_repo_https_with_git_suffix() {

--- a/src-tauri/src/commands/ide/screenshots/playwright.rs
+++ b/src-tauri/src/commands/ide/screenshots/playwright.rs
@@ -82,14 +82,25 @@ fn is_broken_loader_error(stderr: &str) -> bool {
 }
 
 /// Map a failed capture-script run to a `CommandError`. A connection refused
-/// that survived the in-script retry means the dev server went away mid-flight
-/// (crashed, restarted on another port) — an expected state exactly like the
-/// pre-capture readiness miss (#349), not an app malfunction (issue #514).
+/// or invalid-HTTP-response that survived the in-script retry means the dev
+/// server went away mid-flight (crashed, restarted on another port) — an
+/// expected state exactly like the pre-capture readiness miss (#349), not an
+/// app malfunction (issues #514/#703).
 fn capture_script_error(what: &str, url: &str, output: &std::process::Output) -> CommandError {
     let stderr = String::from_utf8_lossy(&output.stderr);
     if stderr.contains("ERR_CONNECTION_REFUSED") {
         return CommandError::expected(format!(
             "The dev server at {url} stopped responding while the screenshot was being captured. Wait for the preview to finish reloading, then try again."
+        ));
+    }
+    // A malformed/empty HTTP response mid-navigation is the same dev-server
+    // restart race as the refused connection above, caught one step later:
+    // the server accepted the socket but died mid-answer (issue #703). The
+    // script already retried it once — persisting means the server is still
+    // down, an expected state, not an app bug.
+    if stderr.contains("ERR_INVALID_HTTP_RESPONSE") {
+        return CommandError::expected(format!(
+            "The dev server at {url} stopped responding while loading the page — it was probably restarting mid-request. Wait for the preview to finish reloading, then try again."
         ));
     }
     // Node itself failing to start (dyld can't resolve a linked library) is a
@@ -383,8 +394,11 @@ const {{ chromium }} = require('playwright');
             // A refused connection here, right after the Rust-side TCP
             // readiness check passed, means the dev server died or is
             // restarting in the gap between check and capture (issue #514) —
-            // give it a short beat before the one retry.
-            if (msg.includes('ERR_CONNECTION_REFUSED')) {{
+            // give it a short beat before the one retry. A malformed/empty
+            // HTTP response is the same race caught one step later: the
+            // server accepted the socket but died mid-answer while
+            // restarting (issue #703) — same beat, same retry.
+            if (msg.includes('ERR_CONNECTION_REFUSED') || msg.includes('ERR_INVALID_HTTP_RESPONSE')) {{
                 await new Promise((resolve) => setTimeout(resolve, 2000));
             }} else if (!msg.includes('Timeout')) {{
                 throw err;
@@ -599,8 +613,11 @@ const {{ chromium }} = require('playwright');
             // A refused connection here, right after the Rust-side TCP
             // readiness check passed, means the dev server died or is
             // restarting in the gap between check and capture (issue #514) —
-            // give it a short beat before the one retry.
-            if (msg.includes('ERR_CONNECTION_REFUSED')) {{
+            // give it a short beat before the one retry. A malformed/empty
+            // HTTP response is the same race caught one step later: the
+            // server accepted the socket but died mid-answer while
+            // restarting (issue #703) — same beat, same retry.
+            if (msg.includes('ERR_CONNECTION_REFUSED') || msg.includes('ERR_INVALID_HTTP_RESPONSE')) {{
                 await new Promise((resolve) => setTimeout(resolve, 2000));
             }} else if (!msg.includes('Timeout')) {{
                 throw err;
@@ -740,6 +757,24 @@ mod capture_error_tests {
         match capture_script_error("Playwright screenshot", "http://localhost:3000", &output) {
             CommandError::Expected { message } => {
                 assert!(message.contains("stopped responding"), "got: {message}")
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_http_response_after_retry_is_expected_not_telemetry() {
+        // Issue #703: the dev server accepting the socket but dying mid-answer
+        // (restart race) surfaces as ERR_INVALID_HTTP_RESPONSE — the same
+        // expected class as the refused-connection race (#514), and it must
+        // not dump raw stderr or auto-file a report.
+        let output = failed_output(
+            "page.goto: net::ERR_INVALID_HTTP_RESPONSE at http://localhost:3000/\nCall log:\n  - navigating to \"http://localhost:3000/\", waiting until \"load\"",
+        );
+        match capture_script_error("Playwright screenshot", "http://localhost:3000", &output) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("stopped responding"), "got: {message}");
+                assert!(message.contains("http://localhost:3000"), "got: {message}");
             }
             other => panic!("expected Expected, got {other:?}"),
         }

--- a/src-tauri/src/commands/ide/screenshots/webview_snapshot.rs
+++ b/src-tauri/src/commands/ide/screenshots/webview_snapshot.rs
@@ -205,47 +205,64 @@ async fn snapshot_webview_region(
         .with_webview(move |webview| {
             // Runs on the main thread. All Obj-C work happens here; only the
             // finished PNG bytes cross back to the async command.
-            let wk: *mut AnyObject = webview.inner().cast();
-            if wk.is_null() {
-                let _ = tx.send(Err("webview handle is null".to_string()));
-                return;
-            }
-            unsafe {
-                let config: *mut AnyObject = msg_send![class!(WKSnapshotConfiguration), new];
-                let cg_rect = CGRect {
-                    origin: CGPoint {
-                        x: rect.x,
-                        y: rect.y,
-                    },
-                    size: CGSize {
-                        width: rect.width,
-                        height: rect.height,
-                    },
-                };
-                let _: () = msg_send![config, setRect: cg_rect];
-                // Ask WebKit to hand back a pre-scaled image: 640pt wide, the
-                // dashboard thumbnail size. (Retina still doubles the pixels;
-                // resize_thumbnail_image normalizes after the write.)
-                let width_num: *mut AnyObject =
-                    msg_send![class!(NSNumber), numberWithDouble: 640.0f64];
-                let _: () = msg_send![config, setSnapshotWidth: width_num];
+            //
+            // The ENTIRE body is panic-guarded, not just the completion block:
+            // a panic anywhere in the setup msg_send! calls (building
+            // WKSnapshotConfiguration, NSNumber, dispatching the snapshot)
+            // would unwind across the main-thread dispatch boundary and abort
+            // the whole app ("panic in a function that cannot unwind" —
+            // issue #684). Degrade any panic to a failed capture instead; the
+            // explicit send on the panic path keeps the waiting receiver from
+            // sitting out its full 10s timeout.
+            let panic_tx = tx.clone();
+            let setup = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+                let wk: *mut AnyObject = webview.inner().cast();
+                if wk.is_null() {
+                    let _ = tx.send(Err("webview handle is null".to_string()));
+                    return;
+                }
+                unsafe {
+                    let config: *mut AnyObject = msg_send![class!(WKSnapshotConfiguration), new];
+                    let cg_rect = CGRect {
+                        origin: CGPoint {
+                            x: rect.x,
+                            y: rect.y,
+                        },
+                        size: CGSize {
+                            width: rect.width,
+                            height: rect.height,
+                        },
+                    };
+                    let _: () = msg_send![config, setRect: cg_rect];
+                    // Ask WebKit to hand back a pre-scaled image: 640pt wide, the
+                    // dashboard thumbnail size. (Retina still doubles the pixels;
+                    // resize_thumbnail_image normalizes after the write.)
+                    let width_num: *mut AnyObject =
+                        msg_send![class!(NSNumber), numberWithDouble: 640.0f64];
+                    let _: () = msg_send![config, setSnapshotWidth: width_num];
 
-                let block = block2::RcBlock::new(
-                    move |image: *mut AnyObject, error: *mut AnyObject| {
-                        // A panic here unwinds across the Objective-C block
-                        // boundary and aborts the entire app — degrade any
-                        // internal error to a failed capture instead.
-                        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
-                            || png_bytes_from_snapshot(image, error),
-                        ))
-                        .unwrap_or_else(|_| {
-                            Err("internal panic during snapshot conversion".to_string())
-                        });
-                        let _ = tx.send(result);
-                    },
-                );
-                let _: () = msg_send![wk, takeSnapshotWithConfiguration: config, completionHandler: &*block];
-                let _: () = msg_send![config, release];
+                    let block = block2::RcBlock::new(
+                        move |image: *mut AnyObject, error: *mut AnyObject| {
+                            // A panic here unwinds across the Objective-C block
+                            // boundary and aborts the entire app — degrade any
+                            // internal error to a failed capture instead.
+                            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+                                || png_bytes_from_snapshot(image, error),
+                            ))
+                            .unwrap_or_else(|_| {
+                                Err("internal panic during snapshot conversion".to_string())
+                            });
+                            let _ = tx.send(result);
+                        },
+                    );
+                    let _: () = msg_send![wk, takeSnapshotWithConfiguration: config, completionHandler: &*block];
+                    let _: () = msg_send![config, release];
+                }
+            }));
+            if setup.is_err() {
+                let _ = panic_tx.send(Err(
+                    "internal panic while preparing the webview snapshot".to_string(),
+                ));
             }
         })
         .map_err(|e| CommandError::from(format!("Could not reach the app webview: {e}")))?;

--- a/src-tauri/src/commands/monorepo.rs
+++ b/src-tauri/src/commands/monorepo.rs
@@ -4,8 +4,13 @@
 //! import wizard can ask the user which one they want to focus on. Detects:
 //! - `pnpm-workspace.yaml` (`packages:` list)
 //! - root `package.json#workspaces` (array or `{ packages: [...] }` form)
+//! - `nx.json` (integrated-style Nx repos without npm workspaces: apps live
+//!   under `workspaceLayout.appsDir`, default `apps/`)
 //!
-//! Returns subdirs that have a `package.json` with a `dev` or `start` script.
+//! Returns subdirs that are runnable: either their `package.json` has a
+//! `dev`/`start` script, or (Nx) their `project.json` declares a `serve`/`dev`
+//! target (issue #691) — in that case the reported dev script is a synthesized
+//! `nx <target> <project>` hint.
 
 use crate::errors::CommandError;
 use crate::utils::validate_project_path;
@@ -55,7 +60,8 @@ pub fn detect_workspaces_at(root: &Path) -> Vec<WorkspaceInfo> {
     workspaces
 }
 
-/// Read workspace globs from `pnpm-workspace.yaml` and root `package.json#workspaces`.
+/// Read workspace globs from `pnpm-workspace.yaml`, root
+/// `package.json#workspaces`, and — for Nx — `nx.json`.
 fn collect_workspace_globs(root: &Path) -> Vec<String> {
     let mut out = Vec::new();
 
@@ -66,6 +72,31 @@ fn collect_workspace_globs(root: &Path) -> Vec<String> {
     if let Ok(contents) = std::fs::read_to_string(root.join("package.json")) {
         if let Ok(json) = serde_json::from_str::<serde_json::Value>(&contents) {
             out.extend(parse_package_json_workspaces(&json));
+        }
+    }
+
+    // Integrated-style Nx repos declare no npm workspaces at all — apps live
+    // under nx.json's workspaceLayout.appsDir (default "apps"). Without this,
+    // such repos never even reach the runnable-workspace check (issue #691).
+    // Non-runnable dirs matched by these globs are still filtered out later.
+    if let Ok(contents) = std::fs::read_to_string(root.join("nx.json")) {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&contents) {
+            let layout = json.get("workspaceLayout");
+            let dir_glob = |key: &str, default: &str| {
+                let dir = layout
+                    .and_then(|l| l.get(key))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(default)
+                    .trim_matches('/')
+                    .to_string();
+                if dir.is_empty() {
+                    None
+                } else {
+                    Some(format!("{dir}/*"))
+                }
+            };
+            out.extend(dir_glob("appsDir", "apps"));
+            out.extend(dir_glob("libsDir", "libs"));
         }
     }
 
@@ -166,32 +197,118 @@ fn expand_pattern(root: &Path, pattern: &str) -> Vec<PathBuf> {
     }
 }
 
+/// The Nx run target a workspace can be served with, pulled from its
+/// `project.json`.
+struct NxRunTarget {
+    /// Target name (`serve` or `dev`) — becomes part of the `nx <target> <project>` hint.
+    name: &'static str,
+    /// Executor (modern `executor`, legacy `builder`) — used to guess web-ness.
+    executor: Option<String>,
+    /// `targets.<name>.options.port` when explicitly configured.
+    port: Option<u16>,
+}
+
+/// Find a runnable target in an Nx `project.json`: a `targets` (or legacy
+/// `architect`) object containing a `serve` or `dev` entry, in that priority.
+fn nx_serve_target(project_json: &serde_json::Value) -> Option<NxRunTarget> {
+    let targets = project_json
+        .get("targets")
+        .or_else(|| project_json.get("architect"))?
+        .as_object()?;
+    for name in ["serve", "dev"] {
+        if let Some(target) = targets.get(name) {
+            let executor = target
+                .get("executor")
+                .or_else(|| target.get("builder"))
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let port = target
+                .get("options")
+                .and_then(|o| o.get("port"))
+                .and_then(|v| v.as_u64())
+                .and_then(|n| u16::try_from(n).ok());
+            return Some(NxRunTarget {
+                name,
+                executor,
+                port,
+            });
+        }
+    }
+    None
+}
+
+/// Web-ness guess for an Nx executor string. Framework executors carry the
+/// framework name (`@nx/next:server`, `@nx/vite:dev-server`); plain React /
+/// Angular apps serve via webpack/angular dev-server executors.
+fn is_web_nx_executor(executor: &str) -> bool {
+    let lowered = executor.to_lowercase();
+    is_web_dev_command(&lowered)
+        || ["dev-server", "angular", "webpack", "@nx/web"]
+            .iter()
+            .any(|needle| lowered.contains(needle))
+}
+
 fn inspect_workspace(root: &Path, dir: &Path) -> Option<WorkspaceInfo> {
-    let pkg_path = dir.join("package.json");
-    let contents = std::fs::read_to_string(&pkg_path).ok()?;
-    let json: serde_json::Value = serde_json::from_str(&contents).ok()?;
+    let read_json = |file: &str| -> Option<serde_json::Value> {
+        let contents = std::fs::read_to_string(dir.join(file)).ok()?;
+        serde_json::from_str(&contents).ok()
+    };
+    let pkg = read_json("package.json");
+    let nx = read_json("project.json");
 
-    let name = json
-        .get("name")
-        .and_then(|v| v.as_str())
-        .map(String::from)
-        .unwrap_or_else(|| {
-            dir.file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("workspace")
-                .to_string()
-        });
+    // A dir with neither manifest isn't a workspace we can describe.
+    if pkg.is_none() && nx.is_none() {
+        return None;
+    }
 
-    let scripts = json.get("scripts").and_then(|v| v.as_object());
-    let dev_script = scripts.and_then(|s| {
+    let get_name = |json: &Option<serde_json::Value>| -> Option<String> {
+        json.as_ref()
+            .and_then(|j| j.get("name"))
+            .and_then(|v| v.as_str())
+            .map(String::from)
+    };
+    let pkg_name = get_name(&pkg);
+    let nx_name = get_name(&nx);
+    let dir_name = || {
+        dir.file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("workspace")
+            .to_string()
+    };
+
+    let scripts = pkg
+        .as_ref()
+        .and_then(|j| j.get("scripts"))
+        .and_then(|v| v.as_object());
+    let mut dev_script = scripts.and_then(|s| {
         s.get("dev")
             .and_then(|v| v.as_str())
             .or_else(|| s.get("start").and_then(|v| v.as_str()))
             .map(String::from)
     });
 
-    let port_hint = dev_script.as_deref().and_then(parse_port_from_script);
-    let is_web = dev_script.as_deref().is_some_and(is_web_dev_command);
+    let mut port_hint = dev_script.as_deref().and_then(parse_port_from_script);
+    let mut is_web = dev_script.as_deref().is_some_and(is_web_dev_command);
+
+    // Nx apps declare run targets in a per-app project.json instead of
+    // package.json scripts; without this they were filtered out as "not
+    // runnable" and the picker never offered them (issue #691). The
+    // synthesized `nx <target> <project>` value is a *hint* — the picker
+    // displays it, and it's what the user runs (or saves as the custom dev
+    // command) to serve the app; it is never executed blindly.
+    if dev_script.is_none() {
+        if let Some(target) = nx.as_ref().and_then(nx_serve_target) {
+            let nx_project = nx_name
+                .clone()
+                .or_else(|| pkg_name.clone())
+                .unwrap_or_else(dir_name);
+            dev_script = Some(format!("nx {} {}", target.name, nx_project));
+            port_hint = target.port;
+            is_web = target.executor.as_deref().is_some_and(is_web_nx_executor);
+        }
+    }
+
+    let name = pkg_name.or(nx_name).unwrap_or_else(dir_name);
 
     let relative = dir.strip_prefix(root).ok()?;
     let relative_path = relative
@@ -357,6 +474,187 @@ mod tests {
             Some(8080)
         );
         assert_eq!(parse_port_from_script("next dev"), None);
+    }
+
+    // ── Nx (issue #691) ──────────────────────────────────────────────────
+
+    #[test]
+    fn offers_nx_app_with_project_json_serve_target() {
+        // Package-based Nx repo: npm workspaces exist, but the app declares
+        // its run target in project.json, not package.json scripts.
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "package.json",
+            r#"{ "name": "root", "workspaces": ["apps/*"] }"#,
+        );
+        write(
+            tmp.path(),
+            "apps/web/package.json",
+            r#"{ "name": "@x/web" }"#,
+        );
+        write(
+            tmp.path(),
+            "apps/web/project.json",
+            r#"{
+                "name": "web",
+                "targets": {
+                    "build": { "executor": "@nx/next:build" },
+                    "serve": {
+                        "executor": "@nx/next:server",
+                        "options": { "port": 4200 }
+                    }
+                }
+            }"#,
+        );
+
+        let workspaces = detect_workspaces_at(tmp.path());
+        assert_eq!(workspaces.len(), 1);
+        let web = &workspaces[0];
+        assert_eq!(web.relative_path, "apps/web");
+        // Package name wins for display; the nx hint uses the Nx project name.
+        assert_eq!(web.name, "@x/web");
+        assert_eq!(web.dev_script.as_deref(), Some("nx serve web"));
+        assert_eq!(web.port_hint, Some(4200));
+        assert!(web.is_web);
+    }
+
+    #[test]
+    fn offers_nx_app_without_package_json_via_nx_json_layout() {
+        // Integrated-style Nx repo: no npm workspaces at all; apps found via
+        // nx.json's default apps/ layout, described by project.json alone.
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path(), "package.json", r#"{ "name": "root" }"#);
+        write(tmp.path(), "nx.json", r#"{ "npmScope": "x" }"#);
+        write(
+            tmp.path(),
+            "apps/site/project.json",
+            r#"{
+                "name": "site",
+                "targets": {
+                    "serve": { "executor": "@nx/vite:dev-server" }
+                }
+            }"#,
+        );
+        // A lib without a serve target must stay filtered out.
+        write(
+            tmp.path(),
+            "libs/ui/project.json",
+            r#"{ "name": "ui", "targets": { "build": { "executor": "@nx/js:tsc" } } }"#,
+        );
+
+        let workspaces = detect_workspaces_at(tmp.path());
+        assert_eq!(workspaces.len(), 1);
+        assert_eq!(workspaces[0].relative_path, "apps/site");
+        assert_eq!(workspaces[0].name, "site");
+        assert_eq!(workspaces[0].dev_script.as_deref(), Some("nx serve site"));
+        assert_eq!(workspaces[0].port_hint, None);
+        assert!(workspaces[0].is_web);
+    }
+
+    #[test]
+    fn respects_nx_json_workspace_layout_override() {
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path(), "package.json", r#"{ "name": "root" }"#);
+        write(
+            tmp.path(),
+            "nx.json",
+            r#"{ "workspaceLayout": { "appsDir": "applications" } }"#,
+        );
+        write(
+            tmp.path(),
+            "applications/store/project.json",
+            r#"{ "name": "store", "targets": { "serve": { "executor": "@nx/webpack:dev-server" } } }"#,
+        );
+
+        let workspaces = detect_workspaces_at(tmp.path());
+        assert_eq!(workspaces.len(), 1);
+        assert_eq!(workspaces[0].relative_path, "applications/store");
+        assert!(workspaces[0].is_web);
+    }
+
+    #[test]
+    fn parses_legacy_architect_dev_target() {
+        // Older Angular-flavored config: `architect` instead of `targets`,
+        // `builder` instead of `executor`; `dev` accepted when `serve` absent.
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path(), "package.json", r#"{ "name": "root" }"#);
+        write(tmp.path(), "nx.json", "{}");
+        write(
+            tmp.path(),
+            "apps/admin/project.json",
+            r#"{
+                "name": "admin",
+                "architect": {
+                    "dev": {
+                        "builder": "@angular-devkit/build-angular:dev-server",
+                        "options": { "port": 4300 }
+                    }
+                }
+            }"#,
+        );
+
+        let workspaces = detect_workspaces_at(tmp.path());
+        assert_eq!(workspaces.len(), 1);
+        assert_eq!(workspaces[0].dev_script.as_deref(), Some("nx dev admin"));
+        assert_eq!(workspaces[0].port_hint, Some(4300));
+        assert!(workspaces[0].is_web);
+    }
+
+    #[test]
+    fn package_json_dev_script_takes_precedence_over_nx_target() {
+        // When the app has a real dev script, keep it — it's what the dev
+        // server will actually run at the workspace cwd.
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "package.json",
+            r#"{ "name": "root", "workspaces": ["apps/*"] }"#,
+        );
+        make_app(tmp.path(), "apps/web", "web", "next dev -p 3001");
+        write(
+            tmp.path(),
+            "apps/web/project.json",
+            r#"{ "name": "web", "targets": { "serve": { "executor": "@nx/next:server" } } }"#,
+        );
+
+        let workspaces = detect_workspaces_at(tmp.path());
+        assert_eq!(workspaces.len(), 1);
+        assert_eq!(
+            workspaces[0].dev_script.as_deref(),
+            Some("next dev -p 3001")
+        );
+        assert_eq!(workspaces[0].port_hint, Some(3001));
+    }
+
+    #[test]
+    fn nx_project_json_without_serve_or_dev_is_not_runnable() {
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path(), "package.json", r#"{ "name": "root" }"#);
+        write(tmp.path(), "nx.json", "{}");
+        write(
+            tmp.path(),
+            "apps/tool/project.json",
+            r#"{ "name": "tool", "targets": { "build": { "executor": "@nx/js:tsc" } } }"#,
+        );
+        assert!(detect_workspaces_at(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn non_web_nx_executor_is_not_marked_web() {
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path(), "package.json", r#"{ "name": "root" }"#);
+        write(tmp.path(), "nx.json", "{}");
+        write(
+            tmp.path(),
+            "apps/api/project.json",
+            r#"{ "name": "api", "targets": { "serve": { "executor": "@nx/js:node" } } }"#,
+        );
+
+        let workspaces = detect_workspaces_at(tmp.path());
+        assert_eq!(workspaces.len(), 1);
+        assert_eq!(workspaces[0].dev_script.as_deref(), Some("nx serve api"));
+        assert!(!workspaces[0].is_web);
     }
 
     #[test]

--- a/src-tauri/src/commands/projects/detection.rs
+++ b/src-tauri/src/commands/projects/detection.rs
@@ -410,7 +410,7 @@ struct ScanEntry {
 /// - **Unreadable subdirectories are skipped** (with a warning) instead of
 ///   failing the entire scan; only a failure to read the scan root is an error,
 ///   and that error carries the operation + path + underlying cause.
-fn read_scan_dir(dir: &std::path::Path, depth: usize) -> Result<Vec<ScanEntry>, String> {
+fn read_scan_dir(dir: &std::path::Path, depth: usize) -> Result<Vec<ScanEntry>, CommandError> {
     if depth > MAX_SCAN_DEPTH {
         tracing::warn!(
             dir = %dir.display(),
@@ -431,10 +431,15 @@ fn read_scan_dir(dir: &std::path::Path, depth: usize) -> Result<Vec<ScanEntry>, 
             return Ok(Vec::new());
         }
         Err(e) => {
-            return Err(format!(
-                "Failed to read directory '{}' during page scan: {e}",
-                dir.display()
-            ))
+            // Root-read failures carry real remediation on macOS/Windows
+            // (TCC "Operation not permitted" under ~/Desktop & co., transient
+            // AV locks, read-only volumes) — classify instead of dumping the
+            // raw io::Error to telemetry (issue #688).
+            return Err(crate::utils::classify_fs_error(
+                "read this project's page routes",
+                dir,
+                &e,
+            ));
         }
     };
 
@@ -472,7 +477,7 @@ pub(crate) fn scan_nextjs_pages(
     if !dir.exists() {
         return Ok(pages);
     }
-    scan_nextjs_pages_at(dir, base_dir, 0, &mut pages).map_err(CommandError::from)?;
+    scan_nextjs_pages_at(dir, base_dir, 0, &mut pages)?;
     Ok(pages)
 }
 
@@ -481,7 +486,7 @@ fn scan_nextjs_pages_at(
     base_dir: &std::path::Path,
     depth: usize,
     pages: &mut Vec<PageInfo>,
-) -> Result<(), String> {
+) -> Result<(), CommandError> {
     for entry in read_scan_dir(dir, depth)? {
         let path = entry.path;
 
@@ -546,7 +551,7 @@ fn scan_nextjs_pages_at(
 pub(crate) fn scan_sveltekit_pages(
     dir: &std::path::Path,
     base_dir: &std::path::Path,
-) -> Result<Vec<PageInfo>, String> {
+) -> Result<Vec<PageInfo>, CommandError> {
     let mut pages = Vec::new();
     if !dir.exists() {
         return Ok(pages);
@@ -560,7 +565,7 @@ fn scan_sveltekit_pages_at(
     base_dir: &std::path::Path,
     depth: usize,
     pages: &mut Vec<PageInfo>,
-) -> Result<(), String> {
+) -> Result<(), CommandError> {
     for entry in read_scan_dir(dir, depth)? {
         let path = entry.path;
 
@@ -622,7 +627,7 @@ fn scan_sveltekit_pages_at(
 pub(crate) fn scan_astro_pages(
     dir: &std::path::Path,
     base_dir: &std::path::Path,
-) -> Result<Vec<PageInfo>, String> {
+) -> Result<Vec<PageInfo>, CommandError> {
     let mut pages = Vec::new();
     if !dir.exists() {
         return Ok(pages);
@@ -636,7 +641,7 @@ fn scan_astro_pages_at(
     base_dir: &std::path::Path,
     depth: usize,
     pages: &mut Vec<PageInfo>,
-) -> Result<(), String> {
+) -> Result<(), CommandError> {
     for entry in read_scan_dir(dir, depth)? {
         let path = entry.path;
 
@@ -701,7 +706,7 @@ fn scan_astro_pages_at(
 pub(crate) fn scan_nuxt_pages(
     dir: &std::path::Path,
     base_dir: &std::path::Path,
-) -> Result<Vec<PageInfo>, String> {
+) -> Result<Vec<PageInfo>, CommandError> {
     let mut pages = Vec::new();
     if !dir.exists() {
         return Ok(pages);
@@ -715,7 +720,7 @@ fn scan_nuxt_pages_at(
     base_dir: &std::path::Path,
     depth: usize,
     pages: &mut Vec<PageInfo>,
-) -> Result<(), String> {
+) -> Result<(), CommandError> {
     for entry in read_scan_dir(dir, depth)? {
         let path = entry.path;
 
@@ -770,7 +775,7 @@ fn scan_nuxt_pages_at(
 pub(crate) fn scan_html_pages(
     dir: &std::path::Path,
     base_dir: &std::path::Path,
-) -> Result<Vec<PageInfo>, String> {
+) -> Result<Vec<PageInfo>, CommandError> {
     let mut pages = Vec::new();
     scan_html_pages_recursive(dir, base_dir, 0, &mut pages)?;
     Ok(pages)
@@ -781,7 +786,7 @@ fn scan_html_pages_recursive(
     base_dir: &std::path::Path,
     depth: usize,
     pages: &mut Vec<PageInfo>,
-) -> Result<(), String> {
+) -> Result<(), CommandError> {
     if !dir.exists() {
         return Ok(());
     }
@@ -1304,9 +1309,18 @@ mod tests {
             Ok(_) => panic!("unreadable scan root must error"),
             Err(e) => e,
         };
+        // Root-read failures route through classify_fs_error (issue #688):
+        // the message names the operation and the path, and on macOS a real
+        // TCC denial (EPERM, not reproducible here) maps to Expected with
+        // System Settings guidance.
+        let msg = err.to_string();
         assert!(
-            err.contains(&root.display().to_string()),
-            "error must include the path, got: {err}"
+            msg.contains(&root.display().to_string()),
+            "error must include the path, got: {msg}"
+        );
+        assert!(
+            msg.contains("read this project's page routes"),
+            "error must name the operation, got: {msg}"
         );
     }
 }

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -1096,13 +1096,13 @@ pub async fn delete_project(path: String) -> Result<(), CommandError> {
         message: format!("Couldn't resolve project path {path}: {e}"),
     })?;
 
-    // Check if this is an external project
+    // Check if this is an external project. A by-design guard with a
+    // user-side path forward, not a malfunction — Expected keeps it out of
+    // telemetry (issue #699).
     if crate::commands::external_projects::is_registered_external_path(&canonical)? {
-        return Err(
-            "Cannot delete external projects. Use 'Remove from Ship Studio' instead."
-                .to_string()
-                .into(),
-        );
+        return Err(CommandError::expected(
+            "Cannot delete external projects. Use 'Remove from Ship Studio' instead.",
+        ));
     }
 
     if !crate::utils::allowed_project_roots()
@@ -1280,13 +1280,13 @@ pub async fn rename_project(
     })?;
     let project_path = project_path.as_path();
 
-    // Reject external projects (their folders live outside ~/ShipStudio).
+    // Reject external projects (their folders live outside ~/ShipStudio). A
+    // by-design refusal with a user-side path forward, not a malfunction —
+    // Expected keeps it out of telemetry (issue #699).
     if crate::commands::external_projects::is_registered_external_path(project_path)? {
-        return Err(
-            "Renaming external projects isn't supported yet. Remove it from the list and re-add it under a new folder name."
-                .to_string()
-                .into(),
-        );
+        return Err(CommandError::expected(
+            "Renaming external projects isn't supported yet. Remove it from the list and re-add it under a new folder name.",
+        ));
     }
 
     // Must live inside an allowed projects root.

--- a/src-tauri/src/commands/projects/mod.rs
+++ b/src-tauri/src/commands/projects/mod.rs
@@ -31,7 +31,9 @@ pub use window_registry::*;
 use crate::errors::CommandError;
 use crate::external_command::run_with_timeout;
 use crate::types::{DashboardProject, PageInfo, ProjectInfo, ProjectMetadata, ProjectType};
-use crate::utils::{create_command, validate_project_path};
+use crate::utils::{
+    create_command, is_retryable_delete_error, remove_dir_all_robust, validate_project_path,
+};
 use futures_util::{stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -953,108 +955,10 @@ pub async fn remove_git_history(project_path: String) -> Result<(), CommandError
     Ok(())
 }
 
-fn make_writable_recursive(path: &Path) -> std::io::Result<()> {
-    let metadata = std::fs::symlink_metadata(path)?;
-
-    // Never follow symlinks. A project can link outside itself — pnpm's
-    // node_modules links into the machine-global content-addressable store,
-    // whose files are deliberately read-only and shared by every project —
-    // and chmod-ing through the link would mutate files the delete below
-    // never touches. remove_dir_all removes the link itself, not its target,
-    // so the link needs no permission help either.
-    if metadata.file_type().is_symlink() {
-        return Ok(());
-    }
-
-    if metadata.file_type().is_dir() {
-        for entry in std::fs::read_dir(path)? {
-            make_writable_recursive(&entry?.path())?;
-        }
-    }
-
-    #[cfg(windows)]
-    {
-        let mut permissions = metadata.permissions();
-        if permissions.readonly() {
-            permissions.set_readonly(false);
-            std::fs::set_permissions(path, permissions)?;
-        }
-    }
-    #[cfg(unix)]
-    {
-        // Owner-write only — Permissions::set_readonly(false) would make the
-        // file world-writable on Unix (clippy::permissions_set_readonly_false).
-        use std::os::unix::fs::PermissionsExt;
-        let mode = metadata.permissions().mode();
-        if mode & 0o200 == 0 {
-            std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode | 0o200))?;
-        }
-    }
-    Ok(())
-}
-
-/// Whether a failed `remove_dir_all` is worth retrying after a short wait.
-///
-/// ERROR_SHARING_VIOLATION (32) / ERROR_LOCK_VIOLATION (33) are Windows'
-/// "file open by another process" errors — the transient locks (antivirus,
-/// Search indexer, a just-killed PTY's children winding down) this retry
-/// exists for. ERROR_ACCESS_DENIED (5) covers in-use executables.
-fn is_retryable_delete_error(e: &std::io::Error) -> bool {
-    matches!(e.raw_os_error(), Some(5) | Some(32) | Some(33))
-        || e.kind() == std::io::ErrorKind::PermissionDenied
-}
-
-/// Blocking delete with read-only clearing and lock retries. Call from
-/// `spawn_blocking` — the chmod walk and retry sleeps can hold a thread for
-/// seconds on a large node_modules.
-fn remove_dir_all_robust(path: &Path) -> std::io::Result<()> {
-    if !path.exists() {
-        return Ok(());
-    }
-
-    // Fast path first: on a healthy tree remove_dir_all just works, and the
-    // chmod walk below stats every file — seconds of pure overhead on a large
-    // node_modules if paid unconditionally.
-    let first_err = match std::fs::remove_dir_all(path) {
-        Ok(()) => return Ok(()),
-        Err(e) => e,
-    };
-    tracing::info!(
-        "remove_dir_all failed ({}), retrying with read-only clearing: {}",
-        path.display(),
-        first_err
-    );
-
-    // Clear read-only attributes (Windows refuses to delete read-only files;
-    // git objects and some packages ship them). Best-effort: a partial chmod
-    // still lets most of the tree go.
-    if let Err(e) = make_writable_recursive(path) {
-        tracing::warn!(
-            "Failed to set write permissions recursively on {}: {}",
-            path.display(),
-            e
-        );
-    }
-
-    // Backoff schedule totalling ~8s: field reports show antivirus / Search
-    // indexer locks routinely outlasting the previous flat ~1s budget (10 ×
-    // 100ms), still surfacing "os error 32" to the user (issue #253). Growing
-    // sleeps keep the common quick-release case fast while giving a slow
-    // scanner time to let go.
-    let mut delay = std::time::Duration::from_millis(100);
-    let mut retries = 10;
-    loop {
-        match std::fs::remove_dir_all(path) {
-            Ok(()) => return Ok(()),
-            Err(e) if retries > 0 && is_retryable_delete_error(&e) => {
-                retries -= 1;
-                std::thread::sleep(delay);
-                delay = (delay * 2).min(std::time::Duration::from_secs(1));
-            }
-            Err(e) => return Err(e),
-        }
-    }
-}
+// `make_writable_recursive` / `is_retryable_delete_error` /
+// `remove_dir_all_robust` were extracted to `crate::utils` so
+// `delete_asset` (assets.rs) can share the Windows lock-retry treatment
+// (issue #696). `rename_robust` stays here — it's only used by this module.
 
 /// Blocking rename with the same lock-retry treatment as
 /// [`remove_dir_all_robust`]: a transient Windows sharing violation
@@ -1806,30 +1710,6 @@ mod tests {
         assert!(err.contains("Failed to parse removed projects config"));
     }
 
-    // The #559/#253 shape: Windows sharing/lock violations are the transient
-    // states the rename/delete retry loops exist for; anything else must fail
-    // immediately.
-    #[test]
-    fn retryable_delete_error_matches_windows_lock_codes() {
-        assert!(is_retryable_delete_error(
-            &std::io::Error::from_raw_os_error(32) // ERROR_SHARING_VIOLATION
-        ));
-        assert!(is_retryable_delete_error(
-            &std::io::Error::from_raw_os_error(33) // ERROR_LOCK_VIOLATION
-        ));
-        assert!(is_retryable_delete_error(
-            &std::io::Error::from_raw_os_error(5) // ERROR_ACCESS_DENIED
-        ));
-        assert!(is_retryable_delete_error(&std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
-            "denied"
-        )));
-        assert!(!is_retryable_delete_error(&std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "gone"
-        )));
-    }
-
     #[test]
     fn rename_robust_renames_a_directory() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1854,59 +1734,7 @@ mod tests {
         assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     }
 
-    #[test]
-    fn remove_dir_all_robust_deletes_readonly_files() {
-        let tmp = tempfile::tempdir().unwrap();
-        let file_path = tmp.path().join("readonly_file.txt");
-        std::fs::write(&file_path, "test content").unwrap();
-
-        // Set the file to read-only
-        let mut perms = std::fs::metadata(&file_path).unwrap().permissions();
-        perms.set_readonly(true);
-        std::fs::set_permissions(&file_path, perms).unwrap();
-
-        // Verify it is indeed read-only
-        assert!(std::fs::metadata(&file_path)
-            .unwrap()
-            .permissions()
-            .readonly());
-
-        // Use remove_dir_all_robust to delete the directory tree
-        remove_dir_all_robust(tmp.path()).unwrap();
-
-        // Verify the directory no longer exists
-        assert!(!tmp.path().exists());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn remove_dir_all_robust_never_chmods_through_symlinks() {
-        // pnpm-style layout: the project links to a shared store whose files
-        // are read-only on purpose. Deleting the project must remove the link
-        // itself without touching the store's permissions.
-        let store = tempfile::tempdir().unwrap();
-        let store_file = store.path().join("shared.txt");
-        std::fs::write(&store_file, "shared").unwrap();
-        let mut perms = std::fs::metadata(&store_file).unwrap().permissions();
-        perms.set_readonly(true);
-        std::fs::set_permissions(&store_file, perms).unwrap();
-
-        let project = tempfile::tempdir().unwrap();
-        std::os::unix::fs::symlink(store.path(), project.path().join("node_modules_link")).unwrap();
-
-        remove_dir_all_robust(project.path()).unwrap();
-
-        assert!(!project.path().exists());
-        assert!(
-            store_file.exists(),
-            "symlink target must survive the delete"
-        );
-        assert!(
-            std::fs::metadata(&store_file)
-                .unwrap()
-                .permissions()
-                .readonly(),
-            "store file must stay read-only — chmod escaped through the symlink"
-        );
-    }
+    // Tests for `is_retryable_delete_error` / `remove_dir_all_robust` /
+    // `remove_file_robust` moved to `crate::utils` alongside the extracted
+    // helpers (issue #696).
 }

--- a/src-tauri/src/error_reporting.rs
+++ b/src-tauri/src/error_reporting.rs
@@ -304,9 +304,30 @@ pub fn report_error(message: &str, stack: Option<&str>, source: &str, fingerprin
     });
 }
 
+/// Cap on how much captured backtrace ships with a panic report. Backtraces
+/// from release builds are mostly hex frames plus a handful of symbolized
+/// ones — the useful part is at the top, and reports can end up in public
+/// GitHub issues, so keep the payload bounded.
+const PANIC_BACKTRACE_MAX_CHARS: usize = 4000;
+
+/// The panic report's `stack` field: the panic location (always first — it's
+/// the one guaranteed-symbolized frame) followed by the captured backtrace,
+/// truncated to [`PANIC_BACKTRACE_MAX_CHARS`]. Everything here passes through
+/// `scrub_string` in [`build_body`] before leaving the machine.
+fn panic_stack(location: Option<&str>, backtrace: &str) -> String {
+    let mut truncated: String = backtrace.chars().take(PANIC_BACKTRACE_MAX_CHARS).collect();
+    if truncated.len() < backtrace.len() {
+        truncated.push_str("\n… [backtrace truncated]");
+    }
+    match location {
+        Some(l) => format!("{l}\n{truncated}"),
+        None => truncated,
+    }
+}
+
 /// Panic-path variant: sends synchronously (bounded by [`SEND_TIMEOUT`])
 /// because the process may be about to die and a spawned task would be lost.
-fn report_panic(message: &str, location: Option<&str>) {
+fn report_panic(message: &str, location: Option<&str>, backtrace: &str) {
     if !enabled() {
         return;
     }
@@ -315,9 +336,10 @@ fn report_panic(message: &str, location: Option<&str>) {
     if !allow_report_with_gap(&dedupe_key(message, "panic", fingerprint.as_deref()), false) {
         return;
     }
+    let stack = panic_stack(location, backtrace);
     let body = build_body(
         &format!("panic: {message}"),
-        location,
+        Some(&stack),
         "panic",
         fingerprint.as_deref(),
     );
@@ -349,7 +371,13 @@ pub fn install_panic_hook() {
         let location = info
             .location()
             .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()));
-        report_panic(&message, location.as_deref());
+        // Capture a real stack, not just the panic's file:line — panics that
+        // abort the process (e.g. unwinding across an FFI/dispatch boundary,
+        // issue #684) otherwise leave no trace of how they were reached.
+        // `force_capture` ignores RUST_BACKTRACE, so user machines don't need
+        // any env setup for the frames to exist.
+        let backtrace = std::backtrace::Backtrace::force_capture().to_string();
+        report_panic(&message, location.as_deref(), &backtrace);
         prev(info);
     }));
 }
@@ -700,6 +728,46 @@ mod tests {
             1_000_000,
             "2026-07-28"
         ));
+    }
+
+    // Issue #684: panic reports must carry a real stack (not just file:line),
+    // bounded, and scrubbed like every other payload field.
+
+    #[test]
+    fn panic_stack_leads_with_location_and_keeps_short_backtraces_whole() {
+        let stack = panic_stack(Some("src/foo.rs:10:5"), "0: frame_a\n1: frame_b");
+        assert!(stack.starts_with("src/foo.rs:10:5\n"));
+        assert!(stack.contains("frame_b"));
+        assert!(!stack.contains("[backtrace truncated]"));
+        // No location (panic without one) still yields the backtrace alone.
+        assert_eq!(panic_stack(None, "0: frame_a"), "0: frame_a");
+    }
+
+    #[test]
+    fn panic_stack_truncates_oversized_backtraces_at_the_cap() {
+        let huge = "x".repeat(PANIC_BACKTRACE_MAX_CHARS * 3);
+        let stack = panic_stack(Some("src/foo.rs:1:1"), &huge);
+        assert!(stack.contains("[backtrace truncated]"));
+        // location + newline + cap + truncation marker, nothing more.
+        assert!(
+            stack.len() < PANIC_BACKTRACE_MAX_CHARS + 100,
+            "stack len {} exceeds cap headroom",
+            stack.len()
+        );
+    }
+
+    #[test]
+    fn panic_stack_is_scrubbed_by_build_body_before_sending() {
+        // The backtrace goes out through build_body's stack field — home-dir
+        // paths (usernames) must not survive the scrub.
+        let stack = panic_stack(
+            Some("/Users/julian/ShipStudio/app/src-tauri/src/main.rs:5:9"),
+            "0: ship_studio::thing\n   at /Users/julian/ShipStudio/app/src-tauri/src/thing.rs:42",
+        );
+        let body = build_body("panic: boom", Some(&stack), "panic", None);
+        let text = body.to_string();
+        assert!(!text.contains("julian"), "username leaked: {text}");
+        assert!(text.contains("/Users/<redacted>"), "{text}");
     }
 
     #[test]

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -832,7 +832,10 @@ mod tests {
 
     #[test]
     fn truncate_output_head_tail_passes_short_text_through_trimmed() {
-        assert_eq!(truncate_output_head_tail("  short error  \n"), "short error");
+        assert_eq!(
+            truncate_output_head_tail("  short error  \n"),
+            "short error"
+        );
         assert_eq!(truncate_output_head_tail(""), "");
     }
 
@@ -846,7 +849,10 @@ mod tests {
             "transcript filler line\n".repeat(1_000)
         );
         let capped = truncate_output_head_tail(&long);
-        assert!(capped.starts_with("OpenAI Codex v0.0.0 (banner)"), "head lost");
+        assert!(
+            capped.starts_with("OpenAI Codex v0.0.0 (banner)"),
+            "head lost"
+        );
         assert!(
             capped.ends_with("ERROR: stream disconnected before completion"),
             "tail (the actual error) lost — got tail: {}",
@@ -870,7 +876,10 @@ mod tests {
         // 4-byte emoji straddling both cut points.
         let emoji = "🎉".repeat(MAX_ERROR_OUTPUT_CHARS + 10);
         let capped = truncate_output_head_tail(&emoji);
-        assert!(capped.contains("(10 chars omitted)"), "got marker: {capped}");
+        assert!(
+            capped.contains("(10 chars omitted)"),
+            "got marker: {capped}"
+        );
         assert!(capped.starts_with('🎉') && capped.ends_with('🎉'));
     }
 

--- a/src-tauri/src/external_command.rs
+++ b/src-tauri/src/external_command.rs
@@ -370,6 +370,11 @@ pub const MAX_ERROR_OUTPUT_CHARS: usize = 2048;
 /// useful part — CLIs print the actual error first, then detail/backtrace) and
 /// appending a truncation marker. Use this whenever raw stderr/stdout is
 /// embedded into a `CommandError`.
+///
+/// Head-only is right for git/gh-style CLIs. For transcript-style output where
+/// the actual error arrives at the END (e.g. `codex exec` dumping its whole
+/// session before failing), use [`truncate_output_head_tail`] instead — a
+/// head-only cap there is guaranteed to cut the useful line (issue #665).
 pub fn truncate_output(text: &str) -> String {
     let trimmed = text.trim();
     if trimmed.chars().count() <= MAX_ERROR_OUTPUT_CHARS {
@@ -377,6 +382,31 @@ pub fn truncate_output(text: &str) -> String {
     }
     let head: String = trimmed.chars().take(MAX_ERROR_OUTPUT_CHARS).collect();
     format!("{}… (truncated)", head.trim_end())
+}
+
+/// Like [`truncate_output`], but keeps both ends: the first and last
+/// [`MAX_ERROR_OUTPUT_CHARS`]/2 characters with an omission marker in between.
+/// For output where the useful line can live at either end — a banner up top,
+/// the actual error at the bottom of a session transcript (issue #665).
+///
+/// Operates on `char`s throughout (never byte offsets), so a cut can never
+/// land inside a multi-byte UTF-8 sequence and panic (the #673 class of bug).
+pub fn truncate_output_head_tail(text: &str) -> String {
+    let trimmed = text.trim();
+    let total = trimmed.chars().count();
+    if total <= MAX_ERROR_OUTPUT_CHARS {
+        return trimmed.to_string();
+    }
+    let head_len = MAX_ERROR_OUTPUT_CHARS / 2;
+    let tail_len = MAX_ERROR_OUTPUT_CHARS - head_len;
+    let head: String = trimmed.chars().take(head_len).collect();
+    let tail: String = trimmed.chars().skip(total - tail_len).collect();
+    let omitted = total - head_len - tail_len;
+    format!(
+        "{}\n… ({omitted} chars omitted) …\n{}",
+        head.trim_end(),
+        tail.trim_start()
+    )
 }
 
 #[cfg(test)]
@@ -798,6 +828,50 @@ mod tests {
             &capped[capped.len().saturating_sub(40)..]
         );
         assert!(capped.chars().count() <= MAX_ERROR_OUTPUT_CHARS + "… (truncated)".len());
+    }
+
+    #[test]
+    fn truncate_output_head_tail_passes_short_text_through_trimmed() {
+        assert_eq!(truncate_output_head_tail("  short error  \n"), "short error");
+        assert_eq!(truncate_output_head_tail(""), "");
+    }
+
+    // The #665 shape: `codex exec` fails with a full session transcript on
+    // stderr — banner first, actual error LAST. Head-only capping guaranteed
+    // the useful line was cut; head+tail must preserve both ends.
+    #[test]
+    fn truncate_output_head_tail_keeps_both_ends() {
+        let long = format!(
+            "OpenAI Codex v0.0.0 (banner)\n{}\nERROR: stream disconnected before completion",
+            "transcript filler line\n".repeat(1_000)
+        );
+        let capped = truncate_output_head_tail(&long);
+        assert!(capped.starts_with("OpenAI Codex v0.0.0 (banner)"), "head lost");
+        assert!(
+            capped.ends_with("ERROR: stream disconnected before completion"),
+            "tail (the actual error) lost — got tail: {}",
+            &capped[capped.len().saturating_sub(60)..]
+        );
+        assert!(capped.contains("chars omitted"), "got: no omission marker");
+        // Head + tail + marker, never materially more than the cap.
+        assert!(capped.chars().count() <= MAX_ERROR_OUTPUT_CHARS + 40);
+    }
+
+    // A cut landing mid multi-byte sequence must never panic (the #673 class
+    // of bug in this codebase) — char-based slicing throughout.
+    #[test]
+    fn truncate_output_head_tail_survives_multibyte_boundaries() {
+        // 2-byte chars: every byte offset that isn't even is a non-boundary.
+        let two_byte = "é".repeat(MAX_ERROR_OUTPUT_CHARS + 501);
+        let capped = truncate_output_head_tail(&two_byte);
+        assert!(capped.contains("(501 chars omitted)"), "got: {capped}");
+        assert!(capped.starts_with('é') && capped.ends_with('é'));
+
+        // 4-byte emoji straddling both cut points.
+        let emoji = "🎉".repeat(MAX_ERROR_OUTPUT_CHARS + 10);
+        let capped = truncate_output_head_tail(&emoji);
+        assert!(capped.contains("(10 chars omitted)"), "got marker: {capped}");
+        assert!(capped.starts_with('🎉') && capped.ends_with('🎉'));
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -1333,10 +1333,18 @@ mod tests {
             "refused connect must classify as expected/unavailable, got {:?}",
             err.kind()
         );
+        // Windows doesn't refuse a closed loopback port immediately — the
+        // TCP stack retries SYN for ~1s, so the whole 400ms budget can be
+        // spent inside the first attempt (which then reports TimedOut, still
+        // classified unavailable above). Only Unix gets the fast refusal
+        // needed to observe an actual retry within the budget.
+        #[cfg(unix)]
         assert!(
             attempts >= 2,
             "must have retried, got {attempts} attempt(s)"
         );
+        #[cfg(not(unix))]
+        assert!(attempts >= 1, "got {attempts} attempt(s)");
     }
 
     /// The one-shot WS retry path (issue #466) must feed the SAME

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -28,9 +28,12 @@ use tokio::task::JoinHandle;
 /// Maximum response body size to buffer for HTML injection (50 MB).
 const MAX_BODY_SIZE: usize = 50 * 1024 * 1024;
 
-/// Timeout for establishing the upstream TCP connection. Localhost either
-/// accepts immediately or refuses outright; a hang here means a firewalled or
-/// wedged port and should fail fast instead of holding the request forever.
+/// Overall connect budget (including retries) for the plain-HTTP path.
+/// Localhost either accepts immediately or refuses outright; a hang here means
+/// a firewalled or wedged port and should fail fast instead of holding the
+/// request forever. A refused connect retries within this budget instead of
+/// hard-failing the request — page loads land mid dev-server restart just like
+/// HMR upgrades do (issue #683).
 const UPSTREAM_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Overall connect budget for the WebSocket (HMR) upgrade's retry loop.
@@ -573,6 +576,10 @@ async fn handle_request(
     match proxy_http_request(req, target_port).await {
         Ok(resp) => Ok(resp),
         Err(e) => {
+            // Connect failures never reach here — proxy_http_request handles
+            // them inline (retry + warn-level classification, issue #683).
+            // What's left is post-connect breakage (handshake, send, body
+            // timeouts): genuinely unexpected, so it keeps reporting.
             tracing::error!("[Proxy] Request failed: {}", e);
             let body = format!("Proxy error: {e}");
             Ok(Response::builder()
@@ -599,20 +606,55 @@ async fn proxy_http_request(
     req: Request<Incoming>,
     target_port: u16,
 ) -> Result<Response<ProxyBody>, Box<dyn std::error::Error + Send + Sync>> {
-    // Connect to target via hostname so both IPv4 and IPv6 are tried.
-    // Vite-based dev servers (Astro, SvelteKit, Nuxt) bind to `localhost` which
-    // resolves to `::1` (IPv6) on macOS -- hardcoding 127.0.0.1 fails for those.
-    // Each timeout site names its phase: all three produce the same bare
-    // "deadline has elapsed" otherwise, making a 5s connect stall
-    // indistinguishable from a 5-minute hung response (issue #271).
-    let stream = tokio::time::timeout(
-        UPSTREAM_CONNECT_TIMEOUT,
-        TcpStream::connect(format!("localhost:{target_port}")),
-    )
-    .await
-    .map_err(|_| {
-        format!("connect to localhost:{target_port} timed out after {UPSTREAM_CONNECT_TIMEOUT:?}")
-    })??;
+    // Connect via connect_loopback so both IPv4 and IPv6 are tried: Vite-based
+    // dev servers (Astro, SvelteKit, Nuxt) bind to `localhost` which resolves
+    // to `::1` (IPv6) on macOS -- hardcoding 127.0.0.1 fails for those.
+    // Retry briefly on connection-refused, exactly like the WebSocket path
+    // (issues #258/#353): every preview request rides through here, and a page
+    // load landing mid dev-server restart used to hard-fail with a bare 502
+    // plus a telemetry error report (issue #683). The retry only engages after
+    // a failed connect — the happy path is a single racing connect.
+    let connect_deadline = tokio::time::Instant::now() + UPSTREAM_CONNECT_TIMEOUT;
+    let stream = match connect_upstream_with_retry(target_port, connect_deadline).await {
+        Ok(s) => s,
+        Err((e, attempts)) => {
+            if upstream_unavailable(e.kind()) {
+                // The whole connect budget elapsed with the port refusing or
+                // silent: the dev server is restarting slowly or stopped.
+                // Expected state — an environment condition, not a proxy bug —
+                // so this must not auto-file a bug report (issues #532/#683).
+                tracing::warn!(
+                    "[Proxy] HTTP target localhost:{} unavailable after {} connect attempts over {:?}: {} (dev server restarting or stopped)",
+                    target_port,
+                    attempts,
+                    UPSTREAM_CONNECT_TIMEOUT,
+                    e
+                );
+                return Ok(Response::builder()
+                    .status(StatusCode::BAD_GATEWAY)
+                    .header(hyper::header::CONTENT_TYPE, "text/plain; charset=utf-8")
+                    .header(hyper::header::CACHE_CONTROL, "no-store")
+                    .body(full_body(Bytes::from(format!(
+                        "The dev server on localhost:{target_port} isn't reachable right now — it may be restarting or stopped. Reload the preview once it's running again."
+                    ))))?);
+            }
+            // Genuinely unexpected connect failure (not refused/silent) —
+            // keep this at error level so it still reports.
+            tracing::error!(
+                "[Proxy] HTTP target connection failed (port {}, attempt {}): {}",
+                target_port,
+                attempts,
+                e
+            );
+            return Ok(Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .header(hyper::header::CONTENT_TYPE, "text/plain; charset=utf-8")
+                .header(hyper::header::CACHE_CONTROL, "no-store")
+                .body(full_body(Bytes::from(format!(
+                    "Proxy error: connecting to the dev server on localhost:{target_port} failed: {e}"
+                ))))?);
+        }
+    };
     let io = TokioIo::new(stream);
 
     let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
@@ -826,47 +868,48 @@ async fn proxy_http_request(
 /// surfaced as a per-attempt timeout). Both are normal states while a dev
 /// server restarts or is stopped — an environment condition, not a proxy bug —
 /// so exhausting the retry budget on them logs at warn level instead of
-/// auto-filing an error report (issue #532).
-fn ws_upstream_unavailable(kind: std::io::ErrorKind) -> bool {
+/// auto-filing an error report. Shared by the WebSocket (issue #532) and
+/// plain-HTTP (issue #683) upstream connects.
+fn upstream_unavailable(kind: std::io::ErrorKind) -> bool {
     matches!(
         kind,
         std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::TimedOut
     )
 }
 
-/// Handle WebSocket upgrade by forwarding the upgrade to the target and piping
-/// the upgraded connections bidirectionally.
-async fn handle_websocket_upgrade(
-    req: Request<Incoming>,
-    target_port: u16,
-) -> Result<Response<ProxyBody>, hyper::Error> {
-    // Connect via hostname for IPv4/IPv6 compatibility (see proxy_http_request).
-    // Retry briefly on connection-refused: an HMR socket's upgrade often lands
-    // mid dev-server restart, and a single missed connect used to hard-fail the
-    // upgrade with BAD_GATEWAY instead of riding out the gap (issue #258). The
-    // retry loop stays bounded by UPSTREAM_CONNECT_TIMEOUT overall.
-    // Race IPv4 and IPv6 loopback concurrently rather than connecting to
-    // "localhost": some dev servers (Vite notably) bind only one family, and
-    // the sequential address walk behind a hostname connect can burn a whole
-    // per-attempt timeout on the dead family before reaching the live one
-    // (observed on Windows CI). First successful connection wins; the error
-    // surfaces only when both families fail.
-    async fn connect_loopback(port: u16) -> std::io::Result<TcpStream> {
-        use futures_util::future::select_ok;
-        let v4 = Box::pin(TcpStream::connect(("127.0.0.1", port)));
-        let v6 = Box::pin(TcpStream::connect(("::1", port)));
-        select_ok([v4, v6]).await.map(|(stream, _)| stream)
-    }
+/// Race IPv4 and IPv6 loopback concurrently rather than connecting to
+/// "localhost": some dev servers (Vite notably) bind only one family, and
+/// the sequential address walk behind a hostname connect can burn a whole
+/// per-attempt timeout on the dead family before reaching the live one
+/// (observed on Windows CI). First successful connection wins; the error
+/// surfaces only when both families fail.
+async fn connect_loopback(port: u16) -> std::io::Result<TcpStream> {
+    use futures_util::future::select_ok;
+    let v4 = Box::pin(TcpStream::connect(("127.0.0.1", port)));
+    let v6 = Box::pin(TcpStream::connect(("::1", port)));
+    select_ok([v4, v6]).await.map(|(stream, _)| stream)
+}
 
-    let connect_deadline = tokio::time::Instant::now() + WS_UPSTREAM_CONNECT_TIMEOUT;
-    // Each attempt gets its own short timeout (capped to what's left of the
-    // overall budget) rather than racing the whole deadline: an unready port
-    // doesn't always refuse the connection — on Windows especially, the SYN
-    // can just go unanswered — and a single hung attempt must not eat the
-    // entire retry window (issue #353).
+/// Connect to the dev server's loopback port, retrying briefly while the port
+/// refuses or stays silent (a request often lands mid dev-server restart —
+/// issues #258/#683), bounded by `connect_deadline` overall.
+///
+/// Each attempt gets its own short timeout (capped to what's left of the
+/// overall budget) rather than racing the whole deadline: an unready port
+/// doesn't always refuse the connection — on Windows especially, the SYN
+/// can just go unanswered — and a single hung attempt must not eat the
+/// entire retry window (issue #353).
+///
+/// Zero overhead on the happy path: a successful first connect returns
+/// immediately; retries and backoff only run after a connect failure. On
+/// failure, returns the last error plus the attempt count for logging.
+async fn connect_upstream_with_retry(
+    target_port: u16,
+    connect_deadline: tokio::time::Instant,
+) -> Result<TcpStream, (std::io::Error, u32)> {
     let per_attempt = std::time::Duration::from_secs(1);
     let mut attempts: u32 = 0;
-    let target_stream = loop {
+    loop {
         let remaining = connect_deadline.saturating_duration_since(tokio::time::Instant::now());
         let attempt =
             tokio::time::timeout(remaining.min(per_attempt), connect_loopback(target_port))
@@ -875,10 +918,9 @@ async fn handle_websocket_upgrade(
                 .and_then(|r| r);
         attempts += 1;
         match attempt {
-            Ok(s) => break s,
+            Ok(s) => return Ok(s),
             Err(e) => {
-                let unavailable = ws_upstream_unavailable(e.kind());
-                let retryable = unavailable
+                let retryable = upstream_unavailable(e.kind())
                     && tokio::time::Instant::now() + std::time::Duration::from_millis(250)
                         < connect_deadline;
                 if retryable {
@@ -889,32 +931,52 @@ async fn handle_websocket_upgrade(
                     }
                     continue;
                 }
-                if unavailable {
-                    // The whole connect budget elapsed with the port refusing
-                    // or silent: the dev server is restarting slowly or
-                    // stopped. Expected state — closing the upgrade with 502
-                    // makes the browser-side HMR client retry on its own, so
-                    // this must not auto-file a bug report (issue #532).
-                    tracing::warn!(
-                        "[Proxy] WebSocket target localhost:{} unavailable after {} connect attempts over {:?}: {}",
-                        target_port,
-                        attempts,
-                        WS_UPSTREAM_CONNECT_TIMEOUT,
-                        e
-                    );
-                } else {
-                    tracing::error!(
-                        "[Proxy] WebSocket target connection failed (port {}, attempt {}): {}",
-                        target_port,
-                        attempts,
-                        e
-                    );
-                }
-                return Ok(Response::builder()
-                    .status(StatusCode::BAD_GATEWAY)
-                    .body(full_body(Bytes::from("WebSocket proxy error")))
-                    .unwrap());
+                return Err((e, attempts));
             }
+        }
+    }
+}
+
+/// Handle WebSocket upgrade by forwarding the upgrade to the target and piping
+/// the upgraded connections bidirectionally.
+async fn handle_websocket_upgrade(
+    req: Request<Incoming>,
+    target_port: u16,
+) -> Result<Response<ProxyBody>, hyper::Error> {
+    // Connect via connect_loopback (IPv4/IPv6 race — see its doc comment).
+    // Retry briefly on connection-refused: an HMR socket's upgrade often lands
+    // mid dev-server restart, and a single missed connect used to hard-fail the
+    // upgrade with BAD_GATEWAY instead of riding out the gap (issue #258). The
+    // retry loop stays bounded by WS_UPSTREAM_CONNECT_TIMEOUT overall.
+    let connect_deadline = tokio::time::Instant::now() + WS_UPSTREAM_CONNECT_TIMEOUT;
+    let target_stream = match connect_upstream_with_retry(target_port, connect_deadline).await {
+        Ok(s) => s,
+        Err((e, attempts)) => {
+            if upstream_unavailable(e.kind()) {
+                // The whole connect budget elapsed with the port refusing
+                // or silent: the dev server is restarting slowly or
+                // stopped. Expected state — closing the upgrade with 502
+                // makes the browser-side HMR client retry on its own, so
+                // this must not auto-file a bug report (issue #532).
+                tracing::warn!(
+                    "[Proxy] WebSocket target localhost:{} unavailable after {} connect attempts over {:?}: {}",
+                    target_port,
+                    attempts,
+                    WS_UPSTREAM_CONNECT_TIMEOUT,
+                    e
+                );
+            } else {
+                tracing::error!(
+                    "[Proxy] WebSocket target connection failed (port {}, attempt {}): {}",
+                    target_port,
+                    attempts,
+                    e
+                );
+            }
+            return Ok(Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .body(full_body(Bytes::from("WebSocket proxy error")))
+                .unwrap());
         }
     };
 
@@ -1051,7 +1113,7 @@ async fn handle_websocket_upgrade(
             .await;
             match retried {
                 Ok(r) => r,
-                Err(e) if ws_upstream_unavailable(e.kind()) => {
+                Err(e) if upstream_unavailable(e.kind()) => {
                     // The retry's reconnect was refused or silent: the dev
                     // server is still down/restarting — the same expected
                     // state the initial connect loop logs at warn (issue
@@ -1218,27 +1280,63 @@ mod injector_tests {
 #[cfg(test)]
 mod tests {
     use super::{
-        is_auth_redirect_loop, is_document_navigation, redact_handshake_values,
-        rewrite_localhost_origin, sanitize_csp_for_preview, ws_upstream_unavailable,
+        connect_upstream_with_retry, is_auth_redirect_loop, is_document_navigation,
+        redact_handshake_values, rewrite_localhost_origin, sanitize_csp_for_preview,
+        upstream_unavailable,
     };
     use hyper::header::HeaderValue;
     use hyper::StatusCode;
 
     #[test]
-    fn ws_connect_failure_classification() {
-        // Dev-server-restart states: expected, logged at warn (issue #532).
-        assert!(ws_upstream_unavailable(
-            std::io::ErrorKind::ConnectionRefused
-        ));
-        assert!(ws_upstream_unavailable(std::io::ErrorKind::TimedOut));
+    fn upstream_connect_failure_classification() {
+        // Dev-server-restart states: expected, logged at warn — for both the
+        // WebSocket (issue #532) and plain-HTTP (issue #683) connect paths.
+        assert!(upstream_unavailable(std::io::ErrorKind::ConnectionRefused));
+        assert!(upstream_unavailable(std::io::ErrorKind::TimedOut));
         // Anything else is a genuine proxy problem and stays at error level.
-        assert!(!ws_upstream_unavailable(
-            std::io::ErrorKind::PermissionDenied
-        ));
-        assert!(!ws_upstream_unavailable(
-            std::io::ErrorKind::AddrNotAvailable
-        ));
-        assert!(!ws_upstream_unavailable(std::io::ErrorKind::Other));
+        assert!(!upstream_unavailable(std::io::ErrorKind::PermissionDenied));
+        assert!(!upstream_unavailable(std::io::ErrorKind::AddrNotAvailable));
+        assert!(!upstream_unavailable(std::io::ErrorKind::Other));
+    }
+
+    // ── connect_upstream_with_retry (issues #258/#353/#683) ────────────────
+
+    #[tokio::test]
+    async fn connect_retry_succeeds_first_try_when_upstream_is_listening() {
+        // Happy path: one racing connect, no retries, no backoff sleeps.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        let started = std::time::Instant::now();
+        let result = connect_upstream_with_retry(port, deadline).await;
+        assert!(result.is_ok());
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(1),
+            "happy path must not pay any retry/backoff cost"
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_retry_exhausts_budget_with_refused_kind_for_dead_port() {
+        // Nothing listening: the loop retries until the deadline, then hands
+        // back the refused error so the caller classifies it at warn level
+        // instead of auto-filing a report (issue #683).
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener); // port is now closed (nothing rebinds it in this test)
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(400);
+        let (err, attempts) = connect_upstream_with_retry(port, deadline)
+            .await
+            .expect_err("connect to a closed port must fail");
+        assert!(
+            upstream_unavailable(err.kind()),
+            "refused connect must classify as expected/unavailable, got {:?}",
+            err.kind()
+        );
+        assert!(
+            attempts >= 2,
+            "must have retried, got {attempts} attempt(s)"
+        );
     }
 
     /// The one-shot WS retry path (issue #466) must feed the SAME
@@ -1250,7 +1348,7 @@ mod tests {
     async fn ws_retry_errors_keep_their_classification() {
         // A reconnect refusal keeps ConnectionRefused → expected (warn).
         let refused = std::io::Error::from(std::io::ErrorKind::ConnectionRefused);
-        assert!(ws_upstream_unavailable(refused.kind()));
+        assert!(upstream_unavailable(refused.kind()));
 
         // The retry's reconnect timeout (tokio Elapsed → io::Error, the same
         // `map_err(std::io::Error::from)` the initial loop uses) → TimedOut →
@@ -1270,7 +1368,7 @@ mod tests {
         // Handshake / request-build failures are wrapped via io::Error::other
         // → NOT classified as expected: they stay at error level.
         let other = std::io::Error::other("handshake failed");
-        assert!(!ws_upstream_unavailable(other.kind()));
+        assert!(!upstream_unavailable(other.kind()));
     }
 
     #[test]

--- a/src-tauri/src/static_server.rs
+++ b/src-tauri/src/static_server.rs
@@ -482,8 +482,50 @@ where
     unreachable!("loop returns on the final attempt")
 }
 
+/// Ceiling for a single static-asset read. `tokio::fs::read` pre-allocates
+/// the whole buffer from the metadata length, so a bogus length — a cloud
+/// placeholder (Dropbox/iCloud dataless file) or a corrupt directory entry —
+/// makes the allocation itself fail with `ErrorKind::OutOfMemory` (issue
+/// #697). No sane static preview asset approaches this; refuse up front with
+/// a clear message instead of attempting the allocation.
+const MAX_STATIC_FILE_BYTES: u64 = 512 * 1024 * 1024;
+
+/// True when a reported file length is beyond what the static server will
+/// buffer into memory (see [`MAX_STATIC_FILE_BYTES`]).
+fn exceeds_static_read_cap(len: u64) -> bool {
+    len > MAX_STATIC_FILE_BYTES
+}
+
+/// Allocation failure while buffering the file. With no OS error attached
+/// this is the pre-allocation from a bogus metadata length failing (issue
+/// #697) — a file-metadata/environment condition, not a server bug.
+fn is_allocation_failure(e: &std::io::Error) -> bool {
+    e.kind() == std::io::ErrorKind::OutOfMemory
+}
+
 /// Read a file from disk and return it as an HTTP response with the correct MIME type.
 async fn serve_file(file_path: &Path) -> Result<Response<ServerBody>, hyper::Error> {
+    // Cap reads before allocating: a metadata length beyond the ceiling is
+    // almost certainly bogus (cloud placeholder / corrupt entry) and would
+    // otherwise fail as OutOfMemory inside tokio::fs::read (issue #697).
+    // Metadata errors fall through — the read below reports them properly.
+    if let Ok(meta) = tokio::fs::metadata(file_path).await {
+        if exceeds_static_read_cap(meta.len()) {
+            tracing::warn!(
+                "[StaticServer] Refusing to serve {}: reported size {} bytes exceeds the {} MB static-asset ceiling (likely a cloud placeholder or corrupt metadata)",
+                file_path.display(),
+                meta.len(),
+                MAX_STATIC_FILE_BYTES / (1024 * 1024)
+            );
+            let body = "<html><body><h1>413 - File Too Large</h1><p>This file reports a size beyond what the static preview will serve. If it lives in cloud storage (Dropbox/iCloud), make sure it is fully downloaded locally.</p></body></html>";
+            return Ok(Response::builder()
+                .status(StatusCode::PAYLOAD_TOO_LARGE)
+                .header("Content-Type", "text/html; charset=utf-8")
+                .body(full_body(Bytes::from(body)))
+                .unwrap());
+        }
+    }
+
     match with_fd_pressure_retry(|| tokio::fs::read(file_path)).await {
         Ok(contents) => {
             let mime = file_path
@@ -509,6 +551,17 @@ async fn serve_file(file_path: &Path) -> Result<Response<ServerBody>, hyper::Err
             if is_fd_pressure(&e) {
                 tracing::warn!(
                     "[StaticServer] Failed to read file {} after fd-pressure retries (os error {:?}): {}",
+                    file_path.display(),
+                    e.raw_os_error(),
+                    e
+                );
+            } else if is_allocation_failure(&e) {
+                // A read that still hits OutOfMemory (racing metadata change,
+                // or genuine memory pressure) is a file-metadata/allocation
+                // condition of the environment, not an app bug — warn, don't
+                // auto-file a report (issue #697).
+                tracing::warn!(
+                    "[StaticServer] Failed to allocate for file {} (os error {:?}): {} — likely bogus metadata length (cloud placeholder / corrupt entry) or memory pressure",
                     file_path.display(),
                     e.raw_os_error(),
                     e
@@ -616,6 +669,46 @@ mod tests {
         .await;
         assert!(result.is_err());
         assert_eq!(calls.get(), 1);
+    }
+
+    // ===== #697: size cap + OutOfMemory classification =====
+
+    #[test]
+    fn static_read_cap_refuses_bogus_lengths_and_passes_real_assets() {
+        // Real static assets — even huge videos — sit under the ceiling.
+        assert!(!exceeds_static_read_cap(0));
+        assert!(!exceeds_static_read_cap(25 * 1024 * 1024));
+        assert!(!exceeds_static_read_cap(MAX_STATIC_FILE_BYTES));
+        // A cloud-placeholder / corrupt metadata length gets refused before
+        // tokio::fs::read pre-allocates from it.
+        assert!(exceeds_static_read_cap(MAX_STATIC_FILE_BYTES + 1));
+        assert!(exceeds_static_read_cap(u64::MAX));
+    }
+
+    #[test]
+    fn allocation_failure_is_classified_environmental() {
+        // The #697 shape: ErrorKind::OutOfMemory with no OS error attached —
+        // the pre-allocation from a bogus metadata length failing.
+        assert!(is_allocation_failure(&std::io::Error::from(
+            std::io::ErrorKind::OutOfMemory
+        )));
+        // Ordinary read failures keep the error-level path.
+        assert!(!is_allocation_failure(&std::io::Error::from(
+            std::io::ErrorKind::NotFound
+        )));
+        assert!(!is_allocation_failure(&std::io::Error::other(
+            "Too many open files (os error 24)"
+        )));
+    }
+
+    #[tokio::test]
+    async fn serve_file_still_serves_ordinary_files() {
+        // The new metadata pre-check must not break the normal path.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("index.html");
+        fs::write(&path, "<html>ok</html>").unwrap();
+        let resp = serve_file(&path).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     #[test]

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -1258,6 +1258,155 @@ pub fn validate_workspace_path(project_path: &str) -> Result<std::path::PathBuf,
     Ok(resolve_workspace_path(&root))
 }
 
+/// Recursively clear read-only attributes so Windows will delete the tree.
+/// Never follows symlinks — see the body comment.
+fn make_writable_recursive(path: &std::path::Path) -> std::io::Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+
+    // Never follow symlinks. A project can link outside itself — pnpm's
+    // node_modules links into the machine-global content-addressable store,
+    // whose files are deliberately read-only and shared by every project —
+    // and chmod-ing through the link would mutate files the delete below
+    // never touches. remove_dir_all removes the link itself, not its target,
+    // so the link needs no permission help either.
+    if metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+
+    if metadata.file_type().is_dir() {
+        for entry in std::fs::read_dir(path)? {
+            make_writable_recursive(&entry?.path())?;
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        let mut permissions = metadata.permissions();
+        if permissions.readonly() {
+            permissions.set_readonly(false);
+            std::fs::set_permissions(path, permissions)?;
+        }
+    }
+    #[cfg(unix)]
+    {
+        // Owner-write only — Permissions::set_readonly(false) would make the
+        // file world-writable on Unix (clippy::permissions_set_readonly_false).
+        use std::os::unix::fs::PermissionsExt;
+        let mode = metadata.permissions().mode();
+        if mode & 0o200 == 0 {
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode | 0o200))?;
+        }
+    }
+    Ok(())
+}
+
+/// Whether a failed filesystem delete/rename is worth retrying after a wait.
+///
+/// ERROR_SHARING_VIOLATION (32) / ERROR_LOCK_VIOLATION (33) are Windows'
+/// "file open by another process" errors — the transient locks (antivirus,
+/// Search indexer, a just-killed PTY's children winding down) this retry
+/// exists for. ERROR_ACCESS_DENIED (5) covers in-use executables.
+pub fn is_retryable_delete_error(e: &std::io::Error) -> bool {
+    matches!(e.raw_os_error(), Some(5) | Some(32) | Some(33))
+        || e.kind() == std::io::ErrorKind::PermissionDenied
+}
+
+/// Run a filesystem operation, retrying on transient Windows lock errors.
+///
+/// Backoff schedule totalling ~8s: field reports show antivirus / Search
+/// indexer locks routinely outlasting a flat ~1s budget (10 × 100ms), still
+/// surfacing "os error 32" to the user (issue #253). Growing sleeps keep the
+/// common quick-release case fast while giving a slow scanner time to let go.
+fn retry_on_transient_locks<F>(mut op: F) -> std::io::Result<()>
+where
+    F: FnMut() -> std::io::Result<()>,
+{
+    let mut delay = std::time::Duration::from_millis(100);
+    let mut retries = 10;
+    loop {
+        match op() {
+            Ok(()) => return Ok(()),
+            Err(e) if retries > 0 && is_retryable_delete_error(&e) => {
+                retries -= 1;
+                std::thread::sleep(delay);
+                delay = (delay * 2).min(std::time::Duration::from_secs(1));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+/// Blocking delete with read-only clearing and lock retries. Call from
+/// `spawn_blocking` — the chmod walk and retry sleeps can hold a thread for
+/// seconds on a large node_modules.
+pub fn remove_dir_all_robust(path: &std::path::Path) -> std::io::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    // Fast path first: on a healthy tree remove_dir_all just works, and the
+    // chmod walk below stats every file — seconds of pure overhead on a large
+    // node_modules if paid unconditionally.
+    let first_err = match std::fs::remove_dir_all(path) {
+        Ok(()) => return Ok(()),
+        Err(e) => e,
+    };
+    tracing::info!(
+        "remove_dir_all failed ({}), retrying with read-only clearing: {}",
+        path.display(),
+        first_err
+    );
+
+    // Clear read-only attributes (Windows refuses to delete read-only files;
+    // git objects and some packages ship them). Best-effort: a partial chmod
+    // still lets most of the tree go.
+    if let Err(e) = make_writable_recursive(path) {
+        tracing::warn!(
+            "Failed to set write permissions recursively on {}: {}",
+            path.display(),
+            e
+        );
+    }
+
+    retry_on_transient_locks(|| std::fs::remove_dir_all(path))
+}
+
+/// Blocking single-file delete with the same read-only clearing and lock
+/// retries as [`remove_dir_all_robust`] — on Windows a file open in another
+/// process (antivirus, Search indexer) fails an unretried `fs::remove_file`
+/// with "Access is denied (os error 5)" / "os error 32" (issue #696). Call
+/// from `spawn_blocking`; the retry sleeps can hold a thread for seconds.
+///
+/// Unlike `remove_dir_all_robust`, a missing file is an error (surfaced from
+/// the underlying `remove_file`) so callers keep their existing semantics.
+pub fn remove_file_robust(path: &std::path::Path) -> std::io::Result<()> {
+    let first_err = match std::fs::remove_file(path) {
+        Ok(()) => return Ok(()),
+        Err(e) => e,
+    };
+    // NotFound etc. are not helped by chmod or waiting — fail immediately.
+    if !is_retryable_delete_error(&first_err) {
+        return Err(first_err);
+    }
+    tracing::info!(
+        "remove_file failed ({}), retrying with read-only clearing: {}",
+        path.display(),
+        first_err
+    );
+
+    // Windows also refuses to delete read-only files with "access denied";
+    // clear the attribute best-effort before retrying. (No-op for symlinks.)
+    if let Err(e) = make_writable_recursive(path) {
+        tracing::warn!(
+            "Failed to clear read-only attribute on {}: {}",
+            path.display(),
+            e
+        );
+    }
+
+    retry_on_transient_locks(|| std::fs::remove_file(path))
+}
+
 /// Check if Homebrew is installed
 pub fn check_homebrew() -> (bool, Option<String>) {
     let paths = [
@@ -2223,6 +2372,127 @@ mod tests {
                 result.is_err(),
                 "symlinked final component must be rejected, got {result:?}"
             );
+        }
+    }
+
+    mod robust_delete {
+        use super::*;
+
+        // The #559/#253 shape: Windows sharing/lock violations are the
+        // transient states the rename/delete retry loops exist for; anything
+        // else must fail immediately.
+        #[test]
+        fn retryable_delete_error_matches_windows_lock_codes() {
+            assert!(is_retryable_delete_error(
+                &std::io::Error::from_raw_os_error(32) // ERROR_SHARING_VIOLATION
+            ));
+            assert!(is_retryable_delete_error(
+                &std::io::Error::from_raw_os_error(33) // ERROR_LOCK_VIOLATION
+            ));
+            assert!(is_retryable_delete_error(
+                &std::io::Error::from_raw_os_error(5) // ERROR_ACCESS_DENIED
+            ));
+            assert!(is_retryable_delete_error(&std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "denied"
+            )));
+            assert!(!is_retryable_delete_error(&std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "gone"
+            )));
+        }
+
+        #[test]
+        fn remove_dir_all_robust_deletes_readonly_files() {
+            let tmp = tempfile::tempdir().unwrap();
+            let file_path = tmp.path().join("readonly_file.txt");
+            std::fs::write(&file_path, "test content").unwrap();
+
+            // Set the file to read-only
+            let mut perms = std::fs::metadata(&file_path).unwrap().permissions();
+            perms.set_readonly(true);
+            std::fs::set_permissions(&file_path, perms).unwrap();
+
+            // Verify it is indeed read-only
+            assert!(std::fs::metadata(&file_path)
+                .unwrap()
+                .permissions()
+                .readonly());
+
+            // Use remove_dir_all_robust to delete the directory tree
+            remove_dir_all_robust(tmp.path()).unwrap();
+
+            // Verify the directory no longer exists
+            assert!(!tmp.path().exists());
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn remove_dir_all_robust_never_chmods_through_symlinks() {
+            // pnpm-style layout: the project links to a shared store whose files
+            // are read-only on purpose. Deleting the project must remove the link
+            // itself without touching the store's permissions.
+            let store = tempfile::tempdir().unwrap();
+            let store_file = store.path().join("shared.txt");
+            std::fs::write(&store_file, "shared").unwrap();
+            let mut perms = std::fs::metadata(&store_file).unwrap().permissions();
+            perms.set_readonly(true);
+            std::fs::set_permissions(&store_file, perms).unwrap();
+
+            let project = tempfile::tempdir().unwrap();
+            std::os::unix::fs::symlink(store.path(), project.path().join("node_modules_link"))
+                .unwrap();
+
+            remove_dir_all_robust(project.path()).unwrap();
+
+            assert!(!project.path().exists());
+            assert!(
+                store_file.exists(),
+                "symlink target must survive the delete"
+            );
+            assert!(
+                std::fs::metadata(&store_file)
+                    .unwrap()
+                    .permissions()
+                    .readonly(),
+                "store file must stay read-only — chmod escaped through the symlink"
+            );
+        }
+
+        // The #696 shape: a read-only asset file (checked-out git object,
+        // Windows attribute) must delete after the attribute is cleared.
+        #[test]
+        fn remove_file_robust_deletes_readonly_file() {
+            let tmp = tempfile::tempdir().unwrap();
+            let file_path = tmp.path().join("readonly_asset.png");
+            std::fs::write(&file_path, "png-bytes").unwrap();
+
+            let mut perms = std::fs::metadata(&file_path).unwrap().permissions();
+            perms.set_readonly(true);
+            std::fs::set_permissions(&file_path, perms).unwrap();
+
+            remove_file_robust(&file_path).unwrap();
+
+            assert!(!file_path.exists());
+        }
+
+        #[test]
+        fn remove_file_robust_deletes_plain_file() {
+            let tmp = tempfile::tempdir().unwrap();
+            let file_path = tmp.path().join("asset.txt");
+            std::fs::write(&file_path, "hi").unwrap();
+            remove_file_robust(&file_path).unwrap();
+            assert!(!file_path.exists());
+        }
+
+        #[test]
+        fn remove_file_robust_surfaces_not_found_immediately() {
+            let tmp = tempfile::tempdir().unwrap();
+            let missing = tmp.path().join("never-existed.txt");
+            let err = remove_file_robust(&missing).unwrap_err();
+            // NotFound is not a lock — must not burn ~8s of retries, and the
+            // caller keeps remove_file's missing-file error semantics.
+            assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
         }
     }
 }

--- a/src/components/branches/BranchesTab.tsx
+++ b/src/components/branches/BranchesTab.tsx
@@ -48,7 +48,12 @@ import { trackEvent, trackError } from '../../lib/analytics';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { useOptionalToast } from '../../contexts/ToastContext';
-import { asCommandError, formatCommandError, humanizeGitError } from '../../lib/errors';
+import {
+  asCommandError,
+  formatCommandError,
+  humanizeGitError,
+  isRecognizedGitFailure,
+} from '../../lib/errors';
 import { logger } from '../../lib/logger';
 
 /** A Tauri-rejected `CommandError` is an object — `String(err)` renders it as
@@ -306,14 +311,23 @@ export function BranchesTab({
             return;
           }
         }
-        onToast?.(humanizeGitError(raw, { branch: branchName }), 'error');
+        // Recognized, by-design refusals ride the info channel — an 'error'
+        // toast would re-report a failure the backend already classified
+        // Expected (issue #690, same pattern as useBranchManagement).
+        onToast?.(
+          humanizeGitError(raw, { branch: branchName }),
+          isRecognizedGitFailure(raw, { branch: branchName }) ? 'info' : 'error'
+        );
         // The branch is gone (deleted/renamed elsewhere) but still showing in a
         // stale list — refresh to drop the phantom entry.
         if (isBranchGoneError(raw)) onRefresh();
       }
     } catch (e) {
       trackError('branch_switch', e, 'Workspace');
-      onToast?.(humanizeGitError(e, { branch: branchName }), 'error');
+      onToast?.(
+        humanizeGitError(e, { branch: branchName }),
+        isRecognizedGitFailure(e, { branch: branchName }) ? 'info' : 'error'
+      );
       if (isBranchGoneError(errText(e))) onRefresh();
     } finally {
       setSwitchingBranch(null);
@@ -391,7 +405,10 @@ export function BranchesTab({
       onRefresh();
     } catch (e) {
       trackError('branch_publish', e, 'Workspace');
-      onToast?.(humanizeGitError(e, { branch: branchName }), 'error');
+      onToast?.(
+        humanizeGitError(e, { branch: branchName }),
+        isRecognizedGitFailure(e, { branch: branchName }) ? 'info' : 'error'
+      );
       // Same recovery as handleSwitch: the ref is gone but a stale entry is
       // still listed — refresh to drop the phantom (issue #334).
       if (isBranchGoneError(e)) onRefresh();
@@ -413,7 +430,10 @@ export function BranchesTab({
       onRefresh();
     } catch (e) {
       trackError('branch_delete', e, 'Workspace');
-      onToast?.(humanizeGitError(e, { branch: branchName }), 'error');
+      onToast?.(
+        humanizeGitError(e, { branch: branchName }),
+        isRecognizedGitFailure(e, { branch: branchName }) ? 'info' : 'error'
+      );
       if (isBranchGoneError(e)) onRefresh();
     } finally {
       setDeletingBranch(null);
@@ -498,7 +518,7 @@ export function BranchesTab({
       onRefresh();
     } catch (e) {
       trackError('branch_create', e, 'Workspace');
-      onToast?.(humanizeGitError(e), 'error');
+      onToast?.(humanizeGitError(e), isRecognizedGitFailure(e) ? 'info' : 'error');
       // e.g. the chosen base branch was deleted elsewhere — refresh the list.
       if (isBranchGoneError(e)) onRefresh();
     } finally {

--- a/src/components/dashboard/ImportProject.tsx
+++ b/src/components/dashboard/ImportProject.tsx
@@ -42,6 +42,7 @@ import {
 import { logger } from '../../lib/logger';
 import {
   asCommandError,
+  describeAccountsLoadError,
   describeProcessError,
   formatCommandError,
   friendlyProcessError,
@@ -93,18 +94,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       setSelectedOwner(user);
     } catch (err) {
       trackError('github_accounts_load', err, 'Dashboard');
-      const message = formatCommandError(asCommandError(err));
-      // A blown time budget means a slow network, not stale credentials —
-      // "sign out and back in" can't fix it (issue #686). Matches both the
-      // raw Timeout wording ("`gh api user` timed out after 15s") and the
-      // backend's Expected mapping ("GitHub took too long to respond").
-      const isTimeout = /timed out|took too long/i.test(message);
-      setError(
-        `Couldn't load your GitHub accounts: ${message}. ` +
-          (isTimeout
-            ? 'Check your internet connection and try again.'
-            : 'Try signing out and back into GitHub.')
-      );
+      setError(describeAccountsLoadError(err));
     } finally {
       setLoadingAccounts(false);
     }

--- a/src/components/dashboard/ImportProject.tsx
+++ b/src/components/dashboard/ImportProject.tsx
@@ -93,9 +93,17 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       setSelectedOwner(user);
     } catch (err) {
       trackError('github_accounts_load', err, 'Dashboard');
+      const message = formatCommandError(asCommandError(err));
+      // A blown time budget means a slow network, not stale credentials —
+      // "sign out and back in" can't fix it (issue #686). Matches both the
+      // raw Timeout wording ("`gh api user` timed out after 15s") and the
+      // backend's Expected mapping ("GitHub took too long to respond").
+      const isTimeout = /timed out|took too long/i.test(message);
       setError(
-        `Couldn't load your GitHub accounts: ${formatCommandError(asCommandError(err))}. ` +
-          'Try signing out and back into GitHub.'
+        `Couldn't load your GitHub accounts: ${message}. ` +
+          (isTimeout
+            ? 'Check your internet connection and try again.'
+            : 'Try signing out and back into GitHub.')
       );
     } finally {
       setLoadingAccounts(false);

--- a/src/components/dashboard/ProjectList.tsx
+++ b/src/components/dashboard/ProjectList.tsx
@@ -23,7 +23,7 @@ import {
   renameProject,
   exportProjectAsTemplate,
 } from '../../lib/project';
-import { asCommandError, formatCommandError } from '../../lib/errors';
+import { asCommandError, formatCommandError, isProjectFolderGoneError } from '../../lib/errors';
 import { logger } from '../../lib/logger';
 import { trackEvent, trackError } from '../../lib/analytics';
 import {
@@ -222,10 +222,23 @@ export function ProjectList({
             try {
               thumbnailData = await getProjectThumbnail(project.path);
             } catch (e) {
-              logger.error('Failed to load thumbnail', {
-                error: e instanceof Error ? e.message : String(e),
-                projectName: project.name,
-              });
+              // `get_project_thumbnail` rejects with a plain CommandError
+              // object (not an Error instance) — String() renders it as
+              // "[object Object]" (issue #685). A gone project folder is a
+              // by-design Expected state (canonicalize_tagged), not a bug:
+              // warn locally instead of auto-filing a report.
+              const message = formatCommandError(asCommandError(e));
+              if (isProjectFolderGoneError(e)) {
+                logger.warn('Thumbnail unavailable — project folder no longer exists', {
+                  error: message,
+                  projectName: project.name,
+                });
+              } else {
+                logger.error('Failed to load thumbnail', {
+                  error: message,
+                  projectName: project.name,
+                });
+              }
             }
           }
           return { ...project, thumbnailData };
@@ -239,7 +252,7 @@ export function ProjectList({
       }
     } catch (error) {
       logger.error('Failed to load projects', {
-        error: error instanceof Error ? error.message : String(error),
+        error: formatCommandError(asCommandError(error)),
       });
     }
   };

--- a/src/components/dashboard/ProjectRail.tsx
+++ b/src/components/dashboard/ProjectRail.tsx
@@ -25,6 +25,7 @@
 import { useEffect, useRef, useState, useLayoutEffect, useCallback } from 'react';
 import type { PinnedProjectRow } from '../../hooks/usePinnedProjects';
 import { getProjectThumbnail, listProjects } from '../../lib/project';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 import { logger } from '../../lib/logger';
 import { Button } from '../primitives/Button';
 
@@ -510,9 +511,11 @@ function RailItem({
       })
       .catch((err) => {
         thumbnailCache.set(row.projectPath, null);
+        // Plain CommandError objects aren't Error instances — String()
+        // renders them "[object Object]" (issue #685).
         logger.debug('[ProjectRail] No thumbnail for pin', {
           projectPath: row.projectPath,
-          error: String(err),
+          error: formatCommandError(asCommandError(err)),
         });
       });
     return () => {

--- a/src/components/plugins/PluginSlot.test.tsx
+++ b/src/components/plugins/PluginSlot.test.tsx
@@ -6,9 +6,15 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockIPC } from '@tauri-apps/api/mocks';
-import { buildContext } from './PluginSlot';
+import { render } from '@testing-library/react';
+import { buildContext, PluginSlot } from './PluginSlot';
 import { unloadPluginModule } from '../../lib/plugin-loader';
-import type { PluginAppActions, PluginThemeData } from '../../contexts/PluginContext';
+import type {
+  PluginAppActions,
+  PluginContextValue,
+  PluginThemeData,
+} from '../../contexts/PluginContext';
+import type { LoadedPlugin } from '../../hooks/usePlugins';
 
 const theme: PluginThemeData = {
   bgPrimary: '',
@@ -175,5 +181,61 @@ describe('buildContext failure reporting', () => {
 
     await expect(ctx.storage.read()).resolves.toEqual({ key: 'value' });
     expect(showToast).not.toHaveBeenCalled();
+  });
+});
+
+describe('legacy plugin context global (#389/#465/#695)', () => {
+  function makeLegacyPlugin(id: string, name: string, seen: Record<string, string>) {
+    // Mimics a pre-React-context SDK bundle: reads the single window global
+    // during render instead of using PluginContext.
+    function LegacySlotComponent() {
+      const ctx = (window as unknown as Record<string, unknown>).__SHIPSTUDIO_PLUGIN_CONTEXT__ as
+        | PluginContextValue
+        | undefined;
+      seen[id] = ctx?.pluginId ?? '(missing)';
+      return null;
+    }
+    const plugin: LoadedPlugin = {
+      info: {
+        manifest: {
+          id,
+          name,
+          version: '1.0.0',
+          description: '',
+          slots: ['toolbar'],
+          author: '',
+          repository: '',
+          setup: [],
+          min_app_version: '0.0.0',
+          icon: '',
+          required_commands: [],
+        },
+        enabled: true,
+        installed_at: 0,
+        source_url: '',
+        is_dev: false,
+        local_path: '',
+      },
+      module: { name, slots: { toolbar: LegacySlotComponent } },
+    };
+    return plugin;
+  }
+
+  it('each legacy plugin sees its own context during render, not the last-mounted one', () => {
+    const seen: Record<string, string> = {};
+    const { actions } = makeActions();
+    render(
+      <PluginSlot
+        name="toolbar"
+        plugins={[
+          makeLegacyPlugin('vercel', 'Vercel', seen),
+          makeLegacyPlugin('webflow-cloud', 'Webflow Cloud', seen),
+        ]}
+        project={project}
+        actions={actions}
+        theme={theme}
+      />
+    );
+    expect(seen).toEqual({ vercel: 'vercel', 'webflow-cloud': 'webflow-cloud' });
   });
 });

--- a/src/components/plugins/PluginSlot.tsx
+++ b/src/components/plugins/PluginSlot.tsx
@@ -285,12 +285,14 @@ export function buildContext(
  */
 function SafePluginWrapper({
   Component: PluginComponent,
+  ctx,
   pluginId,
   pluginName,
   compact,
   onCrash,
 }: {
   Component: ComponentType;
+  ctx: PluginContextValue;
   pluginId: string;
   pluginName: string;
   compact: boolean;
@@ -318,6 +320,17 @@ function SafePluginWrapper({
       <PluginErrorChip pluginName={pluginName} compact={compact} detail={crashError.message} />
     );
   }
+
+  // Legacy plugin bundles (built before the React-context SDK) read a single
+  // window global inside their hooks at render time. A parent's render body
+  // runs synchronously immediately before its children's in the same pass, so
+  // setting the global here means it holds THIS plugin's context while this
+  // plugin's components render — with several plugins mounted, setting it any
+  // earlier (e.g. while PluginSlot maps over plugins) leaves every legacy
+  // bundle reading the last plugin's context (issues #389/#465/#695). A
+  // legacy bundle that re-reads the global from an async callback after
+  // render can still race; only render-time reads are guaranteed.
+  exposePluginContext(ctx);
 
   return (
     <div ref={containerRef} style={{ display: 'contents' }}>
@@ -355,12 +368,17 @@ export function PluginSlot({ name, plugins, project, actions, theme }: PluginSlo
           plugin.info.manifest.required_commands || []
         );
 
-        // Expose context on window globals for raw-JS and legacy plugins.
+        // Expose context on the id-keyed window global for raw-JS plugins.
+        // The single-value legacy global is NOT set here: this map callback
+        // runs for every plugin before React renders any of them, so setting
+        // it here left it pointing at whichever plugin happened to be last —
+        // legacy bundles then executed with another plugin's identity
+        // ("Plugin 'vercel' tried to run 'webflow'", issues #389/#465/#695).
+        // SafePluginWrapper sets it during each plugin's own render instead.
         const pluginsMap = ((
           window as unknown as Record<string, unknown>
         ).__SHIPSTUDIO_PLUGINS__ ??= {}) as Record<string, PluginContextValue>;
         pluginsMap[pluginId] = ctx;
-        exposePluginContext(ctx);
 
         const handleCrash = () => {
           // Both boundaries (and the safety wrapper) can fire for the same
@@ -393,6 +411,7 @@ export function PluginSlot({ name, plugins, project, actions, theme }: PluginSlo
               >
                 <SafePluginWrapper
                   Component={SlotComponent}
+                  ctx={ctx}
                   pluginId={pluginId}
                   pluginName={pluginName}
                   compact={compact}

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -64,7 +64,7 @@ import { PluginsDropdown } from '../plugins/PluginsDropdown';
 import { getAgentById } from '../../lib/agent';
 import type { AgentConfig } from '../../lib/agent';
 import type { Project } from '../../lib/project';
-import { isMobileProjectType, type ProjectType } from '../../lib/static-server';
+import { hasWebPreview, isMobileProjectType, type ProjectType } from '../../lib/static-server';
 import { ShopifySetup } from '../shopify/ShopifySetup';
 import { useShopifyTheme } from '../../hooks/useShopifyTheme';
 import { isMac } from '../../lib/setup';
@@ -613,16 +613,16 @@ export const WorkspaceView = memo(function WorkspaceView({
     handleSaveDevCommand,
   } = lifecycle;
 
+  // Whether this project gets the web iframe Preview — the #691 rule lives in
+  // hasWebPreview: web frameworks always, `generic` only when a custom dev
+  // command is configured (Nx/monorepo roots), never for unknown/mobile.
+  const isWebProject = hasWebPreview(projectType, customDevCommand);
+
   // Cmd+Shift+S — capture viewport screenshot, Cmd+Shift+C — toggle crop mode
   // Screenshot accelerators only make sense over the web iframe preview, not
-  // the device mirror (which captures a simulator, not localhost) or generic/
-  // unknown projects with no preview at all.
-  const previewVisible =
-    projectType !== 'generic' &&
-    projectType !== 'unknown' &&
-    !isMobileProjectType(projectType) &&
-    workspaceTab === 'preview' &&
-    !isPreviewHidden;
+  // the device mirror (which captures a simulator, not localhost) or projects
+  // with no preview at all.
+  const previewVisible = isWebProject && workspaceTab === 'preview' && !isPreviewHidden;
 
   // Listen for native menu accelerators (Cmd+Shift+S / Cmd+Shift+C).
   // Native accelerators work even when the cross-origin preview iframe has focus,
@@ -652,13 +652,14 @@ export const WorkspaceView = memo(function WorkspaceView({
     setIsCropMode,
   ]);
 
-  // Generic/unknown (Tauri, CLI) projects have no preview pane at all. Web
-  // projects get the iframe Preview; native mobile (RN/Expo, Flutter) gets the
-  // device mirror — but only on macOS, where the simulator/emulator toolchains are
-  // validated (mobile preview is untested on Windows, so we don't offer it there).
+  // Projects with no web preview and no mobile mirror have no preview pane at
+  // all. Web projects (see `isWebProject` above — includes generic projects
+  // with a configured dev command, issue #691) get the iframe Preview; native
+  // mobile (RN/Expo, Flutter) gets the device mirror — but only on macOS,
+  // where the simulator/emulator toolchains are validated (mobile preview is
+  // untested on Windows, so we don't offer it there).
   const isMobileProject = isMobileProjectType(projectType);
   const mobilePreviewAvailable = isMobileProject && isMac();
-  const isWebProject = projectType !== 'generic' && projectType !== 'unknown' && !isMobileProject;
   const hasPreview = isWebProject || mobilePreviewAvailable;
 
   // Reset the preview-side tab to its default whenever the user switches

--- a/src/hooks/usePreviewConnection.test.ts
+++ b/src/hooks/usePreviewConnection.test.ts
@@ -471,4 +471,47 @@ describe('usePreviewConnection page-list load failures (issue #541)', () => {
       await vi.advanceTimersByTimeAsync(0);
     });
   });
+
+  it('warn-logs (not error-logs) the by-design gone-folder rejection (issue #698)', async () => {
+    // The backend's canonicalize_tagged classifies a moved/renamed/deleted
+    // project folder as Expected — but Expected serializes as Other over IPC,
+    // so the hook must recognize the message shape. loadPages runs on a 5s
+    // poll: at error level this auto-filed a bug report every tick.
+    const goneMessage =
+      "The folder '/path/to/project' no longer exists — it may have been moved, renamed, or deleted outside Ship Studio";
+    const { invoke } = await import('@tauri-apps/api/core');
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === 'start_preview_proxy') return Promise.resolve(8080);
+      if (cmd === 'list_pages')
+        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- deliberately a plain CommandError object, the shape under test
+        return Promise.reject({ type: 'Other', message: goneMessage });
+      return Promise.resolve(undefined);
+    });
+    const server = installSlowServerFetch();
+    const { unmount } = renderHook(() => usePreviewConnection(baseParams));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    await act(async () => {
+      server.finishCompile();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the mock's calls, not invoking it bound
+    const warnCalls = vi.mocked(logger.warn).mock.calls;
+    const warned = warnCalls.find(([msg]) => msg.includes('Failed to load pages'));
+    expect(warned).toBeDefined();
+    expect(warned?.[1]).toEqual({ error: goneMessage });
+    // The whole point: nothing reaches the auto-bug-report channel.
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the mock's calls, not invoking it bound
+    const errorCalls = vi.mocked(logger.error).mock.calls;
+    expect(errorCalls.find(([msg]) => msg.includes('Failed to load pages'))).toBeUndefined();
+
+    await act(async () => {
+      unmount();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+  });
 });

--- a/src/hooks/usePreviewConnection.ts
+++ b/src/hooks/usePreviewConnection.ts
@@ -16,7 +16,7 @@ import {
   IFRAME_BLANK_TIMEOUT_MS,
 } from './previewIframeWatchdog';
 import { logger } from '../lib/logger';
-import { asCommandError, formatCommandError } from '../lib/errors';
+import { asCommandError, formatCommandError, isProjectFolderGoneError } from '../lib/errors';
 import { getWindowLabel } from '../lib/window';
 import { trackEvent } from '../lib/analytics';
 
@@ -220,9 +220,19 @@ export function usePreviewConnection({
     } catch (error) {
       // `list_pages` rejects with a plain CommandError object (not an Error
       // instance) — String() renders it as "[object Object]" (issue #541).
-      logger.error('Failed to load pages', {
-        error: formatCommandError(asCommandError(error)),
-      });
+      const message = formatCommandError(asCommandError(error));
+      if (isProjectFolderGoneError(error)) {
+        // The project's folder is gone (moved/renamed/deleted outside Ship
+        // Studio) — a by-design Expected state the backend deliberately keeps
+        // out of telemetry (canonicalize_tagged in src-tauri/src/utils.rs).
+        // This runs on a 5s poll, so logging it at error level auto-filed a
+        // bug report every tick (issue #698).
+        logger.warn('Failed to load pages — project folder no longer exists', {
+          error: message,
+        });
+      } else {
+        logger.error('Failed to load pages', { error: message });
+      }
     }
   }, [projectPath]);
 

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -42,6 +42,7 @@ import {
   getAutoAcceptMode,
   setAutoAcceptMode as setAutoAcceptModeApi,
   detectWorkspaces,
+  getCustomDevCommand,
   getWorkspaceSubpath,
   setWorkspaceSubpath,
 } from '../lib/project';
@@ -716,11 +717,17 @@ export function useProjectLifecycle({
       return;
     }
 
-    // Generic projects don't have a web preview — default to branches tab.
-    // We only force this for fresh starts; when reusing a pinned session we
-    // preserve whichever tab the user was on.
+    // Generic projects without a configured dev command don't have a web
+    // preview — default to branches tab. A generic project WITH a custom dev
+    // command (e.g. an Nx monorepo root running `nx serve`, issue #691) does
+    // get the Preview tab, so leave it on the default. We only force this for
+    // fresh starts; when reusing a pinned session we preserve whichever tab
+    // the user was on.
     if (!reuseIncomingServer && detectedType === 'generic') {
-      setWorkspaceTab('branches');
+      const customCmd = await getCustomDevCommand(project.path).catch(() => null);
+      if (!customCmd) {
+        setWorkspaceTab('branches');
+      }
     }
 
     setView('workspace');

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   asCommandError,
+  describeAccountsLoadError,
   describeProcessError,
   formatCommandError,
   friendlyProcessError,
@@ -545,5 +546,25 @@ describe('isProjectFolderGoneError', () => {
       isProjectFolderGoneError('feature/x no longer exists. It may have been deleted or renamed.')
     ).toBe(false);
     expect(isProjectFolderGoneError(new Error('connection refused'))).toBe(false);
+  });
+});
+
+describe('describeAccountsLoadError (issue #686)', () => {
+  it('uses retry wording for timeouts instead of sign-out advice', () => {
+    const raw = { type: 'Timeout', message: '`gh api user/orgs` timed out after 15s' };
+    const backendMapped = {
+      type: 'Other',
+      message: 'GitHub took too long to respond. Check your internet connection and try again.',
+    };
+    for (const err of [raw, backendMapped]) {
+      const msg = describeAccountsLoadError(err);
+      expect(msg).toContain('Check your internet connection');
+      expect(msg).not.toContain('signing out');
+    }
+  });
+
+  it('keeps sign-out advice for non-timeout failures', () => {
+    const msg = describeAccountsLoadError({ type: 'Other', message: 'HTTP 401 bad credentials' });
+    expect(msg).toContain('Try signing out and back into GitHub.');
   });
 });

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -337,6 +337,18 @@ describe('humanizeGitError', () => {
       raw: 'Failed to merge: merge: origin/chore/remove-footer-logomark-block - not something we can merge',
       expect: /couldn't be found.*deleted or renamed/i,
     },
+    {
+      // `git checkout -b X origin/Y` when the base's remote ref is gone —
+      // must name the missing base, not surface a raw fatal (issue #692).
+      raw: "fatal: 'origin/feat/base' is not a commit and a branch 'feat/new' cannot be created from it",
+      expect: /\(origin\/feat\/base\) no longer exists on GitHub.*refresh your branches/i,
+    },
+    {
+      // gh's own top-level DNS-failure output — it swallows the Go error and
+      // prints only this guidance (issue #473).
+      raw: 'error connecting to api.github.com\ncheck your internet connection or https://githubstatus.com',
+      expect: /couldn't reach GitHub/i,
+    },
   ];
 
   it.each(cases)('humanizes: $raw', ({ raw, expect: pattern }) => {
@@ -382,6 +394,40 @@ describe('humanizeGitError', () => {
     // Unrecognized failures fall through — those stay on the error channels.
     expect(isRecognizedGitFailure('some completely novel git failure')).toBe(false);
     expect(isRecognizedGitFailure(new Error('segfault in gh'))).toBe(false);
+  });
+
+  // The backend's own Expected friendly strings (github.rs / branches.rs)
+  // arrive tagged as Other over IPC and pass through humanizeGitError
+  // unchanged (they're already the friendly form) — they must still count as
+  // recognized so they never re-enter the error/telemetry channels
+  // (issue #687). Keep these literals byte-identical to the Rust strings.
+  it('recognizes backend-authored friendly Expected messages (issue #687)', () => {
+    const backendMessages = [
+      // gh_network_error
+      "Couldn't reach GitHub. Check your internet connection and try again.",
+      // the gh timeout mapping (issue #686)
+      'GitHub took too long to respond. Check your internet connection and try again.',
+      // gh_tls_error
+      "GitHub's secure connection couldn't be verified. This usually means a corporate proxy, VPN, or antivirus is inspecting HTTPS traffic on this computer (its certificate isn't trusted yet), or the system's certificate store is out of date. Install your proxy's certificate or update your system, then try again.",
+      // gh_server_error
+      "GitHub's API is temporarily unavailable (a GitHub server error). Try again in a moment.",
+      // gh_malformed_request_error
+      "GitHub couldn't process the request (a temporary GitHub API error). Try again in a moment.",
+      // gh_config_error
+      "The GitHub CLI (gh) can't read its own settings because of a file-permissions problem on this computer — this isn't a GitHub sign-in issue. Open a terminal and run `sudo chown -R $(whoami) ~/.config/gh`, then try again.",
+      // gh_crash_error (both variants)
+      'The GitHub CLI (gh) crashed unexpectedly. Try again — if it keeps happening, reinstalling the GitHub CLI may help.',
+      "The GitHub CLI (gh) couldn't start because the system is low on memory. Close some other apps (on Windows, increasing the paging file size can also help) and try again.",
+      // create_branch's vanished base ref (issue #692)
+      'The branch this was based on no longer exists on GitHub. Refresh your branches and try again.',
+    ];
+    for (const message of backendMessages) {
+      expect(isRecognizedGitFailure(message), message).toBe(true);
+      // The humanized form must stay friendly — either the backend's own
+      // wording passed through or an equivalent frontend humanization, never
+      // a regression to raw stderr.
+      expect(humanizeGitError(message)).not.toBe('');
+    }
   });
 
   it('accepts CommandError objects, not just strings', () => {

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -191,6 +191,46 @@ describe('friendlyProcessError', () => {
     ).toBe(true);
   });
 
+  it('maps corrupted pnpm store ENOENT failures to `pnpm store prune` guidance (issue #681)', () => {
+    // Exact shape from issue #681: dangling links in the content-addressable
+    // store make installs die with an ENOENT inside pnpm/store.
+    const raw =
+      "Process exited with code 1\n\n[ERROR] ENOENT: no such file or directory, open '~/Library/pnpm/store/v11/links/@pnpm/some-pkg'";
+    const info = describeProcessError(raw);
+    expect(info.expected).toBe(true);
+    expect(info.message).toContain('pnpm store prune');
+    expect(info.message).not.toContain('ENOENT');
+    // Windows store paths use backslashes.
+    expect(
+      describeProcessError(
+        "ENOENT: no such file or directory, open 'C:\\Users\\me\\AppData\\Local\\pnpm\\store\\v11\\links\\esbuild'"
+      ).expected
+    ).toBe(true);
+    // An ENOENT outside the pnpm store is NOT the corrupted-cache state.
+    expect(
+      describeProcessError("ENOENT: no such file or directory, open '/tmp/whatever.json'").expected
+    ).toBe(false);
+  });
+
+  it('maps Windows path-length checkout failures to core.longpaths guidance (issue #701)', () => {
+    // git downloads the repo fine, then fails writing long paths on Windows.
+    const raw =
+      "Process exited with code 1\n\nCloning into 'deep-repo'...\nerror: unable to create file src/some/extremely/deeply/nested/component/file.tsx: Filename too long\nfatal: unable to checkout working tree\nwarning: Clone succeeded, but checkout failed.\nYou can inspect what was checked out with 'git status'";
+    const info = describeProcessError(raw);
+    expect(info.expected).toBe(true);
+    expect(info.message).toContain('git config --global core.longpaths true');
+    expect(info.message).toMatch(/LongPathsEnabled/);
+    expect(info.message).not.toContain('Cloning into');
+    // Each phrase alone classifies too — output can be truncated.
+    expect(describeProcessError('error: unable to create file x: Filename too long').expected).toBe(
+      true
+    );
+    expect(describeProcessError('fatal: unable to checkout working tree').expected).toBe(true);
+    expect(describeProcessError('warning: Clone succeeded, but checkout failed.').expected).toBe(
+      true
+    );
+  });
+
   it('classifies recognized shapes as expected and unknown ones as not', () => {
     expect(describeProcessError('sh: pnpm: command not found').expected).toBe(true);
     expect(describeProcessError('Process exited with code 128').expected).toBe(true);

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -69,6 +69,48 @@ export interface GitErrorContext {
 }
 
 /**
+ * Wording (lowercased substrings) of the friendly messages the BACKEND already
+ * authored for recognized git/GitHub failures — `CommandError::expected(...)`
+ * strings in `src-tauri/src/commands/github.rs` (gh_network_error,
+ * gh_tls_error, gh_server_error, gh_malformed_request_error, gh_config_error,
+ * gh_crash_error, plus the gh timeout mapping) and
+ * `src-tauri/src/commands/git/branches.rs` (vanished base ref). Expected
+ * serializes identically to Other across IPC, so the tag is gone by the time
+ * the frontend sees the error — the wording itself is the only signal. Keep
+ * these in sync with the Rust strings byte-for-byte.
+ *
+ * Without this list, {@link humanizeGitError} returns these already-humanized
+ * messages unchanged and {@link isRecognizedGitFailure}'s inequality test
+ * misreads "unchanged" as "unrecognized", routing failures the backend
+ * deliberately kept out of telemetry straight back into the error-toast
+ * channels that auto-file bug reports (issue #687).
+ */
+const BACKEND_HUMANIZED_GIT_PHRASES = [
+  // gh_network_error / the gh timeout → Expected mapping (issues #375, #686)
+  "couldn't reach github",
+  'check your internet connection',
+  // gh_tls_error (issue #658)
+  "secure connection couldn't be verified",
+  // gh_server_error / gh_malformed_request_error (issues #627, #602)
+  "github's api is temporarily unavailable",
+  "github couldn't process the request",
+  // gh_config_error (issue #631)
+  "can't read its own settings",
+  // gh_crash_error (issue #610)
+  'the github cli (gh) crashed',
+  "couldn't start because the system is low on memory",
+  // create_branch's vanished base ref (issue #692)
+  'no longer exists on github',
+];
+
+/** True when a message is one the backend already humanized (see
+ *  {@link BACKEND_HUMANIZED_GIT_PHRASES}). */
+function isBackendHumanizedGitMessage(message: string): boolean {
+  const m = message.toLowerCase();
+  return BACKEND_HUMANIZED_GIT_PHRASES.some((phrase) => m.includes(phrase));
+}
+
+/**
  * Turn a raw git/GitHub error into a plain-language message a non-git-expert can
  * act on. Recognizes the common failures (empty branch, merge conflict, out of
  * date, auth, network, protected branch, existing PR, unsaved changes) and falls
@@ -108,8 +150,11 @@ export function humanizeGitError(value: unknown, ctx: GitErrorContext = {}): str
   // GitHub" — advice that can't fix a file the OS won't let gh read
   // (issue #631).
   if (
-    (m.includes('failed to read configuration') || m.includes('failed to load config')) &&
-    m.includes('permission denied')
+    // The backend's own friendly wording for this state (gh_config_error,
+    // issue #687) as well as gh's raw stderr.
+    m.includes("can't read its own settings") ||
+    ((m.includes('failed to read configuration') || m.includes('failed to load config')) &&
+      m.includes('permission denied'))
   ) {
     return `The GitHub CLI (gh) can't read its own settings because of a file-permissions problem on this computer — this isn't a GitHub sign-in issue. Open a terminal and run \`sudo chown -R $(whoami) ~/.config/gh\`, then try again.`;
   }
@@ -135,7 +180,13 @@ export function humanizeGitError(value: unknown, ctx: GitErrorContext = {}): str
   // Must be checked BEFORE the generic network branch: "check your internet
   // connection" can't fix a trust chain (issue #658, mirroring gh_tls_error
   // in src-tauri/src/commands/github.rs).
-  if (m.includes('failed to verify certificate') || m.includes('x509:')) {
+  if (
+    m.includes('failed to verify certificate') ||
+    m.includes('x509:') ||
+    // The backend's own friendly wording for this state (gh_tls_error,
+    // issue #687).
+    m.includes("secure connection couldn't be verified")
+  ) {
     return `GitHub's secure connection couldn't be verified. This usually means a corporate proxy, VPN, or antivirus is inspecting HTTPS traffic on this computer, or the system's certificate store is out of date. Install your proxy's certificate or update your system, then try again.`;
   }
 
@@ -156,7 +207,12 @@ export function humanizeGitError(value: unknown, ctx: GitErrorContext = {}): str
     // false-positive on ordinary words like "thereof" (issues #434/#642,
     // mirroring gh_network_error in src-tauri/src/commands/github.rs).
     m.includes('unexpected eof') ||
-    /:\s*eof\s*$/m.test(m)
+    /:\s*eof\s*$/m.test(m) ||
+    // The backend's own friendly wording (gh_network_error / the gh timeout
+    // mapping, issues #687/#686) — and gh's raw top-level DNS-failure output,
+    // which also says "check your internet connection" (issue #473).
+    m.includes("couldn't reach github") ||
+    m.includes('check your internet connection')
   ) {
     return `Couldn't reach GitHub. Check your internet connection and try again.`;
   }
@@ -201,6 +257,17 @@ export function humanizeGitError(value: unknown, ctx: GitErrorContext = {}): str
     return `The branch to merge (${base}) couldn't be found — it may have been deleted or renamed on GitHub, or the latest fetch didn't complete. Refresh your branches and try again.`;
   }
 
+  // Creating a branch from a base whose remote ref is gone: "fatal:
+  // 'origin/Y' is not a commit and a branch 'X' cannot be created from it" —
+  // the base branch was deleted or renamed on GitHub after the branch list
+  // loaded (issue #692). The backend classifies this Expected with its own
+  // friendly wording (see BACKEND_HUMANIZED_GIT_PHRASES); this matches git's
+  // raw phrasing for any path that misses that classification.
+  if (m.includes('is not a commit and a branch')) {
+    const missing = raw.match(/'([^']+)' is not a commit/)?.[1];
+    return `The branch this was based on${missing ? ` (${missing})` : ''} no longer exists on GitHub. Refresh your branches and try again.`;
+  }
+
   // The ref is gone — git couldn't find the branch, so it treated it as a path.
   if (
     m.includes('did not match') ||
@@ -232,7 +299,16 @@ export function humanizeGitError(value: unknown, ctx: GitErrorContext = {}): str
  * error channels that auto-file bug reports (issue #538).
  */
 export function isRecognizedGitFailure(value: unknown, ctx: GitErrorContext = {}): boolean {
-  return humanizeGitError(value, ctx) !== formatCommandError(asCommandError(value));
+  const raw = formatCommandError(asCommandError(value));
+  // Messages the backend already humanized can come back from
+  // humanizeGitError byte-identical (they ARE the friendly form — e.g.
+  // gh_network_error's "Couldn't reach GitHub…" maps to the same string), so
+  // the inequality test alone would misread them as unrecognized and route
+  // an already-classified failure back into telemetry (issue #687).
+  if (isBackendHumanizedGitMessage(raw)) {
+    return true;
+  }
+  return humanizeGitError(value, ctx) !== raw;
 }
 
 /**

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -549,3 +549,22 @@ export function friendlyProcessError(
 ): string {
   return describeProcessError(err, extraExitCodeMessages).message;
 }
+
+/**
+ * User-facing message for a failed GitHub accounts load (username + orgs).
+ *
+ * A blown time budget means a slow network, not stale credentials — "sign
+ * out and back in" can't fix it (issue #686). Matches both the raw Timeout
+ * wording ("`gh api user` timed out after 15s") and the backend's Expected
+ * mapping ("GitHub took too long to respond").
+ */
+export function describeAccountsLoadError(err: unknown): string {
+  const message = formatCommandError(asCommandError(err));
+  const isTimeout = /timed out|took too long/i.test(message);
+  return (
+    `Couldn't load your GitHub accounts: ${message}. ` +
+    (isTimeout
+      ? 'Check your internet connection and try again.'
+      : 'Try signing out and back into GitHub.')
+  );
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -359,6 +359,24 @@ export function describeProcessError(
         "GitHub couldn't authenticate this computer over HTTPS — git needed to ask for a password, and there's no saved credential to use. Open a terminal and run `gh auth login`, then `gh auth setup-git`, and try again.",
     };
   }
+  // Windows path-length limit during clone checkout: the download itself
+  // succeeded, but git couldn't write files whose paths exceed Windows'
+  // 260-character default ("error: unable to create file <path>: Filename too
+  // long", then "fatal: unable to checkout working tree" / "Clone succeeded,
+  // but checkout failed."). A machine-configuration state with a one-line
+  // fix, not an app bug — without this branch the raw clone dump reached the
+  // user (issue #701).
+  if (
+    lower.includes('filename too long') ||
+    lower.includes('unable to checkout working tree') ||
+    lower.includes('clone succeeded, but checkout failed')
+  ) {
+    return {
+      expected: true,
+      message:
+        "The repository was downloaded, but some of its files have names or paths longer than Windows allows by default, so git couldn't write them. Open a terminal and run `git config --global core.longpaths true` (and enable Windows long-path support — LongPathsEnabled — if it still fails), then delete the incomplete project folder and try again.",
+    };
+  }
   // GitHub's own API returning a transient 5xx (e.g. "HTTP 504: We couldn't
   // respond to your request in time…" from api.github.com/graphql during
   // `gh repo clone`). gh exits with the generic code 1, so only the wording
@@ -390,6 +408,18 @@ export function describeProcessError(
       expected: true,
       message:
         "npm couldn't sign in to the package registry — your saved npm login or token is expired or incorrect. Open a terminal and run `npm login` (or refresh the token in your .npmrc if this project uses a private registry), then try again.",
+    };
+  }
+  // Corrupted pnpm store: the content-addressable cache has dangling links,
+  // so installs die with "ENOENT: no such file or directory, open
+  // '…/pnpm/store/v11/links/…'". A local-cache state that `pnpm store prune`
+  // repairs, not an app or project bug (issue #681). Checked before the
+  // generic exit-code mapping — only the ENOENT text identifies it.
+  if (lower.includes('enoent') && (lower.includes('pnpm/store') || lower.includes('pnpm\\store'))) {
+    return {
+      expected: true,
+      message:
+        "pnpm's local package cache looks corrupted. Open a terminal and run `pnpm store prune`, then retry the install.",
     };
   }
   // pnpm's build-script approval gate: the install itself succeeded, but

--- a/src/lib/static-server.test.ts
+++ b/src/lib/static-server.test.ts
@@ -1,5 +1,55 @@
+/**
+ * Tests for lib/static-server helpers — most importantly the `hasWebPreview`
+ * rule (issue #691): which projects get the web iframe Preview pane.
+ */
+
 import { describe, it, expect } from 'vitest';
-import { isMobileProjectType } from './static-server';
+import { hasWebPreview, isMobileProjectType, type ProjectType } from './static-server';
+
+describe('hasWebPreview', () => {
+  it('always grants a preview to detected web frameworks and static sites', () => {
+    const webTypes: ProjectType[] = [
+      'nextjs',
+      'sveltekit',
+      'astro',
+      'nuxt',
+      'vite',
+      'statichtml',
+      'shopifytheme',
+    ];
+    for (const type of webTypes) {
+      expect(hasWebPreview(type, null), type).toBe(true);
+      // A custom command must not revoke a framework preview either.
+      expect(hasWebPreview(type, 'npm run dev'), type).toBe(true);
+    }
+  });
+
+  it('grants generic projects a preview only with a configured dev command', () => {
+    // The #691 case: an Nx monorepo root (workspaces + nx.json, no framework
+    // config) detects as `generic`; once the user configures a dev command the
+    // dev server runs, so the Preview tab must appear.
+    expect(hasWebPreview('generic', 'npx nx serve web')).toBe(true);
+
+    // Plain script collections / Rust CLIs with a tooling-only package.json
+    // must keep hiding the Preview.
+    expect(hasWebPreview('generic', null)).toBe(false);
+    expect(hasWebPreview('generic', '')).toBe(false);
+    expect(hasWebPreview('generic', '   ')).toBe(false);
+  });
+
+  it('never grants unknown projects a web preview', () => {
+    expect(hasWebPreview('unknown', null)).toBe(false);
+    // `unknown` means no framework, no package.json, no HTML — a custom
+    // command isn't even loaded for these, but be defensive.
+    expect(hasWebPreview('unknown', 'npm run dev')).toBe(false);
+  });
+
+  it('never grants native mobile projects a web preview (device mirror instead)', () => {
+    expect(hasWebPreview('reactnative', null)).toBe(false);
+    expect(hasWebPreview('flutter', null)).toBe(false);
+    expect(hasWebPreview('reactnative', 'expo start')).toBe(false);
+  });
+});
 
 describe('isMobileProjectType', () => {
   it('is true for native mobile project types', () => {
@@ -11,6 +61,7 @@ describe('isMobileProjectType', () => {
     expect(isMobileProjectType('vite')).toBe(false);
     expect(isMobileProjectType('nextjs')).toBe(false);
     expect(isMobileProjectType('statichtml')).toBe(false);
+    expect(isMobileProjectType('generic')).toBe(false);
     expect(isMobileProjectType('unknown')).toBe(false);
   });
 });

--- a/src/lib/static-server.ts
+++ b/src/lib/static-server.ts
@@ -30,6 +30,28 @@ export function isMobileProjectType(type: ProjectType): boolean {
   return MOBILE_PROJECT_TYPES.includes(type);
 }
 
+/**
+ * Whether a project gets the web (iframe) Preview pane.
+ *
+ * The rule (issue #691):
+ * - Detected web frameworks (next/vite/astro/…, static HTML, Shopify themes)
+ *   always have a preview.
+ * - `generic` projects have a preview ONLY when a custom dev command is
+ *   configured — an Nx/monorepo root (or any tooling-only package.json
+ *   project) detects as `generic`, but once the user configures a dev command
+ *   the dev server actually runs on the project's port, so the Preview tab
+ *   must appear. Generic projects without a configured command (script
+ *   collections, Rust CLIs, …) still hide the Preview.
+ * - `unknown` and native mobile types never get the web preview (mobile uses
+ *   the device mirror instead).
+ */
+export function hasWebPreview(type: ProjectType, customDevCommand: string | null): boolean {
+  if (type === 'generic') {
+    return customDevCommand !== null && customDevCommand.trim() !== '';
+  }
+  return type !== 'unknown' && !isMobileProjectType(type);
+}
+
 /** Detect the project type for a given project path */
 export async function detectProjectType(projectPath: string): Promise<ProjectType> {
   return invoke<ProjectType>('detect_project_type_command', { projectPath });


### PR DESCRIPTION
Fixes 20 open auto-reported issues, grouped by theme.

## Plugin context bleed — the hosting-plugin "wrong CLI" mystery (#389, #465, #695)
`PluginSlot` set the single legacy `__SHIPSTUDIO_PLUGIN_CONTEXT__` global while mapping over plugins — before React rendered any of them — so with several plugins mounted, every legacy (pre-React-context SDK) bundle executed under the **last-mounted plugin's identity**. That's why "cloudflare" appeared to run `vercel`, "netlify" ran `vercel`, and "vercel" ran `webflow`: never hardcoded wrong binaries, always another plugin's code holding the wrong context. The global is now exposed in `SafePluginWrapper`'s render body, synchronously correct for each plugin's own render pass. Regression test renders two legacy-style plugins and asserts each sees its own id.

## Git/GitHub error classification (#682, #686, #687, #690, #692, #699, #702)
- #682: empty-stderr `git status` failures now carry the exit code (or signal death)
- #686: `gh api user/orgs` / username timeouts → Expected with retry wording; ImportProject stops suggesting sign-out for timeouts
- #687: `humanizeGitError`/`isRecognizedGitFailure` now self-recognize all 9 backend-authored friendly Expected strings (network, TLS, 5xx, config, crash, timeout…) so they stop re-entering telemetry via error toasts
- #690: BranchesTab's four handlers route recognized git failures to info toasts
- #692: `create_branch` on a vanished base ref → Expected + friendly message (base ref name extracted from git's wording) on both sides
- #699: delete/rename external-project refusals → Expected
- #702: `git_stage_and_commit` recognizes git's third no-op wording ("no changes added to commit" — unstageable nested repos)

## Frontend logging hygiene (#681, #685, #698, #701)
- #681: corrupted pnpm store (ENOENT in pnpm/store) → `pnpm store prune` guidance, expected
- #685: thumbnail failures log real errors instead of "[object Object]"; gone-folder → warn
- #698: `loadPages` 5s poll warn-routes the by-design gone-folder rejection
- #701: Windows "Filename too long" checkout failures → `core.longpaths` guidance, expected

## Capture / proxy / static server (#683, #684, #697, #703)
- #683: plain-HTTP proxy path gets the WebSocket path's treatment — loopback race, bounded retry, warn-level "dev server restarting" classification (shared helper extracted)
- #684: entire `with_webview` snapshot closure now panic-guarded (was: unguarded `msg_send!` setup could abort the app across the ObjC boundary); panic hook now captures a scrubbed, capped backtrace so the next abort of this class is attributable
- #697: static server refuses bogus >512MB metadata lengths (413) and classifies allocator `OutOfMemory` as environmental
- #703: Playwright scripts retry `ERR_INVALID_HTTP_RESPONSE` like connection-refused; persistent case → Expected message

## Agent CLI (#665, #689)
- #665: failure output now truncated head+tail (UTF-8-boundary-safe) so Codex's trailing error line survives, and the echoed prompt (including the user's diff) is stripped from stderr/stdout before reporting — less noise, less data exposure
- #689: Codex stale models-cache → Expected with delete-cache guidance; classification now runs on full pre-truncation text

## Assets + Nx monorepos (#696, #691)
- #696: `remove_dir_all_robust`/new `remove_file_robust` extracted to utils and used by asset deletes (Windows lock retry + read-only clearing, spawn_blocking)
- #691: Nx apps with `project.json` serve/dev targets are now offered by the workspace picker (incl. integrated-style repos via `nx.json` layout); generic projects with a configured custom dev command get the Preview tab (`hasWebPreview` is the single documented rule)

## Page scan (#688)
Scan-root read failures route through `classify_fs_error` — macOS TCC denial under ~/Desktop now yields Expected + System Settings guidance instead of telemetry noise; scanners migrated from String errors to CommandError end to end.

## Verification
- Rust: 969 passed / 0 failed; `cargo fmt --check` clean; clippy no new warnings
- Frontend: 111 files, 1526 passed / 4 skipped; typecheck, `check:patterns`, LOC limits clean
- Not verified live: real Windows lock/long-path behavior, real TCC denial, real restarting-dev-server races, WKWebView panic path — all covered at unit level against the reported shapes

Companion plugin-repo fixes for #693/#694 are prepared locally and await separate approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added web previews for generic projects with custom development commands.
  * Improved Nx workspace detection, including custom layouts, project targets, and configured ports.
  * Added safer handling for large static files and unreliable development servers.

* **Bug Fixes**
  * Improved Git, GitHub, AI CLI, screenshot, and project error messages with clearer recovery guidance.
  * Branch, asset, and project deletion now better handle missing references, read-only files, and transient locks.
  * Fixed plugin context isolation and preview behavior for missing project folders.
  * Improved account-loading guidance, panic reporting, and macOS snapshot reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->