### PR TITLE
Fix dashboard crash when GitHub returns no contribution data

### DIFF
--- a/src/components/dashboard/GitHubCalendar.test.tsx
+++ b/src/components/dashboard/GitHubCalendar.test.tsx
@@ -16,22 +16,43 @@ import { GitHubCalendar } from './GitHubCalendar';
 
 const libState = vi.hoisted(() => ({ shouldThrow: false }));
 
-vi.mock('react-github-calendar', () => ({
-  // Mirrors the real library: it hands the fetched contributions to
-  // transformData during render, then renders the calendar — which validates
-  // the data and can throw in that same render pass.
-  GitHubCalendar: ({
-    transformData,
-  }: {
-    transformData: (data: Array<{ date: string; count: number; level: 0 }>) => unknown;
-  }) => {
-    transformData([]);
-    if (libState.shouldThrow) {
-      throw new Error('Activity data must not be empty.');
-    }
-    return <div data-testid="calendar-graph" />;
-  },
-}));
+// A contributions payload shaped like the real API's: the failing case mirrors
+// the empty list GitHub returns for accounts with no public contributions,
+// which is exactly what makes the library throw.
+const CONTRIBUTIONS = [{ date: '2026-01-01', count: 1, level: 1 as const }];
+
+vi.mock('react-github-calendar', async () => {
+  const { useState, useEffect } = await import('react');
+
+  // Mirrors the real library's ordering: it renders nothing while fetching,
+  // then — once the request resolves — hands the contributions to transformData
+  // *during* the render that follows, and validates them in that same pass.
+  // The async arrival matters: it lands after the parent's mount effects, which
+  // is what lets the parent's dataLoaded flag stick.
+  return {
+    GitHubCalendar: ({
+      transformData,
+    }: {
+      transformData: (
+        data: Array<{ date: string; count: number; level: 0 | 1 | 2 | 3 | 4 }>
+      ) => unknown;
+    }) => {
+      const [data, setData] = useState<typeof CONTRIBUTIONS | null>(null);
+
+      useEffect(() => {
+        setData(libState.shouldThrow ? [] : CONTRIBUTIONS);
+      }, []);
+
+      if (!data) return null;
+
+      transformData(data);
+      if (libState.shouldThrow) {
+        throw new Error('Activity data must not be empty.');
+      }
+      return <div data-testid="calendar-graph" />;
+    },
+  };
+});
 
 describe('GitHubCalendar', () => {
   beforeEach(() => {
@@ -47,7 +68,13 @@ describe('GitHubCalendar', () => {
   it('renders the calendar when the contribution data is valid', async () => {
     render(<GitHubCalendar username="octocat" isAuthenticated isAuthCheckDone />);
 
-    expect(await screen.findByTestId('calendar-graph')).toBeTruthy();
+    const graph = await screen.findByTestId('calendar-graph');
+    expect(graph).toBeTruthy();
+    // Valid data reaching transformData flips the widget out of its skeleton
+    // state, so the calendar is actually visible rather than merely mounted.
+    await waitFor(() => {
+      expect(graph.parentElement?.style.display).toBe('block');
+    });
   });
 
   it('hides itself instead of crashing when the calendar throws', async () => {

--- a/src/components/dashboard/GitHubCalendar.test.tsx
+++ b/src/components/dashboard/GitHubCalendar.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Tests for GitHubCalendar — the dashboard contribution graph.
+ *
+ * Covers:
+ *   - a throwing calendar (react-activity-calendar validates its data during
+ *     render and throws on an empty contribution list — accounts with no public
+ *     contributions, EMU accounts, new accounts) hides the widget instead of
+ *     escaping to the app-level ErrorBoundary and crashing the whole dashboard
+ *   - the surrounding dashboard content stays mounted when that happens
+ *   - a healthy calendar still renders
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { GitHubCalendar } from './GitHubCalendar';
+
+const libState = vi.hoisted(() => ({ shouldThrow: false }));
+
+vi.mock('react-github-calendar', () => ({
+  // Mirrors the real library: it hands the fetched contributions to
+  // transformData during render, then renders the calendar — which validates
+  // the data and can throw in that same render pass.
+  GitHubCalendar: ({
+    transformData,
+  }: {
+    transformData: (data: Array<{ date: string; count: number; level: 0 }>) => unknown;
+  }) => {
+    transformData([]);
+    if (libState.shouldThrow) {
+      throw new Error('Activity data must not be empty.');
+    }
+    return <div data-testid="calendar-graph" />;
+  },
+}));
+
+describe('GitHubCalendar', () => {
+  beforeEach(() => {
+    libState.shouldThrow = false;
+    // React re-throws caught render errors to console.error; keep test output clean.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the calendar when the contribution data is valid', async () => {
+    render(<GitHubCalendar username="octocat" isAuthenticated isAuthCheckDone />);
+
+    expect(await screen.findByTestId('calendar-graph')).toBeTruthy();
+  });
+
+  it('hides itself instead of crashing when the calendar throws', async () => {
+    libState.shouldThrow = true;
+
+    render(
+      <div>
+        <GitHubCalendar username="octocat" isAuthenticated isAuthCheckDone />
+        <div data-testid="dashboard-content">projects</div>
+      </div>
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector('.github-calendar-wrapper')).toBeNull();
+    });
+    // The rest of the dashboard survives — the error never reaches the app boundary.
+    expect(screen.getByTestId('dashboard-content')).toBeTruthy();
+  });
+});

--- a/src/components/dashboard/GitHubCalendar.tsx
+++ b/src/components/dashboard/GitHubCalendar.tsx
@@ -8,11 +8,12 @@
  * @module components/GitHubCalendar
  */
 
-import { useState, useEffect, useCallback, memo } from 'react';
+import { useState, useEffect, useCallback, memo, Component, ReactNode } from 'react';
 import { GitHubCalendar as GitHubCalendarLib } from 'react-github-calendar';
 import { Tooltip } from 'react-tooltip';
 import 'react-tooltip/dist/react-tooltip.css';
 import { EyeOffIcon } from '../icons';
+import { logger } from '../../lib/logger';
 
 interface Activity {
   date: string;
@@ -76,6 +77,32 @@ function CalendarSkeleton() {
   );
 }
 
+// react-activity-calendar validates its data *during render* and throws on anything
+// it dislikes — most commonly "Activity data must not be empty.", which happens
+// whenever the contributions API answers 200 with an empty list (accounts with no
+// public contributions in the requested year, EMU/enterprise accounts, brand new
+// accounts). An uncaught throw there reaches the app-level ErrorBoundary and replaces
+// the entire dashboard with the crash screen, so the calendar gets its own boundary:
+// a decorative widget must never be able to take the app down.
+class CalendarErrorBoundary extends Component<
+  { onError: (error: Error) => void; children: ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    this.props.onError(error);
+  }
+
+  render() {
+    return this.state.hasError ? null : this.props.children;
+  }
+}
+
 // Stable renderBlock callback — avoids creating a new function reference every render,
 // which would cause react-github-calendar to re-render all 365+ SVG blocks.
 const renderBlock = (block: React.ReactElement, activity: Activity) => (
@@ -92,11 +119,26 @@ export const GitHubCalendar = memo(function GitHubCalendar({
 }: GitHubCalendarProps) {
   const currentYear = new Date().getFullYear();
   const [dataLoaded, setDataLoaded] = useState(false);
+  // Username the calendar blew up for, rather than a plain boolean: the reset
+  // effect below runs *after* the boundary's componentDidCatch on mount, so a
+  // flag cleared there would immediately un-hide a calendar that just failed.
+  const [failedFor, setFailedFor] = useState<string | null>(null);
 
   // Reset data loaded state when username changes
   useEffect(() => {
     setDataLoaded(false); // eslint-disable-line react-hooks/set-state-in-effect -- intentional: reset loading state when username prop changes
   }, [username]);
+
+  const handleCalendarError = useCallback(
+    (error: Error) => {
+      logger.warn('GitHub contribution calendar failed to render, hiding it', {
+        error: error.message,
+        username,
+      });
+      setFailedFor(username ?? null);
+    },
+    [username]
+  );
 
   // Stable transformData callback — prevents the library from re-fetching/re-processing
   // data on every parent re-render (unstable function refs trigger library effects).
@@ -111,6 +153,12 @@ export const GitHubCalendar = memo(function GitHubCalendar({
 
   // Only hide after auth check is DONE and confirmed NOT authenticated
   if (isAuthCheckDone && !isAuthenticated) {
+    return null;
+  }
+
+  // The calendar threw for this user (no contribution data, unsupported CSS color
+  // function, …). Drop the whole widget rather than leaving an empty frame behind.
+  if (username && failedFor === username) {
     return null;
   }
 
@@ -132,20 +180,22 @@ export const GitHubCalendar = memo(function GitHubCalendar({
       {showSkeleton && <CalendarSkeleton />}
       {username && (
         <div style={{ display: dataLoaded ? 'block' : 'none' }}>
-          <GitHubCalendarLib
-            username={username}
-            colorScheme="dark"
-            theme={theme}
-            blockSize={12}
-            blockMargin={4}
-            blockRadius={3}
-            fontSize={12}
-            showColorLegend={false}
-            showTotalCount={false}
-            year={currentYear}
-            renderBlock={renderBlock}
-            transformData={handleTransformData}
-          />
+          <CalendarErrorBoundary key={username} onError={handleCalendarError}>
+            <GitHubCalendarLib
+              username={username}
+              colorScheme="dark"
+              theme={theme}
+              blockSize={12}
+              blockMargin={4}
+              blockRadius={3}
+              fontSize={12}
+              showColorLegend={false}
+              showTotalCount={false}
+              year={currentYear}
+              renderBlock={renderBlock}
+              transformData={handleTransformData}
+            />
+          </CalendarErrorBoundary>
         </div>
       )}
       <Tooltip id="github-calendar-tooltip" className="github-calendar-tooltip" />


### PR DESCRIPTION
## Summary

The dashboard's contribution calendar can take down the whole app.

`react-activity-calendar` validates its data **during render** and throws
`Activity data must not be empty.` whenever the contributions API answers
`200` with an empty list:

```
$ curl 'https://github-contributions-api.jogruber.de/v4/<user>?y=2026'
{"total":{},"contributions":[]}
```

That happens for any account with no public contributions in the requested
year — EMU/enterprise accounts, brand new accounts, or anyone whose work
lives on a GitHub Enterprise instance. Because the throw happens in render,
it escapes to the app-level `ErrorBoundary`, so a *decorative widget*
replaces the entire dashboard with the crash screen a few seconds after
launch, once the calendar data loads.

Observed on a fresh `pnpm tauri dev` run:

```
ERROR ship_studio_lib::logging: Activity data must not be empty. source="frontend"
  componentStack: ActivityCalendar → GitHubCalendar → ProjectList → ProjectsView → App → ErrorBoundary
```

**Fix:** wrap the third-party calendar in its own error boundary. Any throw
now hides just the calendar, logs a warning, and leaves the dashboard
intact. Same log line after the fix — note `WARN`, and the app stays usable:

```
WARN ship_studio_lib::logging: GitHub contribution calendar failed to render, hiding it
  {"error":"Activity data must not be empty.","username":"<user>"}
```

This also backstops the `color-mix` failure already documented in this file,
should that theme workaround ever regress — the widget degrades instead of
white-screening the app.

One subtlety worth calling out for review: the failure is tracked as
`failedFor: string | null` (the username it blew up for) rather than a
boolean. The existing "reset on username change" effect runs *after* the
boundary's `componentDidCatch` on mount, so a boolean cleared there would
immediately un-hide a calendar that had just failed, and it would re-throw
in a loop.

## Test plan

- [x] Added `GitHubCalendar.test.tsx`: the throwing case asserts the widget
      unmounts **and** that sibling dashboard content survives (i.e. the error
      never reaches the app boundary); the healthy case asserts the calendar
      still renders.
- [x] Reproduced live in `pnpm tauri dev` with an account that has no public
      contributions — before: full crash screen; after: dashboard loads
      normally with the calendar absent and a single `WARN` in the log.
- [x] Verified the healthy path live with an account that *does* have
      contributions — calendar renders as before, no warning.

## CI gates

- [x] `pnpm check:all && pnpm test:run` passes locally
      (typecheck · lint:strict · format:check · check:patterns · check:loc;
      112 test files, 1530 passed / 4 skipped)
- [ ] `pnpm rust:test` — 2 pre-existing failures on my machine, unrelated to
      this PR (it changes **zero** Rust files; `git diff main...HEAD` touches
      only the two files above). For the record:
      `proxy::tests::connect_retry_exhausts_budget_with_refused_kind_for_dead_port`
      passes when run serially — it looks like a port-reuse race under
      parallel test execution — and
      `commands::git::tests::run_git_net_retrying_index_lock_passes_other_failures_through`
      fails its `< 500ms` timing assertion in this environment (a bare
      `git checkout` with the same credential-helper config measures ~30ms
      here, so the budget is being spent elsewhere in the helper's setup).
      Happy to open a separate issue if these aren't already known.
- [x] Also ran the two CI gates that aren't part of that command:
      `bash scripts/check-config-integrity.sh` (the Config Integrity job) and
      the coverage floor step — 31.6% lines / 81.3% branches, comfortably
      above the 4% / 15% thresholds CI enforces.

<details>
<summary><strong>Patterns checklist</strong></summary>

**Frontend**
- ~~New modals use `<ModalFrame>`~~ — n/a
- ~~New buttons use `<Button variant=…>`~~ — n/a
- ~~New async state uses `useAsyncState` / `useInvoke`~~ — n/a, no new async
  state; the added state is a render-failure latch
- ~~New polling uses `usePolling`~~ — n/a
- ~~Modal state uses `useModal('id')`~~ — n/a

An error boundary requires a class component (`getDerivedStateFromError` /
`componentDidCatch` have no hook equivalent), so this one is local to the
file. It's deliberately *not* the shared `ErrorBoundary` — that one is the
app-level crash screen, whereas this needs to render `null` and let the rest
of the dashboard carry on.

**CSS**
- [x] No CSS changed

**Rust**
- [x] No Rust changed

**Tests**
- [x] Added tests for non-trivial logic

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The GitHub contribution calendar now fails gracefully if it encounters a rendering error.
  * When the calendar cannot load, it is hidden while the rest of the dashboard remains available.
  * The calendar resets correctly when viewing a different username.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
