### PR TITLE
fix: catch timeout in push_to_github and remap to expected error (#771)

### DIFF
--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -527,7 +527,12 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
         ])
         .current_dir(&validated_path);
     // Longer timeout: create+push can take a while for bigger repos.
-    let output = run_command_with_timeout(gh_cmd, "gh repo create --push", 60).await?;
+    let output = match run_command_with_timeout(gh_cmd, "gh repo create --push", 60).await {
+        Err(CommandError::Timeout { .. }) => {
+            return Err(CommandError::expected(GH_TIMEOUT_MESSAGE))
+        }
+        other => other?,
+    };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);


### PR DESCRIPTION
## Summary
Catches  in  and remaps it to an expected error, preventing every slow push from being reported as telemetry.

## Problem
In ,  runs  with a 60s timeout. The bare `?` propagates `CommandError::Timeout` straight through with no classification. Since `report_command_error` only skips `NotAuthenticated`, `Validation`, and `Expected`, every timeout is reported as telemetry, fingerprinted `cmderr-timeout-gh repo create --push`.

## Fix
This is the same pattern already fixed for two sibling call sites in the same file by #686 → PR #704: `get_github_username` and `get_github_orgs` both explicitly catch `Err(CommandError::Timeout { .. })` and remap it to `CommandError::expected(GH_TIMEOUT_MESSAGE)`.

Closes #771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub publishing error handling by showing a clear, consistent message when the operation times out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->