### PR TITLE
Fold the config-integrity scan into `pnpm check:all`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ testing, and known gotchas. This file is just the contract in brief.
 
 1. **Run the CI gates before declaring work done:**
    ```bash
-   pnpm check:all     # typecheck + lint + prettier + rustfmt + clippy + pattern/LOC checks
+   pnpm check:all     # config integrity + typecheck + lint + prettier + rustfmt + clippy + pattern/LOC checks
    pnpm test:run      # frontend tests (Vitest)
    pnpm rust:test     # backend tests (cargo test)
    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Every PR runs these checks in CI. Run them locally first and your PR will
 pass on the first try:
 
 ```bash
-pnpm check:all     # typecheck + lint + prettier + rustfmt + clippy + pattern & LOC checks
+pnpm check:all     # config integrity + typecheck + lint + prettier + rustfmt + clippy + pattern & LOC checks
 pnpm test:run      # frontend tests (Vitest)
 pnpm rust:test     # backend tests (cargo test)
 ```
@@ -57,8 +57,14 @@ Notes:
   use instead.
 - `check:loc` enforces per-file line ceilings; if you hit one, split the file
   rather than raising the limit.
-- Frontend coverage thresholds are enforced in CI — add tests for non-trivial
-  logic.
+- `check:config` (`scripts/check-config-integrity.sh`) scans high-trust config
+  and workflow files for anomalously long lines — a guard rail against the
+  config-file injection class. CI runs it as its own job with no dependencies
+  installed, gating every other job, so it fails before anything else does.
+- Frontend coverage thresholds are enforced by a separate CI step that none of
+  the three commands above run. Use `pnpm test:coverage` to see where you
+  stand; the exact floor lives in the "Coverage floor" step of
+  [.github/workflows/ci.yml](.github/workflows/ci.yml).
 
 ## Project Architecture
 

--- a/package.json
+++ b/package.json
@@ -38,9 +38,10 @@
     "rust:clippy": "cd src-tauri && cargo clippy -- -A clippy::uninlined_format_args",
     "rust:clippy:strict": "cd src-tauri && cargo clippy -- -D warnings",
     "rust:test": "cd src-tauri && cargo test",
-    "check:all": "pnpm typecheck && pnpm lint && pnpm format:check && pnpm rust:fmt:check && pnpm rust:clippy && pnpm check:patterns && pnpm check:loc",
+    "check:all": "pnpm check:config && pnpm typecheck && pnpm lint && pnpm format:check && pnpm rust:fmt:check && pnpm rust:clippy && pnpm check:patterns && pnpm check:loc",
     "check:patterns": "bash scripts/check-patterns.sh",
     "check:loc": "bash scripts/check-loc-limits.sh",
+    "check:config": "bash scripts/check-config-integrity.sh",
     "prepare": "husky"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

CI gates every job on a **Config Integrity** scan that no documented command
runs:

```yaml
# .github/workflows/ci.yml
config-integrity:
  - run: bash scripts/check-config-integrity.sh

frontend:  { needs: [config-integrity] }
backend:   { needs: [config-integrity] }
windows:   { needs: [config-integrity] }
```

`scripts/check-config-integrity.sh` has **no `pnpm` script**, and `grep -r`
across every `.md` in the repo returns **zero** mentions of it. So a
contributor who follows [CONTRIBUTING.md](CONTRIBUTING.md) exactly —
`pnpm check:all && pnpm test:run && pnpm rust:test` — can still get a red X
on a check they were never told existed.

That's the guard rail against config-file injection (the 5,297-char payload
hidden in `eslint.config.js`, per the comment in the script), so it's
probably the last gate you want people meeting for the first time as a CI
failure.

**Changes**

- Add a `check:config` script and run it **first** in `check:all`, mirroring
  CI's `needs: [config-integrity]` gating. It's ~0.25s, so putting the
  cheapest security gate first just means it fails fastest.
- Document what the scan covers in the "Before You Push" notes.
- Note that the frontend **coverage floor** is also a separate CI step that
  none of the three documented commands run. The note points at the workflow
  rather than restating the thresholds, so they can move without stranding
  the prose.
- Update the `check:all` one-liner comment in `CONTRIBUTING.md` and
  `AGENTS.md` to match what it now does.

**`.github/workflows/ci.yml` is deliberately untouched.** That job runs with
only `actions/checkout` and no dependencies installed — "Cheap,
deterministic, no deps" — which is the point: it scans config *before*
anything loads it. Routing it through `pnpm` would require an install step
and defeat that. `check:config` is a local-convenience alias only.

## Test plan

- [x] `pnpm check:config` passes standalone, and `pnpm check:all` passes
      end-to-end with the new step wired in first.
- [x] **Verified the gate can actually fail**: appended a 600-char line to
      `vitest.config.ts` → `pnpm check:config` exits `1` with
      `Anomalous line length detected in vitest.config.ts:32 length=603`.
      Reverted; working tree clean.
- [x] Confirmed this PR doesn't trip its own check — `package.json` is in the
      scanned `FILES` list, and the lengthened `check:all` line is 173 chars
      against the 500 limit.
- [x] `pnpm test:run` — 111 files, 1528 passed / 4 skipped.
- [x] Verified the doc claims against the source rather than the script's
      header comment: it scans `.github/workflows/*.{yml,yaml}` in addition to
      the `FILES` list, and all three top-level jobs really do declare
      `needs: [config-integrity]`.

## CI gates

- [x] `pnpm check:all && pnpm test:run` passes locally
- [x] `pnpm rust:test` — not re-run for this PR: it changes **zero** Rust
      files (`package.json` + 2 markdown files). Flagging for transparency
      that on my machine this suite has 2 pre-existing failures unrelated to
      any of my changes, which I described in #728.

<details>
<summary><strong>Patterns checklist</strong></summary>

No app code changed — this is a build-script and documentation change, so the
frontend / CSS / Rust primitives don't apply.

**Tests**
- [x] Behaviour is covered by the mutation check in the test plan above
      (gate flipped red, then back to green). No unit test added — the script
      itself is the check, and it has no test harness in-repo today.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configuration integrity check to the comprehensive project validation command.
  - Added a standalone command for running configuration integrity checks.

- **Documentation**
  - Updated contributor guidance to describe configuration validation and clarify separate frontend coverage checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->