### PR TITLE
fix(git): ask git for its messages in English so they can be classified

### DIFF
--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -63,6 +63,8 @@ pub fn get_gh_command() -> Command {
         create_command("gh")
     };
     cmd.env("PATH", get_extended_path());
+    // gh hands its environment to the git it runs — see git_command().
+    cmd.env("LC_ALL", "C");
     cmd.envs(crate::commands::accounts::get_env_vars_for_active_account());
     // No caller feeds gh stdin, and a GUI-spawned gh has no tty — if gh ever
     // decides to prompt (stale credential, ambiguous host) it must fail fast
@@ -84,6 +86,7 @@ pub fn get_gh_command_for_project(project_path: &std::path::Path) -> Command {
         create_command("gh")
     };
     cmd.env("PATH", get_extended_path());
+    cmd.env("LC_ALL", "C");
     cmd.envs(crate::commands::accounts::get_env_vars_for_project(
         project_path,
     ));

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -423,6 +423,9 @@ pub fn git_command() -> Result<Command, crate::errors::CommandError> {
     // already applies to fetch/pull/push.
     fn with_extended_path(mut cmd: Command) -> Command {
         cmd.env("PATH", get_extended_path());
+        // The error classifiers match git's English, so a translated fatal
+        // reads as an unknown failure (issue #727).
+        cmd.env("LC_ALL", "C");
         cmd
     }
     static GIT_PATH: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();


### PR DESCRIPTION
The error classifiers match git's English, so a translated fatal is read as an unknown failure. Sets LC_ALL=C on the git and gh commands whose output is classified.

Fixes #727. Same cause as #403 and #672, which were worked around case by case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized Git and GitHub CLI error messages in English, improving consistency when displaying errors and diagnosing failed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->