### PR TITLE
Sweep 18: ~118 auto-reported issues — full-app error-hygiene, crashes, visual editor, Windows (v0.18.7 prep)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,16 @@ The latest entry is rendered inside the in-app update dialog, so write user-
 facing language — what changed, in plain English — not commit subjects.
 -->
 
+## What's New in v0.18.7
+
+- **Visual editor breakthroughs** - Elements without a class can finally be inserted/duplicated/deleted, JSX arrow-function props no longer break element mapping, and class/style edits survive mid-edit file changes
+- **Windows terminal fixed** - Claude Code no longer fails to launch with "too many arguments"; agent CLIs spawn correctly whether real executables or npm shims
+- **Three crash fixes** - Full-disk startup, empty GitHub contribution calendar, and terminal GPU hiccups no longer crash the app
+- **Smarter imports** - pnpm/yarn workspace repos install with the right package manager instead of failing with npm errors
+- **Sturdier git & publishing** - Existing origin remotes are reused, detached-HEAD publishes are refused clearly, stash/undo rides out index.lock contention
+- **Calmer errors everywhere** - ~50 error paths that auto-filed bug reports for routine environmental states (cloud-drive stalls, antivirus locks, offline networks, slow dev servers) now explain themselves quietly
+- **~118 auto-reported issues fixed since 0.18.6** - the largest sweep yet
+
 ## What's New in v0.18.6
 
 - **Two crash fixes** - No more panic on commit messages with accents/emoji/non-Latin text; closing a project can no longer crash via the dev-server logs terminal

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -141,6 +141,15 @@ fn headless_invocation(agent: &AgentConfig, prompt: &str) -> Option<HeadlessInvo
 /// - Codex's stale models cache — "failed to load models cache" (logged by
 ///   `codex_models_manager::cache`): a corrupt/outdated local cache file the
 ///   user can just delete (issue #689).
+/// - Codex's OAuth refresh-token rotation failing — "Failed to refresh token",
+///   "refresh_token_reused", "Please log out and sign in again": the stored
+///   credential can't be renewed, so it folds into the expired-sign-in case
+///   above (issue #836).
+/// - Org policy disabling subscription access — "Your organization has disabled
+///   Claude subscription access … ask your admin to enable access": an
+///   account-level setting only the user's admin can change (issue #765).
+/// - The agent's skill loader rejecting a user-installed SKILL.md — "failed to
+///   load skill …: missing field `description`" (issue #805).
 ///
 /// Callers must pass the FULL failure detail, never a truncated copy — Codex
 /// dumps a whole session transcript on failure and the matching line can sit
@@ -173,10 +182,34 @@ fn classify_agent_cli_failure(agent_name: &str, detail: &str) -> Option<CommandE
     if lower.contains("please run /login")
         || lower.contains("oauth token has expired")
         || lower.contains("session expired")
+        // Codex's OAuth refresh-token rotation failing: the stored credential
+        // can no longer be renewed and the user has to sign in again — same
+        // class as an expired session, different wording (issue #836).
+        || lower.contains("failed to refresh token")
+        || lower.contains("refresh_token_reused")
+        || lower.contains("sign in again")
     {
         return Some(CommandError::expected(format!(
             "{agent_name} isn't signed in anymore (its session expired). Open an agent \
              terminal and sign in again — for Claude Code, run /login — then try again."
+        )));
+    }
+    // An Anthropic Team/Enterprise admin has turned off subscription-based
+    // Claude Code access for the org, so the CLI refuses to run without an API
+    // key. An account-policy state, not an app malfunction (issue #765).
+    if lower.contains("subscription access") || lower.contains("ask your admin") {
+        return Some(CommandError::expected(format!(
+            "{agent_name}'s organization has disabled subscription access for this tool. \
+             Use an Anthropic API key instead, or ask your admin to enable access."
+        )));
+    }
+    // The agent's own skill loader rejecting a locally-installed SKILL.md
+    // (e.g. missing the required `description` frontmatter field). The file is
+    // the user's, not something the app wrote (issue #805).
+    if lower.contains("failed to load skill") {
+        return Some(CommandError::expected(format!(
+            "{agent_name} couldn't load one of your installed skills — its SKILL.md is \
+             missing a required field. Fix or remove that skill file, then try again."
         )));
     }
     if lower.contains("has not been trusted") || lower.contains("hastrustdialogaccepted") {
@@ -909,6 +942,51 @@ mod tests {
         assert!(
             classify_agent_cli_failure("Codex", "WARN codex_models_manager::cache: boom").is_some()
         );
+    }
+
+    // The #836 shape: Codex's OAuth refresh token was already consumed, so the
+    // stored credential can't be renewed — the user must sign in again.
+    #[test]
+    fn classify_agent_cli_failure_refresh_token_reuse_is_expected() {
+        let detail = "ERROR codex_login::auth::manager: Failed to refresh token: \
+                      401 Unauthorized: {\"error\":{\"message\":\"Your refresh token has \
+                      already been used to generate a new access token. Please try signing \
+                      in again.\",\"code\":\"refresh_token_reused\"}}";
+        let err = classify_agent_cli_failure("Codex", detail).expect("must classify");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        assert!(
+            format!("{err}").contains("isn't signed in anymore"),
+            "got: {err}"
+        );
+
+        // Either marker alone must classify too.
+        assert!(classify_agent_cli_failure("Codex", "refresh_token_reused").is_some());
+        assert!(classify_agent_cli_failure("Codex", "Please log out and sign in again.").is_some());
+    }
+
+    // The #765 shape: an org admin disabled subscription-based Claude Code
+    // access — an account policy state, not an app malfunction.
+    #[test]
+    fn classify_agent_cli_failure_org_disabled_subscription_is_expected() {
+        let detail = "exit code Some(1): Your organization has disabled Claude subscription \
+                      access for Claude Code · Use an Anthropic API key instead, or ask your \
+                      admin to enable access";
+        let err = classify_agent_cli_failure("Claude Code", detail).expect("must classify");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        let msg = format!("{err}");
+        assert!(msg.contains("disabled subscription access"), "got: {msg}");
+        assert!(msg.contains("Anthropic API key"), "got: {msg}");
+    }
+
+    // The #805 shape: the agent's own skill loader rejecting a user-installed
+    // SKILL.md whose frontmatter is missing a required field.
+    #[test]
+    fn classify_agent_cli_failure_invalid_skill_file_is_expected() {
+        let detail = "ERROR codex_core::session::session: failed to load skill \
+                      ~/.agents/skills/canvas/SKILL.md: missing field `description`";
+        let err = classify_agent_cli_failure("Codex", detail).expect("must classify");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        assert!(format!("{err}").contains("SKILL.md"), "got: {err}");
     }
 
     // The matching line arrives as the FIRST stderr line of a transcript that

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -142,9 +142,10 @@ fn headless_invocation(agent: &AgentConfig, prompt: &str) -> Option<HeadlessInvo
 ///   `codex_models_manager::cache`): a corrupt/outdated local cache file the
 ///   user can just delete (issue #689).
 /// - Codex's OAuth refresh-token rotation failing — "Failed to refresh token",
-///   "refresh_token_reused", "Please log out and sign in again": the stored
-///   credential can't be renewed, so it folds into the expired-sign-in case
-///   above (issue #836).
+///   "refresh_token_reused": the stored credential can't be renewed, so it
+///   folds into the expired-sign-in case above (issue #836). Only these
+///   distinctive wordings count — a bare "sign in again" is ordinary prose that
+///   appears in the transcripts callers pass in.
 /// - Org policy disabling subscription access — "Your organization has disabled
 ///   Claude subscription access … ask your admin to enable access": an
 ///   account-level setting only the user's admin can change (issue #765).
@@ -187,7 +188,10 @@ fn classify_agent_cli_failure(agent_name: &str, detail: &str) -> Option<CommandE
         // class as an expired session, different wording (issue #836).
         || lower.contains("failed to refresh token")
         || lower.contains("refresh_token_reused")
-        || lower.contains("sign in again")
+    // NOT a bare "sign in again": callers pass whole transcripts through here,
+    // and those three ordinary words show up in the user's own prose (or in an
+    // agent's advice about some unrelated service), which would misreport a
+    // working session as expired. Only distinctive CLI wordings qualify.
     {
         return Some(CommandError::expected(format!(
             "{agent_name} isn't signed in anymore (its session expired). Open an agent \
@@ -959,9 +963,20 @@ mod tests {
             "got: {err}"
         );
 
-        // Either marker alone must classify too.
+        // Either distinctive marker alone must classify too.
         assert!(classify_agent_cli_failure("Codex", "refresh_token_reused").is_some());
-        assert!(classify_agent_cli_failure("Codex", "Please log out and sign in again.").is_some());
+        assert!(classify_agent_cli_failure("Codex", "Failed to refresh token").is_some());
+
+        // But "sign in again" on its own must NOT: callers pass whole session
+        // transcripts, so those three ordinary words appear in the user's own
+        // prose and in advice about unrelated services. Matching them reported
+        // a working session as expired and hid the real failure.
+        assert!(classify_agent_cli_failure(
+            "Codex",
+            "The user asked me to check whether they need to sign in again to Vercel."
+        )
+        .is_none());
+        assert!(classify_agent_cli_failure("Codex", "Please log out and sign in again.").is_none());
     }
 
     // The #765 shape: an org admin disabled subscription-based Claude Code

--- a/src-tauri/src/commands/assets.rs
+++ b/src-tauri/src/commands/assets.rs
@@ -46,10 +46,16 @@ fn assets_root_dir(repo_root: &Path, workspace: &Path) -> PathBuf {
 
 /// Validates that an asset path is within the project's assets folder.
 /// Prevents path traversal attacks.
-fn validate_asset_path(root_dir: &Path, asset_path: &str) -> Result<PathBuf, String> {
+///
+/// Returns `CommandError` rather than `String`: `canonicalize_tagged`
+/// classifies a vanished folder as `Expected`, and a `String` hop collapsed it
+/// back to `Other`, auto-reporting it to telemetry (issue #831).
+fn validate_asset_path(root_dir: &Path, asset_path: &str) -> Result<PathBuf, CommandError> {
     // Check for obvious path traversal attempts
     if crate::utils::has_parent_dir_component(asset_path) {
-        return Err("Invalid path: path traversal not allowed".to_string());
+        return Err(CommandError::expected(
+            "Invalid path: path traversal not allowed",
+        ));
     }
 
     let full_path = root_dir.join(asset_path);
@@ -60,20 +66,25 @@ fn validate_asset_path(root_dir: &Path, asset_path: &str) -> Result<PathBuf, Str
         crate::utils::canonicalize_tagged(&full_path, "assets")?
     } else {
         // For non-existent paths, verify parent exists and is within the root
-        let parent = full_path
-            .parent()
-            .ok_or_else(|| format!("Invalid path {}: no parent directory", full_path.display()))?;
+        let parent = full_path.parent().ok_or_else(|| {
+            CommandError::from(format!(
+                "Invalid path {}: no parent directory",
+                full_path.display()
+            ))
+        })?;
         if !parent.exists() {
-            return Err("Parent directory does not exist".to_string());
+            return Err(CommandError::expected("Parent directory does not exist"));
         }
         let canonical_parent = crate::utils::canonicalize_tagged(parent, "assets")?;
         let canonical_root = if root_dir.exists() {
             crate::utils::canonicalize_tagged(root_dir, "assets")?
         } else {
-            return Err("Assets folder does not exist".to_string());
+            return Err(CommandError::expected("Assets folder does not exist"));
         };
         if !canonical_parent.starts_with(&canonical_root) {
-            return Err("Security error: path is outside the assets folder".to_string());
+            return Err(CommandError::expected(
+                "Security error: path is outside the assets folder",
+            ));
         }
         return Ok(full_path);
     };
@@ -81,7 +92,9 @@ fn validate_asset_path(root_dir: &Path, asset_path: &str) -> Result<PathBuf, Str
     let canonical_root = crate::utils::canonicalize_tagged(root_dir, "assets")?;
 
     if !check_path.starts_with(&canonical_root) {
-        return Err("Security error: path is outside the assets folder".to_string());
+        return Err(CommandError::expected(
+            "Security error: path is outside the assets folder",
+        ));
     }
 
     Ok(check_path)

--- a/src-tauri/src/commands/code.rs
+++ b/src-tauri/src/commands/code.rs
@@ -194,8 +194,12 @@ pub fn read_project_file(project_path: &str, file_path: &str) -> Result<FileCont
         });
     }
 
-    // Read the file bytes
-    let bytes = std::fs::read(&canonical).map_err(|e| format!("Failed to read file: {e}"))?;
+    // Read the file bytes. `classify_fs_error` turns the environment shapes —
+    // a Windows access-denied while antivirus/cloud-sync holds the file, a
+    // cloud-drive timeout, a permissions problem — into actionable guidance
+    // instead of raw (and often localized) OS text (issue #837).
+    let bytes = std::fs::read(&canonical)
+        .map_err(|e| crate::utils::classify_fs_error("read this file", &canonical, &e))?;
 
     // Check for binary content (null bytes in first 8KB)
     let check_len = bytes.len().min(8192);
@@ -265,7 +269,8 @@ pub fn save_project_file(
         return Err(("File is too large to save".to_string()).into());
     }
 
-    std::fs::write(&canonical, content).map_err(|e| format!("Failed to write file: {e}"))?;
+    std::fs::write(&canonical, content)
+        .map_err(|e| crate::utils::classify_fs_error("save this file", &canonical, &e))?;
 
     Ok(())
 }

--- a/src-tauri/src/commands/edit.rs
+++ b/src-tauri/src/commands/edit.rs
@@ -21,7 +21,7 @@
 use crate::commands::projects::detect_project_type;
 use crate::errors::CommandError;
 use crate::types::ProjectType;
-use crate::utils::{validate_project_path, validate_workspace_path};
+use crate::utils::{classify_fs_error, validate_project_path, validate_workspace_path};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -572,7 +572,8 @@ pub fn apply_classname_edit(
         });
     }
 
-    let src = std::fs::read_to_string(&abs).map_err(CommandError::from)?;
+    let src = std::fs::read_to_string(&abs)
+        .map_err(|e| classify_fs_error("open this file to edit it", &abs, &e))?;
     let span = find_attr_spans(&src, attrs_for_path(&file))
         .into_iter()
         .find(|s| s.line == line && s.value == old_class)
@@ -586,7 +587,8 @@ pub fn apply_classname_edit(
     updated.push_str(&new_class);
     updated.push_str(&src[span.value_end..]);
 
-    std::fs::write(&abs, updated).map_err(CommandError::from)?;
+    std::fs::write(&abs, updated)
+        .map_err(|e| classify_fs_error("save your change to this file", &abs, &e))?;
     invalidate_index_cache(&root);
     Ok(())
 }
@@ -963,7 +965,9 @@ fn write_class_attr_insert(
     updated.push_str(&inserted);
     updated.push_str(&src[cand.insert_at..]);
 
-    std::fs::write(root.join(&cand.file), &updated).map_err(CommandError::from)?;
+    let abs = root.join(&cand.file);
+    std::fs::write(&abs, &updated)
+        .map_err(|e| classify_fs_error("save your change to this file", &abs, &e))?;
     invalidate_index_cache(root);
 
     // 1-based line/column of the inserted literal's value in the updated file.
@@ -1711,7 +1715,8 @@ pub fn apply_text_edit(
         });
     }
 
-    let src = std::fs::read_to_string(&abs).map_err(CommandError::from)?;
+    let src = std::fs::read_to_string(&abs)
+        .map_err(|e| classify_fs_error("open this file to edit it", &abs, &e))?;
     let span = find_text_spans(&src)
         .into_iter()
         .find(|s| s.line == line && s.column == column && s.value == old_text)
@@ -1725,7 +1730,8 @@ pub fn apply_text_edit(
     updated.push_str(&new_text);
     updated.push_str(&src[span.value_end..]);
 
-    std::fs::write(&abs, updated).map_err(CommandError::from)?;
+    std::fs::write(&abs, updated)
+        .map_err(|e| classify_fs_error("save your change to this file", &abs, &e))?;
     invalidate_index_cache(&root);
     Ok(())
 }
@@ -2120,7 +2126,8 @@ pub fn apply_src_edit(
         });
     }
 
-    let src = std::fs::read_to_string(&abs).map_err(CommandError::from)?;
+    let src = std::fs::read_to_string(&abs)
+        .map_err(|e| classify_fs_error("open this file to edit it", &abs, &e))?;
     let span = find_attr_spans(&src, &["src"])
         .into_iter()
         .find(|s| s.line == line && s.column == column && s.value == old_src)
@@ -2134,7 +2141,8 @@ pub fn apply_src_edit(
     updated.push_str(&new_src);
     updated.push_str(&src[span.value_end..]);
 
-    std::fs::write(&abs, updated).map_err(CommandError::from)?;
+    std::fs::write(&abs, updated)
+        .map_err(|e| classify_fs_error("save your change to this file", &abs, &e))?;
     invalidate_index_cache(&root);
     Ok(())
 }
@@ -2670,8 +2678,14 @@ pub(crate) fn element_span(src: &str, inside_open_tag: usize) -> Option<(usize, 
     }
     let tag = src[name_start..j].to_ascii_lowercase();
 
-    // 2. End of the opening tag ('>'), honoring quoted attribute values.
-    let close_open = scan_to_gt(bytes, j)?;
+    // 2. End of the opening tag ('>'), honoring quoted attribute values AND
+    //    `{…}` expressions: a JSX handler prop (`onClick={() => go()}`) carries a
+    //    bare `>` that `scan_to_gt` would mistake for the end of the tag. That
+    //    truncated the span mid-attribute, and on a self-closing component
+    //    (`<Icon className="x" onClick={() => …} />`) it also hid the `/`, so the
+    //    balancer then hunted a `</icon>` that never comes and returned None —
+    //    surfacing as "couldn't map this element to its source markup" (#789).
+    let close_open = open_tag_end(src, j)?;
     let open_end = close_open + 1;
     let self_closing = bytes[close_open.saturating_sub(1)] == b'/';
     if self_closing || VOID_ELEMENTS.contains(&tag.as_str()) {
@@ -2718,7 +2732,10 @@ pub(crate) fn element_span(src: &str, inside_open_tag: usize) -> Option<(usize, 
             }
             if ne > ns {
                 let oname = src[ns..ne].to_ascii_lowercase();
-                let gt = scan_to_gt(bytes, ne)?;
+                // Same `{…}`-awareness as the opening scan above: a nested tag's
+                // handler prop must not end its tag early, or the depth count
+                // (and the self-closing test) go wrong.
+                let gt = open_tag_end(src, ne)?;
                 let self_closing = bytes[gt.saturating_sub(1)] == b'/';
                 // `<script>`/`<style>` hold raw text where `<` is not a tag (e.g.
                 // `if (a < b)`); skip their whole body so it can't be misread as
@@ -2798,7 +2815,8 @@ fn locate_instance(
     class_name: &str,
 ) -> Result<LocatedInstance, CommandError> {
     let abs = root.join(file);
-    let src = std::fs::read_to_string(&abs).map_err(CommandError::from)?;
+    let src = std::fs::read_to_string(&abs)
+        .map_err(|e| classify_fs_error("open this file to edit it", &abs, &e))?;
     let span = find_attr_spans(&src, attrs_for_path(file))
         .into_iter()
         .find(|s| s.line == line && s.value == class_name)
@@ -2821,6 +2839,36 @@ fn locate_instance(
     })
 }
 
+/// Locate the element's markup span WITHOUT a class anchor, by the same
+/// ancestor-file + text ladder "Add class" uses to pick an insertion site
+/// ([`locate_insert_site`]).
+///
+/// A class-less `<div>`/`<section>` has no literal to anchor on, which used to
+/// dead-end every markup and structural edit on it (issue #318) even though the
+/// editor already trusts this ladder enough to *write a class attribute* into
+/// that exact tag. Ambiguity still fails closed — `locate_insert_site` names
+/// what it searched and why it couldn't pin one tag.
+fn locate_classless_instance(
+    root: &Path,
+    sig: &ElementSignature,
+) -> Result<LocatedInstance, CommandError> {
+    let occurrences = index_occurrences_cached(root);
+    let (cand, src) = locate_insert_site(root, occurrences.as_slice(), sig)?;
+    let (start, end) =
+        element_span(&src, cand.insert_at).ok_or_else(|| CommandError::Validation {
+            field: "element".into(),
+            reason: "couldn't map this element to its source markup".into(),
+        })?;
+    Ok(LocatedInstance {
+        abs: root.join(&cand.file),
+        file: cand.file,
+        src,
+        line: cand.line,
+        start,
+        end,
+    })
+}
+
 /// Locate every editable instance of an element under `root`.
 ///
 /// `Resolved` yields one instance. `Multi` (one class string at several
@@ -2829,10 +2877,15 @@ fn locate_instance(
 /// like the class editor (issue #287) — or the picked one when `target` names
 /// a location from the set. Instances whose markup has diverged can't be
 /// group-edited safely and fail closed.
+///
+/// `sig` is the signature the resolution came from; it's what the class-less
+/// fallback anchors on, so callers that have it unlock editing for elements
+/// with no class attribute (issue #318).
 fn locate_instances_at(
     root: &Path,
     resolution: Resolution,
     target: Option<&Location>,
+    sig: Option<&ElementSignature>,
 ) -> Result<(Vec<LocatedInstance>, Option<Vec<Location>>), CommandError> {
     match resolution {
         Resolution::Resolved {
@@ -2875,10 +2928,17 @@ fn locate_instances_at(
             }
             Ok((instances, Some(locations)))
         }
-        Resolution::NoClass => Err(CommandError::Validation {
-            field: "element".into(),
-            reason: "This element has no class in source to anchor its markup on. Add a class to it first (the Add class action), then its markup becomes editable.".into(),
-        }),
+        // No class literal to anchor on — fall back to the tag/ancestor/text
+        // ladder rather than dead-ending (issue #318). Without a signature
+        // (older call paths / tests) the original "add a class first" refusal
+        // stands.
+        Resolution::NoClass => match sig {
+            Some(sig) => Ok((vec![locate_classless_instance(root, sig)?], None)),
+            None => Err(CommandError::Validation {
+                field: "element".into(),
+                reason: "This element has no class in source to anchor its markup on. Add a class to it first (the Add class action), then its markup becomes editable.".into(),
+            }),
+        },
         // The class resolver couldn't anchor this element to source (its classes
         // are dynamic/generated). The markup editor is class-anchored, so phrase
         // it for *markup*, not the class-string reason.
@@ -2896,9 +2956,9 @@ fn locate_element_instances(
     signature: ElementSignature,
     target: Option<&Location>,
 ) -> Result<(Vec<LocatedInstance>, Option<Vec<Location>>), CommandError> {
-    let resolution = resolve_classname_source(project_path.to_string(), signature)?;
+    let resolution = resolve_classname_source(project_path.to_string(), signature.clone())?;
     let root = validate_project_path(project_path)?;
-    locate_instances_at(&root, resolution, target)
+    locate_instances_at(&root, resolution, target, Some(&signature))
 }
 
 /// Resolve an element to the source markup span, file, and contents, plus the
@@ -2909,7 +2969,7 @@ pub(crate) fn locate_element(
     project_path: &str,
     signature: ElementSignature,
 ) -> Result<(String, std::path::PathBuf, String, usize, usize, usize), CommandError> {
-    let resolution = resolve_classname_source(project_path.to_string(), signature)?;
+    let resolution = resolve_classname_source(project_path.to_string(), signature.clone())?;
     if let Resolution::Multi { .. } = resolution {
         return Err(CommandError::Validation {
             field: "element".into(),
@@ -2917,7 +2977,7 @@ pub(crate) fn locate_element(
         });
     }
     let root = validate_project_path(project_path)?;
-    let (instances, _) = locate_instances_at(&root, resolution, None)?;
+    let (instances, _) = locate_instances_at(&root, resolution, None, Some(&signature))?;
     let inst = instances.into_iter().next().expect("resolved yields one");
     Ok((
         inst.file, inst.abs, inst.src, inst.line, inst.start, inst.end,
@@ -3008,7 +3068,8 @@ fn apply_html_to_instances(
             applied += 1;
         }
         if changed {
-            std::fs::write(abs, updated).map_err(CommandError::from)?;
+            std::fs::write(abs, updated)
+                .map_err(|e| classify_fs_error("save your change to this file", abs, &e))?;
         }
     }
     Ok(applied)
@@ -3068,6 +3129,23 @@ mod tests {
     }
 
     #[test]
+    fn element_span_jsx_arrow_handler_does_not_end_the_tag() {
+        // Issue #789: the `>` in `=>` used to end the opening tag early. On a
+        // self-closing component that also hid the `/`, so the balancer hunted a
+        // `</icon>` that never comes and returned None ("couldn't map this
+        // element to its source markup").
+        let src = r#"<Icon className="cls" onClick={() => go(a > b)} />tail"#;
+        assert_eq!(
+            span_str(src),
+            r#"<Icon className="cls" onClick={() => go(a > b)} />"#
+        );
+        // Same shape with children, and with a nested same-name tag whose own
+        // handler must not throw the depth count off.
+        let nested = r#"<div className="cls" onClick={() => a > b}><div onKeyDown={() => c > d}>x</div></div>"#;
+        assert_eq!(span_str(nested), nested);
+    }
+
+    #[test]
     fn element_span_skips_script_raw_text() {
         // The `<` in `a < b` and the literal `</div>` string inside the script
         // must not be read as markup — the outer div's real close wins.
@@ -3100,7 +3178,7 @@ mod tests {
         std::fs::write(root.join("B.tsx"), card).unwrap();
 
         let res = multi_res(&[("A.tsx", 1), ("B.tsx", 1)], "card");
-        let (instances, locations) = locate_instances_at(root, res, None).unwrap();
+        let (instances, locations) = locate_instances_at(root, res, None, None).unwrap();
         assert_eq!(instances.len(), 2);
         assert_eq!(locations.as_ref().map(Vec::len), Some(2));
         let html = &instances[0].src[instances[0].start..instances[0].end];
@@ -3133,10 +3211,82 @@ mod tests {
         .unwrap();
 
         let res = multi_res(&[("A.tsx", 1), ("B.tsx", 1)], "card");
-        let err = locate_instances_at(root, res, None).unwrap_err();
+        let err = locate_instances_at(root, res, None, None).unwrap_err();
         match err {
             CommandError::Validation { reason, .. } => {
                 assert!(reason.contains("markup differs"), "got: {reason}")
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+
+    // ── Class-less elements are locatable too (issue #318) ───────────────────
+
+    #[test]
+    fn no_class_resolves_via_the_classless_anchor_ladder() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("Hero.tsx"),
+            "export function Hero() {\n  return (\n    <section id=\"hero\">\n      Welcome aboard\n    </section>\n  );\n}\n",
+        )
+        .unwrap();
+
+        // The only class-less <section> in source — insert/duplicate/delete used
+        // to dead-end here with "add a class to it first".
+        let sig = ElementSignature {
+            class_name: String::new(),
+            tag_name: "section".into(),
+            text: Some("Welcome aboard".into()),
+            ancestor_classes: vec![],
+            attr_src: None,
+        };
+        let (instances, locations) =
+            locate_instances_at(root, Resolution::NoClass, None, Some(&sig)).unwrap();
+        assert!(locations.is_none());
+        let inst = &instances[0];
+        assert_eq!(inst.file, "Hero.tsx");
+        assert_eq!(inst.line, 3);
+        assert_eq!(
+            &inst.src[inst.start..inst.end],
+            "<section id=\"hero\">\n      Welcome aboard\n    </section>"
+        );
+    }
+
+    #[test]
+    fn no_class_without_a_signature_still_refuses() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let err = locate_instances_at(dir.path(), Resolution::NoClass, None, None).unwrap_err();
+        match err {
+            CommandError::Validation { reason, .. } => {
+                assert!(reason.contains("no class in source"), "got: {reason}")
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_class_stays_fail_closed_when_several_tags_match() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("A.tsx"), "<div id=\"a\" />\n").unwrap();
+        std::fs::write(root.join("B.tsx"), "<div id=\"b\" />\n").unwrap();
+
+        let sig = ElementSignature {
+            class_name: String::new(),
+            tag_name: "div".into(),
+            text: None,
+            ancestor_classes: vec![],
+            attr_src: None,
+        };
+        let err = locate_instances_at(root, Resolution::NoClass, None, Some(&sig)).unwrap_err();
+        match err {
+            CommandError::Validation { reason, .. } => {
+                // The specific "here's what I searched" wording, not a guess.
+                assert!(
+                    reason.contains("Couldn't tell which <div>"),
+                    "got: {reason}"
+                )
             }
             other => panic!("expected Validation, got {other:?}"),
         }
@@ -3156,7 +3306,7 @@ mod tests {
             column: 1,
         };
         let res = multi_res(&[("A.tsx", 1), ("B.tsx", 1)], "card");
-        let (instances, _) = locate_instances_at(root, res, Some(&target)).unwrap();
+        let (instances, _) = locate_instances_at(root, res, Some(&target), None).unwrap();
         assert_eq!(instances.len(), 1);
         assert_eq!(instances[0].file, "B.tsx");
 
@@ -3186,7 +3336,7 @@ mod tests {
         .unwrap();
 
         let res = multi_res(&[("List.tsx", 3), ("List.tsx", 4)], "item");
-        let (instances, _) = locate_instances_at(root, res, None).unwrap();
+        let (instances, _) = locate_instances_at(root, res, None, None).unwrap();
         assert_eq!(instances.len(), 2);
         let applied = apply_html_to_instances(
             &instances,
@@ -3209,7 +3359,7 @@ mod tests {
         std::fs::write(root.join("B.tsx"), card).unwrap();
 
         let res = multi_res(&[("A.tsx", 1), ("B.tsx", 1)], "card");
-        let (instances, _) = locate_instances_at(root, res, None).unwrap();
+        let (instances, _) = locate_instances_at(root, res, None, None).unwrap();
         // B drifts after locating (user edited the file directly).
         std::fs::write(
             root.join("B.tsx"),

--- a/src-tauri/src/commands/edit.rs
+++ b/src-tauri/src/commands/edit.rs
@@ -1785,7 +1785,7 @@ enum SrcInTag {
 /// `{…}`-aware so a `>` inside an attribute string or an arrow function
 /// (`onLoad={() => a > b}`) can't end the tag early. Unlike [`text_run_in_tag`]'s
 /// scan, self-closing tags are fine — that's the common `<img />`.
-fn open_tag_end(src: &str, from: usize) -> Option<usize> {
+pub(crate) fn open_tag_end(src: &str, from: usize) -> Option<usize> {
     let bytes = src.as_bytes();
     let mut i = from;
     let mut in_str: u8 = 0;

--- a/src-tauri/src/commands/edit_structure.rs
+++ b/src-tauri/src/commands/edit_structure.rs
@@ -25,7 +25,7 @@ use crate::commands::edit::{
 };
 use crate::commands::edit_css::css_class_exists;
 use crate::errors::CommandError;
-use crate::utils::validate_project_path;
+use crate::utils::{classify_fs_error, validate_project_path};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -320,16 +320,34 @@ fn remove_span(src: &str, start: usize, end: usize) -> String {
 /// Append ` token` inside the FIRST class attribute of the copy's own opening
 /// tag (the copy starts at its `<`, so the first class-bearing attribute before
 /// the first unquoted `>` is the element's own — children come later).
-fn append_class_token(copy: &str, attrs: &[&str], token: &str) -> Option<String> {
-    let gt = scan_to_gt(copy.as_bytes(), 1)?;
-    let span = find_attr_spans(copy, attrs)
+///
+/// A class-less element has no attribute to append to, so `new_attr` is spliced
+/// in fresh right after the tag name instead — the copy still needs a unique
+/// class of its own to stay selectable (issue #318).
+fn append_class_token(copy: &str, attrs: &[&str], token: &str, new_attr: &str) -> Option<String> {
+    let bytes = copy.as_bytes();
+    let gt = scan_to_gt(bytes, 1)?;
+    if let Some(span) = find_attr_spans(copy, attrs)
         .into_iter()
-        .find(|s| s.value_end <= gt)?;
-    Some(format!(
-        "{} {token}{}",
-        &copy[..span.value_end],
-        &copy[span.value_end..]
-    ))
+        .find(|s| s.value_end <= gt)
+    {
+        return Some(format!(
+            "{} {token}{}",
+            &copy[..span.value_end],
+            &copy[span.value_end..]
+        ));
+    }
+    let mut name_end = 1;
+    while name_end < gt && (bytes[name_end].is_ascii_alphanumeric() || bytes[name_end] == b'-') {
+        name_end += 1;
+    }
+    (name_end > 1).then(|| {
+        format!(
+            "{} {new_attr}=\"{token}\"{}",
+            &copy[..name_end],
+            &copy[name_end..]
+        )
+    })
 }
 
 /// The tag name at the start of an element span (`<tag …`), lowercased.
@@ -377,7 +395,8 @@ pub fn insert_element(
     let snippet =
         render_template(kind, attr, &class, indent_unit(anchor_indent)).expect("kind validated");
     let (updated, offset) = splice_snippet(&src, start, end, position, &snippet)?;
-    std::fs::write(&abs, &updated).map_err(CommandError::from)?;
+    std::fs::write(&abs, &updated)
+        .map_err(|e| classify_fs_error("save your change to this file", &abs, &e))?;
     invalidate_index_cache(&root);
     Ok(InsertedElement {
         file,
@@ -407,13 +426,18 @@ pub fn duplicate_element(
     }
     let root = validate_project_path(&project_path)?;
     let token = generate_class(&root, &tag);
-    let copy =
-        append_class_token(&src[start..end], attrs_for_path(&file), &token).ok_or_else(|| {
-            validation(
-                "element",
-                "couldn't find the element's class attribute to distinguish the copy",
-            )
-        })?;
+    let copy = append_class_token(
+        &src[start..end],
+        attrs_for_path(&file),
+        &token,
+        class_attr_for_path(&file),
+    )
+    .ok_or_else(|| {
+        validation(
+            "element",
+            "couldn't find the element's class attribute to distinguish the copy",
+        )
+    })?;
     // A line-anchored element gets its copy on the next line at the same depth.
     // The copy's inner lines already carry their absolute indentation — no
     // reindent. Inline anchors keep flowing inline.
@@ -422,12 +446,15 @@ pub fn duplicate_element(
             Some(indent) => splice_at(&src, end, &format!("\n{indent}"), &copy, ""),
             None => splice_at(&src, end, "", &copy, ""),
         };
-    std::fs::write(&abs, &updated).map_err(CommandError::from)?;
+    std::fs::write(&abs, &updated)
+        .map_err(|e| classify_fs_error("save your change to this file", &abs, &e))?;
     invalidate_index_cache(&root);
     Ok(InsertedElement {
         file,
         line: line_of(&updated, offset),
-        class_name: format!("{sig_class} {token}"),
+        // A class-less original contributes nothing, so the copy's class is the
+        // generated token alone — never a leading space (issue #318).
+        class_name: format!("{} {token}", sig_class.trim()).trim().to_string(),
         tag_name: tag,
     })
 }
@@ -453,7 +480,8 @@ pub fn delete_element(
         return Err(validation("element", format!("<{tag}> can't be deleted.")));
     }
     let updated = remove_span(&src, start, end);
-    std::fs::write(&abs, updated).map_err(CommandError::from)?;
+    std::fs::write(&abs, updated)
+        .map_err(|e| classify_fs_error("save your change to this file", &abs, &e))?;
     let root = validate_project_path(&project_path)?;
     invalidate_index_cache(&root);
     Ok(())
@@ -587,7 +615,7 @@ mod tests {
     #[test]
     fn duplicate_token_lands_on_own_tag_not_children() {
         let copy = "<div class=\"a b\">\n  <span class=\"c\">x</span>\n</div>";
-        let out = append_class_token(copy, &["class"], "ss-div-1234").unwrap();
+        let out = append_class_token(copy, &["class"], "ss-div-1234", "class").unwrap();
         assert_eq!(
             out,
             "<div class=\"a b ss-div-1234\">\n  <span class=\"c\">x</span>\n</div>"
@@ -597,8 +625,23 @@ mod tests {
     #[test]
     fn duplicate_token_handles_jsx_brace_form() {
         let copy = "<div className={\"a\"}>x</div>";
-        let out = append_class_token(copy, &["className"], "t0k3").unwrap();
+        let out = append_class_token(copy, &["className"], "t0k3", "className").unwrap();
         assert_eq!(out, "<div className={\"a t0k3\"}>x</div>");
+    }
+
+    #[test]
+    fn duplicate_token_inserts_a_fresh_attribute_on_a_classless_element() {
+        // Issue #318: a class-less element has nothing to append to, but the
+        // copy still needs its own unique class to stay selectable.
+        let copy = "<section id=\"hero\">\n  <span class=\"c\">x</span>\n</section>";
+        let out = append_class_token(copy, &["class"], "ss-section-1234", "class").unwrap();
+        assert_eq!(
+            out,
+            "<section class=\"ss-section-1234\" id=\"hero\">\n  <span class=\"c\">x</span>\n</section>"
+        );
+        // JSX authors `className`, and a self-closing tag is spliced the same way.
+        let jsx = append_class_token("<div />", &["className"], "t0k3", "className").unwrap();
+        assert_eq!(jsx, "<div className=\"t0k3\" />");
     }
 
     #[test]

--- a/src-tauri/src/commands/edit_structure.rs
+++ b/src-tauri/src/commands/edit_structure.rs
@@ -21,7 +21,7 @@
 
 use crate::commands::edit::{
     attrs_for_path, class_token_in_index, find_attr_spans, invalidate_index_cache, locate_element,
-    scan_to_gt, ElementSignature,
+    open_tag_end, ElementSignature,
 };
 use crate::commands::edit_css::css_class_exists;
 use crate::errors::CommandError;
@@ -234,7 +234,7 @@ fn splice_inside(
     snippet: &str,
 ) -> Result<(String, usize), CommandError> {
     let bytes = src.as_bytes();
-    let gt = scan_to_gt(bytes, start + 1)
+    let gt = open_tag_end(src, start + 1)
         .ok_or_else(|| validation("element", "couldn't parse the element's opening tag"))?;
     let open_end = gt + 1;
     // An open-tag-only span (void element or self-closing) has no inside.
@@ -319,14 +319,20 @@ fn remove_span(src: &str, start: usize, end: usize) -> String {
 
 /// Append ` token` inside the FIRST class attribute of the copy's own opening
 /// tag (the copy starts at its `<`, so the first class-bearing attribute before
-/// the first unquoted `>` is the element's own — children come later).
+/// the tag's own `>` is the element's own — children come later).
+///
+/// The tag end comes from the `{…}`-aware [`open_tag_end`], not a bare `>` scan:
+/// a JSX handler prop before className (`onClick={() => go()}`) hides a `>` that
+/// would otherwise end the tag early, push the real className span past `gt`, and
+/// send us down the class-less path — splicing in a SECOND className attribute
+/// and writing a compile error into the user's source (issue #789).
 ///
 /// A class-less element has no attribute to append to, so `new_attr` is spliced
 /// in fresh right after the tag name instead — the copy still needs a unique
 /// class of its own to stay selectable (issue #318).
 fn append_class_token(copy: &str, attrs: &[&str], token: &str, new_attr: &str) -> Option<String> {
     let bytes = copy.as_bytes();
-    let gt = scan_to_gt(bytes, 1)?;
+    let gt = open_tag_end(copy, 1)?;
     if let Some(span) = find_attr_spans(copy, attrs)
         .into_iter()
         .find(|s| s.value_end <= gt)
@@ -627,6 +633,32 @@ mod tests {
         let copy = "<div className={\"a\"}>x</div>";
         let out = append_class_token(copy, &["className"], "t0k3", "className").unwrap();
         assert_eq!(out, "<div className={\"a t0k3\"}>x</div>");
+    }
+
+    #[test]
+    fn duplicate_token_survives_a_handler_prop_before_classname() {
+        // Issue #789: a bare `>` scan stops at the arrow in `=>`, so the real
+        // className span lands past the tag end and the class-less path splices
+        // in a SECOND className — a TSX compile error written into user source.
+        let copy = "<div onClick={() => go()} className=\"a\">x</div>";
+        let out = append_class_token(copy, &["className"], "t0k3", "className").unwrap();
+        assert_eq!(
+            out,
+            "<div onClick={() => go()} className=\"a t0k3\">x</div>"
+        );
+        assert_eq!(out.matches("className").count(), 1);
+    }
+
+    #[test]
+    fn insert_inside_survives_a_handler_prop_with_a_gt() {
+        // Same `{…}`-aware scan on the opening tag that bounds `Inside` inserts:
+        // stopping at the arrow's `>` would misplace the child.
+        let src = "<div onClick={() => go()} className=\"a\">x</div>";
+        let (out, _) = splice_inside(src, 0, src.len(), "<p>new</p>").unwrap();
+        assert_eq!(
+            out,
+            "<div onClick={() => go()} className=\"a\">x<p>new</p></div>"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/external_projects.rs
+++ b/src-tauri/src/commands/external_projects.rs
@@ -12,6 +12,36 @@ use tauri_plugin_dialog::DialogExt;
 
 // ============ Helper Functions ============
 
+/// Directories that look like projects to `is_valid_project` (they contain a
+/// package.json, a manifest, or a .git) but never are: dependency trees and
+/// build output. Excluded from the nested-project scan so a stray
+/// `node_modules` can't masquerade as hundreds of sibling projects (#826).
+const NON_PROJECT_DIRS: &[&str] = &[
+    "node_modules",
+    "dist",
+    "build",
+    "out",
+    "target",
+    "vendor",
+    "bower_components",
+];
+
+/// How many nested-project names the guidance message lists before summarizing.
+const MAX_LISTED_NESTED: usize = 5;
+
+/// Render a folder-name list for a user-facing message, capped so a
+/// pathological folder can't produce an unbounded string (#826).
+fn summarize_names(names: &[String]) -> String {
+    if names.len() <= MAX_LISTED_NESTED {
+        return names.join(", ");
+    }
+    format!(
+        "{}, and {} more",
+        names[..MAX_LISTED_NESTED].join(", "),
+        names.len() - MAX_LISTED_NESTED
+    )
+}
+
 /// Grant the asset protocol (`convertFileSrc`) read access to a directory at
 /// runtime. The static scope in tauri.conf.json deliberately only covers
 /// ~/ShipStudio; external projects live anywhere on disk, so we widen the scope
@@ -158,6 +188,17 @@ pub async fn register_external_project(app: AppHandle) -> Result<Option<String>,
                     {
                         continue;
                     }
+                    // Dependency and build directories aren't nested projects.
+                    // Every package under node_modules has a package.json, so
+                    // without this the guidance listed ~900 npm package names
+                    // instead of the user's actual subfolders (issue #826).
+                    if entry
+                        .file_name()
+                        .to_str()
+                        .is_some_and(|n| NON_PROJECT_DIRS.contains(&n))
+                    {
+                        continue;
+                    }
                     if crate::commands::projects::is_valid_project(&sub) {
                         if let Some(name) = entry.file_name().to_str() {
                             nested_projects.push(name.to_string());
@@ -177,7 +218,7 @@ pub async fn register_external_project(app: AppHandle) -> Result<Option<String>,
         } else if nested_projects.len() > 1 {
             return Err(CommandError::expected(format!(
                 "This folder contains multiple projects inside it: {}. Please select the specific project folder you want to import.",
-                nested_projects.join(", ")
+                summarize_names(&nested_projects)
             )));
         }
 
@@ -451,5 +492,22 @@ mod tests {
         let missing = std::env::temp_dir().join("ss-audit-missing-xyz");
         let _ = fs::remove_dir_all(&missing);
         assert!(!looks_like_project_root(&missing));
+    }
+
+    // #826: an unbounded name list flooded the guidance message (and the
+    // truncated copy no longer matched the frontend's Expected-refusal phrase).
+    #[test]
+    fn summarize_names_caps_long_lists() {
+        let few: Vec<String> = ["api", "web"].iter().map(|s| s.to_string()).collect();
+        assert_eq!(super::summarize_names(&few), "api, web");
+
+        let many: Vec<String> = (0..40).map(|i| format!("pkg{i}")).collect();
+        let summary = super::summarize_names(&many);
+        assert!(
+            summary.starts_with("pkg0, pkg1, pkg2, pkg3, pkg4,"),
+            "{summary}"
+        );
+        assert!(summary.ends_with("and 35 more"), "{summary}");
+        assert!(!summary.contains("pkg5,"), "{summary}");
     }
 }

--- a/src-tauri/src/commands/external_projects.rs
+++ b/src-tauri/src/commands/external_projects.rs
@@ -109,6 +109,21 @@ pub fn is_registered_external_path(canonical: &Path) -> Result<bool, String> {
     Ok(false)
 }
 
+/// True when `canonical` sits directly inside an allowed projects root, which
+/// is exactly what the dashboard's single-level scan lists. A deeper folder is
+/// *contained* by the root but invisible to that scan (issue #747).
+fn is_direct_child_of_projects_root(canonical: &Path) -> bool {
+    is_direct_child_of_any(canonical, &crate::utils::allowed_project_roots())
+}
+
+/// Testable core of [`is_direct_child_of_projects_root`].
+fn is_direct_child_of_any(canonical: &Path, roots: &[PathBuf]) -> bool {
+    match canonical.parent() {
+        Some(parent) => roots.iter().any(|root| parent == root),
+        None => false,
+    }
+}
+
 // ============ Tauri Commands ============
 
 /// Opens a native folder picker and registers the selected folder as an external project.
@@ -192,10 +207,14 @@ pub async fn register_external_project(app: AppHandle) -> Result<Option<String>,
 
     // Reject folders that already live under a projects root (configured or
     // default) — those are listed automatically and aren't "external".
-    if crate::utils::allowed_project_roots()
-        .iter()
-        .any(|root| canonical.starts_with(root))
-    {
+    //
+    // Only *direct children* qualify: `list_projects`/`get_dashboard_projects`
+    // scan the projects root one level deep, so a folder nested deeper is never
+    // discovered. Refusing it with "it will appear automatically" left those
+    // projects permanently invisible, with no way to add them (issue #747) —
+    // they fall through to normal external registration instead, which does
+    // list them.
+    if is_direct_child_of_projects_root(&canonical) {
         if crate::commands::projects::restore_removed_project(&canonical)? {
             return Ok(Some(canonical_str));
         }
@@ -421,8 +440,35 @@ pub async fn is_project_external(path: String) -> Result<bool, CommandError> {
 
 #[cfg(test)]
 mod tests {
-    use super::looks_like_project_root;
+    use super::{is_direct_child_of_any, looks_like_project_root};
     use std::fs;
+    use std::path::{Path, PathBuf};
+
+    // Issue #747: the "already inside your projects folder, it will appear
+    // automatically" refusal must only cover folders the single-level dashboard
+    // scan actually lists — deeper ones need external registration to show up.
+    #[test]
+    fn only_direct_children_count_as_inside_a_projects_root() {
+        let roots = vec![PathBuf::from("/Users/me/ShipStudio")];
+        assert!(is_direct_child_of_any(
+            Path::new("/Users/me/ShipStudio/my-app"),
+            &roots
+        ));
+        assert!(!is_direct_child_of_any(
+            Path::new("/Users/me/ShipStudio/clients/my-app"),
+            &roots
+        ));
+        // The root itself and unrelated paths aren't direct children either.
+        assert!(!is_direct_child_of_any(
+            Path::new("/Users/me/ShipStudio"),
+            &roots
+        ));
+        assert!(!is_direct_child_of_any(
+            Path::new("/Users/me/other"),
+            &roots
+        ));
+        assert!(!is_direct_child_of_any(Path::new("/"), &roots));
+    }
 
     #[test]
     fn rejects_sensitive_non_project_dirs() {

--- a/src-tauri/src/commands/external_projects.rs
+++ b/src-tauri/src/commands/external_projects.rs
@@ -154,6 +154,27 @@ fn is_direct_child_of_any(canonical: &Path, roots: &[PathBuf]) -> bool {
     }
 }
 
+/// Whether the picked folder IS a projects root (configured or default).
+///
+/// A root is not a direct child of itself, so the #747 narrowing to direct
+/// children stopped covering it — leaving `~/ShipStudio` itself registerable as
+/// an "external project", which would scope destructive git ops to the whole
+/// workspace tree.
+fn is_projects_root(canonical: &Path) -> bool {
+    is_any_of_roots(canonical, &crate::utils::allowed_project_roots())
+}
+
+/// Testable core of [`is_projects_root`]. Roots come from config/home lookups
+/// and may not be canonical, so compare both forms.
+fn is_any_of_roots(canonical: &Path, roots: &[PathBuf]) -> bool {
+    roots.iter().any(|root| {
+        canonical == root
+            || dunce::canonicalize(root)
+                .map(|c| c == canonical)
+                .unwrap_or(false)
+    })
+}
+
 // ============ Tauri Commands ============
 
 /// Opens a native folder picker and registers the selected folder as an external project.
@@ -255,6 +276,14 @@ pub async fn register_external_project(app: AppHandle) -> Result<Option<String>,
     // projects permanently invisible, with no way to add them (issue #747) —
     // they fall through to normal external registration instead, which does
     // list them.
+    // The root folder itself is a container, never a project.
+    if is_projects_root(&canonical) {
+        return Err(CommandError::expected(
+            "That folder is your projects folder itself, not a project. Pick one of the project \
+             folders inside it instead.",
+        ));
+    }
+
     if is_direct_child_of_projects_root(&canonical) {
         if crate::commands::projects::restore_removed_project(&canonical)? {
             return Ok(Some(canonical_str));
@@ -481,7 +510,7 @@ pub async fn is_project_external(path: String) -> Result<bool, CommandError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_direct_child_of_any, looks_like_project_root};
+    use super::{is_any_of_roots, is_direct_child_of_any, looks_like_project_root};
     use std::fs;
     use std::path::{Path, PathBuf};
 
@@ -509,6 +538,25 @@ mod tests {
             &roots
         ));
         assert!(!is_direct_child_of_any(Path::new("/"), &roots));
+    }
+
+    // The #747 direct-child narrowing must not leave the projects root itself
+    // registerable — a separate guard covers it.
+    #[test]
+    fn the_projects_root_itself_is_still_refused() {
+        let roots = vec![PathBuf::from("/Users/me/ShipStudio")];
+        assert!(is_any_of_roots(Path::new("/Users/me/ShipStudio"), &roots));
+        // Children — direct or deeper — are not the root and stay registerable
+        // by this predicate.
+        assert!(!is_any_of_roots(
+            Path::new("/Users/me/ShipStudio/my-app"),
+            &roots
+        ));
+        assert!(!is_any_of_roots(
+            Path::new("/Users/me/ShipStudio/clients/my-app"),
+            &roots
+        ));
+        assert!(!is_any_of_roots(Path::new("/Users/me/other"), &roots));
     }
 
     #[test]

--- a/src-tauri/src/commands/git/branches.rs
+++ b/src-tauri/src/commands/git/branches.rs
@@ -27,6 +27,24 @@ use super::{
     save_project_metadata,
 };
 
+/// Failure message for a non-zero `git branch -a` exit. Git can die with a
+/// completely silent stderr (killed by the OS, an exec-level failure on
+/// Windows), and the unconditional `: {stderr}` suffix then produced "Failed
+/// to list branches: " — an empty, undiagnosable report (issue #811). Fall
+/// back to the exit code so telemetry always carries something, mirroring
+/// `git_status_failure_message` in status.rs (issue #682).
+fn list_branches_failure_message(stderr_trimmed: &str, exit_code: Option<i32>) -> String {
+    if stderr_trimmed.is_empty() {
+        return match exit_code {
+            Some(code) => format!("Failed to list branches (exit {code})"),
+            None => "Failed to list branches (terminated by signal)".to_string(),
+        };
+    }
+    // Include git's stderr — a bare "Failed to list branches" is
+    // undiagnosable from telemetry (issue #252).
+    format!("Failed to list branches: {stderr_trimmed}")
+}
+
 /// List all branches (local and remote) with metadata
 #[tauri::command]
 #[instrument(name = "list_branches", skip(project_path), fields(project = %project_path))]
@@ -73,8 +91,6 @@ pub async fn list_branches(project_path: String) -> Result<Vec<BranchInfo>, Comm
     })?;
 
     if !output.status.success() {
-        // Include git's stderr — a bare "Failed to list branches" is
-        // undiagnosable from telemetry (issue #252).
         let stderr = String::from_utf8_lossy(&output.stderr);
         // Environment gaps (unaccepted Xcode license, missing CLT, macOS TCC
         // denial) mean git itself can't run — an expected machine state with a
@@ -83,7 +99,7 @@ pub async fn list_branches(project_path: String) -> Result<Vec<BranchInfo>, Comm
             warn!(error = %stderr.trim(), "git blocked by an environment gap while listing branches");
             return Err(gap);
         }
-        return Err((format!("Failed to list branches: {}", stderr.trim())).into());
+        return Err(list_branches_failure_message(stderr.trim(), output.status.code()).into());
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -297,9 +313,35 @@ pub async fn switch_branch(
         });
     }
 
-    // Try to checkout the branch
+    // Try to checkout the branch. When no local branch of that name exists,
+    // a bare `checkout <name>` leaves the choice to git's DWIM resolution,
+    // which refuses outright ("matched multiple (2) remote tracking branches")
+    // in a project with more than one remote carrying the same branch name.
+    // Qualify against origin ourselves in that case — the same explicit
+    // base-ref approach create_branch already takes (issue #729).
+    let local_exists = crate::utils::git_command_in(&validated_path)?
+        .args(["show-ref", "--verify", "--quiet"])
+        .arg(format!("refs/heads/{branch_name}"))
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    let origin_exists = !local_exists
+        && crate::utils::git_command_in(&validated_path)?
+            .args(["show-ref", "--verify", "--quiet"])
+            .arg(format!("refs/remotes/origin/{branch_name}"))
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+
     let mut checkout_cmd = crate::utils::git_command_in(&validated_path)?;
-    checkout_cmd.args(["checkout", "--end-of-options", &branch_name]);
+    if origin_exists {
+        checkout_cmd
+            .arg("checkout")
+            .arg("--track")
+            .arg(format!("origin/{branch_name}"));
+    } else {
+        checkout_cmd.args(["checkout", "--end-of-options", &branch_name]);
+    }
     let checkout_output =
         crate::external_command::spawn_with_pressure_retry("git checkout", || {
             checkout_cmd.output()
@@ -437,6 +479,15 @@ pub async fn switch_branch(
     })
 }
 
+/// User-facing message for the taken-name case, naming the branch instead of
+/// echoing git's raw `fatal:` line (issue #791).
+fn branch_already_exists_error(branch_name: &str) -> CommandError {
+    CommandError::expected(format!(
+        "A branch named '{branch_name}' already exists. Pick a different name, or switch to the \
+         existing branch."
+    ))
+}
+
 /// Create a new branch from a base branch
 #[tauri::command]
 #[instrument(name = "create_branch", skip(project_path), fields(project = %project_path, branch = %branch_name, from = %from_branch))]
@@ -484,6 +535,10 @@ pub async fn create_branch(
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
+            if is_branch_already_exists_error(&stderr) {
+                warn!(error = %stderr, "Branch creation blocked: name already taken");
+                return Err(branch_already_exists_error(&branch_name));
+            }
             return Err((stderr.to_string()).into());
         }
     } else {
@@ -553,6 +608,12 @@ pub async fn create_branch(
                      Refresh your branches and try again.",
                 ));
             }
+            // The name is already taken locally — a retried create or a stale
+            // branch list, fixable by picking another name (issue #791).
+            if is_branch_already_exists_error(&stderr) {
+                warn!(error = %stderr, "Branch creation blocked: name already taken");
+                return Err(branch_already_exists_error(&branch_name));
+            }
             error!(error = %stderr, "Failed to create branch");
             return Err((stderr.to_string()).into());
         }
@@ -597,12 +658,26 @@ pub async fn push_branch(project_path: String, branch_name: String) -> Result<()
     }
 
     info!("Publishing branch to GitHub");
-    let output = run_git_net(
+    let output = match run_git_net(
         &["push", "-u", "origin", &branch_name],
         &validated_path,
         "push branch",
     )
-    .await?;
+    .await
+    {
+        // A blown network budget is the connection (or a large repo), not a
+        // malfunction — the bare `?` used to send every slow push to telemetry
+        // as `cmderr-timeout-git push branch` (issue #819). Same mapping as
+        // get_github_username's gh timeouts (#686).
+        Err(CommandError::Timeout { .. }) => {
+            warn!("Publishing branch timed out waiting for GitHub");
+            return Err(CommandError::expected(
+                "Publishing took too long — GitHub didn't respond in time. Check your internet \
+                 connection and try again.",
+            ));
+        }
+        other => other?,
+    };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -638,6 +713,24 @@ pub async fn push_branch(project_path: String, branch_name: String) -> Result<()
 /// renamed on the remote after the branch list loaded (issue #692).
 fn is_missing_base_ref_error(stderr: &str) -> bool {
     stderr.contains("is not a commit and a branch")
+}
+
+/// Git refusing `checkout -b <name>` because that branch name is taken —
+/// "fatal: a branch named 'X' already exists". An everyday user state (a
+/// retried create, or a stale branch list), not a malfunction (issue #791).
+fn is_branch_already_exists_error(stderr: &str) -> bool {
+    let lower = stderr.to_lowercase();
+    lower.contains("a branch named") && lower.contains("already exists")
+}
+
+/// GitHub's pre-receive hook refusing `push --delete` for the repository's
+/// default branch — "! [remote rejected] X (refusing to delete the current
+/// branch: refs/heads/X)". By design on GitHub's side, whatever the branch is
+/// named, so the local main/master name check can't catch it (issue #792).
+fn is_default_branch_delete_refusal(stderr: &str) -> bool {
+    stderr
+        .to_lowercase()
+        .contains("refusing to delete the current branch")
 }
 
 /// Git refusing `branch -D` because the branch is checked out in another
@@ -716,16 +809,42 @@ pub async fn delete_branch(
 
     // Delete remote branch if requested
     if delete_remote {
-        let remote_output = run_git_net(
+        let remote_output = match run_git_net(
             &["push", "origin", "--delete", &branch_name],
             &validated_path,
             "push origin --delete",
         )
-        .await?;
+        .await
+        {
+            // Same network-not-malfunction mapping as push_branch (issue #819).
+            Err(CommandError::Timeout { .. }) => {
+                warn!("Remote branch delete timed out waiting for GitHub");
+                return Err(CommandError::expected(
+                    "GitHub didn't respond in time while deleting the remote branch. The local \
+                     branch is gone — check your connection and try deleting the remote copy \
+                     again.",
+                ));
+            }
+            other => other?,
+        };
 
         if !remote_output.status.success() {
             let stderr = String::from_utf8_lossy(&remote_output.stderr);
             if !stderr.contains("remote ref does not exist") {
+                // GitHub refuses `push --delete` for the repo's default branch
+                // ("refusing to delete the current branch: refs/heads/<name>")
+                // — by design, and the name check above only covers
+                // main/master, so a renamed default branch landed here as raw
+                // stderr + telemetry (issue #792).
+                if is_default_branch_delete_refusal(&stderr) {
+                    warn!(error = %stderr, "Remote branch delete refused: default branch on GitHub");
+                    return Err(CommandError::expected(format!(
+                        "'{branch_name}' is this repository's default branch on GitHub, so GitHub \
+                         won't let it be deleted. The local copy has been removed; change the \
+                         default branch in the repository's GitHub settings if you also want the \
+                         remote one gone."
+                    )));
+                }
                 // Same expected gh/git failure classification as push_branch
                 // (issue #560).
                 if let Some(err) = classify_git_net_error(&stderr) {
@@ -778,7 +897,10 @@ pub async fn delete_branch(
 
 #[cfg(test)]
 mod tests {
-    use super::{is_missing_base_ref_error, is_worktree_delete_refusal};
+    use super::{
+        is_branch_already_exists_error, is_default_branch_delete_refusal,
+        is_missing_base_ref_error, is_worktree_delete_refusal, list_branches_failure_message,
+    };
 
     // The #562 shape: deleting a branch that another worktree has checked out.
     #[test]
@@ -810,6 +932,56 @@ mod tests {
             "fatal: a branch named 'my-branch' already exists"
         ));
         assert!(!is_missing_base_ref_error(""));
+    }
+
+    // The #791 shape: creating a branch whose name is already taken locally.
+    #[test]
+    fn branch_already_exists_error_matches_git_wording() {
+        assert!(is_branch_already_exists_error(
+            "fatal: a branch named 'relaynorth/field-technician-execution' already exists"
+        ));
+        // Older git capitalizes the sentence.
+        assert!(is_branch_already_exists_error(
+            "fatal: A branch named 'feature/x' already exists."
+        ));
+        // An open PR collision says "already exists" too, but not about a
+        // branch — that one belongs to the PR flow, not branch creation.
+        assert!(!is_branch_already_exists_error(
+            "a pull request for branch \"feature/x\" already exists"
+        ));
+        assert!(!is_branch_already_exists_error(""));
+    }
+
+    // The #792 shape: GitHub refusing to delete the repo's default branch,
+    // whatever it's named.
+    #[test]
+    fn default_branch_delete_refusal_matches_github_wording() {
+        let stderr = " ! [remote rejected] studio-eg/showcase (refusing to delete the current \
+                       branch: refs/heads/studio-eg/showcase)";
+        assert!(is_default_branch_delete_refusal(stderr));
+        // An ordinary non-fast-forward rejection must keep its own handling.
+        assert!(!is_default_branch_delete_refusal(
+            " ! [rejected] main -> main (non-fast-forward)"
+        ));
+        assert!(!is_default_branch_delete_refusal(""));
+    }
+
+    // Issue #811: git can exit non-zero with nothing on stderr, and the old
+    // unconditional suffix produced a message with no signal at all.
+    #[test]
+    fn list_branches_failure_message_falls_back_to_exit_code() {
+        assert_eq!(
+            list_branches_failure_message("", Some(128)),
+            "Failed to list branches (exit 128)"
+        );
+        assert_eq!(
+            list_branches_failure_message("", None),
+            "Failed to list branches (terminated by signal)"
+        );
+        assert_eq!(
+            list_branches_failure_message("fatal: bad object", Some(128)),
+            "Failed to list branches: fatal: bad object"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/git/branches.rs
+++ b/src-tauri/src/commands/git/branches.rs
@@ -41,8 +41,13 @@ fn list_branches_failure_message(stderr_trimmed: &str, exit_code: Option<i32>) -
         };
     }
     // Include git's stderr — a bare "Failed to list branches" is
-    // undiagnosable from telemetry (issue #252).
-    format!("Failed to list branches: {stderr_trimmed}")
+    // undiagnosable from telemetry (issue #252) — but capped, like its
+    // status.rs twin: an unbounded dump floods the toast and telemetry
+    // (issue #547).
+    format!(
+        "Failed to list branches: {}",
+        super::status::truncate_stderr(stderr_trimmed)
+    )
 }
 
 /// List all branches (local and remote) with metadata
@@ -658,26 +663,14 @@ pub async fn push_branch(project_path: String, branch_name: String) -> Result<()
     }
 
     info!("Publishing branch to GitHub");
-    let output = match run_git_net(
+    // A blown network budget maps to Expected inside run_git_net itself, so
+    // every push path gets it, not just this one (issue #819).
+    let output = run_git_net(
         &["push", "-u", "origin", &branch_name],
         &validated_path,
         "push branch",
     )
-    .await
-    {
-        // A blown network budget is the connection (or a large repo), not a
-        // malfunction — the bare `?` used to send every slow push to telemetry
-        // as `cmderr-timeout-git push branch` (issue #819). Same mapping as
-        // get_github_username's gh timeouts (#686).
-        Err(CommandError::Timeout { .. }) => {
-            warn!("Publishing branch timed out waiting for GitHub");
-            return Err(CommandError::expected(
-                "Publishing took too long — GitHub didn't respond in time. Check your internet \
-                 connection and try again.",
-            ));
-        }
-        other => other?,
-    };
+    .await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -809,24 +802,13 @@ pub async fn delete_branch(
 
     // Delete remote branch if requested
     if delete_remote {
-        let remote_output = match run_git_net(
+        // Timeouts map to Expected inside run_git_net (issue #819).
+        let remote_output = run_git_net(
             &["push", "origin", "--delete", &branch_name],
             &validated_path,
             "push origin --delete",
         )
-        .await
-        {
-            // Same network-not-malfunction mapping as push_branch (issue #819).
-            Err(CommandError::Timeout { .. }) => {
-                warn!("Remote branch delete timed out waiting for GitHub");
-                return Err(CommandError::expected(
-                    "GitHub didn't respond in time while deleting the remote branch. The local \
-                     branch is gone — check your connection and try deleting the remote copy \
-                     again.",
-                ));
-            }
-            other => other?,
-        };
+        .await?;
 
         if !remote_output.status.success() {
             let stderr = String::from_utf8_lossy(&remote_output.stderr);
@@ -982,6 +964,17 @@ mod tests {
             list_branches_failure_message("fatal: bad object", Some(128)),
             "Failed to list branches: fatal: bad object"
         );
+    }
+
+    /// Same cap as `git_status_failure_message` (issue #547): an unbounded
+    /// stderr dump floods the toast and telemetry.
+    #[test]
+    fn list_branches_failure_message_truncates_a_huge_stderr() {
+        let huge = "x".repeat(5000);
+        let msg = list_branches_failure_message(&huge, Some(128));
+        assert!(msg.len() < 700, "must be capped, got {} chars", msg.len());
+        assert!(msg.ends_with('…'), "got tail: {}", &msg[msg.len() - 20..]);
+        assert!(msg.starts_with("Failed to list branches: xxx"));
     }
 
     #[test]

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -32,6 +32,16 @@ use tracing::{debug, error, info, instrument};
 /// generous but protects the UI/worker against an indefinitely-hanging remote.
 const GIT_NETWORK_TIMEOUT_SECS: u64 = 60;
 
+/// User-facing message when a [`run_git_net`] call blows its network budget.
+///
+/// Keeps the "check your internet connection" wording that errors.ts's
+/// `BACKEND_HUMANIZED_GIT_PHRASES` keys on (same as github.rs's
+/// `GH_PUSH_TIMEOUT_MESSAGE`), so the frontend still recognizes it as
+/// already-humanized and doesn't re-word it.
+pub(crate) const GIT_NET_TIMEOUT_MESSAGE: &str =
+    "GitHub took too long to respond and the operation timed out. Larger projects can take a \
+     while to upload — check your internet connection and try again.";
+
 /// Run a git command that touches the network (fetch / pull / push), scoped to
 /// the workspace the project at `cwd` belongs to.
 ///
@@ -90,7 +100,28 @@ pub(crate) async fn run_git_net(
     // background, holding .git locks and stalling the next push/fetch too
     // (issue #556; same pattern as projects/mod.rs et al.).
     tokio_cmd.kill_on_drop(true);
-    run_with_timeout(tokio_cmd, format!("git {label}"), GIT_NETWORK_TIMEOUT_SECS).await
+
+    map_git_net_timeout(
+        run_with_timeout(tokio_cmd, format!("git {label}"), GIT_NETWORK_TIMEOUT_SECS).await,
+        label,
+    )
+}
+
+/// A blown network budget is the connection (or a large repo), not a
+/// malfunction, so it belongs in `Expected` and out of telemetry.
+///
+/// Applied inside [`run_git_net`] rather than per call site: only push_branch
+/// and delete_branch carried the mapping, so pushes from publishing.rs (4
+/// sites), pull_requests.rs and github.rs still reported every slow push as
+/// `cmderr-timeout-git push` (issue #819).
+fn map_git_net_timeout<T>(result: Result<T, CommandError>, label: &str) -> Result<T, CommandError> {
+    match result {
+        Err(CommandError::Timeout { .. }) => {
+            tracing::warn!(label, "git network operation timed out waiting for GitHub");
+            Err(CommandError::expected(GIT_NET_TIMEOUT_MESSAGE))
+        }
+        other => other,
+    }
 }
 
 /// [`run_git_net`] plus a bounded retry when git loses the `.git/index.lock`
@@ -611,6 +642,39 @@ mod tests {
     use super::*;
     use std::process::Command;
     use tempfile::TempDir;
+
+    // Issue #819: every run_git_net call site — not just push_branch and
+    // delete_branch — must classify a blown network budget as Expected, or
+    // slow pushes from publishing.rs / pull_requests.rs / github.rs keep
+    // reaching telemetry as `cmderr-timeout-git push`.
+    #[test]
+    fn git_net_timeouts_map_to_expected_not_telemetry() {
+        let timed_out: Result<(), CommandError> = Err(CommandError::Timeout {
+            cmd: "git push".into(),
+            secs: GIT_NETWORK_TIMEOUT_SECS,
+        });
+        let err = map_git_net_timeout(timed_out, "push").expect_err("still an error");
+        assert!(matches!(err, CommandError::Expected { .. }), "got: {err:?}");
+        // errors.ts's BACKEND_HUMANIZED_GIT_PHRASES keys on this phrase to know
+        // the backend already humanized the message.
+        assert!(
+            err.to_string()
+                .to_lowercase()
+                .contains("check your internet connection"),
+            "got: {err}"
+        );
+
+        // Nothing else is touched: successes and other failures pass through.
+        assert_eq!(
+            map_git_net_timeout(Ok::<_, CommandError>(7), "push").ok(),
+            Some(7)
+        );
+        let other: Result<(), CommandError> = Err(CommandError::expected("nope"));
+        assert_eq!(
+            map_git_net_timeout(other, "push").unwrap_err().to_string(),
+            "nope"
+        );
+    }
 
     // The #560 shape: a connectivity blip during `git push` (credentials
     // resolved via gh, so the error text is gh's GraphQL dial failure) must

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -136,9 +136,15 @@ pub(crate) async fn run_git_net_retrying_index_lock(
 /// the gh classifiers in `commands::github` already cover — call sites must
 /// route through this instead of forwarding raw stderr (issue #560). Returns
 /// `None` for anything genuinely unexplained.
+///
+/// A remote that no longer exists (deleted, renamed, transferred, or access
+/// revoked) belongs to the same family — publishing.rs already classified it,
+/// but push_branch/delete_branch/create_pull_request forwarded it raw to
+/// telemetry on every retry (issue #825), so the shared helper covers it here.
 pub(crate) fn classify_git_net_error(stderr: &str) -> Option<CommandError> {
     crate::commands::github::gh_auth_error(stderr)
         .or_else(|| crate::commands::github::gh_common_error(stderr))
+        .or_else(|| crate::commands::publishing::push_missing_remote_error(stderr))
 }
 
 // ============ Git Helper Functions ============
@@ -622,6 +628,15 @@ mod tests {
         assert!(matches!(
             classify_git_net_error("To get started with GitHub CLI, please run:  gh auth login"),
             Some(CommandError::NotAuthenticated { .. })
+        ));
+        // A remote that no longer exists — publishing.rs already treated this
+        // as expected; push_branch/delete_branch/create_pull_request now get
+        // the same classification through the shared helper (issue #825).
+        assert!(matches!(
+            classify_git_net_error(
+                "remote: Repository not found.\nfatal: repository 'https://github.com/o/r.git/' not found"
+            ),
+            Some(CommandError::Expected { .. })
         ));
         // A real push rejection must NOT be swallowed as expected.
         assert!(classify_git_net_error(

--- a/src-tauri/src/commands/git/stash.rs
+++ b/src-tauri/src/commands/git/stash.rs
@@ -34,16 +34,24 @@ pub async fn get_stash_info(
 pub async fn stash_changes(project_path: String) -> Result<bool, CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let output = crate::utils::git_command_in(&validated_path)?
-        .args([
-            "stash",
-            "push",
-            "--include-untracked",
-            "-m",
-            "Ship Studio: set aside before creating a branch",
-        ])
-        .output()
-        .map_err(|e| e.to_string())?;
+    // `stash push` writes the index just like add/commit/checkout, so it can
+    // lose the .git lock race against the background snapshot watcher or any
+    // agent CLI running git — retry on contention the same way
+    // git_stage_and_commit/discard_changes do (issues #377/#597/#820).
+    let output = crate::utils::output_retrying_index_lock(|| {
+        crate::utils::git_command_in(&validated_path)?
+            .args([
+                "stash",
+                "push",
+                "--include-untracked",
+                "-m",
+                "Ship Studio: set aside before creating a branch",
+            ])
+            .output()
+            .map_err(|e| CommandError::Io {
+                message: e.to_string(),
+            })
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -62,10 +70,16 @@ pub async fn stash_changes(project_path: String) -> Result<bool, CommandError> {
 pub async fn apply_stash(project_path: String) -> Result<bool, CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let pop_output = crate::utils::git_command_in(&validated_path)?
-        .args(["stash", "pop"])
-        .output()
-        .map_err(|e| e.to_string())?;
+    // Same index.lock retry as stash_changes — popping rewrites the working
+    // tree and index (issue #820).
+    let pop_output = crate::utils::output_retrying_index_lock(|| {
+        crate::utils::git_command_in(&validated_path)?
+            .args(["stash", "pop"])
+            .output()
+            .map_err(|e| CommandError::Io {
+                message: e.to_string(),
+            })
+    })?;
 
     if pop_output.status.success() {
         // Clear stash info from metadata
@@ -89,10 +103,16 @@ pub async fn apply_stash(project_path: String) -> Result<bool, CommandError> {
 pub async fn drop_stash(project_path: String) -> Result<bool, CommandError> {
     let validated_path = validate_project_path(&project_path)?;
 
-    let drop_output = crate::utils::git_command_in(&validated_path)?
-        .args(["stash", "drop"])
-        .output()
-        .map_err(|e| e.to_string())?;
+    // `stash drop` rewrites refs/stash, which takes the same lock family
+    // (issue #820).
+    let drop_output = crate::utils::output_retrying_index_lock(|| {
+        crate::utils::git_command_in(&validated_path)?
+            .args(["stash", "drop"])
+            .output()
+            .map_err(|e| CommandError::Io {
+                message: e.to_string(),
+            })
+    })?;
 
     // Clear stash info from metadata regardless of drop success
     let mut metadata = load_project_metadata(&validated_path);
@@ -200,10 +220,17 @@ pub async fn restore_backup(
     let has_changes = git_has_any_changes(&validated_path)?;
     if has_changes {
         info!("Stashing current changes");
-        let stash_output = crate::utils::git_command_in(&validated_path)?
-            .args(["stash", "push", "-m", "Auto-stash before restore"])
-            .output()
-            .map_err(|e| e.to_string())?;
+        // Index-lock retry on every mutating step of the restore, same as the
+        // commit/discard paths — a snapshot-watcher collision here aborted the
+        // whole restore halfway (issue #820).
+        let stash_output = crate::utils::output_retrying_index_lock(|| {
+            crate::utils::git_command_in(&validated_path)?
+                .args(["stash", "push", "-m", "Auto-stash before restore"])
+                .output()
+                .map_err(|e| CommandError::Io {
+                    message: e.to_string(),
+                })
+        })?;
 
         if !stash_output.status.success() {
             let stderr = String::from_utf8_lossy(&stash_output.stderr);
@@ -228,10 +255,14 @@ pub async fn restore_backup(
             .output();
     }
 
-    let create_output = crate::utils::git_command_in(&validated_path)?
-        .args(["checkout", "-b", &branch_name])
-        .output()
-        .map_err(|e| e.to_string())?;
+    let create_output = crate::utils::output_retrying_index_lock(|| {
+        crate::utils::git_command_in(&validated_path)?
+            .args(["checkout", "-b", &branch_name])
+            .output()
+            .map_err(|e| CommandError::Io {
+                message: e.to_string(),
+            })
+    })?;
 
     if !create_output.status.success() {
         // Restore stash if we created one
@@ -251,10 +282,14 @@ pub async fn restore_backup(
     }
 
     // 3. Checkout all files from the target commit
-    let checkout_output = crate::utils::git_command_in(&validated_path)?
-        .args(["checkout", &commit_hash, "--", "."])
-        .output()
-        .map_err(|e| e.to_string())?;
+    let checkout_output = crate::utils::output_retrying_index_lock(|| {
+        crate::utils::git_command_in(&validated_path)?
+            .args(["checkout", &commit_hash, "--", "."])
+            .output()
+            .map_err(|e| CommandError::Io {
+                message: e.to_string(),
+            })
+    })?;
 
     if !checkout_output.status.success() {
         // Switch back to original branch and restore stash

--- a/src-tauri/src/commands/git/stash.rs
+++ b/src-tauri/src/commands/git/stash.rs
@@ -48,9 +48,7 @@ pub async fn stash_changes(project_path: String) -> Result<bool, CommandError> {
                 "Ship Studio: set aside before creating a branch",
             ])
             .output()
-            .map_err(|e| CommandError::Io {
-                message: e.to_string(),
-            })
+            .map_err(CommandError::from)
     })?;
 
     if !output.status.success() {
@@ -76,9 +74,7 @@ pub async fn apply_stash(project_path: String) -> Result<bool, CommandError> {
         crate::utils::git_command_in(&validated_path)?
             .args(["stash", "pop"])
             .output()
-            .map_err(|e| CommandError::Io {
-                message: e.to_string(),
-            })
+            .map_err(CommandError::from)
     })?;
 
     if pop_output.status.success() {
@@ -109,9 +105,7 @@ pub async fn drop_stash(project_path: String) -> Result<bool, CommandError> {
         crate::utils::git_command_in(&validated_path)?
             .args(["stash", "drop"])
             .output()
-            .map_err(|e| CommandError::Io {
-                message: e.to_string(),
-            })
+            .map_err(CommandError::from)
     })?;
 
     // Clear stash info from metadata regardless of drop success
@@ -227,9 +221,7 @@ pub async fn restore_backup(
             crate::utils::git_command_in(&validated_path)?
                 .args(["stash", "push", "-m", "Auto-stash before restore"])
                 .output()
-                .map_err(|e| CommandError::Io {
-                    message: e.to_string(),
-                })
+                .map_err(CommandError::from)
         })?;
 
         if !stash_output.status.success() {
@@ -259,9 +251,7 @@ pub async fn restore_backup(
         crate::utils::git_command_in(&validated_path)?
             .args(["checkout", "-b", &branch_name])
             .output()
-            .map_err(|e| CommandError::Io {
-                message: e.to_string(),
-            })
+            .map_err(CommandError::from)
     })?;
 
     if !create_output.status.success() {
@@ -286,9 +276,7 @@ pub async fn restore_backup(
         crate::utils::git_command_in(&validated_path)?
             .args(["checkout", &commit_hash, "--", "."])
             .output()
-            .map_err(|e| CommandError::Io {
-                message: e.to_string(),
-            })
+            .map_err(CommandError::from)
     })?;
 
     if !checkout_output.status.success() {
@@ -378,4 +366,27 @@ pub async fn restore_backup(
         branch_name,
         commit_message,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CommandError;
+
+    /// Every `git` spawn in this file maps its `io::Error` with
+    /// `CommandError::from`, never by hand-constructing `CommandError::Io`.
+    /// Six copy-pasted `map_err(|e| CommandError::Io { … })` blocks bypassed
+    /// the `From` impl's `windows_out_of_memory` classification, so a Windows
+    /// paging-file exhaustion during a stash/checkout reached the user as a
+    /// bare OS string and telemetry as an app malfunction (issues #356/#783).
+    #[test]
+    fn spawn_failures_keep_the_windows_out_of_memory_classification() {
+        let oom = std::io::Error::from_raw_os_error(1455);
+        let err = CommandError::from(oom);
+        assert!(matches!(err, CommandError::Expected { .. }), "got: {err:?}");
+        assert!(err.to_string().contains("paging file"), "got: {err}");
+
+        // Ordinary spawn failures still land in Io so telemetry keeps them.
+        let other = std::io::Error::other("boom");
+        assert!(matches!(CommandError::from(other), CommandError::Io { .. }));
+    }
 }

--- a/src-tauri/src/commands/git/status.rs
+++ b/src-tauri/src/commands/git/status.rs
@@ -15,7 +15,7 @@ use super::git_has_uncommitted_changes;
 /// Cap git stderr carried inside an error message so a pathological failure
 /// (e.g. a hook dumping its whole log) can't flood the toast/telemetry, while
 /// keeping enough text to diagnose the actual cause (issue #547).
-fn truncate_stderr(stderr: &str) -> String {
+pub(super) fn truncate_stderr(stderr: &str) -> String {
     const MAX: usize = 500;
     if stderr.len() <= MAX {
         return stderr.to_string();

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -884,15 +884,47 @@ pub(crate) fn gh_crash_error(stderr: &str) -> Option<CommandError> {
 /// readline, which Node ≥ 24 turns into a thrown `ERR_USE_AFTER_CLOSE`
 /// (issue #737). Nothing the app can retry: `Expected` keeps the dump out of
 /// telemetry and the message names the real fix.
+///
+/// The Node-crash shape alone isn't enough to conclude that: `gh_common_error`
+/// is also reached from [`classify_git_net_error`], which sees plain
+/// `git push` stderr, and a husky/Node pre-push hook crashing there has
+/// nothing to do with `gh`. The dump must also point at a program actually
+/// named `gh` — otherwise the user gets the wrong remedy and the real failure
+/// is hidden behind it.
 pub(crate) fn gh_shadowed_binary_error(stderr: &str) -> Option<CommandError> {
     let is_node_crash = stderr.contains("node:internal/") || stderr.contains("ERR_USE_AFTER_CLOSE");
-    is_node_crash.then(|| {
+    (is_node_crash && stderr_names_gh_program(stderr)).then(|| {
         CommandError::expected(
             "The program named `gh` on this computer isn't GitHub's CLI — something else \
              (most often an unrelated global npm package called \"gh\") is being found first. \
              Remove it (`npm uninstall -g gh`) or reinstall the GitHub CLI, then try again.",
         )
     })
+}
+
+/// Whether a stack trace points at a file or directory actually named `gh` —
+/// `…\node_modules\gh\…`, `…/bin/gh`, `…\gh.cmd`. Requires `gh` to be a whole
+/// path component (or a script stem), so `github.com`, `gh-pages` and
+/// `~/gh-repos` don't count.
+fn stderr_names_gh_program(stderr: &str) -> bool {
+    let bytes = stderr.as_bytes();
+    let mut from = 0;
+    while let Some(rel) = stderr[from..].find("gh") {
+        let i = from + rel;
+        from = i + 2;
+        let after_sep = i > 0 && matches!(bytes[i - 1], b'/' | b'\\');
+        let ends_component = match bytes.get(i + 2) {
+            None => true,
+            Some(c) => matches!(
+                c,
+                b'/' | b'\\' | b'.' | b'\'' | b'"' | b' ' | b'\t' | b'\r' | b'\n' | b':'
+            ),
+        };
+        if after_sep && ends_component {
+            return true;
+        }
+    }
+    false
 }
 
 /// A `gh` invocation that hits GitHub can fail these ways regardless of which
@@ -1109,7 +1141,7 @@ fn preferred_package_manager(path: &Path) -> Option<String> {
         }
     }
 
-    // pnpm-only markers: a workspace file, or workspace:/catalog: deps.
+    // A pnpm workspace file is pnpm's alone.
     if path.join("pnpm-workspace.yaml").exists() || path.join("pnpm-workspace.yml").exists() {
         return Some("pnpm".to_string());
     }
@@ -1117,6 +1149,14 @@ fn preferred_package_manager(path: &Path) -> Option<String> {
         .as_ref()
         .is_some_and(manifest_uses_workspace_protocol)
     {
+        // `workspace:` is NOT pnpm-only — Yarn 2+ (berry) uses the same
+        // protocol, and `catalog:` landed in Yarn 4.9. A berry repo whose
+        // yarn.lock isn't reachable (gitignored, or a package cloned without
+        // its root lockfile) would otherwise get a pnpm install it can't use,
+        // so check berry's own on-disk markers first.
+        if path.join(".yarnrc.yml").exists() || path.join(".yarn").is_dir() {
+            return Some("yarn".to_string());
+        }
         return Some("pnpm".to_string());
     }
 
@@ -1627,6 +1667,32 @@ mod tests {
         assert!(gh_shadowed_binary_error("").is_none());
     }
 
+    // gh_common_error is reached from classify_git_net_error, so it also sees
+    // plain `git push` stderr. A husky/Node pre-push hook crashing there is not
+    // a shadowed `gh`: blaming npm would give the wrong fix and bury the real
+    // failure. The dump must name a program called `gh`.
+    #[test]
+    fn a_node_pre_push_hook_crash_is_not_a_shadowed_gh() {
+        let stderr = "node:internal/modules/cjs/loader:1215\n  throw err;\n  ^\n\nError: Cannot find module '/Users/me/proj/.husky/lint-staged.mjs'\n    at Module._resolveFilename (node:internal/modules/cjs/loader:1212:15)\n\nNode.js v22.3.0\nhusky - pre-push script failed (code 1)\nerror: failed to push some refs to 'https://github.com/o/r.git'";
+        assert!(gh_shadowed_binary_error(stderr).is_none());
+        assert!(gh_common_error(stderr).is_none());
+        assert!(crate::commands::git::classify_git_net_error(stderr).is_none());
+    }
+
+    #[test]
+    fn stderr_names_gh_program_needs_a_whole_path_component() {
+        assert!(stderr_names_gh_program(
+            "C:\\npm\\node_modules\\gh\\index.js"
+        ));
+        assert!(stderr_names_gh_program("/usr/local/bin/gh"));
+        assert!(stderr_names_gh_program("/opt/homebrew/bin/gh.cmd:1"));
+        // Near-misses that must not count.
+        assert!(!stderr_names_gh_program("https://github.com/o/r.git"));
+        assert!(!stderr_names_gh_program("/Users/me/gh-repos/app/index.js"));
+        assert!(!stderr_names_gh_program("running the gh command"));
+        assert!(!stderr_names_gh_program(""));
+    }
+
     // The #779 pre-flight: an existing `origin` decides whether the create
     // step can run at all. A remote pointing at the repo being created means a
     // half-finished earlier run (create succeeded, push didn't) — reuse it.
@@ -1767,6 +1833,45 @@ mod tests {
                 "package.json",
                 r#"{"devDependencies":{"eslint":"catalog:lint"}}"#,
             )]);
+            assert_eq!(
+                preferred_package_manager(dir.path()).as_deref(),
+                Some("pnpm")
+            );
+        }
+
+        // `workspace:` is Yarn 2+'s protocol too, so berry's own markers decide
+        // before the pnpm fallback does — otherwise a berry repo without a
+        // reachable yarn.lock gets a pnpm install it can't use.
+        #[test]
+        fn yarn_berry_markers_beat_the_workspace_protocol_fallback() {
+            let dir = project(&[
+                (
+                    "package.json",
+                    r#"{"dependencies":{"@acme/ui":"workspace:*"}}"#,
+                ),
+                (".yarnrc.yml", "nodeLinker: node-modules\n"),
+            ]);
+            assert_eq!(
+                preferred_package_manager(dir.path()).as_deref(),
+                Some("yarn")
+            );
+
+            // A `.yarn/` directory (releases, plugins, cache) counts the same.
+            let dir = project(&[(
+                "package.json",
+                r#"{"devDependencies":{"eslint":"catalog:lint"}}"#,
+            )]);
+            fs::create_dir(dir.path().join(".yarn")).expect("mkdir");
+            assert_eq!(
+                preferred_package_manager(dir.path()).as_deref(),
+                Some("yarn")
+            );
+
+            // A pnpm workspace file is still pnpm's alone, berry markers or not.
+            let dir = project(&[
+                ("pnpm-workspace.yaml", "packages:\n  - apps/*\n"),
+                (".yarnrc.yml", ""),
+            ]);
             assert_eq!(
                 preferred_package_manager(dir.path()).as_deref(),
                 Some("pnpm")

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -898,7 +898,84 @@ pub async fn list_collaborator_repos() -> Result<Vec<GitHubRepo>, CommandError> 
     Ok(repos)
 }
 
-/// Detects the package manager used in a project by checking for lock files
+/// True when any dependency map in a package.json uses pnpm/yarn's
+/// `workspace:` or pnpm's `catalog:` specifier. npm understands neither and
+/// aborts the whole install with EUNSUPPORTEDPROTOCOL (issues #707/#708), so
+/// their presence is a stronger signal than the missing lockfile.
+fn manifest_uses_workspace_protocol(manifest: &serde_json::Value) -> bool {
+    const DEP_KEYS: [&str; 4] = [
+        "dependencies",
+        "devDependencies",
+        "optionalDependencies",
+        "peerDependencies",
+    ];
+    DEP_KEYS.iter().any(|key| {
+        manifest
+            .get(key)
+            .and_then(|deps| deps.as_object())
+            .is_some_and(|deps| {
+                deps.values().any(|spec| {
+                    spec.as_str()
+                        .is_some_and(|s| s.starts_with("workspace:") || s.starts_with("catalog:"))
+                })
+            })
+    })
+}
+
+/// The package manager a project structurally requires, ignoring whether that
+/// tool is actually installed. `None` means "no signal" — the caller defaults
+/// to npm.
+///
+/// Lockfiles come first: they're the repo's own record of what it was installed
+/// with. When none is committed (gitignored lockfile, a workspace package cloned
+/// without its root lockfile), fall back to what the manifest declares —
+/// Corepack's `packageManager` field, a `pnpm-workspace.yaml`, or `workspace:`/
+/// `catalog:` dependency specifiers. Defaulting to npm in those cases ran the
+/// one package manager the project can't be installed with (issues #707/#708).
+fn preferred_package_manager(path: &Path) -> Option<String> {
+    // Check in order of specificity
+    if path.join("pnpm-lock.yaml").exists() {
+        return Some("pnpm".to_string());
+    }
+    if path.join("yarn.lock").exists() {
+        return Some("yarn".to_string());
+    }
+    if path.join("bun.lockb").exists() {
+        return Some("bun".to_string());
+    }
+
+    let manifest = std::fs::read_to_string(path.join("package.json"))
+        .ok()
+        .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok());
+
+    // Corepack declaration, e.g. "packageManager": "pnpm@9.0.0"
+    if let Some(spec) = manifest
+        .as_ref()
+        .and_then(|m| m.get("packageManager"))
+        .and_then(|v| v.as_str())
+    {
+        let name = spec.split('@').next().unwrap_or("").trim();
+        if matches!(name, "pnpm" | "yarn" | "bun" | "npm") {
+            return Some(name.to_string());
+        }
+    }
+
+    // pnpm-only markers: a workspace file, or workspace:/catalog: deps.
+    if path.join("pnpm-workspace.yaml").exists() || path.join("pnpm-workspace.yml").exists() {
+        return Some("pnpm".to_string());
+    }
+    if manifest
+        .as_ref()
+        .is_some_and(manifest_uses_workspace_protocol)
+    {
+        return Some("pnpm".to_string());
+    }
+
+    None
+}
+
+/// Detects the package manager a project needs (lockfiles first, then the
+/// manifest's own declarations), falling back to npm.
 #[tauri::command]
 #[tracing::instrument]
 pub async fn detect_package_manager(project_path: String) -> Result<String, CommandError> {
@@ -921,18 +998,11 @@ pub async fn detect_package_manager(project_path: String) -> Result<String, Comm
         }
     }
 
-    // Check in order of specificity
-    if path.join("pnpm-lock.yaml").exists() {
-        return Ok(or_npm("pnpm"));
+    match preferred_package_manager(path) {
+        Some(preferred) if preferred != "npm" => Ok(or_npm(&preferred)),
+        // No signal (or the project asks for npm explicitly) → npm.
+        _ => Ok("npm".to_string()),
     }
-    if path.join("yarn.lock").exists() {
-        return Ok(or_npm("yarn"));
-    }
-    if path.join("bun.lockb").exists() {
-        return Ok(or_npm("bun"));
-    }
-    // Default to npm
-    Ok("npm".to_string())
 }
 
 #[cfg(test)]
@@ -1390,5 +1460,91 @@ mod tests {
         )
         .is_some());
         assert!(gh_auth_error("fatal: not a git repository").is_none());
+    }
+
+    // Issues #707/#708: a repo whose lockfile isn't committed but whose
+    // manifest structurally requires pnpm must not be installed with npm.
+    mod package_manager_detection {
+        use super::*;
+        use std::fs;
+
+        fn project(files: &[(&str, &str)]) -> tempfile::TempDir {
+            let dir = tempfile::tempdir().expect("tempdir");
+            for (name, contents) in files {
+                fs::write(dir.path().join(name), contents).expect("write");
+            }
+            dir
+        }
+
+        #[test]
+        fn lockfiles_still_win() {
+            let dir = project(&[("pnpm-lock.yaml", ""), ("package.json", "{}")]);
+            assert_eq!(
+                preferred_package_manager(dir.path()).as_deref(),
+                Some("pnpm")
+            );
+            let dir = project(&[("yarn.lock", "")]);
+            assert_eq!(
+                preferred_package_manager(dir.path()).as_deref(),
+                Some("yarn")
+            );
+            let dir = project(&[("bun.lockb", "")]);
+            assert_eq!(
+                preferred_package_manager(dir.path()).as_deref(),
+                Some("bun")
+            );
+        }
+
+        #[test]
+        fn corepack_package_manager_field_is_honored_without_a_lockfile() {
+            let dir = project(&[(
+                "package.json",
+                r#"{"name":"x","packageManager":"pnpm@9.0.0"}"#,
+            )]);
+            assert_eq!(
+                preferred_package_manager(dir.path()).as_deref(),
+                Some("pnpm")
+            );
+        }
+
+        #[test]
+        fn workspace_and_catalog_specifiers_select_pnpm() {
+            let dir = project(&[(
+                "package.json",
+                r#"{"dependencies":{"@acme/ui":"workspace:*"}}"#,
+            )]);
+            assert_eq!(
+                preferred_package_manager(dir.path()).as_deref(),
+                Some("pnpm")
+            );
+            let dir = project(&[(
+                "package.json",
+                r#"{"devDependencies":{"eslint":"catalog:lint"}}"#,
+            )]);
+            assert_eq!(
+                preferred_package_manager(dir.path()).as_deref(),
+                Some("pnpm")
+            );
+        }
+
+        #[test]
+        fn pnpm_workspace_file_selects_pnpm() {
+            let dir = project(&[("pnpm-workspace.yaml", "packages:\n  - apps/*\n")]);
+            assert_eq!(
+                preferred_package_manager(dir.path()).as_deref(),
+                Some("pnpm")
+            );
+        }
+
+        #[test]
+        fn plain_npm_projects_keep_falling_back_to_npm() {
+            let dir = project(&[("package.json", r#"{"dependencies":{"react":"^19.0.0"}}"#)]);
+            assert_eq!(preferred_package_manager(dir.path()), None);
+            // Unparseable or absent manifests must not panic or misdetect.
+            let dir = project(&[("package.json", "not json {")]);
+            assert_eq!(preferred_package_manager(dir.path()), None);
+            let dir = project(&[]);
+            assert_eq!(preferred_package_manager(dir.path()), None);
+        }
     }
 }

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -196,6 +196,14 @@ fn gh_command_and_account(project_path: Option<&str>) -> Result<(Command, String
 const GH_TIMEOUT_MESSAGE: &str =
     "GitHub took too long to respond. Check your internet connection and try again.";
 
+/// User-facing message when `gh repo create --push` blows its (longer) time
+/// budget — a big repo or a slow uplink, not a malfunction (issue #771).
+/// Keeps the "check your internet connection" wording so errors.ts's
+/// BACKEND_HUMANIZED_GIT_PHRASES still recognizes it as already-humanized.
+const GH_PUSH_TIMEOUT_MESSAGE: &str =
+    "Creating the repository on GitHub took too long and timed out. Larger projects can take a \
+     while to upload — check your internet connection and try again.";
+
 #[tauri::command]
 #[tracing::instrument]
 pub async fn get_github_username(project_path: Option<String>) -> Result<String, CommandError> {
@@ -455,6 +463,75 @@ pub fn ensure_git_identity(repo_path: &std::path::Path) -> Result<(), CommandErr
     Ok(())
 }
 
+/// The project's configured `origin` remote URL, if it has one. A missing
+/// remote (or a repo git can't read) is simply "none" — the caller only uses
+/// this to decide whether `gh repo create --remote origin` can safely run.
+fn existing_origin_url(repo_path: &Path) -> Option<String> {
+    let output = crate::utils::git_command_in(repo_path)
+        .ok()?
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!url.is_empty()).then_some(url)
+}
+
+/// True when an existing `origin` already points at the repository the user is
+/// asking to create — the signature of a half-finished earlier run (`gh repo
+/// create` succeeded, the push after it didn't). `repo_name` is either bare
+/// ("my-app") or owner-qualified ("acme/my-app"); a bare name can only be
+/// matched on the repo segment, since which account gh would create it under
+/// isn't known here.
+fn origin_matches_repo(origin_url: &str, repo_name: &str) -> bool {
+    let Some(existing) = parse_github_repo(origin_url) else {
+        return false;
+    };
+    let existing = existing.to_lowercase();
+    let target = repo_name.trim().to_lowercase();
+    if target.is_empty() {
+        return false;
+    }
+    if target.contains('/') {
+        return existing == target;
+    }
+    existing.rsplit('/').next() == Some(target.as_str())
+}
+
+/// Finish a run that already created the GitHub repo and wired up `origin`:
+/// push the branch and report the repo URL derived from the *actual* remote
+/// (never a guessed one). Failures classify through the shared git/gh
+/// classifiers so a connectivity blip here reads like it does everywhere else.
+async fn push_to_existing_origin(
+    repo_path: &Path,
+    origin_url: &str,
+) -> Result<String, CommandError> {
+    let output =
+        crate::commands::git::run_git_net(&["push", "-u", "origin", "HEAD"], repo_path, "push")
+            .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.contains("Everything up-to-date") {
+            if let Some(err) = crate::commands::git::classify_git_net_error(&stderr) {
+                return Err(err);
+            }
+            return Err(CommandError::Process {
+                cmd: "git push".to_string(),
+                exit_code: output.status.code().unwrap_or(-1),
+                stderr: truncate_output(&stderr),
+            });
+        }
+    }
+
+    let slug = parse_github_repo(origin_url).ok_or_else(|| CommandError::Other {
+        message: format!("Couldn't read the GitHub repository from the remote URL {origin_url}"),
+    })?;
+    Ok(format!("https://github.com/{slug}"))
+}
+
 #[tauri::command]
 #[tracing::instrument(skip(options), fields(project = %options.project_path, repo = %options.repo_name))]
 pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, CommandError> {
@@ -517,6 +594,25 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
         }
     }
 
+    // `gh repo create --remote origin` runs `git remote add origin` itself —
+    // *after* creating the repo on GitHub — so a project that already has an
+    // origin leaves a partial success: the repo exists, the project isn't
+    // linked, and the user sees gh's raw `Unable to add remote "origin"`
+    // (issue #779). Settle it before anything is created.
+    if let Some(origin_url) = existing_origin_url(&validated_path) {
+        if origin_matches_repo(&origin_url, repo_name) {
+            // The remote already points at the repo being created — a retry of
+            // an earlier run whose push failed after the create succeeded.
+            // Reuse it and finish the job instead of re-creating anything.
+            return push_to_existing_origin(&validated_path, &origin_url).await;
+        }
+        return Err(CommandError::expected(format!(
+            "This project is already connected to a different GitHub repository ({origin_url}). \
+             Publish to that repository, or remove the existing remote \
+             (`git remote remove origin`) before creating a new one."
+        )));
+    }
+
     // Create GitHub repo and push, scoped to the project's workspace so the repo
     // is created under that workspace's GitHub account, not the active one.
     let mut gh_cmd = get_gh_command_for_project(&validated_path);
@@ -527,7 +623,15 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
         ])
         .current_dir(&validated_path);
     // Longer timeout: create+push can take a while for bigger repos.
-    let output = run_command_with_timeout(gh_cmd, "gh repo create --push", 60).await?;
+    let output = match run_command_with_timeout(gh_cmd, "gh repo create --push", 60).await {
+        // A blown time budget on a big upload is the network, not a
+        // malfunction — the same mapping the gh api calls above use
+        // (issues #771/#686).
+        Err(CommandError::Timeout { .. }) => {
+            return Err(CommandError::expected(GH_PUSH_TIMEOUT_MESSAGE))
+        }
+        other => other?,
+    };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -538,6 +642,21 @@ pub async fn push_to_github(options: PushToGitHubOptions) -> Result<String, Comm
         if stderr.contains("Name already exists on this account") {
             return Err(CommandError::expected(format!(
                 "A repository named \"{repo_name}\" already exists on this account. Choose a different name."
+            )));
+        }
+        // The remote-add step still lost the race (a remote appeared between
+        // the pre-flight check and now). gh creates the repo on GitHub before
+        // wiring the remote up, so the repo exists and only the local link is
+        // missing — say that instead of forwarding gh's raw wording, and don't
+        // silently repoint a remote the user set up (issue #779).
+        let lower = stderr.to_lowercase();
+        if lower.contains("unable to add remote") || lower.contains("remote origin already exists")
+        {
+            return Err(CommandError::expected(format!(
+                "The repository \"{repo_name}\" was created on GitHub, but this project couldn't \
+                 be connected to it because it already has a remote named \"origin\". Point that \
+                 remote at the new repository (`git remote set-url origin <url>`) and push, or \
+                 remove it and try again."
             )));
         }
         // Connectivity blips and GitHub's transient API 400s are the
@@ -672,25 +791,31 @@ pub(crate) fn gh_malformed_request_error(stderr: &str) -> Option<CommandError> {
         })
 }
 
-/// GitHub's API answering with a transient server-side 5xx — gh passes the
+/// GitHub's API answering with a transient server-side status — gh passes the
 /// response text through ("HTTP 504: We couldn't respond to your request in
 /// time…", "HTTP 502: Bad Gateway", …). The request reached GitHub and
 /// GitHub fell over; nothing the app did wrong and nothing the user can do
 /// but retry — the sibling of the HTTP 400 case below (issues #627/#602).
 /// `Expected` keeps it out of telemetry.
+///
+/// HTTP 499 ("Client Closed Request") belongs here too despite not being a
+/// 5xx: it's the nginx-originated status GitHub's edge returns when the
+/// request is abandoned before a response is produced — an infrastructure
+/// blip on the same retry-and-it-works footing (issue #806).
 pub(crate) fn gh_server_error(stderr: &str) -> Option<CommandError> {
     let s = stderr.to_lowercase();
-    let is_5xx = s.contains("http 500")
+    let is_transient = s.contains("http 500")
         || s.contains("http 502")
         || s.contains("http 503")
         || s.contains("http 504")
+        || s.contains("http 499")
         || s.contains("bad gateway")
         || s.contains("service unavailable")
         || s.contains("gateway timeout")
         // The prose GitHub uses for its GraphQL 504s ("We couldn't respond to
         // your request in time. Sorry about that. Please try resubmitting…").
         || s.contains("respond to your request in time");
-    is_5xx.then(|| {
+    is_transient.then(|| {
         CommandError::expected(
             "GitHub's API is temporarily unavailable (a GitHub server error). \
              Try again in a moment.",
@@ -749,11 +874,32 @@ pub(crate) fn gh_crash_error(stderr: &str) -> Option<CommandError> {
     })
 }
 
+/// A Node.js crash dump from a program named `gh` that isn't GitHub's CLI.
+/// GitHub ships `gh` as a Go binary — it never emits `node:internal/...`
+/// frames — so this shape means PATH resolved something else: in the reported
+/// case the unrelated npm package literally named `gh`, installed globally
+/// under `%APPDATA%\npm` where `find_executable` can find it ahead of the real
+/// `gh.exe`. Handed real-gh arguments and the null stdin
+/// [`get_gh_command`] sets, its `inquirer` prompt tears down an already-closed
+/// readline, which Node ≥ 24 turns into a thrown `ERR_USE_AFTER_CLOSE`
+/// (issue #737). Nothing the app can retry: `Expected` keeps the dump out of
+/// telemetry and the message names the real fix.
+pub(crate) fn gh_shadowed_binary_error(stderr: &str) -> Option<CommandError> {
+    let is_node_crash = stderr.contains("node:internal/") || stderr.contains("ERR_USE_AFTER_CLOSE");
+    is_node_crash.then(|| {
+        CommandError::expected(
+            "The program named `gh` on this computer isn't GitHub's CLI — something else \
+             (most often an unrelated global npm package called \"gh\") is being found first. \
+             Remove it (`npm uninstall -g gh`) or reinstall the GitHub CLI, then try again.",
+        )
+    })
+}
+
 /// A `gh` invocation that hits GitHub can fail these ways regardless of which
 /// subcommand ran: a connectivity blip, GitHub's transient HTTP 400 or 5xx,
-/// an unreadable gh config file, or gh itself crashing. One-stop
-/// classification for the shared cases — call sites still layer their own
-/// auth / subcommand-specific checks on top.
+/// an unreadable gh config file, gh itself crashing, or `gh` not being
+/// GitHub's CLI at all. One-stop classification for the shared cases — call
+/// sites still layer their own auth / subcommand-specific checks on top.
 pub(crate) fn gh_common_error(stderr: &str) -> Option<CommandError> {
     // TLS first: a cert-verification failure needs its trust-store guidance,
     // not the generic "check your internet connection" message (issue #658).
@@ -762,6 +908,9 @@ pub(crate) fn gh_common_error(stderr: &str) -> Option<CommandError> {
         .or_else(|| gh_malformed_request_error(stderr))
         .or_else(|| gh_server_error(stderr))
         .or_else(|| gh_config_error(stderr))
+        // Before gh_crash_error: a wrong-binary crash needs its own remedy,
+        // not "reinstalling the GitHub CLI may help" (issue #737).
+        .or_else(|| gh_shadowed_binary_error(stderr))
         .or_else(|| gh_crash_error(stderr))
 }
 
@@ -953,6 +1102,17 @@ mod tests {
     fn gh_timeout_message_keeps_the_frontend_matched_wording() {
         assert!(GH_TIMEOUT_MESSAGE.contains("took too long"));
         assert!(GH_TIMEOUT_MESSAGE
+            .to_lowercase()
+            .contains("check your internet connection"));
+    }
+
+    /// The #771 mapping: a timed-out `gh repo create --push` must still read
+    /// as a network condition to errors.ts's BACKEND_HUMANIZED_GIT_PHRASES,
+    /// which matches on "check your internet connection".
+    #[test]
+    fn gh_push_timeout_message_keeps_the_frontend_matched_wording() {
+        assert!(GH_PUSH_TIMEOUT_MESSAGE.contains("took too long"));
+        assert!(GH_PUSH_TIMEOUT_MESSAGE
             .to_lowercase()
             .contains("check your internet connection"));
     }
@@ -1345,12 +1505,98 @@ mod tests {
         assert!(gh_server_error("HTTP 503: Service Unavailable").is_some());
     }
 
+    // The #806 shape: GitHub's edge answering 499 ("Client Closed Request")
+    // — not a 5xx, but the same abandoned-request blip that retrying fixes.
+    #[test]
+    fn gh_server_error_classifies_http_499_as_expected() {
+        let stderr = "HTTP 499: 499  (https://api.github.com/graphql)";
+        let err = gh_server_error(stderr).expect("should classify as expected");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        assert!(err.to_string().contains("Try again"), "got: {err}");
+        // And through the shared classifier every gh call site funnels into.
+        assert!(gh_common_error(stderr).is_some());
+    }
+
     #[test]
     fn gh_server_error_ignores_non_5xx_stderr() {
         assert!(gh_server_error("HTTP 404: Not Found (https://api.github.com/graphql)").is_none());
         assert!(gh_server_error("HTTP 400: We received a malformed request").is_none());
         assert!(gh_server_error("GraphQL: name already exists on this account").is_none());
         assert!(gh_server_error("").is_none());
+    }
+
+    // The #737 shape: an unrelated global npm package named `gh` resolving
+    // ahead of GitHub's CLI and dying with a Node crash dump. GitHub's gh is a
+    // Go binary, so Node frames mean the wrong program ran.
+    #[test]
+    fn gh_shadowed_binary_error_classifies_node_crash_as_expected() {
+        let stderr = "node:internal/readline/interface:564\n      throw new ERR_USE_AFTER_CLOSE('readline');\n      ^\n\nError [ERR_USE_AFTER_CLOSE]: readline was closed\n    at Interface.pause (node:internal/readline/interface:564:13)\n    at PromptUI.close (C:\\Users\\x\\AppData\\Roaming\\npm\\node_modules\\gh\\node_modules\\inquirer\\lib\\ui\\baseUI.js:57:13)\n\nNode.js v24.14.0";
+        let err = gh_shadowed_binary_error(stderr).expect("should classify as expected");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        let msg = err.to_string();
+        assert!(msg.contains("isn't GitHub's CLI"), "got: {msg}");
+        assert!(
+            msg.contains("npm uninstall -g gh"),
+            "must name the fix, got: {msg}"
+        );
+        assert!(!msg.contains("node:internal"), "must not forward the dump");
+        // Routed through the shared classifier, and ahead of gh_crash_error so
+        // it doesn't get the misleading "reinstall the GitHub CLI" advice.
+        let common = gh_common_error(stderr).expect("common classifier must cover it");
+        assert!(format!("{common}").contains("isn't GitHub's CLI"));
+    }
+
+    #[test]
+    fn gh_shadowed_binary_error_ignores_real_gh_output() {
+        // A genuine Go crash stays with gh_crash_error's wording.
+        assert!(gh_shadowed_binary_error(
+            "panic: runtime error: nil pointer\n\ngoroutine 1 [running]:"
+        )
+        .is_none());
+        assert!(gh_shadowed_binary_error("GraphQL: no commits between main and x").is_none());
+        assert!(gh_shadowed_binary_error("").is_none());
+    }
+
+    // The #779 pre-flight: an existing `origin` decides whether the create
+    // step can run at all. A remote pointing at the repo being created means a
+    // half-finished earlier run (create succeeded, push didn't) — reuse it.
+    #[test]
+    fn origin_matches_repo_recognizes_the_repo_being_created() {
+        assert!(origin_matches_repo(
+            "https://github.com/alice/my-app.git",
+            "my-app"
+        ));
+        assert!(origin_matches_repo(
+            "git@github.com:alice/my-app.git",
+            "alice/my-app"
+        ));
+        // Case differences in GitHub repo names are not meaningful.
+        assert!(origin_matches_repo(
+            "https://github.com/Alice/My-App",
+            "my-app"
+        ));
+    }
+
+    #[test]
+    fn origin_matches_repo_rejects_a_different_remote() {
+        // A remote for some other project — the case that must stop the
+        // create instead of leaving an orphan repo on GitHub.
+        assert!(!origin_matches_repo(
+            "https://github.com/alice/other-project.git",
+            "my-app"
+        ));
+        // Same repo name under a different owner, when the owner was given.
+        assert!(!origin_matches_repo(
+            "https://github.com/bob/my-app.git",
+            "alice/my-app"
+        ));
+        // Non-GitHub and unparseable remotes are never a match.
+        assert!(!origin_matches_repo(
+            "https://gitlab.com/alice/my-app.git",
+            "my-app"
+        ));
+        assert!(!origin_matches_repo("", "my-app"));
+        assert!(!origin_matches_repo("https://github.com/alice/my-app", ""));
     }
 
     // The #631 shape: gh dying at startup because its own config file is

--- a/src-tauri/src/commands/ide/screenshots/playwright.rs
+++ b/src-tauri/src/commands/ide/screenshots/playwright.rs
@@ -48,24 +48,116 @@ async fn run_capture_script(
         install
             .args(["playwright", "install", "chromium"])
             .current_dir(playwright_env);
-        let install_out = run_with_timeout(
+        let install_out = match run_with_timeout(
             tokio::process::Command::from(install),
             "playwright install chromium",
             BROWSER_INSTALL_TIMEOUT_SECS,
         )
-        .await?;
+        .await
+        {
+            Ok(out) => out,
+            // A ~130MB download not finishing inside the ceiling is a slow or
+            // interrupted connection, not an app malfunction — say so instead
+            // of surfacing the raw timeout (issue #718).
+            Err(CommandError::Timeout { .. }) => {
+                return Err(CommandError::expected(format!(
+                    "Downloading the screenshot browser (Chromium, about 130MB) didn't finish \
+                     within {BROWSER_INSTALL_TIMEOUT_SECS} seconds. This is usually a slow or \
+                     interrupted connection — check your network (including any VPN or proxy), \
+                     then try again."
+                )));
+            }
+            Err(e) => return Err(e),
+        };
         if !install_out.status.success() {
-            let install_stderr = String::from_utf8_lossy(&install_out.stderr);
-            return Err((format!(
-                "Playwright's Chromium browser is missing and reinstalling it failed: {install_stderr}"
-            ))
-            .into());
+            return Err(browser_install_error(&install_out));
         }
         return run().await;
     }
 
     // Other failures pass through — callers report status + stderr in detail.
     Ok(output)
+}
+
+/// How a failed process exited, in words. A capture that wrote nothing at all
+/// must still be able to say *whether* it crashed, was killed, or exited
+/// cleanly (issues #829/#796).
+fn exit_status_detail(output: &std::process::Output) -> String {
+    if let Some(code) = output.status.code() {
+        return format!("exit code {code}");
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = output.status.signal() {
+            return format!("killed by signal {signal}");
+        }
+    }
+    "killed by signal".to_string()
+}
+
+/// Map a failed `playwright install chromium` run to a `CommandError`. The
+/// reinstall downloads ~130MB from Playwright's CDN and unpacks it into the
+/// user's browser cache, so its failures are overwhelmingly environmental —
+/// network, disk, permissions — and those classify Expected. Anything else
+/// stays reportable, but must still say something: this process can exit
+/// non-zero having written no stderr at all, which previously produced a
+/// message that trailed off after the colon (issue #796).
+fn browser_install_error(output: &std::process::Output) -> CommandError {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let combined = format!("{}\n{}", stderr.trim(), stdout.trim());
+
+    const NETWORK_SIGNATURES: &[&str] = &[
+        "ECONNRESET",
+        "ECONNREFUSED",
+        "ETIMEDOUT",
+        "ENOTFOUND",
+        "EAI_AGAIN",
+        "socket hang up",
+        "getaddrinfo",
+        "unable to verify the first certificate",
+        "self-signed certificate",
+    ];
+    if NETWORK_SIGNATURES.iter().any(|s| combined.contains(s)) {
+        return CommandError::expected(
+            "The screenshot browser couldn't be downloaded — Ship Studio couldn't reach \
+             Playwright's download server. Check your internet connection (including any VPN, \
+             proxy, or firewall), then try again.",
+        );
+    }
+    if combined.contains("ENOSPC")
+        || combined.contains("No space left on device")
+        || combined.contains("not enough space on the disk")
+    {
+        return CommandError::expected(
+            "The screenshot browser couldn't be downloaded — this computer is out of disk \
+             space. Free up some space, then try again.",
+        );
+    }
+    if combined.contains("EACCES") || combined.contains("EPERM") {
+        return CommandError::expected(
+            "The screenshot browser couldn't be downloaded — Ship Studio wasn't allowed to \
+             write to Playwright's browser cache. Check the permissions on that folder \
+             (~/Library/Caches/ms-playwright on macOS, %LOCALAPPDATA%\\ms-playwright on \
+             Windows), then try again.",
+        );
+    }
+
+    let status = exit_status_detail(output);
+    let detail = combined.trim();
+    let detail = if detail.is_empty() {
+        String::new()
+    } else {
+        let snippet: String = detail.chars().take(300).collect();
+        format!(" Output: {snippet}")
+    };
+    (format!(
+        "Playwright's Chromium browser is missing and reinstalling it failed ({status}). Try \
+         again — if it keeps failing, running `npx playwright install chromium` in a terminal \
+         shows the full output.{detail}"
+    ))
+    .into()
 }
 
 /// True when stderr shows the process (Node itself, or a child) failing at
@@ -138,6 +230,39 @@ fn capture_script_error(what: &str, url: &str, output: &std::process::Output) ->
              closing other applications or restarting your machine usually clears it.",
         );
     }
+    // A URL that serves a file download instead of a document (a PDF export,
+    // an invoice API route) aborts the navigation with "Download is starting"
+    // every single time — a fact about that page, not a transient race, so
+    // there is nothing to retry (issue #801).
+    if stderr.contains("Download is starting") {
+        return CommandError::expected(format!(
+            "{url} starts a file download instead of rendering a page, so there's nothing to \
+             screenshot. Point the preview at a page URL and try again."
+        ));
+    }
+    // Chromium aborting the navigation (net::ERR_ABORTED) means something
+    // superseded it mid-flight — a dev-server hot reload or a client-side
+    // redirect landing while page.goto was still waiting for `load`. The
+    // script already retries it once; one that persists is the same
+    // dev-server race as #514/#703, not an app bug (issue #782).
+    if stderr.contains("ERR_ABORTED") {
+        return CommandError::expected(format!(
+            "Loading {url} was interrupted before the page finished — the preview was probably \
+             reloading (hot reload or a redirect) as the screenshot started. Wait for it to \
+             settle, then try again."
+        ));
+    }
+    // The page going away mid-session ("Target page, context or browser has
+    // been closed") means the renderer died after the navigation had already
+    // succeeded — the same environment-level browser failure as the startup
+    // crash above (#558), caught later in the run (issue #815).
+    if stderr.contains("Target page, context or browser has been closed") {
+        return CommandError::expected(
+            "The screenshot browser closed unexpectedly while capturing the page. This is \
+             usually a one-off (memory pressure, or security software stopping the headless \
+             browser) — try again in a moment.",
+        );
+    }
     // Both goto attempts exhausting their navigation timeout is a recurring,
     // environmental condition on slow dev servers (Windows first-compile +
     // antivirus overhead — issues #385/#606), not a malfunction: the route
@@ -150,7 +275,29 @@ fn capture_script_error(what: &str, url: &str, output: &std::process::Output) ->
         ));
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
-    (format!("{what} failed. stdout: {stdout} stderr: {stderr}")).into()
+    let status = exit_status_detail(output);
+    // A capture that produced neither stdout nor stderr told us nothing about
+    // why it died. The exit status is then the only signal there is, so name
+    // it and say what a silent death usually means (issue #829).
+    if stdout.trim().is_empty() && stderr.trim().is_empty() {
+        if output.status.success() {
+            // The script ran to completion but no screenshot file is there —
+            // a different shape entirely from a killed process, so don't
+            // describe it as a crash.
+            return (format!(
+                "{what} finished without writing a screenshot and without reporting why. \
+                 Try again in a moment."
+            ))
+            .into();
+        }
+        return (format!(
+            "{what} failed with no output at all ({status}) — the capture process died before \
+             it could report anything, which usually means it was killed (security software, \
+             or the machine running out of memory). Try again in a moment."
+        ))
+        .into();
+    }
+    (format!("{what} failed ({status}). stdout: {stdout} stderr: {stderr}")).into()
 }
 
 /// Parse the major version out of `node --version` output ("v16.17.0" -> 16).
@@ -228,7 +375,7 @@ fn installed_playwright_version(playwright_dir: &std::path::Path) -> Option<(u32
 
 /// Get or create a shared Playwright environment directory.
 /// Installs Playwright and Chromium once, reused for all screenshots.
-pub(super) fn get_playwright_env() -> Result<std::path::PathBuf, String> {
+pub(super) fn get_playwright_env() -> Result<std::path::PathBuf, CommandError> {
     let home = dirs::home_dir().ok_or("Could not determine home directory")?;
     let playwright_dir = home.join(".ship-studio").join("playwright-env");
 
@@ -246,7 +393,9 @@ pub(super) fn get_playwright_env() -> Result<std::path::PathBuf, String> {
                     .args(["install", PLAYWRIGHT_INSTALL_SPEC])
                     .current_dir(&playwright_dir)
                     .output()
-                    .map_err(|e| format!("Failed to upgrade playwright: {e}"))?;
+                    .map_err(|e| {
+                        CommandError::from(format!("Failed to upgrade playwright: {e}"))
+                    })?;
                 if !upgrade.status.success() {
                     let stderr = String::from_utf8_lossy(&upgrade.stderr);
                     tracing::warn!(
@@ -263,16 +412,28 @@ pub(super) fn get_playwright_env() -> Result<std::path::PathBuf, String> {
         return Ok(playwright_dir);
     }
 
+    // Nothing below can work without npm. `node_tool_command` falls back to
+    // the bare name when it can't resolve the binary, and spawning that on a
+    // machine with no Node.js installed dies with Rust's raw "program not
+    // found" — an unhelpful, unclassified error for what is simply a missing
+    // prerequisite (issue #738, same treatment as git in #297).
+    if crate::utils::find_executable("npm").is_none() {
+        return Err(CommandError::expected(
+            "Screenshots need Node.js (which provides npm), and it isn't installed or couldn't \
+             be found. Install Node.js from https://nodejs.org, then try again.",
+        ));
+    }
+
     tracing::info!("Setting up Playwright environment at {:?}", playwright_dir);
 
     // Create the directory
     std::fs::create_dir_all(&playwright_dir)
-        .map_err(|e| format!("Failed to create playwright env dir: {e}"))?;
+        .map_err(|e| CommandError::from(format!("Failed to create playwright env dir: {e}")))?;
 
     // Write package.json
     let package_json = r#"{"name": "ship-studio-playwright", "private": true}"#;
     std::fs::write(playwright_dir.join("package.json"), package_json)
-        .map_err(|e| format!("Failed to write package.json: {e}"))?;
+        .map_err(|e| CommandError::from(format!("Failed to write package.json: {e}")))?;
 
     // Install playwright
     tracing::info!("Installing Playwright (this may take a moment on first run)...");
@@ -280,11 +441,11 @@ pub(super) fn get_playwright_env() -> Result<std::path::PathBuf, String> {
         .args(["install", PLAYWRIGHT_INSTALL_SPEC])
         .current_dir(&playwright_dir)
         .output()
-        .map_err(|e| format!("Failed to run npm install playwright: {e}"))?;
+        .map_err(|e| CommandError::from(format!("Failed to run npm install playwright: {e}")))?;
 
     if !install_output.status.success() {
         let stderr = String::from_utf8_lossy(&install_output.stderr);
-        return Err(format!("Failed to install playwright: {stderr}"));
+        return Err(format!("Failed to install playwright: {stderr}").into());
     }
 
     // Install Chromium browser
@@ -293,7 +454,7 @@ pub(super) fn get_playwright_env() -> Result<std::path::PathBuf, String> {
         .args(["playwright", "install", "chromium"])
         .current_dir(&playwright_dir)
         .output()
-        .map_err(|e| format!("Failed to install chromium: {e}"))?;
+        .map_err(|e| CommandError::from(format!("Failed to install chromium: {e}")))?;
 
     if !browser_output.status.success() {
         let stderr = String::from_utf8_lossy(&browser_output.stderr);
@@ -397,8 +558,11 @@ const {{ chromium }} = require('playwright');
             // give it a short beat before the one retry. A malformed/empty
             // HTTP response is the same race caught one step later: the
             // server accepted the socket but died mid-answer while
-            // restarting (issue #703) — same beat, same retry.
-            if (msg.includes('ERR_CONNECTION_REFUSED') || msg.includes('ERR_INVALID_HTTP_RESPONSE')) {{
+            // restarting (issue #703) — same beat, same retry. An aborted
+            // navigation (ERR_ABORTED) is the same family once more: a hot
+            // reload or client-side redirect superseded this goto before
+            // `load` fired (issue #782).
+            if (msg.includes('ERR_CONNECTION_REFUSED') || msg.includes('ERR_INVALID_HTTP_RESPONSE') || msg.includes('ERR_ABORTED')) {{
                 await new Promise((resolve) => setTimeout(resolve, 2000));
             }} else if (!msg.includes('Timeout')) {{
                 throw err;
@@ -616,8 +780,11 @@ const {{ chromium }} = require('playwright');
             // give it a short beat before the one retry. A malformed/empty
             // HTTP response is the same race caught one step later: the
             // server accepted the socket but died mid-answer while
-            // restarting (issue #703) — same beat, same retry.
-            if (msg.includes('ERR_CONNECTION_REFUSED') || msg.includes('ERR_INVALID_HTTP_RESPONSE')) {{
+            // restarting (issue #703) — same beat, same retry. An aborted
+            // navigation (ERR_ABORTED) is the same family once more: a hot
+            // reload or client-side redirect superseded this goto before
+            // `load` fired (issue #782).
+            if (msg.includes('ERR_CONNECTION_REFUSED') || msg.includes('ERR_INVALID_HTTP_RESPONSE') || msg.includes('ERR_ABORTED')) {{
                 await new Promise((resolve) => setTimeout(resolve, 2000));
             }} else if (!msg.includes('Timeout')) {{
                 throw err;
@@ -876,6 +1043,121 @@ mod capture_error_tests {
             CommandError::Expected { message } => {
                 assert!(message.contains("didn't finish loading"), "got: {message}");
                 assert!(message.contains("http://localhost:59973"), "got: {message}");
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn download_url_is_expected_with_no_retry_advice() {
+        // Issue #801: a PDF/export route always aborts navigation this way —
+        // deterministic, so the message must not promise a retry will help.
+        let output = failed_output(
+            "page.goto: Download is starting\nCall log:\n  - navigating to \"http://localhost:58648/api/facturen/1/pdf\", waiting until \"load\"",
+        );
+        match capture_script_error(
+            "Playwright viewport screenshot",
+            "http://localhost:58648/api/facturen/1/pdf",
+            &output,
+        ) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("file download"), "got: {message}");
+                assert!(message.contains("/api/facturen/1/pdf"), "got: {message}");
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn aborted_navigation_is_expected_reload_race() {
+        // Issue #782: a hot reload or redirect superseding the goto.
+        let output = failed_output(
+            "page.goto: net::ERR_ABORTED at http://localhost:51379/opa\nCall log:\n  - navigating to \"http://localhost:51379/opa\", waiting until \"load\"",
+        );
+        match capture_script_error(
+            "Playwright viewport screenshot",
+            "http://localhost:51379/opa",
+            &output,
+        ) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("was interrupted"), "got: {message}");
+                assert!(
+                    message.contains("http://localhost:51379/opa"),
+                    "got: {message}"
+                );
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn closed_target_mid_capture_is_expected_not_telemetry() {
+        // Issue #815: the renderer dying after a successful navigation.
+        let output =
+            failed_output("page.screenshot: Target page, context or browser has been closed");
+        match capture_script_error("Playwright screenshot", "http://localhost:3000", &output) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("closed unexpectedly"), "got: {message}")
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn silent_failure_still_names_the_exit_status() {
+        // Issue #829: no stdout, no stderr — the exit status is the only
+        // signal there is, so the message must carry it.
+        let output = failed_output("");
+        let err = capture_script_error(
+            "Playwright viewport screenshot",
+            "http://localhost:3000",
+            &output,
+        );
+        assert!(!matches!(err, CommandError::Expected { .. }));
+        let message = format!("{err}");
+        assert!(message.contains("no output at all"), "got: {message}");
+        assert!(
+            message.contains("exit code") || message.contains("killed by signal"),
+            "got: {message}"
+        );
+    }
+
+    #[test]
+    fn empty_stderr_install_failure_still_says_something_actionable() {
+        // Issue #796: the reinstall exiting non-zero with no output at all
+        // used to produce a message that trailed off after the colon.
+        let err = browser_install_error(&failed_output(""));
+        assert!(!matches!(err, CommandError::Expected { .. }));
+        let message = format!("{err}");
+        assert!(
+            message.contains("exit code") || message.contains("killed by signal"),
+            "got: {message}"
+        );
+        assert!(
+            message.contains("npx playwright install chromium"),
+            "got: {message}"
+        );
+    }
+
+    #[test]
+    fn network_install_failure_is_expected_with_connection_guidance() {
+        let err = browser_install_error(&failed_output(
+            "Error: getaddrinfo ENOTFOUND cdn.playwright.dev",
+        ));
+        match err {
+            CommandError::Expected { message } => {
+                assert!(message.contains("internet connection"), "got: {message}")
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disk_full_install_failure_is_expected_with_disk_guidance() {
+        let err = browser_install_error(&failed_output("Error: ENOSPC: no space left on device"));
+        match err {
+            CommandError::Expected { message } => {
+                assert!(message.contains("out of disk"), "got: {message}")
             }
             other => panic!("expected Expected, got {other:?}"),
         }

--- a/src-tauri/src/commands/ide/screenshots/thumbnail.rs
+++ b/src-tauri/src/commands/ide/screenshots/thumbnail.rs
@@ -88,8 +88,11 @@ fn sweep_stale_thumbnail_profiles(shipstudio_dir: &Path) {
 /// True for Chromium stderr lines that are subsystem chatter, never a failure
 /// cause: crashpad's IPC teardown races (issue #422), GoogleUpdater process
 /// lifecycle, GCM push-registration retries, TensorFlow Lite delegate init,
-/// and the allocator double-load warning (issues #498–#500). A headless
-/// capture emits these freely; keeping them buries the actionable line.
+/// and the allocator double-load warning (issues #498–#500), Windows' PDH
+/// CPU-telemetry counter registration failing inside Hyper-V-backed VMs
+/// (issue #807), and macOS CoreVideo's display-link probe finding no display
+/// in a headless process (issue #817). A headless capture emits these freely;
+/// keeping them buries the actionable line.
 fn is_chromium_noise(line: &str) -> bool {
     const NOISE_MARKERS: &[&str] = &[
         "crashpad",
@@ -101,6 +104,10 @@ fn is_chromium_noise(line: &str) -> bool {
         "TensorFlow Lite",
         "XNNPACK delegate",
         "Trying to load the allocator multiple times",
+        "cpu_probe_win",
+        "PdhAddEnglishCounter",
+        "cv_display_link_mac",
+        "CVDisplayLinkCreateWithCGDisplay",
     ];
     NOISE_MARKERS.iter().any(|m| line.contains(m))
 }
@@ -136,6 +143,64 @@ fn browser_failure_detail(stderr: &str) -> Option<String> {
 /// not an app malfunction (issue #644).
 fn is_profile_singleton_error(stderr: &str) -> bool {
     stderr.contains("ProcessSingleton") || stderr.contains("SingletonLock")
+}
+
+/// Chromium stderr signatures naming a machine-level resource exhaustion
+/// rather than anything about the page: Windows' commit limit running out
+/// while the loader maps chrome.dll (ERROR_COMMITMENT_LIMIT / 0x5AF —
+/// issue #812), and the throwaway GPU cache failing to write because the
+/// volume is full (ERROR_DISK_FULL / 0x70 on Windows, ENOSPC elsewhere —
+/// issue #784). Both are user-fixable environment states, not app
+/// malfunctions, and the retry ladder can't help either — so name them
+/// instead of surfacing the raw C++ log dump.
+fn browser_resource_exhaustion_error(stderr: &str) -> Option<CommandError> {
+    if stderr.contains("paging file is too small") || stderr.contains("(0x5AF)") {
+        return Some(CommandError::expected(
+            "The capture browser couldn't start because this computer is low on memory (its \
+             paging file is too small or full). Close some other apps, or increase the paging \
+             file size (Settings → System → About → Advanced system settings → Performance → \
+             Virtual memory) — the thumbnail will be retried automatically.",
+        ));
+    }
+    if stderr.contains("not enough space on the disk")
+        || stderr.contains("(0x70)")
+        || stderr.contains("No space left on device")
+        || stderr.contains("ENOSPC")
+    {
+        return Some(CommandError::expected(
+            "The capture browser couldn't write its temporary cache — this computer's disk is \
+             full or nearly full. Free up some disk space and the thumbnail will be retried \
+             automatically.",
+        ));
+    }
+    None
+}
+
+/// Name the exit codes a capture browser reports when it dies with no output
+/// at all: Crashpad's `kCrashExitCodeNoDump` (0xFFFF7001 — the crash server
+/// never answered, so the process self-terminated after its internal wait,
+/// issue #821) and Windows NTSTATUS fatal-exception codes such as
+/// STATUS_ACCESS_VIOLATION (0xC0000005 — issue #705). Either way the browser
+/// process itself crashed: an environment-level failure (damaged browser
+/// install, graphics driver, security software), not an app malfunction.
+fn browser_crash_exit_message(code: i32) -> Option<String> {
+    /// Crashpad's `kCrashExitCodeNoDump`.
+    const CRASHPAD_NO_DUMP: i32 = -36863;
+    if code == CRASHPAD_NO_DUMP {
+        return Some(
+            "The capture browser crashed and self-terminated without a diagnostic dump."
+                .to_string(),
+        );
+    }
+    // NTSTATUS values with the error severity bits set (0xC0000000–0xCFFFFFFF)
+    // are the crash codes Windows reports for a fatally faulting process.
+    let unsigned = code as u32;
+    if (0xC000_0000..=0xCFFF_FFFF).contains(&unsigned) {
+        return Some(format!(
+            "The capture browser crashed (Windows fatal exception 0x{unsigned:08X})."
+        ));
+    }
+    None
 }
 
 /// Map an `image` crate failure decoding user-uploaded thumbnail bytes to an
@@ -378,6 +443,12 @@ pub async fn capture_project_thumbnail(
                      cleaned up automatically — the next capture attempt should succeed.",
                 ));
             }
+            // The machine running out of memory or disk mid-capture is an
+            // environment condition with a user-side fix — name it instead of
+            // dumping Chromium's raw loader/cache log line (issues #812/#784).
+            if let Some(err) = browser_resource_exhaustion_error(&stderr) {
+                return Err(err);
+            }
             // Headless Chromium can die with EMPTY stderr (crash, killed by
             // AV/security software) — fall back to the exit code plus a
             // stdout snippet so the report says something (issue #291).
@@ -424,6 +495,19 @@ pub async fn capture_project_thumbnail(
                             temp_path.display()
                         )));
                     } else if stdout.is_empty() {
+                        // A hard crash exits with a nameable code and writes
+                        // nothing at all. Say what happened instead of the
+                        // bare number, and treat it as the environment-level
+                        // failure it is (issues #705/#821).
+                        if let Some(crash) =
+                            output.status.code().and_then(browser_crash_exit_message)
+                        {
+                            return Err(CommandError::expected(format!(
+                                "{crash} This is usually a graphics driver, security software, \
+                                 or a damaged browser install interfering with headless capture \
+                                 — the thumbnail will be retried automatically."
+                            )));
+                        }
                         format!("exit code {code}, no output")
                     } else {
                         let snippet: String = stdout.chars().take(300).collect();
@@ -524,9 +608,16 @@ pub async fn upload_project_thumbnail(
     let resized = img.resize(640, 400, image::imageops::FilterType::Lanczos3);
 
     let thumbnail_path = shipstudio_dir.join("thumbnail.png");
-    resized
-        .save(&thumbnail_path)
-        .map_err(|e| format!("Failed to save thumbnail: {e}"))?;
+    // `save` wraps the underlying io::Error, so unwrap it and route through
+    // classify_fs_error like every other fs step here — macOS TCC denials
+    // (EPERM) and Windows access-denied are environment states with a
+    // user-side fix, not app malfunctions (issue #768).
+    resized.save(&thumbnail_path).map_err(|e| match e {
+        image::ImageError::IoError(io) => {
+            crate::utils::classify_fs_error("save this project's thumbnail", &thumbnail_path, &io)
+        }
+        other => format!("Failed to save thumbnail: {other}").into(),
+    })?;
 
     // Mark the metadata so capture_project_thumbnail no-ops next time.
     // Reads-then-writes the whole file rather than calling the
@@ -621,6 +712,97 @@ mod singleton_classification_tests {
         assert!(!is_profile_singleton_error(
             "ERROR:gpu_init.cc(523)] Passthrough is not supported"
         ));
+    }
+}
+
+#[cfg(test)]
+mod browser_environment_tests {
+    use super::*;
+
+    #[test]
+    fn pagefile_exhaustion_is_expected_with_memory_guidance() {
+        // Condensed from the real report behind issue #812.
+        let stderr = "[0825/123326.200:ERROR:chrome\\app\\main_dll_loader_win.cc:208] Failed to \
+            load Chrome DLL from C:\\Program Files\\Google\\Chrome\\Application\\151.0.7922.174\\chrome.dll: \
+            The paging file is too small for this operation to complete. (0x5AF)";
+        match browser_resource_exhaustion_error(stderr).expect("must classify") {
+            CommandError::Expected { message } => {
+                assert!(message.contains("low on memory"), "got: {message}");
+                assert!(message.contains("paging file"), "got: {message}");
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disk_full_gpu_cache_failure_is_expected_with_disk_guidance() {
+        // Condensed from the real report behind issue #784.
+        let stderr = "[29376:25724:0820/180957.319:ERROR:components\\viz\\host\\persistent_cache_sandboxed_file_factory.cc:83] \
+            Failed to create cache directory: C:\\Users\\x\\ShipStudio\\p\\.shipstudio\\thumbnail_profile_1\\GPUPersistentCache: \
+            There is not enough space on the disk. (0x70)";
+        match browser_resource_exhaustion_error(stderr).expect("must classify") {
+            CommandError::Expected { message } => {
+                assert!(message.contains("disk is full"), "got: {message}");
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn posix_enospc_is_also_classified_disk_full() {
+        assert!(browser_resource_exhaustion_error(
+            "ERROR:disk_cache.cc(91)] write failed: No space left on device"
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn unrelated_stderr_is_not_resource_exhaustion() {
+        assert!(browser_resource_exhaustion_error("").is_none());
+        assert!(browser_resource_exhaustion_error(
+            "ERROR:gpu_init.cc(523)] Passthrough is not supported"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn benign_pdh_and_display_link_lines_are_filtered_as_noise() {
+        // Issues #807 / #817: unrelated Chromium subsystems logging to stderr
+        // must never become the reported failure cause.
+        let stderr = "[4044:40428:0824/184726.367:ERROR:components\\system_cpu\\cpu_probe_win.cc:112] \
+            PdhAddEnglishCounter failed for '\\Hyper-V Hypervisor Logical Processor(_Total)\\% Total Run Time': \
+            Error (0x13D) while retrieving error. (0xC0000BC8)\n\
+            [1:2:0824/184726.368:ERROR:media/base/mac/cv_display_link_mac.cc:64] CVDisplayLinkCreateWithCGDisplay failed";
+        assert_eq!(browser_failure_detail(stderr), None);
+    }
+
+    #[test]
+    fn crashpad_no_dump_exit_code_is_named() {
+        // Issue #821: 0xFFFF7001 is Crashpad's kCrashExitCodeNoDump.
+        let message = browser_crash_exit_message(-36863).expect("must be named");
+        assert!(message.contains("crashed"), "got: {message}");
+        assert!(
+            message.contains("without a diagnostic dump"),
+            "got: {message}"
+        );
+    }
+
+    #[test]
+    fn windows_ntstatus_crash_codes_are_named() {
+        // Issue #705: the reported -1073741205 plus the canonical
+        // STATUS_ACCESS_VIOLATION both live in the NTSTATUS error range.
+        for code in [-1073741205, 0xC000_0005u32 as i32] {
+            let message = browser_crash_exit_message(code)
+                .unwrap_or_else(|| panic!("{code} must be named as a crash"));
+            assert!(message.contains("crashed"), "got: {message}");
+        }
+    }
+
+    #[test]
+    fn ordinary_exit_codes_are_not_treated_as_crashes() {
+        assert_eq!(browser_crash_exit_message(1), None);
+        assert_eq!(browser_crash_exit_message(21), None);
+        assert_eq!(browser_crash_exit_message(-1), None);
     }
 }
 

--- a/src-tauri/src/commands/ide/screenshots/webview_snapshot.rs
+++ b/src-tauri/src/commands/ide/screenshots/webview_snapshot.rs
@@ -126,6 +126,27 @@ fn snapshot_timeout_error() -> CommandError {
     ))
 }
 
+/// Map a failed snapshot's message to a `CommandError`. WebKit can reject
+/// `takeSnapshotWithConfiguration` with nothing but Cocoa's generic fallback
+/// text ("An unknown error occurred") — the backing layer being momentarily
+/// unavailable (window occluded or minimized, display asleep, a compositor
+/// hiccup) leaves no further detail to act on. Classified Expected for the
+/// same reason as the timeout above: there's nothing here an engineer can
+/// fix, and the frontend falls back to the headless capture path on any
+/// failure, so a thumbnail is still produced (issue #778). Our own internal
+/// failure strings stay reportable — those *are* app-level defects.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn snapshot_failure_error(message: &str) -> CommandError {
+    if message.to_lowercase().contains("unknown error") {
+        return CommandError::expected(
+            "The app's preview couldn't produce a snapshot just now (the system reported no \
+             reason — the window may have been hidden or the display asleep). The thumbnail \
+             will be captured with the standard fallback path instead.",
+        );
+    }
+    CommandError::from(format!("Webview snapshot failed: {message}"))
+}
+
 /// Max per-channel spread within a row/column for it to count as a uniform
 /// sliver (tolerates anti-aliased boundary pixels; real content spreads far
 /// wider — the observed background sliver measured spread ≤ 12).
@@ -276,9 +297,7 @@ async fn snapshot_webview_region(
     .await
     {
         Ok(Some(Ok(bytes))) => Ok(bytes),
-        Ok(Some(Err(message))) => Err(CommandError::from(format!(
-            "Webview snapshot failed: {message}"
-        ))),
+        Ok(Some(Err(message))) => Err(snapshot_failure_error(&message)),
         Ok(None) => Err(CommandError::from(
             "Webview snapshot callback dropped without a result".to_string(),
         )),
@@ -434,6 +453,37 @@ mod timeout_error_tests {
                 assert!(message.contains("10s"), "got: {message}");
             }
             other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opaque_webkit_error_is_expected_not_telemetry() {
+        // Issue #778: WebKit's generic NSError localizedDescription carries no
+        // actionable detail, and the frontend falls back to headless capture.
+        match snapshot_failure_error("An unknown error occurred") {
+            CommandError::Expected { message } => {
+                assert!(
+                    message.contains("couldn't produce a snapshot"),
+                    "got: {message}"
+                )
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn our_own_internal_failures_stay_reportable() {
+        // These strings come from this file, not from WebKit — a real defect.
+        for message in [
+            "webview handle is null",
+            "PNG encoding of the snapshot failed",
+        ] {
+            let err = snapshot_failure_error(message);
+            assert!(
+                !matches!(err, CommandError::Expected { .. }),
+                "{message} must stay reportable"
+            );
+            assert!(format!("{err}").contains(message));
         }
     }
 }

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -551,14 +551,15 @@ fn classify_mcp_failure(action: &str, details: &str) -> CommandError {
         ));
     }
 
-    // Recent Claude Code CLI versions mis-parse `mcp add -e KEY=value …` and
-    // echo a stray token back as an invalid environment variable — an
-    // upstream regression (anthropics/claude-code#23365) Ship Studio can't
-    // fix from here, so give the workaround instead of filing it as our bug
-    // (issue #763).
+    // The CLI rejected an `-e` environment variable. Usually a typo in the
+    // user's own entry (a missing `=`, a stray quote), but recent Claude Code
+    // versions also mis-parse valid `-e KEY=value` pairs and echo a stray
+    // token back (anthropics/claude-code#23365). Either way the app can't fix
+    // it from here, so state the format requirement first and offer the known
+    // CLI bug as a possibility rather than asserting it (issue #763).
     if lower.contains("invalid environment variable format") {
         return CommandError::expected(format!(
-            "{message}\n\nThis is a known bug in recent Claude Code CLI versions — its `mcp add` parser mishandles `-e` environment variables (anthropics/claude-code#23365). Add the server without its `-e` flags for now (set those variables in the server's own config instead), or update Claude Code once the fix ships."
+            "{message}\n\nEnvironment variables must be entered as `KEY=value`, one per line, with no surrounding quotes — check the entries for a missing `=` or a stray character. If they already look right, recent Claude Code CLI versions have a known `mcp add` parsing bug (anthropics/claude-code#23365): add the server without its `-e` variables for now (set them in the server's own config instead), or update Claude Code."
         ));
     }
 
@@ -1057,14 +1058,23 @@ mod tests {
 
     #[test]
     fn invalid_env_var_format_is_expected() {
-        // Upstream Claude Code CLI regression (issue #763,
-        // anthropics/claude-code#23365) — nothing Ship Studio can fix.
+        // Nothing Ship Studio can fix, either way — but the same refusal fires
+        // for a genuine typo in the user's own entry, so the message must lead
+        // with the format requirement and offer the known upstream CLI bug
+        // (issue #763, anthropics/claude-code#23365) as a possibility rather
+        // than asserting it.
         match classify_mcp_failure(
             "add MCP server",
             "Invalid environment variable format: \\, environment variables should be added as: -e KEY1=value1 -e KEY2=value2",
         ) {
             CommandError::Expected { message } => {
+                assert!(message.contains("KEY=value"), "got: {message}");
                 assert!(message.contains("anthropics/claude-code#23365"));
+                // Not asserted as the cause.
+                assert!(
+                    !message.contains("This is a known bug"),
+                    "must not blame the CLI outright, got: {message}"
+                );
             }
             other => panic!("expected Expected, got {other:?}"),
         }

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -238,7 +238,9 @@ pub async fn list_mcp_servers(
         {
             return Ok(Vec::new());
         }
-        return Err((format!("{} mcp list failed: {}", agent.display_name, stderr)).into());
+        // The same config-parse / gateway / policy conditions that break add
+        // and remove break listing too (issue #755).
+        return Err(classify_mcp_failure("list MCP servers", &stderr));
     }
 
     let mut servers = parse_mcp_list_output(&stdout);
@@ -499,17 +501,23 @@ pub async fn add_mcp_server(
         } else {
             stderr
         };
-        return Err(classify_mcp_add_failure(&details));
+        return Err(classify_mcp_failure("add MCP server", &details));
     }
 
     Ok(())
 }
 
-/// Turn a failed `<agent> mcp add` invocation's output into a `CommandError`,
-/// classifying the shapes that reflect machine state or org policy — not a
-/// Ship Studio bug — as `Expected` so they stay out of telemetry.
-fn classify_mcp_add_failure(details: &str) -> CommandError {
-    let message = format!("Failed to add MCP server: {details}");
+/// Turn a failed `<agent> mcp …` invocation's output into a `CommandError`,
+/// classifying the shapes that reflect machine state, org policy or the
+/// user's own agent config — not a Ship Studio bug — as `Expected` so they
+/// stay out of telemetry.
+///
+/// Shared by the add, remove and list paths: the add path has classified
+/// these since #675/#677 while remove and list forwarded the very same CLI
+/// failures raw (issues #746, #755, #800). `action` completes "Failed to …"
+/// ("add MCP server", "remove MCP server", "list MCP servers").
+fn classify_mcp_failure(action: &str, details: &str) -> CommandError {
+    let message = format!("Failed to {action}: {details}");
     let lower = details.to_ascii_lowercase();
 
     // "Already exists" is a benign race with a concurrent registration —
@@ -526,6 +534,46 @@ fn classify_mcp_add_failure(details: &str) -> CommandError {
     if lower.contains("enterprise policy") || lower.contains("enterprise mcp configuration") {
         return CommandError::expected(format!(
             "{message}\n\nYour organization's managed agent settings block this MCP server. Ask your admin to allowlist it, then try again."
+        ));
+    }
+
+    // Enterprise Claude Code installs route through an org-managed "Cloud
+    // gateway"; when it's unreachable or the session with it has expired the
+    // CLI refuses to run at all ("Couldn't load settings from Cloud gateway
+    // <host>. Check your network connection, or run `claude auth login` to
+    // re-authenticate."). An org network/session condition on the user's
+    // machine, not an app bug (issues #799, #800).
+    if lower.contains("cloud gateway")
+        || (lower.contains("couldn't load settings") && lower.contains("auth login"))
+    {
+        return CommandError::expected(format!(
+            "{message}\n\nYour organization's agent gateway couldn't be reached. Check your network (or VPN) connection, or run `claude auth login` in a terminal to sign in again, then try again."
+        ));
+    }
+
+    // Recent Claude Code CLI versions mis-parse `mcp add -e KEY=value …` and
+    // echo a stray token back as an invalid environment variable — an
+    // upstream regression (anthropics/claude-code#23365) Ship Studio can't
+    // fix from here, so give the workaround instead of filing it as our bug
+    // (issue #763).
+    if lower.contains("invalid environment variable format") {
+        return CommandError::expected(format!(
+            "{message}\n\nThis is a known bug in recent Claude Code CLI versions — its `mcp add` parser mishandles `-e` environment variables (anthropics/claude-code#23365). Add the server without its `-e` flags for now (set those variables in the server's own config instead), or update Claude Code once the fix ships."
+        ));
+    }
+
+    // The agent CLI parses its entire config file before running any `mcp`
+    // subcommand, so a single value the installed version no longer accepts
+    // (e.g. `service_tier = "default"` in ~/.codex/config.toml) breaks add,
+    // remove and list alike. The user's own config, not our call (issue #755).
+    if lower.contains("failed to load configuration")
+        || (lower.contains("unknown variant") && lower.contains("config.toml"))
+    {
+        let setting = invalid_config_key(details)
+            .map(|key| format!(" (`{key}`)"))
+            .unwrap_or_default();
+        return CommandError::expected(format!(
+            "{message}\n\nThe agent CLI couldn't read its own config file — a setting in it{setting} has a value this version no longer accepts. Fix or remove that setting in the config file named above, then try again."
         ));
     }
 
@@ -550,6 +598,20 @@ fn classify_mcp_add_failure(details: &str) -> CommandError {
     }
 
     message.into()
+}
+
+/// Pull the offending setting's name out of a Codex config-parse error,
+/// whose final line is `in \`service_tier\`` (issue #755). Without that shape
+/// the guidance simply omits the name rather than guessing one.
+fn invalid_config_key(details: &str) -> Option<String> {
+    details.lines().rev().find_map(|line| {
+        let key = line.trim().strip_prefix("in `")?.strip_suffix('`')?;
+        if key.is_empty() {
+            None
+        } else {
+            Some(key.to_string())
+        }
+    })
 }
 
 /// Does this CLI error text mean "no server with that name exists"?
@@ -632,7 +694,20 @@ pub async fn remove_mcp_server(
             tracing::info!(server = %name, "mcp remove: server already absent — treating as success");
             return Ok(());
         }
-        return Err((format!("Failed to remove MCP server: {details}")).into());
+        // A non-zero exit with nothing on either stream used to surface as
+        // "Failed to remove MCP server: " — an empty string with no signal
+        // for the user or for telemetry. Keep the exit code instead (#710).
+        if details.trim().is_empty() {
+            return Err(CommandError::Process {
+                cmd: format!("{} mcp remove", agent.binary_name),
+                exit_code: output.status.code().unwrap_or(-1),
+                stderr: String::new(),
+            });
+        }
+        // Everything the add path already classifies — enterprise policy,
+        // config read/write failures, gateway auth — fails the same way here
+        // (issues #746, #755, #800).
+        return Err(classify_mcp_failure("remove MCP server", &details));
     }
 
     Ok(())
@@ -866,7 +941,8 @@ mod tests {
 
     #[test]
     fn add_failure_already_exists_is_expected() {
-        let err = classify_mcp_add_failure(
+        let err = classify_mcp_failure(
+            "add MCP server",
             "MCP server shipstudio-preview already exists in local config",
         );
         assert!(matches!(err, CommandError::Expected { .. }));
@@ -875,7 +951,8 @@ mod tests {
     #[test]
     fn add_failure_enterprise_policy_is_expected() {
         // Exact wording from issue #675.
-        let err = classify_mcp_add_failure(
+        let err = classify_mcp_failure(
+            "add MCP server",
             "Cannot add MCP server \"shipstudio-preview\": not allowed by enterprise policy",
         );
         match err {
@@ -887,11 +964,15 @@ mod tests {
         }
         // Wording variants of the same policy denial.
         assert!(matches!(
-            classify_mcp_add_failure("MCP server \"x\" is explicitly blocked by enterprise policy"),
+            classify_mcp_failure(
+                "add MCP server",
+                "MCP server \"x\" is explicitly blocked by enterprise policy"
+            ),
             CommandError::Expected { .. }
         ));
         assert!(matches!(
-            classify_mcp_add_failure(
+            classify_mcp_failure(
+                "add MCP server",
                 "Cannot modify MCP servers: enterprise MCP configuration is active"
             ),
             CommandError::Expected { .. }
@@ -901,8 +982,7 @@ mod tests {
     #[test]
     fn add_failure_windows_config_access_denied_is_expected() {
         // Exact shape from issue #677 (Codex CLI on Windows).
-        let err = classify_mcp_add_failure(
-            "Error: failed to write MCP servers to C:\\Users\\me\\.codex\n\nCaused by:\n    0: failed to persist config at C:\\Users\\me\\.codex\\config.toml\n    1: Access is denied. (os error 5)",
+        let err = classify_mcp_failure("add MCP server", "Error: failed to write MCP servers to C:\\Users\\me\\.codex\n\nCaused by:\n    0: failed to persist config at C:\\Users\\me\\.codex\\config.toml\n    1: Access is denied. (os error 5)",
         );
         match err {
             CommandError::Expected { message } => {
@@ -913,8 +993,7 @@ mod tests {
         }
         // POSIX flavor of the same machine state.
         assert!(matches!(
-            classify_mcp_add_failure(
-                "failed to persist config at /Users/me/.codex/config.toml: Permission denied (os error 13)"
+            classify_mcp_failure("add MCP server", "failed to persist config at /Users/me/.codex/config.toml: Permission denied (os error 13)"
             ),
             CommandError::Expected { .. }
         ));
@@ -925,14 +1004,69 @@ mod tests {
         // Unrecognized failures must remain `Other` so telemetry still sees
         // genuine bugs.
         assert!(matches!(
-            classify_mcp_add_failure("unexpected argument '--transport'"),
+            classify_mcp_failure("add MCP server", "unexpected argument '--transport'"),
             CommandError::Other { .. }
         ));
         // Access-denied wording without any config-write context isn't the
         // #677 shape — don't over-classify.
         assert!(matches!(
-            classify_mcp_add_failure("Access is denied."),
+            classify_mcp_failure("add MCP server", "Access is denied."),
             CommandError::Other { .. }
         ));
+    }
+
+    #[test]
+    fn cloud_gateway_failure_is_expected_on_every_action() {
+        // Exact wording from issues #799 (add) and #800 (remove).
+        let details = "Couldn't load settings from Cloud gateway https://claude-gateway.internal.example.com. Check your network connection, or run `claude auth login` to re-authenticate.";
+        for action in ["add MCP server", "remove MCP server", "list MCP servers"] {
+            match classify_mcp_failure(action, details) {
+                CommandError::Expected { message } => {
+                    assert!(message.contains(&format!("Failed to {action}")));
+                    assert!(message.contains("claude auth login"));
+                }
+                other => panic!("expected Expected for {action}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn config_parse_failure_is_expected_and_names_the_setting() {
+        // Exact shape from issue #755 (Codex CLI, Windows).
+        let details = "Error: failed to load configuration\n\nCaused by:\n    0: C:\\Users\\me\\.codex\\config.toml:3:16: unknown variant `default`, expected `fast` or `flex`\n    1: unknown variant `default`, expected `fast` or `flex`\n       in `service_tier`";
+        // The same broken config breaks list and remove too — the CLI parses
+        // it before running any `mcp` subcommand.
+        for action in ["add MCP server", "remove MCP server", "list MCP servers"] {
+            match classify_mcp_failure(action, details) {
+                CommandError::Expected { message } => {
+                    assert!(message.contains("`service_tier`"));
+                    assert!(message.contains("config file"));
+                }
+                other => panic!("expected Expected for {action}, got {other:?}"),
+            }
+        }
+        // Without the trailing `in \`key\`` line the guidance just omits the
+        // name instead of guessing one.
+        assert!(matches!(
+            classify_mcp_failure("add MCP server", "Error: failed to load configuration"),
+            CommandError::Expected { .. }
+        ));
+        assert_eq!(invalid_config_key(details).as_deref(), Some("service_tier"));
+        assert_eq!(invalid_config_key("no key here"), None);
+    }
+
+    #[test]
+    fn invalid_env_var_format_is_expected() {
+        // Upstream Claude Code CLI regression (issue #763,
+        // anthropics/claude-code#23365) — nothing Ship Studio can fix.
+        match classify_mcp_failure(
+            "add MCP server",
+            "Invalid environment variable format: \\, environment variables should be added as: -e KEY1=value1 -e KEY2=value2",
+        ) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("anthropics/claude-code#23365"));
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
     }
 }

--- a/src-tauri/src/commands/mobile.rs
+++ b/src-tauri/src/commands/mobile.rs
@@ -2172,13 +2172,25 @@ async fn boot_specific_simulator(udid: &str) -> Result<BootResult, CommandError>
             });
         }
     }
-    // Block until fully booted (deterministic, no sleeps).
-    let _ = simctl_stdout(
+    // Block until fully booted (deterministic, no sleeps). A cold Simulator on a
+    // busy machine can legitimately exceed the wait budget — that's the machine
+    // being slow, not a malfunction, so classify it like the sibling simctl call
+    // sites do (issues #411/#554) instead of reporting a raw timeout (#814).
+    if let Err(e) = simctl_stdout(
         &["bootstatus", udid, "-b"],
         "xcrun simctl bootstatus",
         BOOT_WAIT_TIMEOUT_SECS,
     )
-    .await?;
+    .await
+    {
+        if matches!(e, CommandError::Timeout { .. }) {
+            return Err(CommandError::expected(
+                "The iOS Simulator is taking a long time to finish booting. Give it a moment \
+                 and try again — if it stays stuck, quit Simulator.app and retry.",
+            ));
+        }
+        return Err(e);
+    }
     let sim = list_booted_simulators()
         .await?
         .into_iter()

--- a/src-tauri/src/commands/plugins/mod.rs
+++ b/src-tauri/src/commands/plugins/mod.rs
@@ -325,7 +325,12 @@ fn plugins_owner_root(validated: &Path) -> PathBuf {
 
 /// Get the plugins directory for a project: `<main worktree>/.shipstudio/plugins/`.
 /// All git worktrees of one repository share a single plugin store.
-pub(crate) fn get_plugins_dir(project_path: &str) -> Result<PathBuf, String> {
+///
+/// Returns `CommandError` rather than `String`: `validate_project_path`
+/// classifies a vanished project folder as `Expected`, and round-tripping that
+/// through `String` collapsed it back to `Other`, so every plugin command
+/// auto-reported "folder no longer exists" to telemetry (issue #831).
+pub(crate) fn get_plugins_dir(project_path: &str) -> Result<PathBuf, CommandError> {
     let validated = validate_project_path(project_path)?;
     Ok(plugins_owner_root(&validated)
         .join(".shipstudio")
@@ -424,8 +429,12 @@ pub(crate) fn validate_plugin_id(plugin_id: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Get the storage file path for a plugin
-pub(crate) fn get_storage_path(plugin_id: &str, project_path: &str) -> Result<PathBuf, String> {
+/// Get the storage file path for a plugin. `CommandError` for the same reason
+/// as [`get_plugins_dir`] — a `String` hop erases `Expected` (issue #831).
+pub(crate) fn get_storage_path(
+    plugin_id: &str,
+    project_path: &str,
+) -> Result<PathBuf, CommandError> {
     validate_plugin_id(plugin_id)?;
 
     let plugins_dir = get_plugins_dir(project_path)?;
@@ -458,8 +467,17 @@ pub fn read_plugin_bundle(project_path: String, plugin_id: String) -> Result<Str
             .join("index.js")
     };
 
+    // Expected, not Other: a missing bundle is a broken-install machine state
+    // the frontend already handles (usePlugins' self-heal re-installs from
+    // source, then warns). `Other` auto-reported it at the IPC boundary before
+    // any of that ran, so every session re-filed the same bug (issue #770).
+    // The message text is load-bearing — usePlugins' `isMissingBundleError`
+    // matches on it — so it stays byte-identical.
     if !bundle_path.exists() {
-        return Err((format!("Plugin bundle not found: {}", bundle_path.display())).into());
+        return Err(CommandError::expected(format!(
+            "Plugin bundle not found: {}",
+            bundle_path.display()
+        )));
     }
 
     fs::read_to_string(&bundle_path).map_err(|e| CommandError::Io {
@@ -531,6 +549,21 @@ mod tests {
         assert_eq!(manifest.id, "test");
         assert!(manifest.slots.is_empty());
         assert!(manifest.setup.is_empty());
+    }
+
+    /// Issue #831: these helpers used to return `Result<_, String>`, which
+    /// collapsed `validate_project_path`'s `Expected` ("folder no longer
+    /// exists") into `Other` — auto-reporting a vanished project folder as a
+    /// bug from every plugin command.
+    #[test]
+    fn plugins_dir_keeps_expected_for_a_vanished_project() {
+        let gone = std::env::temp_dir().join("shipstudio-not-a-real-project-831");
+        assert!(!gone.exists());
+        let err = get_plugins_dir(&gone.to_string_lossy()).unwrap_err();
+        assert!(matches!(err, CommandError::Expected { .. }), "got: {err:?}");
+
+        let err = get_storage_path("vercel", &gone.to_string_lossy()).unwrap_err();
+        assert!(matches!(err, CommandError::Expected { .. }), "got: {err:?}");
     }
 
     #[test]

--- a/src-tauri/src/commands/plugins/plugin_lifecycle.rs
+++ b/src-tauri/src/commands/plugins/plugin_lifecycle.rs
@@ -21,13 +21,16 @@ use super::{
 /// 2. Local/command-executing transports — git's `ext::` transport runs an
 ///    arbitrary command, and `file://`/bare local paths can pull from anywhere
 ///    on disk. Only network transports to a remote host are allowed.
+///
+/// Every refusal here is `Expected`: the URL is user input, so a bad one is the
+/// app working correctly, not a malfunction to auto-report (issue #803).
 fn validate_clone_url(url: &str) -> Result<(), CommandError> {
     let trimmed = url.trim();
     if trimmed.is_empty() {
-        return Err("Plugin repository URL is empty".to_string().into());
+        return Err(CommandError::expected("Plugin repository URL is empty"));
     }
     if trimmed.starts_with('-') {
-        return Err("Invalid plugin repository URL".to_string().into());
+        return Err(CommandError::expected("Invalid plugin repository URL"));
     }
     let lowered = trimmed.to_ascii_lowercase();
     let allowed = lowered.starts_with("https://")
@@ -35,13 +38,116 @@ fn validate_clone_url(url: &str) -> Result<(), CommandError> {
         || lowered.starts_with("ssh://")
         || lowered.starts_with("git@");
     if !allowed {
-        return Err(
-            "Plugin repository URL must be an https://, ssh://, git:// or git@ remote"
-                .to_string()
-                .into(),
-        );
+        return Err(CommandError::expected(
+            "Plugin repository URL must be an https://, ssh://, git:// or git@ remote",
+        ));
+    }
+    // A link to a *page inside* a repository (GitHub's /blob/ or /tree/ web
+    // views) is well-formed but not clonable — pasting a docs page URL is a
+    // common mistake, and it used to sail through validation and only fail on
+    // git's "repository not found" 404 (issue #803). Reject it up front with
+    // wording that points at the repository root.
+    if lowered.contains("/blob/") || lowered.contains("/tree/") {
+        return Err(CommandError::expected(
+            "That link points at a page inside a repository, not the repository itself. \
+             Use the repository's main URL (e.g. https://github.com/owner/repo).",
+        ));
     }
     Ok(())
+}
+
+/// Network-git failures that are the user's URL, credentials, or connection —
+/// not a Ship Studio defect. `Some(Expected)` with actionable wording for the
+/// shapes we recognize (issues #803, #732); `None` for anything else so a
+/// genuinely novel git failure still reaches telemetry with its raw stderr.
+fn classify_remote_git_failure(stderr: &str) -> Option<CommandError> {
+    let lower = stderr.to_lowercase();
+    // git fell back to an interactive credential prompt and there's no tty in a
+    // GUI-spawned process, so it dies with "Device not configured" (macOS) or
+    // "terminal prompts disabled" (with GIT_TERMINAL_PROMPT=0). Mirrors
+    // github.rs's gh_auth_error / publishing.rs's push_auth_error (issue #732).
+    if lower.contains("could not read username")
+        || lower.contains("could not read password")
+        || lower.contains("terminal prompts disabled")
+        || lower.contains("authentication failed")
+    {
+        return Some(CommandError::expected(
+            "This plugin's repository requires sign-in, and Ship Studio can't authenticate to \
+             it automatically. Use a plugin hosted in a public repository, or clone it yourself \
+             and add it with Link Dev Plugin.",
+        ));
+    }
+    // A mistyped, renamed, deleted, or private repository URL (issue #803).
+    if lower.contains("repository not found")
+        || lower.contains("could not read from remote repository")
+        || (lower.contains("not found") && lower.contains("fatal:"))
+    {
+        return Some(CommandError::expected(
+            "Couldn't find a git repository at that URL. Double-check the plugin's repository \
+             link — it may be mistyped, private, renamed, or deleted.",
+        ));
+    }
+    // Offline / DNS / firewall — the machine's network, not the app.
+    if lower.contains("could not resolve host")
+        || lower.contains("could not resolve proxy")
+        || lower.contains("connection timed out")
+        || lower.contains("connection refused")
+        || lower.contains("network is unreachable")
+    {
+        return Some(CommandError::expected(
+            "Couldn't reach the plugin's repository — check your internet connection and \
+             try again.",
+        ));
+    }
+    None
+}
+
+/// [`classify_remote_git_failure`] with the clone call sites' raw fallback.
+fn classify_clone_failure(stderr: &str) -> CommandError {
+    classify_remote_git_failure(stderr)
+        .unwrap_or_else(|| CommandError::from(format!("Git clone failed: {stderr}")))
+}
+
+/// Run `git clone` for a plugin, with the shared spawn-pressure retry and the
+/// no-interactive-prompt guard.
+///
+/// * The spawn is retried on transient EAGAIN/EMFILE (a one-shot install used
+///   to die outright on momentary process-table pressure, issue #774).
+/// * `GIT_TERMINAL_PROMPT=0` makes a credential-requiring host fail fast
+///   instead of blocking on a prompt no one can answer, matching `run_git_net`
+///   in `commands/git/mod.rs` (issue #732).
+fn run_plugin_clone(
+    git: &Path,
+    repo_url: &str,
+    dest: &Path,
+) -> Result<std::process::Output, CommandError> {
+    let dest = dest.to_string_lossy().to_string();
+    crate::external_command::spawn_with_pressure_retry("git clone", || {
+        create_command(git)
+            .args(["clone", "--depth", "1", "--", repo_url, &dest])
+            .env("PATH", get_extended_path())
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .output()
+    })
+}
+
+/// `remove_dir_all_relaxed` with the same backoff `rename_with_retry` uses.
+/// A stale `.tmp-install` left by a previous run can be transiently locked
+/// (Windows AV/indexer, a cloud-sync daemon); the old single best-effort
+/// attempt silently gave up, and `git clone` then failed with the baffling
+/// "destination path already exists" (issue #839).
+fn remove_dir_all_with_retry(dir: &Path) -> std::io::Result<()> {
+    let mut result = remove_dir_all_relaxed(dir);
+    let mut delay = std::time::Duration::from_millis(100);
+    for _ in 0..4 {
+        if result.is_ok() || !dir.exists() {
+            return Ok(());
+        }
+        std::thread::sleep(delay);
+        delay = (delay * 2).min(std::time::Duration::from_millis(800));
+        result = remove_dir_all_relaxed(dir);
+    }
+    result
 }
 
 /// Resolve the `git` executable to an absolute path, mirroring how the setup
@@ -50,10 +156,11 @@ fn validate_clone_url(url: &str) -> Result<(), CommandError> {
 /// path first avoids that and lets us return a clear "install git" error.
 fn resolve_git() -> Result<PathBuf, CommandError> {
     find_executable("git").ok_or_else(|| {
-        "Git isn't installed or couldn't be located. Install Git (https://git-scm.com) \
-         and restart Ship Studio, then try again."
-            .to_string()
-            .into()
+        // A missing tool is an environment gap, not an app malfunction.
+        CommandError::expected(
+            "Git isn't installed or couldn't be located. Install Git (https://git-scm.com) \
+             and restart Ship Studio, then try again.",
+        )
     })
 }
 
@@ -242,33 +349,36 @@ pub async fn install_plugin(
     validate_clone_url(&repo_url)?;
 
     let plugins_dir = get_plugins_dir(&project_path)?;
-    fs::create_dir_all(&plugins_dir).map_err(|e| format!("Failed to create plugins dir: {e}"))?;
+    // classify_fs_error, like write_registry: a denied/read-only project folder
+    // is an environment state with a user-side fix, not telemetry (#762/#831).
+    fs::create_dir_all(&plugins_dir).map_err(|e| {
+        crate::utils::classify_fs_error("create this project's plugins folder", &plugins_dir, &e)
+    })?;
 
     let git = resolve_git()?;
 
-    // Clone into a temp directory first, then move
+    // Clone into a temp directory first, then move. A leftover .tmp-install
+    // from an interrupted run must actually be gone before the clone: git's
+    // own "destination path already exists" is unactionable for a directory
+    // the user never made and can't see (issue #839).
     let temp_dir = plugins_dir.join(".tmp-install");
     if temp_dir.exists() {
-        let _ = remove_dir_all_relaxed(&temp_dir);
+        remove_dir_all_with_retry(&temp_dir).map_err(|e| {
+            CommandError::expected(format!(
+                "Couldn't clear the leftover install folder at {} ({e}). Something else is \
+                 holding it open — close other apps that may be scanning or syncing this \
+                 project, then try again.",
+                temp_dir.display()
+            ))
+        })?;
     }
 
-    let output = create_command(&git)
-        .args([
-            "clone",
-            "--depth",
-            "1",
-            "--",
-            &repo_url,
-            &temp_dir.to_string_lossy(),
-        ])
-        .env("PATH", get_extended_path())
-        .output()
-        .map_err(|e| format!("Failed to run git clone: {e}"))?;
+    let output = run_plugin_clone(&git, &repo_url, &temp_dir)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         let _ = remove_dir_all_relaxed(&temp_dir);
-        return Err((format!("Git clone failed: {stderr}")).into());
+        return Err(classify_clone_failure(&stderr));
     }
 
     // Read manifest to get plugin ID
@@ -470,22 +580,11 @@ pub async fn update_plugin(
     }
 
     // Clone fresh
-    let output = create_command(&git)
-        .args([
-            "clone",
-            "--depth",
-            "1",
-            "--",
-            &source_url,
-            &plugin_dir.to_string_lossy(),
-        ])
-        .env("PATH", get_extended_path())
-        .output()
-        .map_err(|e| format!("Failed to run git clone: {e}"))?;
+    let output = run_plugin_clone(&git, &source_url, &plugin_dir)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err((format!("Git clone failed: {stderr}")).into());
+        return Err(classify_clone_failure(&stderr));
     }
 
     // Validate the built bundle exists — same guard as install_plugin (issue
@@ -574,16 +673,24 @@ pub async fn check_plugin_update(
     let installed_version = manifest.version.clone();
 
     // Get remote HEAD commit via git ls-remote
+    // Same guards as the clone paths: no interactive credential prompt with no
+    // tty to answer it (#732), an EAGAIN-tolerant spawn (#774), and Expected
+    // classification for URL/auth/offline failures (#803). This one runs
+    // unattended for every installed plugin on each Plugin Manager open, so an
+    // unreachable remote would otherwise file a report per plugin per open.
     let git = resolve_git()?;
-    let output = create_command(&git)
-        .args(["ls-remote", &source_url, "HEAD"])
-        .env("PATH", get_extended_path())
-        .output()
-        .map_err(|e| format!("Failed to run git ls-remote: {e}"))?;
+    let output = crate::external_command::spawn_with_pressure_retry("git ls-remote", || {
+        create_command(&git)
+            .args(["ls-remote", &source_url, "HEAD"])
+            .env("PATH", get_extended_path())
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .output()
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err((format!("Failed to check remote: {stderr}")).into());
+        return Err(classify_remote_git_failure(&stderr)
+            .unwrap_or_else(|| CommandError::from(format!("Failed to check remote: {stderr}"))));
     }
 
     let remote_output = String::from_utf8_lossy(&output.stdout);
@@ -636,8 +743,9 @@ pub fn toggle_plugin(
 #[cfg(test)]
 mod tests {
     use super::{
-        normalize_repo_url, remove_dir_all_relaxed, rename_with_retry, repo_urls_match,
-        validate_clone_url,
+        classify_clone_failure, classify_remote_git_failure, normalize_repo_url,
+        remove_dir_all_relaxed, remove_dir_all_with_retry, rename_with_retry, repo_urls_match,
+        validate_clone_url, CommandError,
     };
     use std::fs;
 
@@ -757,6 +865,88 @@ mod tests {
         assert_eq!(fs::read(to.join("a/b/leaf.txt")).unwrap(), b"3");
         // Source is untouched by the copy itself.
         assert!(from.join("a/b/leaf.txt").exists());
+    }
+
+    #[test]
+    fn rejects_repository_page_urls() {
+        // A GitHub docs page isn't clonable — issue #803's actual occurrence.
+        for url in [
+            "https://github.com/ship-studio/ship-studio/blob/main/docs/plugins.md",
+            "https://github.com/owner/repo/tree/main/packages/plugin",
+        ] {
+            let err = validate_clone_url(url).unwrap_err();
+            assert!(matches!(err, CommandError::Expected { .. }));
+            assert!(err.to_string().contains("repository's main URL"));
+        }
+    }
+
+    #[test]
+    fn url_refusals_are_expected_not_telemetry() {
+        // Bad user input is the app working correctly, not a bug to file.
+        for url in ["", "-oProxyCommand=evil", "file:///etc/passwd"] {
+            assert!(matches!(
+                validate_clone_url(url),
+                Err(CommandError::Expected { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn classifies_missing_repository_as_expected() {
+        // Issue #803: a mistyped/deleted/private repo URL.
+        let err = classify_clone_failure(
+            "Cloning into '.tmp-install'...\n\
+             fatal: repository 'https://github.com/owner/nope/' not found\n",
+        );
+        assert!(matches!(err, CommandError::Expected { .. }));
+        assert!(err.to_string().contains("Couldn't find a git repository"));
+    }
+
+    #[test]
+    fn classifies_credential_prompt_as_expected() {
+        // Issue #732: no tty for git's interactive credential prompt.
+        let err = classify_clone_failure(
+            "fatal: could not read Username for 'https://replit-mcp.com': Device not configured\n",
+        );
+        assert!(matches!(err, CommandError::Expected { .. }));
+        assert!(err.to_string().contains("requires sign-in"));
+        // …including the wording GIT_TERMINAL_PROMPT=0 itself produces.
+        assert!(classify_remote_git_failure(
+            "fatal: could not read Username for 'https://x.dev': terminal prompts disabled"
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn classifies_offline_clone_as_expected() {
+        let err = classify_clone_failure(
+            "fatal: unable to access '...': Could not resolve host: github.com",
+        );
+        assert!(matches!(err, CommandError::Expected { .. }));
+    }
+
+    #[test]
+    fn leaves_unrecognized_clone_failures_reportable() {
+        // Anything we don't recognize must keep reaching telemetry raw.
+        assert!(classify_remote_git_failure("error: object file is empty").is_none());
+        let err = classify_clone_failure("error: object file is empty");
+        assert!(matches!(err, CommandError::Other { .. }));
+        assert!(err.to_string().starts_with("Git clone failed:"));
+    }
+
+    #[test]
+    fn remove_dir_all_with_retry_clears_stale_tmp_install() {
+        // Issue #839: the leftover temp dir must actually be gone, otherwise
+        // git fails with an unactionable "destination path already exists".
+        let tmp = tempfile::tempdir().unwrap();
+        let stale = tmp.path().join(".tmp-install");
+        fs::create_dir_all(stale.join("dist")).unwrap();
+        fs::write(stale.join("dist/index.js"), b"x").unwrap();
+
+        remove_dir_all_with_retry(&stale).unwrap();
+        assert!(!stale.exists());
+        // Already-gone is success, not an error.
+        remove_dir_all_with_retry(&stale).unwrap();
     }
 
     #[test]

--- a/src-tauri/src/commands/plugins/plugin_lifecycle.rs
+++ b/src-tauri/src/commands/plugins/plugin_lifecycle.rs
@@ -108,27 +108,72 @@ fn classify_clone_failure(stderr: &str) -> CommandError {
         .unwrap_or_else(|| CommandError::from(format!("Git clone failed: {stderr}")))
 }
 
-/// Run `git clone` for a plugin, with the shared spawn-pressure retry and the
-/// no-interactive-prompt guard.
+/// Time budget for a plugin's shallow clone. Generous — a plugin repo is small
+/// but the uplink may not be — while still bounded: `GIT_TERMINAL_PROMPT=0`
+/// only prevents a *prompt* from hanging, and a stalled TCP connection would
+/// otherwise leave install/update spinning forever.
+const PLUGIN_CLONE_TIMEOUT_SECS: u64 = 120;
+
+/// Time budget for the remote HEAD lookup. Much tighter than the clone: this
+/// runs unattended for every installed plugin each time the Plugin Manager
+/// opens, so a stalled host must not wedge the whole panel.
+const PLUGIN_LS_REMOTE_TIMEOUT_SECS: u64 = 20;
+
+/// Message for a plugin git call that blows its time budget — the network, not
+/// an app malfunction, so `Expected` keeps it out of telemetry.
+fn plugin_git_timeout_error(what: &str) -> CommandError {
+    CommandError::expected(format!(
+        "{what} took too long and timed out — check your internet connection and try again."
+    ))
+}
+
+/// Run a plugin's network git command with the shared timeout runner.
 ///
-/// * The spawn is retried on transient EAGAIN/EMFILE (a one-shot install used
-///   to die outright on momentary process-table pressure, issue #774).
+/// * `run_with_timeout` bounds the call and kills the child on expiry, retries
+///   transient EAGAIN/EMFILE spawns in place (a one-shot install used to die
+///   outright on momentary process-table pressure, issue #774), and classifies
+///   spawn failures the same way every other call site does.
 /// * `GIT_TERMINAL_PROMPT=0` makes a credential-requiring host fail fast
 ///   instead of blocking on a prompt no one can answer, matching `run_git_net`
 ///   in `commands/git/mod.rs` (issue #732).
-fn run_plugin_clone(
+async fn run_plugin_git(
+    git: &Path,
+    args: &[&str],
+    label: &str,
+    timeout_secs: u64,
+    timed_out_what: &str,
+) -> Result<std::process::Output, CommandError> {
+    let mut cmd = create_command(git);
+    cmd.args(args)
+        .env("PATH", get_extended_path())
+        .env("GIT_TERMINAL_PROMPT", "0");
+    let result = crate::external_command::run_with_timeout(
+        tokio::process::Command::from(cmd),
+        label.to_string(),
+        timeout_secs,
+    )
+    .await;
+    match result {
+        Err(CommandError::Timeout { .. }) => Err(plugin_git_timeout_error(timed_out_what)),
+        other => other,
+    }
+}
+
+/// Run `git clone` for a plugin, bounded and prompt-free.
+async fn run_plugin_clone(
     git: &Path,
     repo_url: &str,
     dest: &Path,
 ) -> Result<std::process::Output, CommandError> {
     let dest = dest.to_string_lossy().to_string();
-    crate::external_command::spawn_with_pressure_retry("git clone", || {
-        create_command(git)
-            .args(["clone", "--depth", "1", "--", repo_url, &dest])
-            .env("PATH", get_extended_path())
-            .env("GIT_TERMINAL_PROMPT", "0")
-            .output()
-    })
+    run_plugin_git(
+        git,
+        &["clone", "--depth", "1", "--", repo_url, &dest],
+        "git clone",
+        PLUGIN_CLONE_TIMEOUT_SECS,
+        "Downloading the plugin",
+    )
+    .await
 }
 
 /// `remove_dir_all_relaxed` with the same backoff `rename_with_retry` uses.
@@ -373,7 +418,7 @@ pub async fn install_plugin(
         })?;
     }
 
-    let output = run_plugin_clone(&git, &repo_url, &temp_dir)?;
+    let output = run_plugin_clone(&git, &repo_url, &temp_dir).await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -580,7 +625,7 @@ pub async fn update_plugin(
     }
 
     // Clone fresh
-    let output = run_plugin_clone(&git, &source_url, &plugin_dir)?;
+    let output = run_plugin_clone(&git, &source_url, &plugin_dir).await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -673,19 +718,21 @@ pub async fn check_plugin_update(
     let installed_version = manifest.version.clone();
 
     // Get remote HEAD commit via git ls-remote
-    // Same guards as the clone paths: no interactive credential prompt with no
-    // tty to answer it (#732), an EAGAIN-tolerant spawn (#774), and Expected
-    // classification for URL/auth/offline failures (#803). This one runs
-    // unattended for every installed plugin on each Plugin Manager open, so an
-    // unreachable remote would otherwise file a report per plugin per open.
+    // Same guards as the clone paths: a bounded time budget, no interactive
+    // credential prompt with no tty to answer it (#732), an EAGAIN-tolerant
+    // spawn (#774), and Expected classification for URL/auth/offline failures
+    // (#803). This one runs unattended for every installed plugin on each
+    // Plugin Manager open, so an unreachable remote would otherwise file a
+    // report per plugin per open — and a stalled one would hang the panel.
     let git = resolve_git()?;
-    let output = crate::external_command::spawn_with_pressure_retry("git ls-remote", || {
-        create_command(&git)
-            .args(["ls-remote", &source_url, "HEAD"])
-            .env("PATH", get_extended_path())
-            .env("GIT_TERMINAL_PROMPT", "0")
-            .output()
-    })?;
+    let output = run_plugin_git(
+        &git,
+        &["ls-remote", &source_url, "HEAD"],
+        "git ls-remote",
+        PLUGIN_LS_REMOTE_TIMEOUT_SECS,
+        "Checking the plugin's repository",
+    )
+    .await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -744,10 +791,60 @@ pub fn toggle_plugin(
 mod tests {
     use super::{
         classify_clone_failure, classify_remote_git_failure, normalize_repo_url,
-        remove_dir_all_relaxed, remove_dir_all_with_retry, rename_with_retry, repo_urls_match,
-        validate_clone_url, CommandError,
+        plugin_git_timeout_error, remove_dir_all_relaxed, remove_dir_all_with_retry,
+        rename_with_retry, repo_urls_match, run_plugin_git, validate_clone_url, CommandError,
+        PLUGIN_CLONE_TIMEOUT_SECS, PLUGIN_LS_REMOTE_TIMEOUT_SECS,
     };
     use std::fs;
+
+    // The network git calls behind install / update / "check for updates" had
+    // no execution timeout at all: `GIT_TERMINAL_PROMPT=0` stops a *prompt* from
+    // hanging, but a stalled TCP connection left them spinning forever — and
+    // ls-remote runs per installed plugin on every Plugin Manager open.
+    #[test]
+    fn plugin_git_calls_have_bounded_budgets_and_expected_timeout_errors() {
+        // The unattended per-plugin check must not wait as long as a download.
+        assert!(
+            (1..PLUGIN_CLONE_TIMEOUT_SECS).contains(&PLUGIN_LS_REMOTE_TIMEOUT_SECS),
+            "ls-remote budget must be positive and tighter than the clone's"
+        );
+
+        let err = plugin_git_timeout_error("Downloading the plugin");
+        assert!(matches!(err, CommandError::Expected { .. }), "got: {err:?}");
+        let msg = err.to_string();
+        assert!(msg.contains("Downloading the plugin"), "got: {msg}");
+        assert!(msg.contains("check your internet connection"), "got: {msg}");
+    }
+
+    /// A hung remote must be killed at the deadline and reported as Expected,
+    /// not left running. `git ls-remote` against a black-holed address never
+    /// answers, so a 1s budget must fire.
+    #[tokio::test]
+    async fn a_stalled_plugin_git_call_times_out_instead_of_hanging() {
+        let Some(git) = crate::utils::find_executable("git") else {
+            return; // no git on this machine — nothing to exercise
+        };
+        let started = std::time::Instant::now();
+        let err = run_plugin_git(
+            &git,
+            // 203.0.113.0/24 is TEST-NET-3: reserved, routed nowhere.
+            &["ls-remote", "https://203.0.113.1/repo.git", "HEAD"],
+            "git ls-remote",
+            1,
+            "Checking the plugin's repository",
+        )
+        .await
+        .expect_err("a black-holed host can't answer");
+        // Either the deadline fired, or the network stack refused fast — both
+        // are bounded, which is the point. Only assert on the timeout shape.
+        if err.to_string().contains("took too long") {
+            assert!(matches!(err, CommandError::Expected { .. }), "got: {err:?}");
+            assert!(
+                started.elapsed() < std::time::Duration::from_secs(15),
+                "must return at the deadline, not hang"
+            );
+        }
+    }
 
     #[test]
     fn accepts_normal_remotes() {

--- a/src-tauri/src/commands/plugins/plugin_storage.rs
+++ b/src-tauri/src/commands/plugins/plugin_storage.rs
@@ -268,24 +268,30 @@ pub async fn link_dev_plugin(
         None => return Ok(None), // User cancelled
     };
 
+    // Every check below rejects the *folder the developer picked*, not an app
+    // malfunction, so they're all `Expected` — mirroring install_plugin's #472
+    // treatment, which link_dev_plugin was simply never given (issue #760).
+
     // Validate plugin.json exists
-    let manifest = read_manifest(&folder_path)?;
+    let manifest = read_manifest(&folder_path)
+        .map_err(|e| CommandError::expected(format!("Invalid plugin: {e}")))?;
 
     warn_on_setup_items(&manifest);
 
     // Validate dist/index.js exists
     let bundle_path = folder_path.join("dist").join("index.js");
     if !bundle_path.exists() {
-        return Err((format!(
+        return Err(CommandError::expected(format!(
             "Plugin bundle not found at {}/dist/index.js. Did you run the build?",
             folder_path.display()
-        ))
-        .into());
+        )));
     }
 
     // Validate manifest has required fields
     if manifest.id.is_empty() || manifest.name.is_empty() {
-        return Err(("Plugin manifest must have 'id' and 'name' fields".to_string()).into());
+        return Err(CommandError::expected(
+            "Plugin manifest must have 'id' and 'name' fields",
+        ));
     }
 
     // Validate plugin ID is safe for filesystem
@@ -294,14 +300,16 @@ pub async fn link_dev_plugin(
         || manifest.id.contains("..")
         || manifest.id.starts_with('.')
     {
-        return Err(("Plugin ID contains invalid characters".to_string()).into());
+        return Err(CommandError::expected(
+            "Plugin ID contains invalid characters",
+        ));
     }
 
     // Check min_app_version compatibility
-    check_min_app_version(&manifest, &app)?;
+    check_min_app_version(&manifest, &app).map_err(CommandError::expected)?;
 
     // Validate required_commands are all in the allowed set
-    validate_required_commands(&manifest)?;
+    validate_required_commands(&manifest).map_err(CommandError::expected)?;
 
     // Check for existing plugin with same ID
     let mut registry = read_registry(&project_path)?;
@@ -310,11 +318,10 @@ pub async fn link_dev_plugin(
         .iter()
         .any(|e| e.plugin_id == manifest.id && !e.is_dev)
     {
-        return Err((format!(
+        return Err(CommandError::expected(format!(
             "A non-dev plugin '{}' is already installed. Uninstall it first.",
             manifest.id
-        ))
-        .into());
+        )));
     }
 
     // Remove existing dev entry for this plugin if present (re-link)

--- a/src-tauri/src/commands/plugins/plugin_storage.rs
+++ b/src-tauri/src/commands/plugins/plugin_storage.rs
@@ -205,6 +205,13 @@ pub async fn exec_plugin_shell(
                         &command,
                     ));
                 }
+                // Windows ERROR_COMMITMENT_LIMIT (os error 1455): the paging
+                // file is too small to commit the spawn. Environment, not an
+                // app malfunction — the shared classifier already carries the
+                // remediation (issue #742).
+                if let Some(oom) = crate::errors::windows_out_of_memory(&e, Some(&command)) {
+                    return Err(oom);
+                }
                 // Windows ERROR_FILENAME_EXCED_RANGE (os error 206): the
                 // resolved absolute path (#475) plus args can exceed the
                 // legacy MAX_PATH limit on long profiles (OneDrive-redirected

--- a/src-tauri/src/commands/publishing.rs
+++ b/src-tauri/src/commands/publishing.rs
@@ -116,7 +116,9 @@ pub(crate) fn push_transient_server_error(stderr: &str) -> Option<CommandError> 
 /// deleted, renamed, transferred, or made inaccessible outside the app.
 /// Environment, not malfunction: telemetry-flooding this on every publish
 /// attempt for a stale remote helps nobody (issue #435).
-fn push_missing_remote_error(stderr: &str) -> Option<CommandError> {
+/// (`pub(crate)`: also reached through `git::classify_git_net_error`, so
+/// push_branch/delete_branch/create_pull_request classify it too — issue #825.)
+pub(crate) fn push_missing_remote_error(stderr: &str) -> Option<CommandError> {
     let lower = stderr.to_lowercase();
     let missing = lower.contains("repository not found")
         || (lower.contains("repository") && lower.contains("not found") && lower.contains("fatal"));
@@ -388,6 +390,20 @@ pub async fn publish_branch(
     let branch = String::from_utf8_lossy(&branch_output.stdout)
         .trim()
         .to_string();
+    // In a detached HEAD (checked-out tag/commit, mid-rebase) `rev-parse
+    // --abbrev-ref HEAD` literally returns "HEAD", which we'd then hand git as
+    // a push destination — git refuses with an unreadable "not a full refname"
+    // wall of text and telemetry logs it as a defect. A normal git state with a
+    // user-side fix, so stop before committing anything (issue #794; same guard
+    // get_current_branch got in #317).
+    if branch == "HEAD" {
+        warn!("Publish blocked: repository is in a detached HEAD state");
+        return Err(CommandError::expected(
+            "This project isn't on a branch right now (git calls this a detached HEAD — it \
+             happens mid-rebase or after checking out a specific commit or tag). Switch to a \
+             branch first, then publish.",
+        ));
+    }
     info!(branch = %branch, message = %message, "Publishing branch");
 
     // Ensure git identity matches GitHub account before committing

--- a/src-tauri/src/commands/pull_requests.rs
+++ b/src-tauri/src/commands/pull_requests.rs
@@ -119,6 +119,31 @@ fn is_push_rejection(stderr: &str) -> bool {
         || lower.contains("tip of your current branch is behind")
 }
 
+/// gh's by-design refusals for `pr create`, classified `Expected` so routine
+/// states stay out of telemetry.
+///
+/// "no commits between" and "a pull request already exists" keep gh's raw text
+/// because the frontend already rephrases both (humanizeGitError, issue #428).
+/// "no history in common" — GitHub refusing to compare an orphan/unrelated-
+/// history branch with the base — has no frontend rephrasing, so the friendly
+/// wording is authored here rather than forwarding the GraphQL text
+/// (issue #838).
+fn pr_create_refusal(stderr: &str, base: &str) -> Option<CommandError> {
+    let lower = stderr.to_lowercase();
+    if lower.contains("no commits between")
+        || (lower.contains("already exists") && lower.contains("pull request"))
+    {
+        return Some(CommandError::expected(stderr.to_string()));
+    }
+    if lower.contains("no history in common") {
+        return Some(CommandError::expected(format!(
+            "This branch shares no history with \"{base}\", so GitHub can't compare them for a \
+             pull request. It was most likely started separately instead of from \"{base}\"."
+        )));
+    }
+    None
+}
+
 /// Create a new pull request.
 /// Automatically pushes the branch to the remote first if needed.
 #[tauri::command]
@@ -205,15 +230,8 @@ pub async fn create_pull_request(
         if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
             return Err(err);
         }
-        // gh's by-design refusals for `pr create` — the frontend already
-        // rephrases both into friendly guidance (humanizeGitError), so keep
-        // the raw text but mark them Expected so they stay out of telemetry
-        // (issue #428).
-        let lower = stderr.to_lowercase();
-        if lower.contains("no commits between")
-            || (lower.contains("already exists") && lower.contains("pull request"))
-        {
-            return Err(CommandError::expected(stderr.to_string()));
+        if let Some(err) = pr_create_refusal(&stderr, &base) {
+            return Err(err);
         }
         return Err(truncate_output(&stderr).into());
     }
@@ -325,6 +343,14 @@ pub async fn checkout_pull_request(
     Ok(branch)
 }
 
+/// Match gh's refusal to close an already-merged pull request. Kept narrow —
+/// "already merged" alone would also claim unrelated merge chatter, so both
+/// halves of gh's sentence must be present (issue #798).
+fn is_already_merged_stderr(stderr: &str) -> bool {
+    let lower = stderr.to_lowercase();
+    lower.contains("already merged") && lower.contains("can't be closed")
+}
+
 /// Close a pull request without merging
 #[tauri::command]
 #[tracing::instrument(skip(project_path), fields(project = %project_path, pr = pr_number))]
@@ -346,6 +372,16 @@ pub async fn close_pull_request(project_path: String, pr_number: i32) -> Result<
         }
         if let Some(err) = crate::commands::github::gh_git_repo_error(&stderr) {
             return Err(err);
+        }
+        // gh refuses to close a PR that GitHub already merged ("can't be
+        // closed because it was already merged"). The list the Close button
+        // was clicked from can be stale by seconds — an anticipated race, not
+        // a malfunction (issue #798, same class as #482/#601).
+        if is_already_merged_stderr(&stderr) {
+            return Err(CommandError::expected(
+                "This pull request was already merged, so there's nothing to close. \
+                 Refresh to see its current state.",
+            ));
         }
         return Err(format!("Failed to close PR: {}", truncate_output(&stderr)).into());
     }
@@ -401,6 +437,53 @@ mod tests {
         let ise = "remote: Internal Server Error\n ! [remote rejected] main -> main (Internal Server Error)\nerror: failed to push some refs to 'https://github.com/o/r.git'";
         assert!(is_push_rejection(ise));
         assert!(crate::commands::publishing::push_transient_server_error(ise).is_some());
+    }
+
+    /// The #838 shape: an orphan-history branch GitHub can't compare with the
+    /// base. A by-design refusal — Expected, with wording that doesn't forward
+    /// gh's GraphQL text.
+    #[test]
+    fn pr_create_refusal_classifies_no_history_in_common() {
+        let stderr = "pull request create failed: GraphQL: The site branch has no history in common with main (createPullRequest)";
+        let err = pr_create_refusal(stderr, "main").expect("should classify as expected");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        let msg = err.to_string();
+        assert!(msg.contains("shares no history"), "got: {msg}");
+        assert!(
+            msg.contains("main"),
+            "must name the base branch, got: {msg}"
+        );
+        assert!(!msg.contains("GraphQL"), "must not forward gh's raw text");
+    }
+
+    /// The #428 refusals must keep their raw text (the frontend rephrases
+    /// them) and stay Expected.
+    #[test]
+    fn pr_create_refusal_keeps_the_428_cases_and_ignores_the_rest() {
+        let no_commits = "GraphQL: No commits between main and feat/empty (createPullRequest)";
+        let err = pr_create_refusal(no_commits, "main").expect("should classify as expected");
+        assert!(err.to_string().contains("No commits between"));
+        assert!(pr_create_refusal(
+            "GraphQL: A pull request already exists for julian:feat/x.",
+            "main"
+        )
+        .is_some());
+        assert!(pr_create_refusal("something genuinely unexplained", "main").is_none());
+        assert!(pr_create_refusal("", "main").is_none());
+    }
+
+    /// The #798 shape: the Close button clicked off a list that went stale
+    /// after the PR was merged elsewhere. A race, not a malfunction.
+    #[test]
+    fn is_already_merged_stderr_matches_ghs_close_refusal() {
+        assert!(is_already_merged_stderr(
+            "X Pull request owner/repo#12 (Add thing) can't be closed because it was already merged"
+        ));
+        // Merge chatter that isn't gh's close refusal must stay unclassified.
+        assert!(!is_already_merged_stderr(
+            "fatal: refusing to merge unrelated histories; branch was already merged"
+        ));
+        assert!(!is_already_merged_stderr(""));
     }
 
     #[test]

--- a/src-tauri/src/commands/setup/agents.rs
+++ b/src-tauri/src/commands/setup/agents.rs
@@ -249,20 +249,41 @@ pub async fn uninstall_agent(agent_id: String) -> Result<String, CommandError> {
         )
     })?;
 
-    #[cfg(windows)]
-    let output = create_command("cmd")
-        .args(["/C", command])
-        .output()
-        .map_err(|e| format!("Failed to run uninstall: {e}"))?;
+    // Retry a file-lock failure before giving up: on Windows npm's unlink of a
+    // just-used binary regularly loses a race with antivirus or a still-open
+    // terminal, and the lock clears on its own within a second or two
+    // (issue #844) — the same shape `rename_with_retry` handles for plugins.
+    let mut attempt: u32 = 0;
+    let output = loop {
+        attempt += 1;
+        let output =
+            run_uninstall_command(command).map_err(|e| format!("Failed to run uninstall: {e}"))?;
+        if output.status.success() {
+            break output;
+        }
 
-    #[cfg(not(windows))]
-    let output = create_command("/bin/bash")
-        .args(["-c", command])
-        .output()
-        .map_err(|e| format!("Failed to run uninstall: {e}"))?;
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        if is_file_lock_failure(&stderr) {
+            if attempt < 4 {
+                tracing::warn!(
+                    agent_id = agent_id.as_str(),
+                    attempt,
+                    "uninstall blocked by a file lock; retrying"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(
+                    300 * 2u64.pow(attempt - 1),
+                ))
+                .await;
+                continue;
+            }
+            return Err(CommandError::expected(format!(
+                "Couldn't uninstall {} because another program still has its files open. \
+                 Close any terminals or editors running it (antivirus can hold the files \
+                 briefly too), then try again.",
+                agent.display_name
+            )));
+        }
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
         // npm uninstall of a non-installed package is not a fatal failure — but
         // we surface any real error so the UI can tell the user.
         return Err((format!(
@@ -270,10 +291,36 @@ pub async fn uninstall_agent(agent_id: String) -> Result<String, CommandError> {
             stderr.lines().next().unwrap_or("unknown").trim()
         ))
         .into());
-    }
+    };
 
     tracing::info!(agent_id = agent_id.as_str(), "Agent uninstalled");
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Run an agent's uninstall command through the platform shell.
+///
+/// The extended PATH is required, not cosmetic: a Finder-launched macOS app
+/// doesn't inherit the user's shell PATH, so `npm` (and anything else the
+/// uninstall line calls) simply isn't found without it (issue #757).
+fn run_uninstall_command(command: &str) -> std::io::Result<std::process::Output> {
+    #[cfg(windows)]
+    let (shell, args) = ("cmd", ["/C", command]);
+    #[cfg(not(windows))]
+    let (shell, args) = ("/bin/bash", ["-c", command]);
+
+    create_command(shell)
+        .args(args)
+        .env("PATH", crate::utils::get_extended_path())
+        .output()
+}
+
+/// npm/OS wording for "the file is locked by another process" — Windows EBUSY
+/// on an unlink, and its localized/OS-level equivalent (issue #844).
+fn is_file_lock_failure(stderr: &str) -> bool {
+    let lower = stderr.to_lowercase();
+    lower.contains("ebusy")
+        || lower.contains("resource busy or locked")
+        || lower.contains("being used by another process")
 }
 
 #[cfg(test)]
@@ -335,6 +382,23 @@ mod tests {
     async fn uninstall_agent_rejects_empty_id() {
         let result = uninstall_agent(String::new()).await;
         assert!(result.is_err());
+    }
+
+    /// Issue #844: npm's EBUSY file-lock shape must be recognized so the
+    /// uninstall retries and, if it still fails, explains itself instead of
+    /// dumping the raw npm error.
+    #[test]
+    fn recognizes_npm_file_lock_failures() {
+        assert!(is_file_lock_failure(
+            "npm error code EBUSY\nnpm error syscall unlink\nnpm error EBUSY: resource busy or \
+             locked, unlink 'C:\\Users\\me\\AppData\\Roaming\\npm\\claude.cmd'"
+        ));
+        assert!(is_file_lock_failure(
+            "The process cannot access the file because it is being used by another process."
+        ));
+        // A genuine npm failure still flows through to the reportable path.
+        assert!(!is_file_lock_failure("npm error 404 Not Found - GET ..."));
+        assert!(!is_file_lock_failure(""));
     }
 
     // ============ get_agents_status ============

--- a/src-tauri/src/commands/setup/install.rs
+++ b/src-tauri/src/commands/setup/install.rs
@@ -283,19 +283,41 @@ fn brew_error_line(stderr: &str) -> &str {
 /// Homebrew's own remediation instead of the bare first stderr line
 /// (issue #448).
 fn brew_permission_error(stderr: &str) -> Option<crate::errors::CommandError> {
-    if !stderr.contains("is not writable") {
-        return None;
+    if stderr.contains("is not writable") {
+        // brew names the offending path in the same message; fall back to the
+        // standard prefix if the format ever changes.
+        let prefix = stderr
+            .lines()
+            .find(|l| l.contains("is not writable"))
+            .and_then(|l| l.split_whitespace().find(|w| w.starts_with('/')))
+            .unwrap_or("$(brew --prefix)");
+        return Some(crate::errors::CommandError::expected(format!(
+            "Homebrew can't install anything because {prefix} isn't writable by your user          (usually left over from a previous sudo or multi-user install). Open Terminal and run:          sudo chown -R $(whoami) {prefix} — then retry this step."
+        )));
     }
-    // brew names the offending path in the same message; fall back to the
-    // standard prefix if the format ever changes.
-    let prefix = stderr
+
+    // Ruby's raw EACCES, surfaced when Homebrew's own preflight check didn't
+    // catch the bad ownership and FileUtils hits it mid-operation instead
+    // (e.g. staging a reinstall into the Cellar). Same leftover-ownership
+    // state as the "is not writable" case above, different wording
+    // (issue #736).
+    if let Some(line) = stderr
         .lines()
-        .find(|l| l.contains("is not writable"))
-        .and_then(|l| l.split_whitespace().find(|w| w.starts_with('/')))
-        .unwrap_or("$(brew --prefix)");
-    Some(crate::errors::CommandError::expected(format!(
-        "Homebrew can't install anything because {prefix} isn't writable by your user          (usually left over from a previous sudo or multi-user install). Open Terminal and run:          sudo chown -R $(whoami) {prefix} — then retry this step."
-    )))
+        .find(|l| l.to_lowercase().contains("permission denied @ apply2files"))
+    {
+        let path = line
+            .split_once(" - ")
+            .map(|(_, path)| path.trim())
+            .filter(|p| p.starts_with('/'))
+            .unwrap_or("$(brew --prefix)");
+        return Some(crate::errors::CommandError::expected(format!(
+            "Homebrew couldn't change {path} because it isn't owned by your user (usually \
+             left over from a previous sudo or multi-user install). Open Terminal and run: \
+             sudo chown -R $(whoami) $(brew --prefix) — then retry this step."
+        )));
+    }
+
+    None
 }
 
 /// Pull a human-readable error line out of winget's output.
@@ -307,7 +329,12 @@ fn brew_permission_error(stderr: &str) -> Option<crate::errors::CommandError> {
 /// bare size/percent readouts), and return the last meaningful line — which on
 /// a failed install is the actual error (e.g. "failed when searching source:
 /// msstore").
-#[cfg(windows)]
+///
+/// winget also ends a failed *installer* run with a "Installer log is available
+/// at: <path>" line, which would otherwise win as the "last meaningful line"
+/// and hide the real reason a line or two above it (issue #745) — the same
+/// trailing-noise problem `brew_error_line` solves for Homebrew's banners.
+#[cfg_attr(not(windows), allow(dead_code))]
 fn extract_winget_error(stderr: &str, stdout: &str) -> String {
     let is_progress_only = |l: &str| {
         l.chars().all(|c| {
@@ -316,14 +343,74 @@ fn extract_winget_error(stderr: &str, stdout: &str) -> String {
             || l.contains('▒')
             || l.contains('░')
     };
+    // Pointers to a log file the user would have to open themselves — never
+    // the error itself.
+    let is_log_pointer = |l: &str| {
+        let lower = l.to_lowercase();
+        lower.starts_with("installer log is available at")
+            || lower.starts_with("please refer to the log")
+    };
     format!("{stderr}\n{stdout}")
         .replace('\r', "\n")
         .lines()
         .map(str::trim)
-        .filter(|&l| !l.is_empty() && !is_progress_only(l))
+        .filter(|&l| !l.is_empty() && !is_progress_only(l) && !is_log_pointer(l))
         .last()
         .unwrap_or("Unknown error")
         .to_string()
+}
+
+/// winget failing only in its *post-install cleanup* step: it deletes the
+/// downloaded installer from `%TEMP%\WinGet\...` after running it, and that
+/// delete loses a race against antivirus (or the installer itself) still
+/// holding the file open. The package is usually installed by then, so this
+/// exit code says nothing about whether the install worked (issue #780).
+#[cfg_attr(not(windows), allow(dead_code))]
+fn is_winget_cleanup_race(stderr: &str, stdout: &str) -> bool {
+    let combined = format!("{stderr}\n{stdout}").to_lowercase();
+    combined.contains("remove:") && combined.contains("being used by another process")
+}
+
+/// Turn a winget *spawn* failure (the process never started, so there's no
+/// output to classify) into a user-facing error.
+///
+/// `which::which("winget")` resolves to the App Execution Alias stub under
+/// `%LOCALAPPDATA%\Microsoft\WindowsApps`, which isn't a real binary. Windows
+/// refuses to launch it with ERROR_CANT_ACCESS_FILE (os error 1920) when the
+/// alias is switched off, App Installer is mid-update, or endpoint software
+/// intercepts alias stubs — all environment states, not app malfunctions
+/// (issue #810).
+#[cfg_attr(not(windows), allow(dead_code))]
+fn winget_spawn_error(err: &std::io::Error) -> CommandError {
+    if err.raw_os_error() == Some(1920) {
+        return CommandError::expected(
+            "Windows wouldn't let Ship Studio start winget (the App Installer alias is \
+             turned off or needs repairing). Open Settings → Apps → Advanced app settings → \
+             App execution aliases and switch on \"App Installer (winget.exe)\", or update \
+             App Installer from the Microsoft Store, then try again."
+                .to_string(),
+        );
+    }
+    (format!("Failed to run winget: {err}")).into()
+}
+
+/// Ask winget whether `package` is installed. Used to tell a genuine install
+/// failure apart from a cleanup-only failure (issue #780); any error answering
+/// the question counts as "not installed" so we never claim success blindly.
+#[cfg(windows)]
+fn winget_package_installed(winget: &std::path::Path, package: &str) -> bool {
+    create_command(winget)
+        .args([
+            "list",
+            "--id",
+            package,
+            "--exact",
+            "--disable-interactivity",
+            "--accept-source-agreements",
+        ])
+        .output()
+        .map(|o| o.status.success() && String::from_utf8_lossy(&o.stdout).contains(package))
+        .unwrap_or(false)
 }
 
 /// Batch install multiple packages via Winget (Windows only).
@@ -401,20 +488,39 @@ pub async fn install_winget_packages(
                 "--accept-source-agreements",
             ])
             .output()
-            .map_err(|e| format!("Failed to run winget: {}", e))?;
+            .map_err(|e| winget_spawn_error(&e))?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             let stdout = String::from_utf8_lossy(&output.stdout);
             // Don't fail if package is already installed
-            if !stdout.contains("already installed") && !stderr.contains("already installed") {
-                return Err((format!(
-                    "Failed to install {}: {}",
-                    package,
-                    extract_winget_error(&stderr, &stdout)
-                ))
-                .into());
+            if stdout.contains("already installed") || stderr.contains("already installed") {
+                continue;
             }
+            // winget's temp-file cleanup lost a race with antivirus. The
+            // install step already ran, so ask winget whether the package
+            // landed before calling this a failure (issue #780).
+            if is_winget_cleanup_race(&stderr, &stdout) {
+                if winget_package_installed(&winget, package) {
+                    tracing::warn!(
+                        package,
+                        "winget installed the package but couldn't delete its temporary \
+                         installer file; treating the install as successful"
+                    );
+                    continue;
+                }
+                return Err(CommandError::expected(format!(
+                    "Windows couldn't finish installing {package} because another program \
+                     (usually antivirus) still had winget's temporary installer file open. \
+                     Try this step again in a moment."
+                )));
+            }
+            return Err((format!(
+                "Failed to install {}: {}",
+                package,
+                extract_winget_error(&stderr, &stdout)
+            ))
+            .into());
         }
     }
 
@@ -459,7 +565,10 @@ pub async fn check_npm_cache_permissions() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{brew_error_line, humanize_brew_failure};
+    use super::{
+        brew_error_line, extract_winget_error, humanize_brew_failure, is_winget_cleanup_race,
+        winget_spawn_error,
+    };
     use crate::errors::CommandError;
 
     /// Issue #580: brew's auto-update banner must never be surfaced as *the*
@@ -532,5 +641,80 @@ mod tests {
         let err = humanize_brew_failure("Failed to install packages", stderr);
         assert!(matches!(err, CommandError::Expected { .. }), "got: {err:?}");
         assert!(err.to_string().contains("sudo chown"), "got: {err}");
+    }
+
+    /// Issue #736: Ruby's raw EACCES wording is the same leftover-ownership
+    /// state as #448 — Expected, with the offending path and chown advice.
+    #[test]
+    fn ruby_apply2files_permission_denied_is_expected() {
+        let stderr = "Error: Permission denied @ apply2files - \
+                      /opt/homebrew/Cellar/mongodb-community/8.2.7.reinstall/bin/mongod";
+        let err = humanize_brew_failure("Failed to install packages", stderr);
+        assert!(matches!(err, CommandError::Expected { .. }), "got: {err:?}");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("/opt/homebrew/Cellar/mongodb-community/8.2.7.reinstall/bin/mongod"),
+            "got: {msg}"
+        );
+        assert!(msg.contains("sudo chown -R $(whoami)"), "got: {msg}");
+    }
+
+    /// Issue #745: the trailing "Installer log is available at" pointer must
+    /// never win over the real error line above it.
+    #[test]
+    fn winget_error_skips_installer_log_pointer() {
+        let stdout = "Found Git [Git.Git]\r\
+                      ██████  50.0%\r\n\
+                      Installer failed with exit code: 1603\n\
+                      Installer log is available at: C:\\Users\\me\\AppData\\Local\\Temp\\WinGet\\x.log\n";
+        assert_eq!(
+            extract_winget_error("", stdout),
+            "Installer failed with exit code: 1603"
+        );
+    }
+
+    #[test]
+    fn winget_error_still_returns_last_real_line() {
+        assert_eq!(
+            extract_winget_error("failed when searching source: msstore", ""),
+            "failed when searching source: msstore"
+        );
+        assert_eq!(extract_winget_error("", ""), "Unknown error");
+    }
+
+    /// Issue #780: winget's post-install temp-file delete losing a race with
+    /// antivirus is a cleanup-only failure, recognizable from its wording.
+    #[test]
+    fn recognizes_winget_cleanup_race() {
+        let stderr = "remove: The process cannot access the file because it is being used by \
+                      another process.: \"C:\\Users\\me\\AppData\\Local\\Temp\\WinGet\\GitHub.cli.2.97.0\\abc\"";
+        assert!(is_winget_cleanup_race(stderr, ""));
+        assert!(is_winget_cleanup_race("", stderr));
+        assert!(!is_winget_cleanup_race(
+            "failed when searching source: msstore",
+            ""
+        ));
+    }
+
+    /// Issue #810: ERROR_CANT_ACCESS_FILE spawning the App Execution Alias is
+    /// an environment state — Expected, with alias/Store guidance.
+    #[test]
+    fn winget_alias_spawn_failure_is_expected() {
+        let err = winget_spawn_error(&std::io::Error::from_raw_os_error(1920));
+        assert!(matches!(err, CommandError::Expected { .. }), "got: {err:?}");
+        let msg = err.to_string();
+        assert!(msg.contains("App execution aliases"), "got: {msg}");
+        assert!(msg.contains("App Installer"), "got: {msg}");
+
+        // Any other spawn failure stays reportable.
+        let other = winget_spawn_error(&std::io::Error::from_raw_os_error(2));
+        assert!(
+            !matches!(other, CommandError::Expected { .. }),
+            "got: {other:?}"
+        );
+        assert!(
+            other.to_string().contains("Failed to run winget"),
+            "got: {other}"
+        );
     }
 }

--- a/src-tauri/src/commands/setup/install.rs
+++ b/src-tauri/src/commands/setup/install.rs
@@ -350,12 +350,25 @@ fn extract_winget_error(stderr: &str, stdout: &str) -> String {
         lower.starts_with("installer log is available at")
             || lower.starts_with("please refer to the log")
     };
-    format!("{stderr}\n{stdout}")
-        .replace('\r', "\n")
+    let normalized = format!("{stderr}\n{stdout}").replace('\r', "\n");
+    let meaningful = normalized
         .lines()
         .map(str::trim)
-        .filter(|&l| !l.is_empty() && !is_progress_only(l) && !is_log_pointer(l))
-        .last()
+        .filter(|&l| !l.is_empty() && !is_progress_only(l));
+    let mut last_real = None;
+    let mut last_pointer = None;
+    for line in meaningful {
+        if is_log_pointer(line) {
+            last_pointer = Some(line);
+        } else {
+            last_real = Some(line);
+        }
+    }
+    // Dropping the log pointer only helps when something better remains. When
+    // it's the ONLY line winget produced, showing it beats a bare "Unknown
+    // error" — the path is at least somewhere the user can look.
+    last_real
+        .or(last_pointer)
         .unwrap_or("Unknown error")
         .to_string()
 }
@@ -680,6 +693,19 @@ mod tests {
             "failed when searching source: msstore"
         );
         assert_eq!(extract_winget_error("", ""), "Unknown error");
+    }
+
+    /// The #745 filter must not be able to leave the user with nothing: when
+    /// the log pointer is the ONLY line winget produced, the path is better
+    /// than a bare "Unknown error".
+    #[test]
+    fn winget_error_falls_back_to_the_log_pointer_when_nothing_else_remains() {
+        let stdout = "██████  50.0%\r\n\
+                      Installer log is available at: C:\\Users\\me\\AppData\\Local\\Temp\\WinGet\\x.log\n";
+        assert_eq!(
+            extract_winget_error("", stdout),
+            "Installer log is available at: C:\\Users\\me\\AppData\\Local\\Temp\\WinGet\\x.log"
+        );
     }
 
     /// Issue #780: winget's post-install temp-file delete losing a race with

--- a/src-tauri/src/commands/setup/mod.rs
+++ b/src-tauri/src/commands/setup/mod.rs
@@ -88,22 +88,51 @@ const TOOL_ITEMS: &[&str] = &[
 
 // ============ App State Persistence (shared helpers) ============
 
-/// Read the persisted app state
+/// Read the persisted app state, falling back to defaults if it can't be read.
+///
+/// Read-only callers can use this directly. Anything doing read-modify-write
+/// must go through [`try_read_app_state`] instead — see its doc comment.
 pub fn read_app_state() -> AppState {
+    try_read_app_state().unwrap_or_else(|e| {
+        // Not `error!`: an unreadable state file is an environment condition
+        // (the file is transiently locked, the disk is busy), and this path
+        // already degrades safely to defaults for read-only callers (#756).
+        tracing::warn!("Failed to read app state file, using defaults: {e}");
+        AppState::default()
+    })
+}
+
+/// Read the persisted app state, distinguishing "nothing saved yet" (`Ok` with
+/// defaults) from "couldn't read what's saved" (`Err`).
+///
+/// A transient read failure — Windows ERROR_NO_SYSTEM_RESOURCES (os error 1450)
+/// was the reported one — used to silently yield `AppState::default()`, which
+/// the read-modify-write call sites then persisted straight over an intact
+/// file, wiping workspaces/accounts/setup flags. Those call sites must abort
+/// the write instead (issue #756). A single retry absorbs the transient case.
+///
+/// A *parse* failure is not an error here: it keeps its existing best-effort
+/// partial recovery, which is strictly better than refusing to write forever.
+pub fn try_read_app_state() -> Result<AppState, std::io::Error> {
     let path = state::get_app_state_path();
     if !path.exists() {
-        return AppState::default();
+        return Ok(AppState::default());
     }
 
     let raw = match std::fs::read_to_string(&path) {
         Ok(s) => s,
-        Err(e) => {
-            tracing::error!("Failed to read app state file: {e}");
-            return AppState::default();
+        Err(first) => {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            match std::fs::read_to_string(&path) {
+                Ok(s) => s,
+                // Report the original error: the retry's may be a different
+                // (less informative) symptom of the same condition.
+                Err(_) => return Err(first),
+            }
         }
     };
 
-    match serde_json::from_str::<AppState>(&raw) {
+    Ok(match serde_json::from_str::<AppState>(&raw) {
         Ok(state) => state,
         Err(e) => {
             // Log the parse failure so it's visible in ~/Library/Logs/ShipStudio/
@@ -124,11 +153,31 @@ pub fn read_app_state() -> AppState {
                 if let Some(id) = raw_value.get("activeAccountId").and_then(|v| v.as_str()) {
                     state.active_account_id = Some(id.to_string());
                 }
-                return state;
+                return Ok(state);
             }
             AppState::default()
         }
-    }
+    })
+}
+
+/// Read-modify-write the persisted app state.
+///
+/// The only safe way to change one field: reading through `try_read_app_state`
+/// means a transient read failure aborts the write instead of persisting
+/// `AppState::default()` over an intact file, which would wipe every field the
+/// caller wasn't even touching — accounts/workspaces included (issue #756).
+pub fn update_app_state<T>(
+    mutate: impl FnOnce(&mut AppState) -> T,
+) -> Result<T, crate::errors::CommandError> {
+    let mut state = try_read_app_state().map_err(|e| {
+        crate::errors::CommandError::expected(format!(
+            "Ship Studio couldn't read its saved settings ({e}), so nothing was changed — \
+             your existing settings are safe. Try again in a moment."
+        ))
+    })?;
+    let out = mutate(&mut state);
+    write_app_state(&state)?;
+    Ok(out)
 }
 
 /// Write the app state to disk

--- a/src-tauri/src/commands/setup/state.rs
+++ b/src-tauri/src/commands/setup/state.rs
@@ -3,7 +3,7 @@
 //! Functions for reading/writing the persisted AppState (setup_complete, default_agent, etc.)
 
 use super::{
-    is_force_onboarding_mode, is_mock_mode, read_app_state, write_app_state,
+    is_force_onboarding_mode, is_mock_mode, read_app_state, update_app_state,
     FORCE_ONBOARDING_COMPLETED,
 };
 use crate::errors::CommandError;
@@ -56,11 +56,10 @@ pub async fn mark_setup_complete() -> Result<(), CommandError> {
         .unwrap_or(0);
 
     // Read existing state to preserve other fields (e.g., compact_mode)
-    let mut state = read_app_state();
-    state.setup_complete = true;
-    state.setup_completed_at = Some(timestamp);
-
-    write_app_state(&state)?;
+    update_app_state(|state| {
+        state.setup_complete = true;
+        state.setup_completed_at = Some(timestamp);
+    })?;
     tracing::info!("Setup marked as complete");
     Ok(())
 }
@@ -76,9 +75,7 @@ pub async fn set_external_agent_opt_in(enabled: bool) -> Result<(), CommandError
         tracing::info!("Test mode: skipping external agent opt-in persistence");
         return Ok(());
     }
-    let mut state = read_app_state();
-    state.external_agent = Some(enabled);
-    write_app_state(&state)?;
+    update_app_state(|state| state.external_agent = Some(enabled))?;
     tracing::info!(enabled, "External agent opt-in persisted");
     Ok(())
 }
@@ -127,9 +124,7 @@ pub async fn set_default_host(host: String) -> Result<(), CommandError> {
         tracing::info!(host, "Test mode: skipping default host persistence");
         return Ok(());
     }
-    let mut state = read_app_state();
-    state.default_host = Some(host.clone());
-    write_app_state(&state)?;
+    update_app_state(|state| state.default_host = Some(host.clone()))?;
     tracing::info!(host, "Default host persisted");
     Ok(())
 }
@@ -146,11 +141,10 @@ pub async fn get_default_host() -> Result<Option<String>, CommandError> {
 #[tracing::instrument]
 pub async fn reset_setup_state() -> Result<(), CommandError> {
     // Read existing state to preserve other fields (e.g., compact_mode)
-    let mut state = read_app_state();
-    state.setup_complete = false;
-    state.setup_completed_at = None;
-
-    write_app_state(&state)?;
+    update_app_state(|state| {
+        state.setup_complete = false;
+        state.setup_completed_at = None;
+    })?;
     tracing::info!("Setup state reset");
     Ok(())
 }
@@ -167,9 +161,7 @@ pub async fn get_default_agent_id() -> Option<String> {
 #[tauri::command]
 #[tracing::instrument]
 pub async fn set_default_agent_id(agent_id: String) -> Result<(), CommandError> {
-    let mut state = read_app_state();
-    state.default_agent_id = Some(agent_id.clone());
-    write_app_state(&state)?;
+    update_app_state(|state| state.default_agent_id = Some(agent_id.clone()))?;
     crate::agent::set_default_agent_cached(&agent_id);
     tracing::info!("Default agent set to: {}", agent_id);
     Ok(())

--- a/src-tauri/src/commands/skills/install.rs
+++ b/src-tauri/src/commands/skills/install.rs
@@ -1,8 +1,8 @@
 //! Skill install/remove commands.
 
-use super::extract_skills_cli_error;
+use super::{extract_skills_cli_error, npx_command, skills_cli_spawn_error};
 use crate::errors::CommandError;
-use crate::utils::{create_command, get_extended_path, validate_project_path};
+use crate::utils::validate_project_path;
 
 /// Install a skill using the Skills CLI
 /// Runs: npx skills add <package> -y --agent <agent-id>
@@ -23,7 +23,7 @@ pub async fn install_skill(
         .unwrap_or_default();
 
     let skills_agent_id = agent.skills_agent_id.unwrap_or(agent.id);
-    let mut cmd = create_command("npx");
+    let mut cmd = npx_command();
     // Pin `skills@latest` (not bare `skills`) so npx resolves from the npm
     // registry instead of preferring a `node_modules/.bin/skills` shipped by a
     // malicious imported repo. `--` before the package stops a package name
@@ -38,7 +38,6 @@ pub async fn install_skill(
         "--",
         &package,
     ])
-    .env("PATH", get_extended_path())
     .env("HOME", &home)
     .envs(crate::commands::accounts::get_env_vars_for_active_account())
     .env_remove("npm_config__jsr-registry")
@@ -61,9 +60,7 @@ pub async fn install_skill(
         cmd.current_dir(&home);
     }
 
-    let output = cmd
-        .output()
-        .map_err(|e| format!("Failed to run skills CLI: {e}"))?;
+    let output = cmd.output().map_err(|e| skills_cli_spawn_error(&e))?;
 
     if !output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -94,7 +91,7 @@ pub async fn remove_skill(
         .unwrap_or_default();
 
     let skills_agent_id = agent.skills_agent_id.unwrap_or(agent.id);
-    let mut cmd = create_command("npx");
+    let mut cmd = npx_command();
     // See install_skill: pin `skills@latest` and `--`-terminate options so a
     // malicious repo's local binary / a `-`-leading package can't be abused.
     cmd.args([
@@ -107,7 +104,6 @@ pub async fn remove_skill(
         "--",
         &package,
     ])
-    .env("PATH", get_extended_path())
     .env("HOME", &home)
     .envs(crate::commands::accounts::get_env_vars_for_active_account())
     .env_remove("npm_config__jsr-registry")
@@ -127,9 +123,7 @@ pub async fn remove_skill(
         cmd.current_dir(&home);
     }
 
-    let output = cmd
-        .output()
-        .map_err(|e| format!("Failed to run skills CLI: {e}"))?;
+    let output = cmd.output().map_err(|e| skills_cli_spawn_error(&e))?;
 
     if !output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);

--- a/src-tauri/src/commands/skills/mod.rs
+++ b/src-tauri/src/commands/skills/mod.rs
@@ -18,6 +18,44 @@ mod search;
 pub use install::*;
 pub use search::*;
 
+/// Build an `npx` command for the Skills CLI with the extended PATH.
+///
+/// Resolves the binary via `find_executable` first. Setting `PATH` on the
+/// *child* doesn't change how the OS resolves the program name itself, so a
+/// bare `Command::new("npx")` fails outright wherever the app didn't inherit
+/// the user's shell PATH — and on Windows npx only ships as a `.cmd` shim,
+/// which Rust's PATH search (which only appends `.exe`) can never find. That
+/// surfaced as a bare "program not found" (issue #719). `find_executable`
+/// prefers the `.cmd`/`.exe` sibling over the extensionless shell script, and
+/// Rust routes a resolved `.cmd` through `cmd.exe` itself. Falls back to the
+/// bare name so behavior is unchanged when resolution misses. Mirrors
+/// `mobile.rs::npx_command()` / `screenshots::node_tool_command()`.
+pub(super) fn npx_command() -> std::process::Command {
+    let mut cmd = match crate::utils::find_executable("npx") {
+        Some(path) => crate::utils::create_command(path),
+        None => crate::utils::create_command("npx"),
+    };
+    cmd.env("PATH", crate::utils::get_extended_path());
+    cmd
+}
+
+/// Turn a failed `npx` *spawn* into a user-facing error.
+///
+/// If [`npx_command`] couldn't resolve npx, the spawn fails with a bare
+/// "program not found" that says nothing about what to do (issue #719). A
+/// missing Node install is an environment state, not an app malfunction, so it
+/// stays out of telemetry.
+pub(super) fn skills_cli_spawn_error(err: &std::io::Error) -> crate::errors::CommandError {
+    if err.kind() == std::io::ErrorKind::NotFound {
+        return crate::errors::CommandError::expected(
+            "Skills need Node.js (npx), which isn't installed or isn't on your PATH. \
+             Install Node.js, then restart Ship Studio and try again."
+                .to_string(),
+        );
+    }
+    (format!("Failed to run skills CLI: {err}")).into()
+}
+
 /// Strip ANSI escape codes from a string
 pub(super) fn strip_ansi_codes(s: &str) -> String {
     let mut result = String::new();
@@ -127,5 +165,36 @@ mod tests {
         let input = "\x1b[38;5;145mvercel-labs/agent-skills@test\x1b[0m";
         let result = strip_ansi_codes(input);
         assert_eq!(result, "vercel-labs/agent-skills@test");
+    }
+
+    /// Issue #719: the skills CLI must be spawned through a PATH-resolved
+    /// binary, with the extended PATH handed to the child too.
+    #[test]
+    fn npx_command_sets_extended_path() {
+        let cmd = npx_command();
+        let path_env = cmd
+            .get_envs()
+            .find(|(key, _)| *key == std::ffi::OsStr::new("PATH"))
+            .and_then(|(_, value)| value);
+        assert_eq!(
+            path_env,
+            Some(std::ffi::OsStr::new(
+                crate::utils::get_extended_path().as_str()
+            ))
+        );
+    }
+
+    #[test]
+    fn npx_command_resolves_absolute_path_when_npx_exists() {
+        // Skip (rather than fail) where npx genuinely isn't installed.
+        if crate::utils::find_executable("npx").is_none() {
+            return;
+        }
+        let cmd = npx_command();
+        assert!(
+            std::path::Path::new(cmd.get_program()).is_absolute(),
+            "expected a resolved absolute path, got {:?}",
+            cmd.get_program()
+        );
     }
 }

--- a/src-tauri/src/commands/skills/search.rs
+++ b/src-tauri/src/commands/skills/search.rs
@@ -1,8 +1,7 @@
 //! Skill listing and search commands.
 
-use super::strip_ansi_codes;
+use super::{npx_command, skills_cli_spawn_error, strip_ansi_codes};
 use crate::errors::CommandError;
-use crate::utils::{create_command, get_extended_path};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -262,9 +261,8 @@ pub async fn check_skills_cli() -> bool {
         .map(|h| h.to_string_lossy().to_string())
         .unwrap_or_default();
 
-    let output = create_command("npx")
+    let output = npx_command()
         .args(["--yes", "skills", "--version"])
-        .env("PATH", get_extended_path())
         .env("HOME", &home)
         .output();
 
@@ -285,15 +283,14 @@ pub async fn search_skills(query: String) -> Result<Vec<SkillSearchResult>, Comm
         .unwrap_or_default();
 
     // Use --yes to ensure we always run the latest version
-    let output = create_command("npx")
+    let output = npx_command()
         .args(["--yes", "skills", "find", &query])
-        .env("PATH", get_extended_path())
         .env("HOME", &home)
         .env_remove("npm_config__jsr-registry")
         .env_remove("npm_config_npm-globalconfig")
         .env_remove("npm_config_verify-deps-before-run")
         .output()
-        .map_err(|e| format!("Failed to run skills CLI: {e}"))?;
+        .map_err(|e| skills_cli_spawn_error(&e))?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src-tauri/src/commands/templates.rs
+++ b/src-tauri/src/commands/templates.rs
@@ -20,6 +20,16 @@ fn describe_reqwest_error(e: &reqwest::Error) -> String {
     msg
 }
 
+/// Wrap a network failure as `Expected`.
+///
+/// A timeout or a dropped connection talking to ship.studio is the user's
+/// network (or our API being briefly unreachable), not an app malfunction —
+/// `Expected` keeps it out of telemetry while still carrying the underlying
+/// cause for the UI to show (issue #754).
+fn network_failure(context: &str, e: &reqwest::Error) -> CommandError {
+    CommandError::expected(format!("{context}: {}", describe_reqwest_error(e)))
+}
+
 /// Fetch community templates from the Ship Studio API.
 /// Accepts optional query parameters that map to the API spec.
 /// Returns the raw JSON string so the frontend can parse it.
@@ -69,15 +79,19 @@ pub async fn fetch_community_templates(
         .get(url)
         .send()
         .await
-        .map_err(|e| format!("Failed to fetch templates: {}", describe_reqwest_error(&e)))?;
+        .map_err(|e| network_failure("Failed to fetch templates", &e))?;
 
     if !response.status().is_success() {
-        return Err((format!("API returned status {}", response.status())).into());
+        return Err(CommandError::expected(format!(
+            "The template gallery is unavailable right now (server returned {}). Try again in a moment.",
+            response.status()
+        )));
     }
 
-    response.text().await.map_err(|e| CommandError::Other {
-        message: format!("Failed to read response: {e}"),
-    })
+    response
+        .text()
+        .await
+        .map_err(|e| network_failure("Failed to read templates response", &e))
 }
 
 /// Download a template zip from a signed URL to a temporary file.
@@ -90,21 +104,23 @@ pub async fn download_template_zip(url: String) -> Result<String, CommandError> 
         .build()
         .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
 
-    let response = client.get(&url).send().await.map_err(|e| {
-        format!(
-            "Failed to download template: {}",
-            describe_reqwest_error(&e)
-        )
-    })?;
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| network_failure("Failed to download template", &e))?;
 
     if !response.status().is_success() {
         return Err((format!("Download failed with status {}", response.status())).into());
     }
 
+    // A truncated/interrupted download is a network condition too, and the
+    // actionable detail lives in the source chain, not the top-level message
+    // (issue #749).
     let bytes = response
         .bytes()
         .await
-        .map_err(|e| format!("Failed to read download: {e}"))?;
+        .map_err(|e| network_failure("Failed to read download", &e))?;
 
     let tmp_dir = std::env::temp_dir().join("shipstudio-templates");
     std::fs::create_dir_all(&tmp_dir).map_err(|e| format!("Failed to create temp dir: {e}"))?;

--- a/src-tauri/src/error_reporting.rs
+++ b/src-tauri/src/error_reporting.rs
@@ -415,6 +415,13 @@ fn command_error_fingerprint(err: &crate::errors::CommandError) -> Option<String
 /// instead catches both word orders while still excluding remote URLs, where
 /// `.git` is glued to the repo name (`…/repo.git'` tokenizes as `…/repo.git`,
 /// never a bare `.git`).
+///
+/// Quotes are deliberately NOT separators. Git substitutes the probe marker
+/// into the not-a-repo sentence bare (`…): .git`) in every locale, but quotes
+/// paths in access failures (`fatal: cannot access '.git': Operation not
+/// permitted` — a real macOS TCC / permissions problem). Treating quotes as
+/// separators made `'.git'` tokenize to `.git`, so that genuine failure was
+/// suppressed as benign and the user's report never arrived.
 fn is_not_a_git_repo_message(message: &str) -> bool {
     if message
         .to_ascii_lowercase()
@@ -423,7 +430,7 @@ fn is_not_a_git_repo_message(message: &str) -> bool {
         return true;
     }
     message
-        .split(|c: char| c.is_whitespace() || "\"'()（）:：".contains(c))
+        .split(|c: char| c.is_whitespace() || "()（）:：".contains(c))
         .any(|token| token == ".git")
 }
 
@@ -608,6 +615,15 @@ mod tests {
         // not treat ".git/index" as the bare probe marker (issue #727).
         assert!(!is_not_a_git_repo_message(
             "error: unable to write to .git/index"
+        ));
+        // A macOS TCC / permissions failure quotes the path. Git never quotes
+        // the bare probe marker in the not-a-repo sentence, so a quoted '.git'
+        // is a genuine access problem — suppressing it hid the real failure.
+        assert!(!is_not_a_git_repo_message(
+            "fatal: cannot access '.git': Operation not permitted"
+        ));
+        assert!(!is_not_a_git_repo_message(
+            "Failed to list branches: fatal: cannot access '.git': Operation not permitted"
         ));
         assert!(!is_not_a_git_repo_message(""));
     }

--- a/src-tauri/src/error_reporting.rs
+++ b/src-tauri/src/error_reporting.rs
@@ -404,11 +404,17 @@ fn command_error_fingerprint(err: &crate::errors::CommandError) -> Option<String
 /// "fatal: no es un repositorio git (ni ninguno de los directorios
 /// superiores): .git", issue #672), so the English substring alone silently
 /// missed non-English machines. Rather than enumerating languages, also match
-/// the locale-invariant part: the message always ends with the untranslated
-/// `.git` marker git was probing for, preceded by a colon (half- or
-/// full-width — CJK translations use "：.git"). The tail check is anchored to
-/// the end of the (trimmed) message so ordinary remote URLs ending in `.git`
-/// ("…/repo.git'") can't false-positive.
+/// the locale-invariant part: the untranslated `.git` marker git was probing
+/// for, which every translation substitutes into the sentence.
+///
+/// The original tail check ("ends with `: .git`") assumed the marker always
+/// lands at the end — true for English/Spanish/French/Chinese, but Italian's
+/// translation moves the placeholder to the *front* (`.git non è un repository
+/// Git (né lo è alcuna delle directory genitrici)`), so those reports kept
+/// reaching telemetry (issue #727). Scanning for a standalone `.git` token
+/// instead catches both word orders while still excluding remote URLs, where
+/// `.git` is glued to the repo name (`…/repo.git'` tokenizes as `…/repo.git`,
+/// never a bare `.git`).
 fn is_not_a_git_repo_message(message: &str) -> bool {
     if message
         .to_ascii_lowercase()
@@ -416,8 +422,9 @@ fn is_not_a_git_repo_message(message: &str) -> bool {
     {
         return true;
     }
-    let trimmed = message.trim_end();
-    trimmed.ends_with(": .git") || trimmed.ends_with("：.git")
+    message
+        .split(|c: char| c.is_whitespace() || "\"'()（）:：".contains(c))
+        .any(|token| token == ".git")
 }
 
 /// Report a `CommandError` the moment it's serialized for the frontend —
@@ -577,6 +584,11 @@ mod tests {
         assert!(is_not_a_git_repo_message(
             "fatal: 不是一个 git 仓库（或者任何父目录）：.git"
         ));
+        // Italian (issue #727) — the translation puts the `.git` placeholder
+        // first, so the sentence ends with ')' and no tail check can see it.
+        assert!(is_not_a_git_repo_message(
+            "Failed to list branches: fatal: .git non è un repository Git (né lo è alcuna delle directory genitrici)"
+        ));
     }
 
     #[test]
@@ -591,6 +603,11 @@ mod tests {
         ));
         assert!(!is_not_a_git_repo_message(
             "fatal: repository 'https://github.com/o/r.git/' not found"
+        ));
+        // Paths *inside* .git are a different failure — the token check must
+        // not treat ".git/index" as the bare probe marker (issue #727).
+        assert!(!is_not_a_git_repo_message(
+            "error: unable to write to .git/index"
         ));
         assert!(!is_not_a_git_repo_message(""));
     }

--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -124,25 +124,31 @@ impl Serialize for CommandError {
     }
 }
 
-/// Windows refusing a memory commit — usually a process spawn — because the
-/// paging file is too small or the machine is under memory pressure
-/// (ERROR_COMMITMENT_LIMIT, os error 1455). That's an environment condition
-/// with a user-side fix, not an app malfunction; returning `Expected` keeps
-/// it out of telemetry and swaps the bare OS string for actionable guidance
-/// (issue #356). The code is Windows-only; matching it unconditionally is
-/// safe because Unix errno values don't reach 1455.
+/// Windows refusing an operation because the machine is out of resources:
+/// ERROR_COMMITMENT_LIMIT (os error 1455, the paging file is too small) or
+/// ERROR_NO_SYSTEM_RESOURCES (os error 1450, kernel pool/handle exhaustion —
+/// same class, and it hits plain filesystem calls like `canonicalize`, not
+/// just spawns). Both are environment conditions with a user-side fix, not app
+/// malfunctions; returning `Expected` keeps them out of telemetry and swaps the
+/// bare OS string for actionable guidance (issues #356, #783). The codes are
+/// Windows-only; matching them unconditionally is safe because Unix errno
+/// values don't reach 1450/1455.
 pub fn windows_out_of_memory(err: &std::io::Error, label: Option<&str>) -> Option<CommandError> {
-    if err.raw_os_error() != Some(1455) {
-        return None;
-    }
     let doing = label
         .map(|l| format!(" while running `{l}`"))
         .unwrap_or_default();
-    Some(CommandError::expected(format!(
-        "Windows ran out of virtual memory{doing} (the paging file is too small). \
-         Close some other apps or increase the paging file size (Settings → System → About → \
-         Advanced system settings → Performance → Virtual memory), then try again."
-    )))
+    match err.raw_os_error() {
+        Some(1455) => Some(CommandError::expected(format!(
+            "Windows ran out of virtual memory{doing} (the paging file is too small). \
+             Close some other apps or increase the paging file size (Settings → System → About → \
+             Advanced system settings → Performance → Virtual memory), then try again."
+        ))),
+        Some(1450) => Some(CommandError::expected(format!(
+            "Windows ran out of system resources{doing}. This usually clears on its own — \
+             close some other apps (or restart the machine if it persists), then try again."
+        ))),
+        _ => None,
+    }
 }
 
 impl From<std::io::Error> for CommandError {
@@ -260,6 +266,17 @@ mod tests {
         // And the blanket io::Error conversion picks it up too.
         let err: CommandError = std::io::Error::from_raw_os_error(1455).into();
         assert!(matches!(err, CommandError::Expected { .. }));
+    }
+
+    // #783: ERROR_NO_SYSTEM_RESOURCES reached users raw from `canonicalize`.
+    #[test]
+    fn windows_no_system_resources_becomes_expected_with_guidance() {
+        let io_err = std::io::Error::from_raw_os_error(1450);
+        let err = windows_out_of_memory(&io_err, None).expect("should classify");
+        assert!(matches!(err, CommandError::Expected { .. }), "got: {err:?}");
+        let msg = err.to_string();
+        assert!(msg.contains("system resources"), "got: {msg}");
+        assert!(!msg.contains("os error"), "got: {msg}");
     }
 
     #[test]

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -136,28 +136,48 @@ fn get_log_dir() -> PathBuf {
 pub fn init_logging() -> Result<(), String> {
     let log_dir = get_log_dir();
 
-    // Create log directory if it doesn't exist
-    std::fs::create_dir_all(&log_dir)
-        .map_err(|e| format!("Failed to create log directory: {e}"))?;
+    // File logging is best-effort: a full disk (or a log directory we can't
+    // create or open) must not take the whole app down at startup. Both the
+    // directory creation and the appender build used to abort — the appender
+    // via `rolling::daily`'s internal panic — leaving the user with a crash
+    // instead of a running app (issue #827). Fall back to no file layer; Sentry
+    // and admin-agent reporting below still work.
+    let file_writer = match std::fs::create_dir_all(&log_dir).and_then(|()| {
+        tracing_appender::rolling::Builder::new()
+            .rotation(tracing_appender::rolling::Rotation::DAILY)
+            .filename_prefix("ship-studio.log")
+            .build(&log_dir)
+            .map_err(std::io::Error::other)
+    }) {
+        Ok(appender) => {
+            let (non_blocking, guard) = tracing_appender::non_blocking(appender);
+            // Store the guard to keep the writer alive
+            LOG_GUARD
+                .set(guard)
+                .map_err(|_| "Logging already initialized")?;
+            Some(non_blocking)
+        }
+        Err(e) => {
+            eprintln!(
+                "Ship Studio: file logging disabled ({}): {e}",
+                log_dir.display()
+            );
+            None
+        }
+    };
 
-    // Set up file appender with daily rotation
-    let file_appender = tracing_appender::rolling::daily(&log_dir, "ship-studio.log");
-    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
-
-    // Store the guard to keep the writer alive
-    LOG_GUARD
-        .set(guard)
-        .map_err(|_| "Logging already initialized")?;
-
-    // Create the file layer with JSON formatting
-    let file_layer = fmt::layer()
-        .json()
-        .with_writer(non_blocking)
-        .with_span_events(FmtSpan::CLOSE)
-        .with_current_span(true)
-        .with_target(true)
-        .with_file(true)
-        .with_line_number(true);
+    // Create the file layer with JSON formatting. `Option<Layer>` is itself a
+    // layer, so the disabled case is a no-op rather than a separate build path.
+    let file_layer = file_writer.map(|writer| {
+        fmt::layer()
+            .json()
+            .with_writer(writer)
+            .with_span_events(FmtSpan::CLOSE)
+            .with_current_span(true)
+            .with_target(true)
+            .with_file(true)
+            .with_line_number(true)
+    });
 
     // Create environment filter
     // Default to info level, can be overridden with RUST_LOG env var

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -576,10 +576,12 @@ async fn handle_request(
     match proxy_http_request(req, target_port).await {
         Ok(resp) => Ok(resp),
         Err(e) => {
-            // Connect failures never reach here — proxy_http_request handles
-            // them inline (retry + warn-level classification, issue #683).
-            // What's left is post-connect breakage (handshake, send, body
-            // timeouts): genuinely unexpected, so it keeps reporting.
+            // Every environment condition is handled inline in
+            // proxy_http_request with a warn-level log and a plain-English
+            // 502: connect failures (issue #683), handshake/send breakage
+            // (issue #709) and the response-budget timeout (issue #795).
+            // What reaches here is a genuine proxy defect — malformed
+            // headers, body-buffering faults — so it keeps reporting.
             tracing::error!("[Proxy] Request failed: {}", e);
             let body = format!("Proxy error: {e}");
             Ok(Response::builder()
@@ -630,13 +632,7 @@ async fn proxy_http_request(
                     UPSTREAM_CONNECT_TIMEOUT,
                     e
                 );
-                return Ok(Response::builder()
-                    .status(StatusCode::BAD_GATEWAY)
-                    .header(hyper::header::CONTENT_TYPE, "text/plain; charset=utf-8")
-                    .header(hyper::header::CACHE_CONTROL, "no-store")
-                    .body(full_body(Bytes::from(format!(
-                        "The dev server on localhost:{target_port} isn't reachable right now — it may be restarting or stopped. Reload the preview once it's running again."
-                    ))))?);
+                return Ok(dev_server_unavailable_response(target_port)?);
             }
             // Genuinely unexpected connect failure (not refused/silent) —
             // keep this at error level so it still reports.
@@ -657,11 +653,30 @@ async fn proxy_http_request(
     };
     let io = TokioIo::new(stream);
 
-    let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
+    // Handshake. A dev server that restarts between accepting the socket and
+    // completing the HTTP/1 handshake drops the connection here — the same
+    // environment condition the connect retry above already rides out, so it
+    // gets the same warn-level classification instead of auto-filing a bug
+    // report (issue #709). The request body is a streaming `Incoming` that
+    // can't be replayed, so this path reports the dev server as unreachable
+    // and lets the browser retry rather than resending.
+    let (mut sender, conn) = match hyper::client::conn::http1::Builder::new()
         .preserve_header_case(true)
         .title_case_headers(true)
         .handshake(io)
-        .await?;
+        .await
+    {
+        Ok(pair) => pair,
+        Err(e) if upstream_connection_lost(&e) => {
+            tracing::warn!(
+                "[Proxy] HTTP handshake with localhost:{} failed: {} (dev server restarting or stopped)",
+                target_port,
+                e
+            );
+            return Ok(dev_server_unavailable_response(target_port)?);
+        }
+        Err(e) => return Err(Box::new(e)),
+    };
 
     // Spawn connection driver
     tokio::spawn(async move {
@@ -712,17 +727,47 @@ async fn proxy_http_request(
 
     let forwarded_req = builder.body(body)?;
 
-    // Send request and get response
-    let resp = tokio::time::timeout(
+    // Send request and get response.
+    //
+    // Both failure shapes here are dev-server states, not proxy defects, so
+    // neither auto-files a bug report (issues #709/#795):
+    //   * the connection breaking mid-send — the dev server restarted after
+    //     the handshake completed;
+    //   * the response budget elapsing — per UPSTREAM_RESPONSE_TIMEOUT's doc
+    //     comment that budget is a backstop against a wedged upstream, and a
+    //     dev server stuck compiling for five minutes is an environment
+    //     problem the user has to fix at the dev server, not here.
+    let resp = match tokio::time::timeout(
         UPSTREAM_RESPONSE_TIMEOUT,
         sender.send_request(forwarded_req),
     )
     .await
-    .map_err(|_| {
-        format!(
-            "dev server on localhost:{target_port} didn't answer within {UPSTREAM_RESPONSE_TIMEOUT:?}"
-        )
-    })??;
+    {
+        Ok(Ok(resp)) => resp,
+        Ok(Err(e)) if upstream_connection_lost(&e) => {
+            tracing::warn!(
+                "[Proxy] Sending to localhost:{} failed: {} (dev server restarting or stopped)",
+                target_port,
+                e
+            );
+            return Ok(dev_server_unavailable_response(target_port)?);
+        }
+        Ok(Err(e)) => return Err(Box::new(e)),
+        Err(_elapsed) => {
+            tracing::warn!(
+                "[Proxy] Dev server on localhost:{} didn't answer within {:?} (stuck compiling or wedged)",
+                target_port,
+                UPSTREAM_RESPONSE_TIMEOUT
+            );
+            return Ok(Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .header(hyper::header::CONTENT_TYPE, "text/plain; charset=utf-8")
+                .header(hyper::header::CACHE_CONTROL, "no-store")
+                .body(full_body(Bytes::from(format!(
+                    "The dev server on localhost:{target_port} didn't respond within 5 minutes — it may be stuck compiling or wedged. Restart the dev server, then reload the preview."
+                ))))?);
+        }
+    };
 
     // Intercept auth-handshake redirect loops before they leave the proxy.
     // Forwarding the redirect would bounce the iframe through a third-party
@@ -875,6 +920,64 @@ fn upstream_unavailable(kind: std::io::ErrorKind) -> bool {
         kind,
         std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::TimedOut
     )
+}
+
+/// The connect-time classification's post-connect twin: I/O kinds that mean
+/// the dev server went away *after* the socket was established (restarted
+/// between accept and handshake, or mid-send). Same environment condition as
+/// [`upstream_unavailable`], one step later in the request lifecycle.
+fn upstream_connection_lost_kind(kind: std::io::ErrorKind) -> bool {
+    upstream_unavailable(kind)
+        || matches!(
+            kind,
+            std::io::ErrorKind::ConnectionReset
+                | std::io::ErrorKind::ConnectionAborted
+                | std::io::ErrorKind::BrokenPipe
+                | std::io::ErrorKind::NotConnected
+                | std::io::ErrorKind::UnexpectedEof
+        )
+}
+
+/// True when a post-connect failure means the dev server dropped the
+/// connection rather than the proxy misbehaving.
+///
+/// hyper wraps the underlying `io::Error` (when there is one) somewhere down
+/// the source chain, so the chain is walked rather than downcast at the top.
+/// hyper's own "peer closed" shapes — a half-written message, a closed or
+/// canceled dispatch — carry no `io::Error` at all, so they're matched
+/// separately by the caller-facing [`upstream_connection_lost`].
+fn upstream_connection_lost_source(err: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current = Some(err);
+    while let Some(e) = current {
+        if let Some(io) = e.downcast_ref::<std::io::Error>() {
+            return upstream_connection_lost_kind(io.kind());
+        }
+        current = e.source();
+    }
+    false
+}
+
+/// [`upstream_connection_lost_source`] plus hyper's own peer-closed flags.
+fn upstream_connection_lost(err: &hyper::Error) -> bool {
+    err.is_closed()
+        || err.is_incomplete_message()
+        || err.is_canceled()
+        || upstream_connection_lost_source(err)
+}
+
+/// The 502 shown whenever the dev server isn't answering for an expected
+/// reason (restarting, stopped, connection dropped mid-request). Shared by
+/// every environment-condition path so the user always reads the same thing.
+fn dev_server_unavailable_response(
+    target_port: u16,
+) -> Result<Response<ProxyBody>, hyper::http::Error> {
+    Response::builder()
+        .status(StatusCode::BAD_GATEWAY)
+        .header(hyper::header::CONTENT_TYPE, "text/plain; charset=utf-8")
+        .header(hyper::header::CACHE_CONTROL, "no-store")
+        .body(full_body(Bytes::from(format!(
+            "The dev server on localhost:{target_port} isn't reachable right now — it may be restarting or stopped. Reload the preview once it's running again."
+        ))))
 }
 
 /// Race IPv4 and IPv6 loopback concurrently rather than connecting to
@@ -1282,7 +1385,7 @@ mod tests {
     use super::{
         connect_upstream_with_retry, is_auth_redirect_loop, is_document_navigation,
         redact_handshake_values, rewrite_localhost_origin, sanitize_csp_for_preview,
-        upstream_unavailable,
+        upstream_connection_lost_kind, upstream_connection_lost_source, upstream_unavailable,
     };
     use hyper::header::HeaderValue;
     use hyper::StatusCode;
@@ -1297,6 +1400,78 @@ mod tests {
         assert!(!upstream_unavailable(std::io::ErrorKind::PermissionDenied));
         assert!(!upstream_unavailable(std::io::ErrorKind::AddrNotAvailable));
         assert!(!upstream_unavailable(std::io::ErrorKind::Other));
+    }
+
+    #[test]
+    fn post_connect_breakage_is_classified_as_the_dev_server_going_away() {
+        // Handshake/send failures after the socket is up (issue #709): the
+        // dev server restarted mid-request. Expected, warn level.
+        assert!(upstream_connection_lost_kind(
+            std::io::ErrorKind::ConnectionReset
+        ));
+        assert!(upstream_connection_lost_kind(
+            std::io::ErrorKind::ConnectionAborted
+        ));
+        assert!(upstream_connection_lost_kind(
+            std::io::ErrorKind::BrokenPipe
+        ));
+        assert!(upstream_connection_lost_kind(
+            std::io::ErrorKind::UnexpectedEof
+        ));
+        assert!(upstream_connection_lost_kind(
+            std::io::ErrorKind::NotConnected
+        ));
+        // Everything the connect path already treats as expected stays so.
+        assert!(upstream_connection_lost_kind(
+            std::io::ErrorKind::ConnectionRefused
+        ));
+        assert!(upstream_connection_lost_kind(std::io::ErrorKind::TimedOut));
+        // Genuine proxy problems keep reporting.
+        assert!(!upstream_connection_lost_kind(
+            std::io::ErrorKind::PermissionDenied
+        ));
+        assert!(!upstream_connection_lost_kind(
+            std::io::ErrorKind::InvalidData
+        ));
+        assert!(!upstream_connection_lost_kind(std::io::ErrorKind::Other));
+    }
+
+    /// Stand-in for hyper's error wrapper: the `io::Error` is never the top
+    /// error, it hangs off the source chain.
+    #[derive(Debug)]
+    struct WrappedIo(std::io::Error);
+
+    impl std::fmt::Display for WrappedIo {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "wrapped: {}", self.0)
+        }
+    }
+
+    impl std::error::Error for WrappedIo {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(&self.0)
+        }
+    }
+
+    #[test]
+    fn connection_lost_classification_walks_the_error_source_chain() {
+        let reset = WrappedIo(std::io::Error::from(std::io::ErrorKind::ConnectionReset));
+        assert!(upstream_connection_lost_source(&reset));
+
+        let denied = WrappedIo(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
+        assert!(!upstream_connection_lost_source(&denied));
+
+        // No io::Error anywhere in the chain — not classifiable from I/O
+        // alone (hyper's own peer-closed flags cover those shapes).
+        #[derive(Debug)]
+        struct Bare;
+        impl std::fmt::Display for Bare {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "bare")
+            }
+        }
+        impl std::error::Error for Bare {}
+        assert!(!upstream_connection_lost_source(&Bare));
     }
 
     // ── connect_upstream_with_retry (issues #258/#353/#683) ────────────────

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -588,6 +588,10 @@ pub fn git_environment_gap(stderr: &str) -> Option<crate::errors::CommandError> 
 ///   ERROR_WRITE_PROTECT os error 19): the volume itself refuses writes —
 ///   e.g. a project opened off a read-only disk image or locked SD card
 ///   (issue #625).
+/// - Windows `ERROR_USER_MAPPED_FILE` (os error 1224): another process holds a
+///   memory-mapped view of the file, so Windows refuses the truncating write.
+///   Typically a dev server/bundler, an editor, or antivirus holding the file
+///   open for a moment (issue #722).
 ///
 /// Anything else stays a labeled `Io` for diagnosability.
 pub fn classify_fs_error(
@@ -614,6 +618,13 @@ pub fn classify_fs_error(
         crate::errors::CommandError::expected(format!(
             "Ship Studio couldn't {action} ({}) — the disk or volume is read-only. Move \
              the project to a writable location, then try again.",
+            path.display()
+        ))
+    } else if cfg!(windows) && e.raw_os_error() == Some(1224) {
+        crate::errors::CommandError::expected(format!(
+            "Ship Studio couldn't {action} ({}) — another program currently has the file open \
+             (often a dev server, code editor, or antivirus). Close it or wait a moment, then \
+             try again.",
             path.display()
         ))
     } else {
@@ -1626,6 +1637,27 @@ mod tests {
             let msg = err.to_string();
             assert!(msg.contains("read-only"), "got: {msg}");
             assert!(msg.contains("project.json"), "got: {msg}");
+        }
+
+        // The #722 shape: ERROR_USER_MAPPED_FILE on a visual-editor source
+        // write ("...ett användarmappat avsnitt är öppnat. (os error 1224)") —
+        // matched by code so the localized OS text never reaches the user.
+        #[test]
+        #[cfg(windows)]
+        fn windows_user_mapped_file_becomes_expected() {
+            let e = std::io::Error::from_raw_os_error(1224);
+            let err = classify_fs_error(
+                "save your change to this file",
+                std::path::Path::new("C:\\p\\src\\Hero.tsx"),
+                &e,
+            );
+            assert!(
+                matches!(err, crate::errors::CommandError::Expected { .. }),
+                "got: {err:?}"
+            );
+            let msg = err.to_string();
+            assert!(msg.contains("another program"), "got: {msg}");
+            assert!(msg.contains("Hero.tsx"), "got: {msg}");
         }
 
         // Unix EPERM outside macOS (and any other permission error not

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -588,6 +588,13 @@ pub fn git_environment_gap(stderr: &str) -> Option<crate::errors::CommandError> 
 ///   ERROR_WRITE_PROTECT os error 19): the volume itself refuses writes —
 ///   e.g. a project opened off a read-only disk image or locked SD card
 ///   (issue #625).
+/// - Unix `EACCES` (os error 13, "Permission denied"): ordinary filesystem
+///   ownership/mode, not TCC — often a folder owned by another user after a
+///   `sudo` install. Same treatment `opencode_config_save` already gave it in
+///   #471, shared here for every call site (issue #832).
+/// - `ETIMEDOUT` (Unix os error 60): the file lives on a cloud-sync provider
+///   (Google Drive / OneDrive / Dropbox / iCloud) whose daemon didn't
+///   materialize it in time — environment friction, not corruption (#758).
 ///
 /// Anything else stays a labeled `Io` for diagnosability.
 pub fn classify_fs_error(
@@ -614,6 +621,27 @@ pub fn classify_fs_error(
         crate::errors::CommandError::expected(format!(
             "Ship Studio couldn't {action} ({}) — the disk or volume is read-only. Move \
              the project to a writable location, then try again.",
+            path.display()
+        ))
+    } else if cfg!(unix) && e.raw_os_error() == Some(13) {
+        // EACCES is ordinary ownership/permissions (often a folder left owned
+        // by root after a `sudo` install), not a malfunction — give the fix and
+        // skip telemetry, matching `opencode_config_save`'s #471 treatment.
+        crate::errors::CommandError::expected(format!(
+            "Ship Studio isn't allowed to {action} ({}) — permission denied. The file or \
+             folder is likely owned by another user. In a terminal, run: \
+             sudo chown -R $(whoami) \"{}\" — then try again.",
+            path.display(),
+            path.display()
+        ))
+    } else if e.kind() == std::io::ErrorKind::TimedOut {
+        // A read/write that times out (macOS ETIMEDOUT, os error 60) means a
+        // cloud-sync provider's file-provider daemon didn't materialize the
+        // file in time. Environment friction, not corruption (issue #758).
+        crate::errors::CommandError::expected(format!(
+            "Ship Studio timed out trying to {action} ({}). The folder looks like it's on a \
+             cloud drive (Google Drive, OneDrive, Dropbox, iCloud) that's still syncing — \
+             wait for sync to finish and try again, or keep the project on your local disk.",
             path.display()
         ))
     } else {
@@ -986,13 +1014,35 @@ pub fn normalize_separators(path: &str) -> String {
 /// from ~20 canonicalize sites and is untraceable from telemetry (issue #284).
 /// Including the path is safe: error reports scrub home directories before
 /// anything leaves the machine.
+///
+/// A `NotFound` is retried a couple of times with a short backoff first: on
+/// SMB/NAS shares and mapped network drives a directory another process just
+/// created can transiently fail to resolve, which surfaced as a spurious
+/// "folder no longer exists" right after a successful clone (issue #841). The
+/// retries only run on the path that was already about to fail, so a folder
+/// that really is gone costs at most a few hundred extra milliseconds.
 pub fn canonicalize_tagged(
     path: impl AsRef<std::path::Path>,
     site: &str,
 ) -> Result<std::path::PathBuf, crate::errors::CommandError> {
     let path = path.as_ref();
-    dunce::canonicalize(path).map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound {
+    let mut result = dunce::canonicalize(path);
+    for delay_ms in [40, 120] {
+        match &result {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                result = dunce::canonicalize(path);
+            }
+            _ => break,
+        }
+    }
+    result.map_err(|e| {
+        if let Some(exhausted) = crate::errors::windows_out_of_memory(&e, None) {
+            // Windows resource exhaustion (os error 1450/1455) reaching a plain
+            // canonicalize is an environment condition, not an invalid path —
+            // don't dress it up as one, and keep it out of telemetry (#783).
+            exhausted
+        } else if e.kind() == std::io::ErrorKind::NotFound {
             // A folder disappearing out from under the app — deleted, renamed,
             // or moved in Finder/Explorer — is an environment change, not a
             // malfunction: say so plainly and keep it out of telemetry
@@ -1547,6 +1597,26 @@ mod tests {
                 }
             }
         }
+
+        // #841: the NotFound retry must not delay (or change) the success path,
+        // and must stay bounded on the failure path.
+        #[test]
+        fn existing_folder_resolves_without_retrying() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let started = std::time::Instant::now();
+            let resolved = canonicalize_tagged(tmp.path(), "test_site").unwrap();
+            assert!(resolved.exists());
+            assert!(started.elapsed() < std::time::Duration::from_millis(40));
+        }
+
+        #[test]
+        fn missing_folder_retry_stays_bounded() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let gone = tmp.path().join("vanished-project");
+            let started = std::time::Instant::now();
+            let _ = canonicalize_tagged(&gone, "test_site").unwrap_err();
+            assert!(started.elapsed() < std::time::Duration::from_millis(800));
+        }
     }
 
     mod classify_fs_errors {
@@ -1606,6 +1676,46 @@ mod tests {
             );
             let msg = err.to_string();
             assert!(msg.contains("denied access"), "got: {msg}");
+            assert!(msg.contains("project.json"), "got: {msg}");
+        }
+
+        // The #832 shape: EACCES writing project.json (folder owned by another
+        // user, e.g. left root-owned by a sudo install).
+        #[test]
+        #[cfg(unix)]
+        fn unix_eacces_becomes_expected_with_chown_remediation() {
+            let e = std::io::Error::from_raw_os_error(13);
+            let err = classify_fs_error(
+                "write project metadata",
+                std::path::Path::new("/p/.shipstudio/project.json"),
+                &e,
+            );
+            assert!(
+                matches!(err, crate::errors::CommandError::Expected { .. }),
+                "got: {err:?}"
+            );
+            let msg = err.to_string();
+            assert!(msg.contains("permission denied"), "got: {msg}");
+            assert!(msg.contains("chown"), "got: {msg}");
+            assert!(!msg.contains("os error"), "got: {msg}");
+        }
+
+        // The #758 shape: ETIMEDOUT reading a project.json that Google Drive's
+        // file provider never materialized.
+        #[test]
+        fn cloud_drive_timeout_becomes_expected() {
+            let e = std::io::Error::new(std::io::ErrorKind::TimedOut, "Operation timed out");
+            let err = classify_fs_error(
+                "read project metadata",
+                std::path::Path::new("/Users/x/Library/CloudStorage/GoogleDrive/p/project.json"),
+                &e,
+            );
+            assert!(
+                matches!(err, crate::errors::CommandError::Expected { .. }),
+                "got: {err:?}"
+            );
+            let msg = err.to_string();
+            assert!(msg.contains("cloud drive"), "got: {msg}");
             assert!(msg.contains("project.json"), "got: {msg}");
         }
 

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -528,23 +528,74 @@ where
 ///   (tried to allocate N bytes)`) — the host machine under memory pressure
 ///   at the moment git spawned; cross-platform, first seen on Windows
 ///   (issue #668).
+/// - Windows pagefile exhaustion reported by git's own runtime (`error
+///   launching git: The paging file is too small for this operation to
+///   complete.`) — the same `ERROR_COMMITMENT_LIMIT` condition
+///   `errors::windows_out_of_memory` covers for our own spawns, arriving as
+///   git stderr text instead of an `io::Error` (issue #835).
+/// - Git-for-Windows' MSYS2 runtime aborting with `BUG (fork bomb)` — a
+///   broken/duplicated git install, not something the app can fix (issue #813).
+/// - A corrupted local repository (truncated packfile / missing object) —
+///   the project's own `.git` needs repairing (issue #842).
+///
+/// Matching is case-insensitive: git's wording varies in capitalization
+/// across versions and platforms (e.g. xcode-select actually prints "No
+/// developer tools were found…", which the original case-sensitive check
+/// missed entirely — issues #724/#725).
 pub fn git_environment_gap(stderr: &str) -> Option<crate::errors::CommandError> {
-    if stderr.contains("You have not agreed to the Xcode license agreements") {
+    let lower = stderr.to_lowercase();
+    if lower.contains("you have not agreed to the xcode license agreements") {
         return Some(crate::errors::CommandError::expected(
             "Xcode's license hasn't been accepted yet, so git can't run. Open Terminal, run \
              `sudo xcodebuild -license accept`, then try again.",
         ));
     }
-    if stderr.contains("invalid active developer path")
-        || stderr.contains("no developer tools were found")
+    if lower.contains("invalid active developer path")
+        || lower.contains("no developer tools were found")
     {
         return Some(crate::errors::CommandError::expected(
             "The Xcode Command Line Tools (which provide git on macOS) are missing or broken. \
              Run `xcode-select --install` in Terminal, then try again.",
         ));
     }
-    if stderr.contains("Unable to read current working directory")
-        && stderr.contains("Operation not permitted")
+    // Git's own runtime failing to launch a helper process because Windows
+    // refused the memory commit — same condition (os error 1455) that
+    // `errors::windows_out_of_memory` classifies for our spawns, so reuse its
+    // remediation wording (issue #835). Must precede the generic out-of-memory
+    // check below so the pagefile guidance wins.
+    if lower.contains("paging file is too small") {
+        return Some(crate::errors::CommandError::expected(
+            "Windows ran out of virtual memory while git was working (the paging file is too \
+             small). Close some other apps or increase the paging file size (Settings → System → \
+             About → Advanced system settings → Performance → Virtual memory), then try again.",
+        ));
+    }
+    // Git for Windows' MSYS2 exec layer refusing to run after detecting a
+    // spawn loop. Almost always a second git install (e.g. Anaconda's)
+    // shadowing Git for Windows on PATH, or a corrupted MSYS2 runtime — no
+    // app-side fix exists (issue #813).
+    if lower.contains("bug (fork bomb)") || lower.contains("bug: forkbomb") {
+        return Some(crate::errors::CommandError::expected(
+            "Git's Windows runtime detected a spawn loop and refused to run — usually a second \
+             Git install (e.g. one bundled with Anaconda or another tool) shadowing Git for \
+             Windows on your PATH, or a damaged Git install. Remove the duplicate git.exe from \
+             your PATH or reinstall Git for Windows from git-scm.com, then try again.",
+        ));
+    }
+    // The project's own object store is damaged — an interrupted gc/fetch, a
+    // crashed process, or a failing disk. Repairable by the user, and no
+    // amount of app-side retrying helps (issue #842).
+    if lower.contains("too short to be a packfile")
+        || (lower.contains("missing object") && lower.contains("fatal:"))
+    {
+        return Some(crate::errors::CommandError::expected(
+            "This project's local git history looks damaged (a file inside its `.git` folder is \
+             corrupted), so git can't read it. Run `git fsck` in the project folder to inspect \
+             the damage, or re-clone the repository into a fresh folder and reopen it here.",
+        ));
+    }
+    if lower.contains("unable to read current working directory")
+        && lower.contains("operation not permitted")
     {
         return Some(crate::errors::CommandError::expected(
             "Ship Studio isn't allowed to read this project's folder — macOS blocked access. \
@@ -556,7 +607,6 @@ pub fn git_environment_gap(stderr: &str) -> Option<crate::errors::CommandError> 
     // to allocate N bytes)" — also "realloc failed" / "mmap failed" variants).
     // The machine is out of memory at the moment git runs, which no app-side
     // fix can address (issue #668).
-    let lower = stderr.to_lowercase();
     if lower.contains("out of memory")
         || lower.contains("malloc failed")
         || lower.contains("realloc failed")
@@ -1886,6 +1936,75 @@ mod tests {
             assert!(git_environment_gap("fatal: Out of memory, realloc failed").is_some());
         }
 
+        /// Issues #724/#725: xcode-select actually capitalizes the sentence
+        /// ("No developer tools were found…"), which the original
+        /// case-sensitive check missed, so a missing-CLT machine reported the
+        /// raw fatal to telemetry instead of the install guidance.
+        #[test]
+        fn classifies_capitalized_missing_developer_tools_as_expected() {
+            let stderr = "xcode-select: note: No developer tools were found, requesting install. \
+                          Choose an option in the dialog to download the command line developer \
+                          tools.";
+            let err = git_environment_gap(stderr).expect("must classify");
+            assert!(matches!(err, crate::errors::CommandError::Expected { .. }));
+            assert!(err.to_string().contains("xcode-select --install"));
+            // The license and TCC signatures are equally case-tolerant.
+            assert!(
+                git_environment_gap("you have not agreed to the Xcode license agreements")
+                    .is_some()
+            );
+            assert!(git_environment_gap(
+                "fatal: unable to read current working directory: operation not permitted"
+            )
+            .is_some());
+        }
+
+        /// Issue #835: Windows pagefile exhaustion reported by git's own
+        /// runtime rather than as our spawn-time os error 1455.
+        #[test]
+        fn classifies_git_paging_file_failure_as_expected() {
+            let stderr =
+                "error launching git: The paging file is too small for this operation to complete.";
+            let err = git_environment_gap(stderr).expect("must classify");
+            assert!(matches!(err, crate::errors::CommandError::Expected { .. }));
+            assert!(
+                err.to_string().contains("paging file"),
+                "message must name the pagefile, got: {err}"
+            );
+        }
+
+        /// Issue #813: Git for Windows' MSYS2 runtime refusing to run after
+        /// detecting a spawn loop — a broken/duplicated git install.
+        #[test]
+        fn classifies_windows_fork_bomb_abort_as_expected() {
+            let stderr = r"BUG (fork bomb): C:\Program Files\Git\bin\git.exe";
+            let err = git_environment_gap(stderr).expect("must classify");
+            assert!(matches!(err, crate::errors::CommandError::Expected { .. }));
+            assert!(
+                err.to_string().contains("PATH"),
+                "message must point at the duplicate install, got: {err}"
+            );
+        }
+
+        /// Issue #842: a truncated packfile in the project's own `.git`
+        /// cascading into a missing-object fatal while listing branches.
+        #[test]
+        fn classifies_corrupted_repository_as_expected() {
+            let stderr = "error: file .git/objects/pack/pack-3301f5a2.pack is far too short to be \
+                          a packfile\nfatal: missing object a17457a0 for refs/remotes/origin/x";
+            let err = git_environment_gap(stderr).expect("must classify");
+            assert!(matches!(err, crate::errors::CommandError::Expected { .. }));
+            assert!(
+                err.to_string().contains("git fsck"),
+                "message must carry the repair step, got: {err}"
+            );
+            // The missing-object fatal on its own (no packfile line) counts too.
+            assert!(git_environment_gap(
+                "fatal: missing object 1234abcd for refs/remotes/origin/main"
+            )
+            .is_some());
+        }
+
         #[test]
         fn leaves_ordinary_git_failures_unclassified() {
             assert!(git_environment_gap("fatal: not a git repository").is_none());
@@ -1896,6 +2015,9 @@ mod tests {
                 "error: unable to unlink old 'a.txt': Operation not permitted"
             )
             .is_none());
+            // "missing object" without a fatal is a warning git recovers from
+            // (e.g. `fsck` output) — not the corrupted-repo abort (#842).
+            assert!(git_environment_gap("warning: missing object 1234abcd").is_none());
         }
     }
 

--- a/src/commands/useWorkspaceCommands.tsx
+++ b/src/commands/useWorkspaceCommands.tsx
@@ -22,7 +22,10 @@ export interface UseWorkspaceCommandsParams {
   openPushDropdown: () => void;
   /** Pulls the latest changes from GitHub (routes conflicts to the resolver) */
   handlePullLatest: () => void;
-  /** Push/pull commands only make sense with a connected GitHub repo */
+  /**
+   * Push/pull need a remote, and the Branches/PRs panes only render for a
+   * connected repo — commands that land there are hidden otherwise (#612).
+   */
   isGitHubConnected: boolean;
   /** Opens the "New worktree" modal. */
   openWorktreeCreate: () => void;
@@ -106,7 +109,10 @@ export function useWorkspaceCommands({
         subtitle: currentBranch ? `Currently on ${currentBranch}` : undefined,
         icon: <BranchIcon size={14} />,
         category: 'branch',
-        when: 'project',
+        // `useWorkspaceLayout` projects the branches/prs tabs back to preview
+        // when GitHub isn't connected, so without this gate the command was
+        // listed, selectable, and did nothing at all (issue #612).
+        when: ({ kind }) => kind === 'project' && isGitHubConnected,
         keywords: ['checkout', 'change', 'git'],
         run: () => setWorkspaceTab('branches'),
       },
@@ -115,7 +121,7 @@ export function useWorkspaceCommands({
         title: 'Create new branch…',
         icon: <PlusIcon size={14} />,
         category: 'branch',
-        when: 'project',
+        when: ({ kind }) => kind === 'project' && isGitHubConnected,
         keywords: ['new', 'git', 'checkout -b'],
         run: () => setWorkspaceTab('branches'),
       },
@@ -142,7 +148,7 @@ export function useWorkspaceCommands({
         title: 'View open pull requests',
         icon: <PullRequestGlyph />,
         category: 'branch',
-        when: 'project',
+        when: ({ kind }) => kind === 'project' && isGitHubConnected,
         keywords: ['prs', 'reviews'],
         run: () => setWorkspaceTab('prs'),
       },
@@ -161,7 +167,8 @@ export function useWorkspaceCommands({
         title: 'Manage worktrees',
         icon: <BranchIcon size={14} />,
         category: 'branch',
-        when: ({ kind }) => kind === 'project' && hasWorktreeData,
+        // Lives inside the Branches pane, so it needs the same gate (#612).
+        when: ({ kind }) => kind === 'project' && hasWorktreeData && isGitHubConnected,
         keywords: ['worktree', 'remove', 'prune', 'git'],
         run: () => setWorkspaceTab('branches'),
       },

--- a/src/components/branches/BranchesTab.revert.test.tsx
+++ b/src/components/branches/BranchesTab.revert.test.tsx
@@ -122,7 +122,7 @@ describe('BranchesTab — Revert to GitHub with no upstream (#539)', () => {
     await waitFor(() => expect(showToast).toHaveBeenCalled());
     const [message, type] = showToast.mock.calls[0];
     expect(type).toBe('info');
-    expect(message).toContain('never been pushed');
+    expect(message).toContain('never pushed');
     expect(message).toContain('feat/unpushed');
     // Honest about the discard that already happened.
     expect(message).toContain('discarded');
@@ -133,6 +133,29 @@ describe('BranchesTab — Revert to GitHub with no upstream (#539)', () => {
     // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
     expect(logger.error as Fn).not.toHaveBeenCalled();
     expect(props.onRefresh).toHaveBeenCalled();
+  });
+
+  it('treats a vanished upstream ref the same as a never-pushed branch (issue #809)', async () => {
+    // git's refusal when branch.<name>.merge points at a ref the remote no
+    // longer has (branch deleted or renamed on GitHub) — a different stderr
+    // signature for the same "nothing on GitHub to pull" situation.
+    vi.mocked(gitPull).mockRejectedValue({
+      type: 'Other',
+      message:
+        "Failed to pull: Your configuration specifies to merge with the ref 'refs/heads/feat/unpushed'\nfrom the remote, but no such ref was fetched.",
+    });
+
+    const { showToast } = renderWithToasts(<BranchesTab {...props} />);
+    await clickThroughRevert();
+
+    await waitFor(() => expect(showToast).toHaveBeenCalled());
+    const [message, type] = showToast.mock.calls[0];
+    expect(type).toBe('info');
+    expect(message).toContain('no matching branch on GitHub');
+    expect(message).toContain('deleted, renamed, or never pushed');
+    expect(message).not.toContain('refs/heads');
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
   });
 
   it('humanizes other pull failures instead of leaking raw stderr', async () => {
@@ -146,9 +169,25 @@ describe('BranchesTab — Revert to GitHub with no upstream (#539)', () => {
 
     await waitFor(() => expect(showToast).toHaveBeenCalled());
     const [message, type] = showToast.mock.calls[0];
-    expect(type).toBe('error');
+    // A recognized condition (offline) — humanized and kept off the 'error'
+    // channel that auto-files bug reports (issues #809/#538).
+    expect(type).toBe('info');
     expect(message).toContain('Failed to revert:');
     expect(message).toMatch(/couldn't reach GitHub/i);
     expect(message).not.toContain('fatal:');
+  });
+
+  it('still reports an unrecognized pull failure as an error', async () => {
+    vi.mocked(gitPull).mockRejectedValue({
+      type: 'Other',
+      message: 'Failed to pull: something nobody has ever seen before',
+    });
+
+    const { showToast } = renderWithToasts(<BranchesTab {...props} />);
+    await clickThroughRevert();
+
+    await waitFor(() => expect(showToast).toHaveBeenCalled());
+    const [, type] = showToast.mock.calls[0];
+    expect(type).toBe('error');
   });
 });

--- a/src/components/branches/BranchesTab.tsx
+++ b/src/components/branches/BranchesTab.tsx
@@ -52,6 +52,7 @@ import {
   asCommandError,
   formatCommandError,
   humanizeGitError,
+  isMissingUpstreamError,
   isRecognizedGitFailure,
 } from '../../lib/errors';
 import { logger } from '../../lib/logger';
@@ -455,12 +456,11 @@ export function BranchesTab({
       onRefresh();
     } catch (e) {
       trackError('branch_revert', e, 'Workspace');
-      // Two git refusals mean the same thing here: there's nothing on GitHub
-      // to pull. "no tracking information" is the never-pushed branch; "no
-      // such ref was fetched" is a configured upstream whose remote ref is
-      // gone (branch deleted or renamed on GitHub) — that second signature
-      // fell through to the raw-error branch (issues #539/#809).
-      if (/no tracking information|no such ref was fetched/i.test(errText(e))) {
+      // Both of git's "nothing on GitHub to pull" refusals (never-pushed
+      // branch; upstream ref deleted or renamed) land here — the second used to
+      // fall through to the raw-error branch (issues #539/#809). The signature
+      // lives in lib/errors so Pull latest can't drift away from it.
+      if (isMissingUpstreamError(e)) {
         // Expected: git's normal refusal, not an app malfunction (the backend
         // classifies it Expected too). The discard above already ran, so local
         // edits ARE gone — say so honestly. Info toast + warn log, never the

--- a/src/components/branches/BranchesTab.tsx
+++ b/src/components/branches/BranchesTab.tsx
@@ -455,22 +455,32 @@ export function BranchesTab({
       onRefresh();
     } catch (e) {
       trackError('branch_revert', e, 'Workspace');
-      if (/no tracking information/i.test(errText(e))) {
-        // Expected: the branch has never been pushed, so there's no GitHub
-        // version to pull — git's normal refusal, not an app malfunction
-        // (the backend classifies it Expected too). The discard above already
-        // ran, so local edits ARE gone — say so honestly. Info toast + warn
-        // log, never the error channels that auto-file bug reports (#539).
-        logger.warn('[BranchesTab] Revert pull skipped: branch has no upstream', {
+      // Two git refusals mean the same thing here: there's nothing on GitHub
+      // to pull. "no tracking information" is the never-pushed branch; "no
+      // such ref was fetched" is a configured upstream whose remote ref is
+      // gone (branch deleted or renamed on GitHub) — that second signature
+      // fell through to the raw-error branch (issues #539/#809).
+      if (/no tracking information|no such ref was fetched/i.test(errText(e))) {
+        // Expected: git's normal refusal, not an app malfunction (the backend
+        // classifies it Expected too). The discard above already ran, so local
+        // edits ARE gone — say so honestly. Info toast + warn log, never the
+        // error channels that auto-file bug reports (#539).
+        logger.warn('[BranchesTab] Revert pull skipped: no matching branch on GitHub', {
           error: errText(e),
         });
         onToast?.(
-          `Your local changes were discarded, but ${currentBranch} has never been pushed to GitHub, so there was no GitHub version to pull. Send the branch to GitHub first if you want a copy to revert to next time.`,
+          `Your local changes were discarded, but there's no matching branch on GitHub for ${currentBranch} to pull — it may have been deleted, renamed, or never pushed. Send the branch to GitHub if you want a copy to revert to next time.`,
           'info'
         );
         onRefresh();
       } else {
-        onToast?.(`Failed to revert: ${humanizeGitError(e, { branch: currentBranch })}`, 'error');
+        // Everything else still goes through the same recognized/unrecognized
+        // split the rest of this file uses, so an anticipated git condition
+        // (auth, network, worktree collision…) doesn't auto-file a bug report.
+        onToast?.(
+          `Failed to revert: ${humanizeGitError(e, { branch: currentBranch })}`,
+          isRecognizedGitFailure(e, { branch: currentBranch }) ? 'info' : 'error'
+        );
       }
     } finally {
       setIsReverting(false);

--- a/src/components/branches/MainBranchBanner.tsx
+++ b/src/components/branches/MainBranchBanner.tsx
@@ -18,9 +18,21 @@ interface MainBranchBannerProps {
   projectPath: string;
   /** Callback to create a new branch */
   onCreateBranch?: () => void;
+  /**
+   * Why "Create branch" can't run right now, or undefined when it can. The
+   * Branches pane only exists for a GitHub-connected project (see
+   * `useWorkspaceLayout`'s tab projection), so without this the button used to
+   * swallow the click with no modal, tab change, or toast — right after the
+   * banner offered it as the fix (issue #612).
+   */
+  createBranchDisabledReason?: string;
 }
 
-export function MainBranchBanner({ projectPath, onCreateBranch }: MainBranchBannerProps) {
+export function MainBranchBanner({
+  projectPath,
+  onCreateBranch,
+  createBranchDisabledReason,
+}: MainBranchBannerProps) {
   const [isDismissed, setIsDismissed] = useState(false);
   const [shouldHide, setShouldHide] = useState<boolean | null>(null);
   const [hideForProject, setHideForProject] = useState(false);
@@ -67,7 +79,12 @@ export function MainBranchBanner({ projectPath, onCreateBranch }: MainBranchBann
           </span>
         </span>
         {onCreateBranch && (
-          <button className="main-branch-banner-action" onClick={onCreateBranch}>
+          <button
+            className="main-branch-banner-action"
+            onClick={onCreateBranch}
+            disabled={createBranchDisabledReason !== undefined}
+            title={createBranchDisabledReason}
+          >
             <BranchIcon size={12} />
             Create branch
           </button>

--- a/src/components/branches/MainBranchBanner.tsx
+++ b/src/components/branches/MainBranchBanner.tsx
@@ -19,20 +19,23 @@ interface MainBranchBannerProps {
   /** Callback to create a new branch */
   onCreateBranch?: () => void;
   /**
-   * Why "Create branch" can't run right now, or undefined when it can. The
-   * Branches pane only exists for a GitHub-connected project (see
-   * `useWorkspaceLayout`'s tab projection), so without this the button used to
-   * swallow the click with no modal, tab change, or toast — right after the
-   * banner offered it as the fix (issue #612).
+   * Whether the project has a GitHub connection. The Branches pane only exists
+   * for a GitHub-connected project (see `useWorkspaceLayout`'s tab
+   * projection), so without this the button used to swallow the click with no
+   * modal, tab change, or toast — right after the banner offered it as the fix
+   * (issue #612).
    */
-  createBranchDisabledReason?: string;
+  isGitHubConnected?: boolean;
 }
 
 export function MainBranchBanner({
   projectPath,
   onCreateBranch,
-  createBranchDisabledReason,
+  isGitHubConnected = true,
 }: MainBranchBannerProps) {
+  const createBranchDisabledReason = isGitHubConnected
+    ? undefined
+    : 'Connect this project to GitHub to create and switch branches';
   const [isDismissed, setIsDismissed] = useState(false);
   const [shouldHide, setShouldHide] = useState<boolean | null>(null);
   const [hideForProject, setHideForProject] = useState(false);

--- a/src/components/branches/PublishBranchDropdown.tsx
+++ b/src/components/branches/PublishBranchDropdown.tsx
@@ -18,7 +18,7 @@ import { useClickOutside } from '../../hooks/useClickOutside';
 import { logger } from '../../lib/logger';
 import { trackEvent, trackError } from '../../lib/analytics';
 import { useOptionalToast } from '../../contexts/ToastContext';
-import { asCommandError, formatCommandError } from '../../lib/errors';
+import { asCommandError, formatCommandError, isRecognizedGitFailure } from '../../lib/errors';
 
 // Module-scoped so the metric spans dropdown re-mounts. Per-project would be
 // better but cross-project publish cadence is also useful and far simpler.
@@ -188,7 +188,16 @@ export function PublishBranchDropdown({
       // Expected (#617). Keep them out of the reporting channels: logger.error
       // and error toasts both auto-file bug reports (issue #643); mirror
       // handlePullLatest's warn/info treatment of the pull-side equivalents.
-      const expectedFailure = errorType === 'push_rejected' || errorType === 'merge_conflict';
+      //
+      // The three tag substrings above are not the only Expected failures this
+      // path sees: git_stage_and_commit's pre-commit-hook refusal (#604) — the
+      // project's own husky/lint chain rejecting the commit — carries none of
+      // them and so reported as a bug every time (issue #766). Ask the shared
+      // recognizer, which knows the backend's humanized wordings.
+      const expectedFailure =
+        errorType === 'push_rejected' ||
+        errorType === 'merge_conflict' ||
+        isRecognizedGitFailure(e, { branch: currentBranch });
       if (expectedFailure) {
         logger.warn('Publish refused (expected state)', {
           branch: currentBranch,

--- a/src/components/branches/PullRequestsTab.close.test.tsx
+++ b/src/components/branches/PullRequestsTab.close.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Regression tests for PullRequestsTab's "Close PR" flow (issue #798).
+ *
+ * `close_pull_request` classifies gh's "already merged" refusal — plus the
+ * shared auth / network / no-repo refusals — as `CommandError::Expected`,
+ * because the PR list the Close button was clicked from can go stale between
+ * fetch and click. `handleClose` nonetheless called `trackError('pr_close', …)`
+ * and raised an 'error' toast for every failure, filing those anticipated
+ * races as bug reports.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { PullRequestsTab } from './PullRequestsTab';
+import type { PullRequestInfo } from '../../lib/branches';
+
+const { showToast } = vi.hoisted(() => ({ showToast: vi.fn() }));
+
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn() }));
+vi.mock('../../lib/branches', () => ({
+  listPullRequests: vi.fn(),
+  mergePullRequest: vi.fn(),
+  checkoutPullRequest: vi.fn(),
+  closePullRequest: vi.fn(),
+  deleteBranch: vi.fn(),
+  switchBranch: vi.fn(),
+}));
+vi.mock('../../lib/analytics', () => ({ trackEvent: vi.fn(), trackError: vi.fn() }));
+vi.mock('../../lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../../contexts/ToastContext', () => ({
+  useOptionalToast: () => ({ showToast }),
+}));
+
+import { listPullRequests, closePullRequest } from '../../lib/branches';
+import { trackError } from '../../lib/analytics';
+import { logger } from '../../lib/logger';
+
+type Fn = ReturnType<typeof vi.fn>;
+
+const OPEN_PR: PullRequestInfo = {
+  number: 12,
+  title: 'Add thing',
+  headRef: 'feature/x',
+  baseRef: 'main',
+  author: 'someone',
+  state: 'OPEN',
+  mergeable: true,
+  isDraft: false,
+  url: 'https://github.com/me/repo/pull/12',
+  createdAt: '2026-08-23T05:00:00Z',
+};
+
+/** Click Close on the PR card, then confirm in the modal. */
+async function closeThePr() {
+  fireEvent.click(await screen.findByRole('button', { name: 'Close' }));
+  const confirm = await screen.findByRole('button', { name: 'Close PR' });
+  // The confirm handler's promise chain (close → refetch → dismiss the modal)
+  // settles after the click returns; let it flush inside act.
+  await act(() => {
+    fireEvent.click(confirm);
+    return Promise.resolve();
+  });
+}
+
+function renderTab() {
+  render(<PullRequestsTab projectPath="/p" githubUsername="me" onRefresh={vi.fn()} />);
+}
+
+describe('PullRequestsTab — closing a pull request (#798)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listPullRequests).mockResolvedValue([OPEN_PR]);
+  });
+
+  it("doesn't file a bug report when GitHub already merged the PR", async () => {
+    vi.mocked(closePullRequest).mockRejectedValue({
+      type: 'Other',
+      message:
+        "This pull request was already merged, so there's nothing to close. Refresh to see its current state.",
+    });
+
+    renderTab();
+    await closeThePr();
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.stringContaining('already merged'), 'info');
+    });
+    expect(trackError as Fn).not.toHaveBeenCalledWith('pr_close', expect.anything(), 'Workspace');
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.warn as Fn).toHaveBeenCalled();
+    // The on-screen list is stale by definition — refetch it.
+    expect(vi.mocked(listPullRequests).mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('still reports a failure it cannot explain', async () => {
+    vi.mocked(closePullRequest).mockRejectedValue({
+      type: 'Other',
+      message: 'Failed to close PR: something exploded',
+    });
+
+    renderTab();
+    await closeThePr();
+
+    await waitFor(() => {
+      expect(trackError as Fn).toHaveBeenCalledWith('pr_close', expect.anything(), 'Workspace');
+    });
+    expect(showToast).toHaveBeenCalledWith(expect.stringContaining('something exploded'), 'error');
+  });
+});

--- a/src/components/branches/PullRequestsTab.tsx
+++ b/src/components/branches/PullRequestsTab.tsx
@@ -24,7 +24,14 @@ import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { Spinner } from '../primitives/Spinner';
 import { useOptionalToast } from '../../contexts/ToastContext';
-import { asCommandError, formatCommandError, isMergeConflictError } from '../../lib/errors';
+import {
+  asCommandError,
+  formatCommandError,
+  humanizeGitError,
+  isMergeConflictError,
+  isRecognizedGitFailure,
+} from '../../lib/errors';
+import { logger } from '../../lib/logger';
 
 interface PullRequestsTabProps {
   /** Project path for PR operations */
@@ -139,7 +146,20 @@ export function PullRequestsTab({
         onToast?.('This pull request has merge conflicts', 'info');
         onResolveConflicts(headRef, baseRef);
       } else {
-        onToast?.(`Failed to merge: ${formatCommandError(asCommandError(e))}`, 'error');
+        // Everything else: a recognized git/GitHub condition (GitHub 5xx, the
+        // head branch deleted, auth, network) is already Expected on the
+        // backend, so an unconditional 'error' toast re-reports it through the
+        // toast telemetry pipeline — and the raw gh stderr told the user
+        // nothing (issue #715).
+        const message = humanizeGitError(e, { branch: headRef, base: baseRef });
+        if (isRecognizedGitFailure(e, { branch: headRef, base: baseRef })) {
+          logger.warn('[PullRequests] Merge refused for a recognized reason', {
+            error: formatCommandError(asCommandError(e)),
+          });
+          onToast?.(`Couldn't merge: ${message}`, 'info');
+        } else {
+          onToast?.(`Failed to merge: ${message}`, 'error');
+        }
       }
     } finally {
       setMergingPr(null);

--- a/src/components/branches/PullRequestsTab.tsx
+++ b/src/components/branches/PullRequestsTab.tsx
@@ -232,8 +232,22 @@ export function PullRequestsTab({
       await fetchPullRequests();
       onRefresh();
     } catch (e) {
-      trackError('pr_close', e, 'Workspace');
-      onToast?.(`Failed to close PR: ${formatCommandError(asCommandError(e))}`, 'error');
+      // gh refuses to close a PR GitHub already merged — the list this button
+      // was clicked from can be stale by seconds, so the backend classifies it
+      // Expected (issue #798), as it does for the auth/network/no-repo
+      // refusals. trackError + an 'error' toast filed all of those as bugs.
+      const message = humanizeGitError(e);
+      if (isRecognizedGitFailure(e)) {
+        logger.warn('[PullRequests] Close refused for a recognized reason', {
+          error: formatCommandError(asCommandError(e)),
+        });
+        onToast?.(`Couldn't close: ${message}`, 'info');
+        // Whatever the reason, the on-screen list may no longer match GitHub.
+        await fetchPullRequests();
+      } else {
+        trackError('pr_close', e, 'Workspace');
+        onToast?.(`Failed to close PR: ${message}`, 'error');
+      }
     } finally {
       setClosingPr(null);
     }

--- a/src/components/branches/SubmitReviewModal.tsx
+++ b/src/components/branches/SubmitReviewModal.tsx
@@ -235,7 +235,18 @@ export function SubmitReviewModal({
       } else {
         const message = humanizeGitError(e, { branch: branchName, base: baseBranch });
         setError(message);
-        onToast?.(message, 'error');
+        if (isRecognizedGitFailure(e, { branch: branchName, base: baseBranch })) {
+          // Same reasoning as handleSubmit above: a known refusal (the head
+          // branch gone, auth, network, GitHub 5xx) is already Expected on the
+          // backend, so an 'error' toast here re-reports it through the toast
+          // telemetry pipeline (issue #730).
+          logger.warn('[SubmitReview] Merge refused for a recognized reason', {
+            error: formatCommandError(asCommandError(e)),
+          });
+          onToast?.(message, 'info');
+        } else {
+          onToast?.(message, 'error');
+        }
       }
     } finally {
       setIsMerging(false);

--- a/src/components/branches/UnsavedChangesModal.tsx
+++ b/src/components/branches/UnsavedChangesModal.tsx
@@ -15,7 +15,14 @@ import { publishBranch, discardChanges, switchBranch } from '../../lib/branches'
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { useOptionalToast } from '../../contexts/ToastContext';
-import { asCommandError, formatCommandError } from '../../lib/errors';
+import {
+  asCommandError,
+  formatCommandError,
+  humanizeGitError,
+  isRecognizedGitFailure,
+} from '../../lib/errors';
+import { logger } from '../../lib/logger';
+import type { ToastType } from '../../hooks/useToasts';
 
 interface UnsavedChangesModalProps {
   /** Current branch name */
@@ -38,9 +45,32 @@ export function UnsavedChangesModal({
   onClose,
 }: UnsavedChangesModalProps) {
   const { showToast } = useOptionalToast();
-  const onToast = (message: string, type?: 'success' | 'error') => showToast(message, type);
+  const onToast = (message: string, type?: ToastType) => showToast(message, type);
   const [isPublishing, setIsPublishing] = useState(false);
   const [isDiscarding, setIsDiscarding] = useState(false);
+
+  /**
+   * Toast a git failure without re-reporting it. Recognized conditions (a
+   * push race the remote rejected, auth, network) are already classified
+   * Expected on the backend and have nothing to do with an app malfunction —
+   * an 'error' toast auto-files a bug report for each one (issue #726).
+   */
+  const toastGitFailure = (prefix: string, e: unknown) => {
+    // git can fail with nothing to say; don't dress up an empty string.
+    if (!e) {
+      onToast(prefix, 'error');
+      return;
+    }
+    const message = humanizeGitError(e, { branch: currentBranch, base: targetBranch });
+    if (isRecognizedGitFailure(e, { branch: currentBranch, base: targetBranch })) {
+      logger.warn('[UnsavedChanges] Action refused for a recognized reason', {
+        error: formatCommandError(asCommandError(e)),
+      });
+      onToast(`${prefix}: ${message}`, 'info');
+    } else {
+      onToast(`${prefix}: ${message}`, 'error');
+    }
+  };
 
   // The working tree can pick up new changes between this modal's action and
   // the switch (dev-server config writes, background tooling), in which case
@@ -65,10 +95,10 @@ export function UnsavedChangesModal({
         onSwitchComplete(targetBranch);
         onClose();
       } else {
-        onToast?.(result.error || 'Failed to switch branch', 'error');
+        toastGitFailure('Failed to switch branch', result.error);
       }
     } catch (e) {
-      onToast?.(`Failed to publish: ${formatCommandError(asCommandError(e))}`, 'error');
+      toastGitFailure('Failed to publish', e);
     } finally {
       setIsPublishing(false);
     }
@@ -84,10 +114,10 @@ export function UnsavedChangesModal({
         onSwitchComplete(targetBranch);
         onClose();
       } else {
-        onToast?.(result.error || 'Failed to switch branch', 'error');
+        toastGitFailure('Failed to switch branch', result.error);
       }
     } catch (e) {
-      onToast?.(`Failed to discard changes: ${formatCommandError(asCommandError(e))}`, 'error');
+      toastGitFailure('Failed to discard changes', e);
     } finally {
       setIsDiscarding(false);
     }

--- a/src/components/code/HealthTabPanel.tsx
+++ b/src/components/code/HealthTabPanel.tsx
@@ -55,7 +55,8 @@ export interface HealthTabPanelRef {
 export const HealthTabPanel = forwardRef<HealthTabPanelRef, HealthTabPanelProps>(
   function HealthTabPanel({ projectPath, onAskClaude, onHealthOutput }, ref) {
     const { showToast } = useOptionalToast();
-    const onToast = (message: string, type?: 'success' | 'error') => showToast(message, type);
+    const onToast = (message: string, type?: 'success' | 'error' | 'info') =>
+      showToast(message, type);
     const { copy: copyOutput } = useCopyToClipboard({
       onCopy: () => onToast('Output copied', 'success'),
     });

--- a/src/components/dashboard/Changelog.tsx
+++ b/src/components/dashboard/Changelog.tsx
@@ -26,6 +26,20 @@ interface ChangelogEntry {
 // Keep ~15 most recent versions for the sidebar
 const CHANGELOG: ChangelogEntry[] = [
   {
+    version: '0.18.7', // v0.18.7
+    items: [
+      'Visual editor: elements without a class attribute can now be inserted, duplicated, and deleted; JSX props like onClick={() => …} no longer break element mapping (a long-standing cause of failed edits); and class/style edits now survive a file being reformatted mid-edit, just like text edits already did',
+      'Windows: the Claude Code terminal no longer fails instantly with "too many arguments" — agent CLIs are spawned correctly whether they\'re real executables or npm shims — and a stray npm package named "gh" shadowing GitHub\'s CLI is now detected and explained',
+      'Startup can no longer crash because the disk is full (logging degrades gracefully), the GitHub contribution calendar no longer crashes the dashboard when there is no activity data, and a GPU hiccup in the terminal falls back cleanly instead of throwing',
+      'Importing a repo that uses pnpm or yarn workspaces now installs with the right package manager instead of failing with npm workspace-protocol errors, and unresolvable repos get a plain explanation instead of a GraphQL dump',
+      'Branches and PRs: publishing to a repo that already has an origin remote works instead of failing with "Unable to add remote", publishing from a detached HEAD is refused with a clear message instead of pushing a branch literally named HEAD, and stash/undo operations now ride out git index.lock contention like commits already did',
+      'MCP servers: failures while removing or listing servers are now explained the same way adding them already was (enterprise gateways, broken agent configs, an upstream Claude CLI env-var bug), and an empty error now at least carries the exit code',
+      'Plugins: installs retry transient failures and no longer prompt invisibly for git credentials, the plugin library survives rate limiting, and a plugin refusal no longer shows up as "[object Object]"',
+      'A huge quiet-telemetry cleanup: ~50 error paths that auto-filed bug reports for routine environmental states (cloud-drive stalls, antivirus file locks, offline networks, permission blocks, slow dev servers) now explain themselves calmly instead',
+      '~118 auto-reported issues fixed since 0.18.6 — the largest sweep yet',
+    ],
+  },
+  {
     version: '0.18.6', // v0.18.6
     items: [
       'Two crash fixes: the app no longer panics when generating a commit message containing accents, emoji, or non-Latin characters, and closing a project no longer risks a crash from the dev-server logs terminal',

--- a/src/components/dashboard/CreateProject.tsx
+++ b/src/components/dashboard/CreateProject.tsx
@@ -83,6 +83,12 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
   const [communitySearch, setCommunitySearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [selectedCommunityId, setSelectedCommunityId] = useState<string | null>(null);
+  /**
+   * Set when the fetch itself failed (offline, API down, parse error) so the
+   * gallery can say so and offer a retry, instead of the identical-looking
+   * "No templates found" the search-miss case shows (issue #754).
+   */
+  const [communityError, setCommunityError] = useState<string | null>(null);
   const [downloading, setDownloading] = useState(false);
 
   // Debounce search input — hit the API server-side
@@ -94,6 +100,7 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
   // Fetch templates from API (server-side search)
   const fetchTemplates = useCallback(() => {
     setCommunityLoading(true);
+    setCommunityError(null);
     const params: Record<string, string | number> = {};
     if (debouncedSearch) params.search = debouncedSearch;
     invoke<string>('fetch_community_templates', params)
@@ -101,8 +108,14 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
         const data = JSON.parse(raw) as { templates: CommunityTemplate[] };
         setCommunityTemplates(data.templates);
       })
-      .catch(() => {
-        // Silently fail — user sees empty state
+      .catch((err: unknown) => {
+        // The backend classifies these Expected (offline / API unreachable), so
+        // warn rather than error — but the user must still be told the fetch
+        // failed instead of being shown "No templates found" (issue #754).
+        const message = formatCommandError(asCommandError(err));
+        logger.warn('[CreateProject] Failed to fetch community templates', { error: message });
+        setCommunityTemplates([]);
+        setCommunityError(message);
       })
       .finally(() => setCommunityLoading(false));
   }, [debouncedSearch]);
@@ -328,6 +341,8 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
                 selectedId={selectedCommunityId}
                 searchQuery={communitySearch}
                 onSearchChange={setCommunitySearch}
+                loadError={communityError}
+                onRetry={fetchTemplates}
               />
 
               <div className="template-divider">

--- a/src/components/dashboard/CreateProject.tsx
+++ b/src/components/dashboard/CreateProject.tsx
@@ -11,7 +11,7 @@
  * @module components/CreateProject
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { trackEvent } from '../../lib/analytics';
 import { logger } from '../../lib/logger';
@@ -26,6 +26,7 @@ import {
   STEPS,
   STATUS_MESSAGES,
 } from '../../hooks/useProjectCreation';
+import { useAsyncState } from '../../hooks/useAsyncState';
 import { TemplateGallery, type CommunityTemplate } from './TemplateGallery';
 import { TemplateCard } from './TemplateCard';
 
@@ -78,17 +79,9 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
   const [activeTab, setActiveTab] = useState<'scratch' | 'template'>('scratch');
 
   // Community templates from API
-  const [communityTemplates, setCommunityTemplates] = useState<CommunityTemplate[]>([]);
-  const [communityLoading, setCommunityLoading] = useState(true);
   const [communitySearch, setCommunitySearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [selectedCommunityId, setSelectedCommunityId] = useState<string | null>(null);
-  /**
-   * Set when the fetch itself failed (offline, API down, parse error) so the
-   * gallery can say so and offer a retry, instead of the identical-looking
-   * "No templates found" the search-miss case shows (issue #754).
-   */
-  const [communityError, setCommunityError] = useState<string | null>(null);
   const [downloading, setDownloading] = useState(false);
 
   // Debounce search input — hit the API server-side
@@ -97,39 +90,53 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
     return () => clearTimeout(timer);
   }, [communitySearch]);
 
-  // Fetch templates from API (server-side search)
-  const fetchTemplates = useCallback(() => {
-    setCommunityLoading(true);
-    setCommunityError(null);
-    const params: Record<string, string | number> = {};
-    if (debouncedSearch) params.search = debouncedSearch;
-    invoke<string>('fetch_community_templates', params)
-      .then((raw) => {
-        const data = JSON.parse(raw) as { templates: CommunityTemplate[] };
-        setCommunityTemplates(data.templates);
-      })
-      .catch((err: unknown) => {
+  // Fetch templates from API (server-side search). The search term is an
+  // argument, not a closure, so `execute` stays stable across keystrokes.
+  const {
+    data: fetchedTemplates,
+    isLoading: isFetchingTemplates,
+    error: fetchTemplatesError,
+    execute: fetchTemplates,
+  } = useAsyncState<CommunityTemplate[], [string]>(
+    async (search: string) => {
+      const params: Record<string, string | number> = {};
+      if (search) params.search = search;
+      const raw = await invoke<string>('fetch_community_templates', params);
+      return (JSON.parse(raw) as { templates: CommunityTemplate[] }).templates;
+    },
+    {
+      onError: (err) => {
         // The backend classifies these Expected (offline / API unreachable), so
         // warn rather than error — but the user must still be told the fetch
         // failed instead of being shown "No templates found" (issue #754).
-        const message = formatCommandError(asCommandError(err));
-        logger.warn('[CreateProject] Failed to fetch community templates', { error: message });
-        setCommunityTemplates([]);
-        setCommunityError(message);
-      })
-      .finally(() => setCommunityLoading(false));
-  }, [debouncedSearch]);
+        logger.warn('[CreateProject] Failed to fetch community templates', { error: err.message });
+      },
+    }
+  );
+
+  /**
+   * Set when the fetch itself failed (offline, API down, parse error) so the
+   * gallery can say so and offer a retry, instead of the identical-looking
+   * "No templates found" the search-miss case shows (issue #754).
+   */
+  const communityError = fetchTemplatesError?.message ?? null;
+  // A failed fetch shows the error, never a stale list from an earlier search.
+  const communityTemplates = communityError ? [] : (fetchedTemplates ?? []);
+  // `data === null` means the first fetch hasn't landed yet — still loading, so
+  // the first paint is skeletons rather than a momentary "No templates found".
+  const communityLoading =
+    isFetchingTemplates || (fetchedTemplates === null && fetchTemplatesError === null);
 
   // Fetch on mount and when search changes
   useEffect(() => {
-    fetchTemplates();
-  }, [fetchTemplates]);
+    void fetchTemplates(debouncedSearch);
+  }, [fetchTemplates, debouncedSearch]);
 
   // Re-fetch every 50 minutes to keep signed zip_urls fresh (they expire after 1 hour)
   useEffect(() => {
-    const interval = setInterval(fetchTemplates, 50 * 60 * 1000);
+    const interval = setInterval(() => void fetchTemplates(debouncedSearch), 50 * 60 * 1000);
     return () => clearInterval(interval);
-  }, [fetchTemplates]);
+  }, [fetchTemplates, debouncedSearch]);
 
   const handleCommunitySelect = (template: CommunityTemplate) => {
     setSelectedCommunityId(template.id === selectedCommunityId ? null : template.id);
@@ -342,7 +349,7 @@ export function CreateProject({ onComplete, onCancel }: CreateProjectProps) {
                 searchQuery={communitySearch}
                 onSearchChange={setCommunitySearch}
                 loadError={communityError}
-                onRetry={fetchTemplates}
+                onRetry={() => void fetchTemplates(debouncedSearch)}
               />
 
               <div className="template-divider">

--- a/src/components/dashboard/GitHubCalendar.test.ts
+++ b/src/components/dashboard/GitHubCalendar.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Tests for the contribution calendar's empty-data guard (issue #721).
+ *
+ * react-activity-calendar throws `Activity data must not be empty.` during
+ * render when handed a zero-length array, which crashed the app to the error
+ * boundary whenever the contributions fetch came back with nothing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { placeholderYearActivity } from './GitHubCalendar';
+
+describe('placeholderYearActivity', () => {
+  it('covers every day of a common year', () => {
+    const days = placeholderYearActivity(2023);
+    expect(days).toHaveLength(365);
+    expect(days[0]).toEqual({ date: '2023-01-01', count: 0, level: 0 });
+    expect(days[days.length - 1]).toEqual({ date: '2023-12-31', count: 0, level: 0 });
+  });
+
+  it('covers the extra day of a leap year', () => {
+    const days = placeholderYearActivity(2024);
+    expect(days).toHaveLength(366);
+    expect(days.some((d) => d.date === '2024-02-29')).toBe(true);
+  });
+
+  it('emits zero-padded ISO dates the library accepts', () => {
+    // react-activity-calendar parses these with parseISO and rejects
+    // anything that isn't a valid YYYY-MM-DD string.
+    for (const day of placeholderYearActivity(2025)) {
+      expect(day.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(Number.isNaN(Date.parse(day.date))).toBe(false);
+    }
+  });
+
+  it('is never empty — that is the whole point of the guard', () => {
+    expect(placeholderYearActivity(2026).length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/dashboard/GitHubCalendar.tsx
+++ b/src/components/dashboard/GitHubCalendar.tsx
@@ -20,6 +20,37 @@ interface Activity {
   level: number;
 }
 
+/** The activity shape react-github-calendar hands to — and expects back from — `transformData`. */
+type CalendarActivity = { date: string; count: number; level: 0 | 1 | 2 | 3 | 4 };
+
+/**
+ * A full year of zero-count days, used when the contributions fetch comes
+ * back empty.
+ *
+ * react-activity-calendar throws `Activity data must not be empty.` from
+ * inside its render when handed a zero-length array — a transient API
+ * failure, a rate limit, or an account with no activity for the requested
+ * year would therefore crash the whole app to the error boundary rather than
+ * degrade (issue #721). Handing it a valid all-zero year keeps it renderable
+ * while the caller keeps the skeleton on top of it.
+ *
+ * Mirrors react-activity-calendar's own internal `generateEmptyData()`.
+ */
+export function placeholderYearActivity(year: number): CalendarActivity[] {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const days: CalendarActivity[] = [];
+  const cursor = new Date(year, 0, 1);
+  while (cursor.getFullYear() === year) {
+    days.push({
+      date: `${year}-${pad(cursor.getMonth() + 1)}-${pad(cursor.getDate())}`,
+      count: 0,
+      level: 0,
+    });
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return days;
+}
+
 interface GitHubCalendarProps {
   /** GitHub username to display contributions for */
   username: string | null | undefined;
@@ -101,12 +132,19 @@ export const GitHubCalendar = memo(function GitHubCalendar({
   // Stable transformData callback — prevents the library from re-fetching/re-processing
   // data on every parent re-render (unstable function refs trigger library effects).
   const handleTransformData = useCallback(
-    (data: Array<{ date: string; count: number; level: 0 | 1 | 2 | 3 | 4 }>) => {
+    (data: CalendarActivity[]) => {
+      if (data.length === 0) {
+        // No contributions came back (transient API failure, rate limit, or
+        // an account with nothing in this year). Stay in the loading state —
+        // the calendar keeps rendering, but off a placeholder year, because
+        // an empty array makes the library throw during render (issue #721).
+        return placeholderYearActivity(currentYear);
+      }
       // Called when data is loaded
       setDataLoaded(true);
       return data;
     },
-    []
+    [currentYear]
   );
 
   // Only hide after auth check is DONE and confirmed NOT authenticated

--- a/src/components/dashboard/ImportProject.tsx
+++ b/src/components/dashboard/ImportProject.tsx
@@ -39,11 +39,11 @@ import {
   Step3WorkspacePicker,
   type WorkspacePick,
 } from '../import-project/steps/Step3WorkspacePicker';
+import { describeImportError } from '../import-project/importErrors';
 import { logger } from '../../lib/logger';
 import {
   asCommandError,
   describeAccountsLoadError,
-  describeProcessError,
   formatCommandError,
   friendlyProcessError,
 } from '../../lib/errors';
@@ -165,7 +165,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       await new Promise((r) => setTimeout(r, 800));
       onComplete(importedProjectPath);
     } catch (err) {
-      const info = describeProcessError(err);
+      const info = describeImportError(err);
       // Recognized user-environment failures (stale npm login, SSH auth, …)
       // log at warn — logger.error auto-files bug reports (issues #505/#531).
       const logContext = {
@@ -292,7 +292,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
 
       await finishImport(projectPath);
     } catch (err) {
-      const info = describeProcessError(err);
+      const info = describeImportError(err);
       // Recognized user-environment failures (SSH keys not set up, stale
       // auth, …) log at warn — logger.error auto-files bug reports
       // (issue #531).
@@ -342,7 +342,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       await new Promise((r) => setTimeout(r, 800));
       onComplete(projectPath);
     } catch (err) {
-      const info = describeProcessError(err);
+      const info = describeImportError(err);
       // Recognized user-environment failures (stale npm login, missing
       // tool, …) log at warn — logger.error auto-files bug reports
       // (issue #505).

--- a/src/components/dashboard/ProjectList.tsx
+++ b/src/components/dashboard/ProjectList.tsx
@@ -478,8 +478,10 @@ export function ProjectList({
       );
       void trackEvent('project_thumbnail_uploaded', { $screen_name: 'Dashboard' });
     } catch (error) {
+      // CommandError rejections are plain objects — String() renders
+      // "[object Object]" (issue #823); format to the real message.
       logger.error('Failed to upload thumbnail', {
-        error: error instanceof Error ? error.message : String(error),
+        error: formatCommandError(asCommandError(error)),
       });
       alert('Failed to upload thumbnail: ' + formatCommandError(asCommandError(error)));
     }

--- a/src/components/dashboard/TemplateGallery.test.tsx
+++ b/src/components/dashboard/TemplateGallery.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * The gallery's three "nothing to show" states must stay distinguishable
+ * (issue #754): loading skeletons, a search that matched nothing, and a fetch
+ * that failed — the last one with a working retry.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TemplateGallery } from './TemplateGallery';
+
+const noop = () => {};
+
+function renderGallery(props: Partial<React.ComponentProps<typeof TemplateGallery>> = {}) {
+  return render(
+    <TemplateGallery
+      templates={[]}
+      loading={false}
+      onSelect={noop}
+      selectedId={null}
+      searchQuery=""
+      onSearchChange={noop}
+      {...props}
+    />
+  );
+}
+
+describe('TemplateGallery empty states', () => {
+  it('shows "no templates" only when the fetch succeeded', () => {
+    renderGallery();
+    expect(screen.getByText('No templates found')).toBeTruthy();
+  });
+
+  it('shows neither empty nor error copy while loading', () => {
+    renderGallery({ loading: true });
+    expect(screen.queryByText('No templates found')).toBeNull();
+    expect(screen.queryByText(/Couldn't load templates/)).toBeNull();
+  });
+
+  it('shows the load error with a retry button instead of "no templates"', () => {
+    const onRetry = vi.fn();
+    renderGallery({ loadError: 'offline', onRetry });
+
+    expect(screen.queryByText('No templates found')).toBeNull();
+    expect(screen.getByText(/Couldn't load templates\. offline/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/dashboard/TemplateGallery.tsx
+++ b/src/components/dashboard/TemplateGallery.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback } from 'react';
+import { Button } from '../primitives/Button';
 
 /** Shape of a community template from the API */
 export interface CommunityTemplate {
@@ -250,9 +251,9 @@ export function TemplateGallery({
             <div className="tg-empty tg-error">
               <span>Couldn't load templates. {loadError}</span>
               {onRetry && (
-                <button type="button" className="tg-retry" onClick={onRetry}>
+                <Button variant="secondary" size="sm" onClick={onRetry}>
                   Try again
-                </button>
+                </Button>
               )}
             </div>
           )}

--- a/src/components/dashboard/TemplateGallery.tsx
+++ b/src/components/dashboard/TemplateGallery.tsx
@@ -20,6 +20,15 @@ interface TemplateGalleryProps {
   selectedId: string | null;
   searchQuery: string;
   onSearchChange: (query: string) => void;
+  /**
+   * Why the template fetch failed, or null when it succeeded. A failed fetch
+   * used to be indistinguishable from a search that matched nothing — both
+   * rendered "No templates found", so an offline user was told the gallery was
+   * empty (issue #754).
+   */
+  loadError?: string | null;
+  /** Re-runs the fetch behind the error state's retry action. */
+  onRetry?: () => void;
 }
 
 function SkeletonCard() {
@@ -100,6 +109,8 @@ export function TemplateGallery({
   selectedId,
   searchQuery,
   onSearchChange,
+  loadError = null,
+  onRetry,
 }: TemplateGalleryProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
@@ -137,7 +148,8 @@ export function TemplateGallery({
     [updateScrollButtons]
   );
 
-  const showEmpty = !loading && templates.length === 0;
+  const showError = !loading && loadError !== null;
+  const showEmpty = !loading && !showError && templates.length === 0;
 
   return (
     <div className="tg-container">
@@ -231,6 +243,17 @@ export function TemplateGallery({
           {showEmpty && (
             <div className="tg-empty">
               <span>No templates found</span>
+            </div>
+          )}
+
+          {showError && (
+            <div className="tg-empty tg-error">
+              <span>Couldn't load templates. {loadError}</span>
+              {onRetry && (
+                <button type="button" className="tg-retry" onClick={onRetry}>
+                  Try again
+                </button>
+              )}
             </div>
           )}
         </div>

--- a/src/components/edit/ElementHtmlEditor.tsx
+++ b/src/components/edit/ElementHtmlEditor.tsx
@@ -90,7 +90,12 @@ export function ElementHtmlEditor({ projectPath, signature }: Props) {
       baselineRef.current = text;
       showToast(applied > 1 ? `Markup saved in ${applied} places` : 'Markup saved', 'success');
     } catch (e) {
-      showToast(editorErrorText(e), 'error');
+      // A `Validation` rejection is the backend declining by design (drift, or
+      // an element it won't guess a write target for) — its reason is already
+      // an actionable sentence. An 'error' toast would re-file it as a bug on
+      // every occurrence via useToasts' `source: 'toast'` reporting (#785).
+      const expected = asCommandError(e).type === 'Validation';
+      showToast(editorErrorText(e), expected ? 'info' : 'error');
     } finally {
       setSaving(false);
     }

--- a/src/components/edit/ElementToolbar.tsx
+++ b/src/components/edit/ElementToolbar.tsx
@@ -13,7 +13,12 @@ import { useEffect, useRef, useState } from 'react';
 import { PlusIcon, CopyIcon, TrashIcon } from '../icons';
 import { Spinner } from '../primitives/Spinner';
 import { InsertMenu } from './InsertMenu';
-import { VOID_ELEMENTS, type ElementKind, type InsertPosition } from '../../lib/edit-structure';
+import {
+  STRUCTURAL_ELEMENTS,
+  VOID_ELEMENTS,
+  type ElementKind,
+  type InsertPosition,
+} from '../../lib/edit-structure';
 import type { StructureSelection } from '../../hooks/useElementStructure';
 
 interface Props {
@@ -88,6 +93,10 @@ export function ElementToolbar({
   const left = Math.max(4, Math.min(rect.left, maxLeft));
 
   const insideDisabled = VOID_ELEMENTS.has(selection.signature.tagName);
+  // <html>/<head>/<body> ARE the page — the backend refuses to duplicate,
+  // delete, or insert beside them, so don't offer it (issues #723/#740).
+  const structural = STRUCTURAL_ELEMENTS.has(selection.signature.tagName);
+  const structuralTitle = `<${selection.signature.tagName}> is part of the page itself`;
 
   return (
     <>
@@ -117,7 +126,8 @@ export function ElementToolbar({
               type="button"
               className="ss-el-toolbar__btn"
               aria-label="Duplicate element"
-              title="Duplicate element"
+              title={structural ? structuralTitle : 'Duplicate element'}
+              disabled={structural}
               onClick={onDuplicate}
             >
               <CopyIcon size={12} />
@@ -126,7 +136,8 @@ export function ElementToolbar({
               type="button"
               className="ss-el-toolbar__btn ss-el-toolbar__btn--danger"
               aria-label="Delete element"
-              title="Delete element"
+              title={structural ? structuralTitle : 'Delete element'}
+              disabled={structural}
               onClick={onDelete}
             >
               <TrashIcon size={12} />
@@ -137,6 +148,7 @@ export function ElementToolbar({
       <InsertMenu
         anchor={menuAnchor}
         insideDisabled={insideDisabled}
+        outsideDisabled={structural}
         onInsert={onInsert}
         onClose={() => setMenuAnchor(null)}
       />

--- a/src/components/edit/ElementTreePanel.tsx
+++ b/src/components/edit/ElementTreePanel.tsx
@@ -15,7 +15,12 @@ import { ElementTreeContextMenu } from './ElementTreeContextMenu';
 import { InsertMenu } from './InsertMenu';
 import type { ElementTreeNode } from '../../hooks/useElementTree';
 import type { ElementSignature } from '../../lib/edit';
-import { VOID_ELEMENTS, type ElementKind, type InsertPosition } from '../../lib/edit-structure';
+import {
+  STRUCTURAL_ELEMENTS,
+  VOID_ELEMENTS,
+  type ElementKind,
+  type InsertPosition,
+} from '../../lib/edit-structure';
 
 /** The structural-edit actions the panel's context menu drives
  *  (from `useElementStructure`). */
@@ -273,6 +278,7 @@ export function ElementTreePanel({
           <InsertMenu
             anchor={insertFor?.anchor ?? null}
             insideDisabled={insertFor ? VOID_ELEMENTS.has(insertFor.tag) : false}
+            outsideDisabled={insertFor ? STRUCTURAL_ELEMENTS.has(insertFor.tag) : false}
             onInsert={(position, kind) => {
               if (!insertFor) return;
               structure.selectAndRun(insertFor.nodeId, () => structure.insert(position, kind));

--- a/src/components/edit/InsertMenu.tsx
+++ b/src/components/edit/InsertMenu.tsx
@@ -15,6 +15,9 @@ interface Props {
   anchor: { left: number; top: number; bottom: number } | null;
   /** The anchor element can't contain children (void tag) — no "Inside". */
   insideDisabled: boolean;
+  /** The anchor IS the document (`<html>`/`<head>`/`<body>`) — nothing can sit
+   *  beside it, so only "Inside" is offered (issues #723/#740). */
+  outsideDisabled?: boolean;
   onInsert: (position: InsertPosition, kind: ElementKind) => void;
   onClose: () => void;
 }
@@ -28,7 +31,7 @@ const POSITIONS: { id: InsertPosition; label: string }[] = [
   { id: 'inside', label: 'Inside' },
 ];
 
-export function InsertMenu({ anchor, insideDisabled, onInsert, onClose }: Props) {
+export function InsertMenu({ anchor, insideDisabled, outsideDisabled, onInsert, onClose }: Props) {
   const [position, setPosition] = useState<InsertPosition>('after');
   const [active, setActive] = useState(0);
   const popRef = useRef<HTMLDivElement>(null);
@@ -36,8 +39,15 @@ export function InsertMenu({ anchor, insideDisabled, onInsert, onClose }: Props)
   const listId = useId();
   const optionId = (i: number) => `${listId}-opt-${i}`;
 
-  // A void anchor loses "Inside" — fall back to the default placement.
-  const effectivePosition = insideDisabled && position === 'inside' ? 'after' : position;
+  const disabledPosition = (id: InsertPosition) =>
+    id === 'inside' ? insideDisabled : !!outsideDisabled;
+  // A void anchor loses "Inside", a structural one loses Before/After — fall
+  // back to whichever placement is still available.
+  const effectivePosition = !disabledPosition(position)
+    ? position
+    : outsideDisabled
+      ? 'inside'
+      : 'after';
 
   // Fresh keyboard highlight each time the menu opens (render-time state
   // adjustment — the sanctioned "derive from prop change" pattern).
@@ -116,11 +126,13 @@ export function InsertMenu({ anchor, insideDisabled, onInsert, onClose }: Props)
             role="radio"
             aria-checked={effectivePosition === p.id}
             className={`ss-insert-menu__position${effectivePosition === p.id ? ' is-active' : ''}`}
-            disabled={p.id === 'inside' && insideDisabled}
+            disabled={disabledPosition(p.id)}
             title={
               p.id === 'inside' && insideDisabled
                 ? 'This element can’t contain children'
-                : undefined
+                : disabledPosition(p.id)
+                  ? 'Nothing can sit beside this element — it’s part of the page itself'
+                  : undefined
             }
             onClick={() => setPosition(p.id)}
           >

--- a/src/components/import-project/importErrors.test.ts
+++ b/src/components/import-project/importErrors.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { describeImportError } from './importErrors';
+
+describe('describeImportError', () => {
+  it('distinguishes illegal-filename checkouts from the long-path case (issue #706)', () => {
+    // The same clone dump also contains the "unable to checkout working tree"
+    // wrapper that the shared long-paths branch (#701) matches — long-path
+    // support can't fix an illegal character, so this must win.
+    const raw =
+      "Process exited with code 1\n\nCloning into 'goova-web-4'...\nerror: invalid path 'GOOVA IMAGES/logos/Google_\"G\"_logo.svg'\nfatal: unable to checkout working tree\nwarning: Clone succeeded, but checkout failed.\nfailed to run git: exit status 128";
+    const info = describeImportError(raw);
+    expect(info.expected).toBe(true);
+    expect(info.message).toContain("Windows doesn't allow");
+    expect(info.message).not.toContain('core.longpaths');
+    expect(info.message).not.toContain('Cloning into');
+  });
+
+  it('still gives long-path guidance for genuine "Filename too long" failures', () => {
+    const raw =
+      'Process exited with code 1\n\nerror: unable to create file some/deep/path: Filename too long\nfatal: unable to checkout working tree';
+    const info = describeImportError(raw);
+    expect(info.expected).toBe(true);
+    expect(info.message).toContain('core.longpaths');
+  });
+
+  it('maps npm EUNSUPPORTEDPROTOCOL for workspace:/catalog: deps to pnpm guidance (issues #707/#708)', () => {
+    const workspace =
+      'Process exited with code 1\n\nnpm error code EUNSUPPORTEDPROTOCOL\nnpm error Unsupported URL Type "workspace:": workspace:*\nnpm error A complete log of this run can be found in: ~/.npm/_logs/debug-0.log';
+    const info = describeImportError(workspace);
+    expect(info.expected).toBe(true);
+    expect(info.message).toContain('pnpm');
+    expect(info.message).not.toContain('npm error');
+
+    const catalog =
+      'Process exited with code 1\n\nnpm error code EUNSUPPORTEDPROTOCOL\nnpm error Unsupported URL Type "catalog:": catalog:lint';
+    expect(describeImportError(catalog).expected).toBe(true);
+  });
+
+  it('recognizes preinstall guards that refuse non-pnpm installers (issue #707)', () => {
+    const raw =
+      'Process exited with code 1\n\n> workspace@0.0.0 preinstall\n> sh -c \'rm -f package-lock.json yarn.lock; case "$npm_config_user_agent" in pnpm/*) ;; *) echo "Use pnpm instead" >&2; exit 1 ;; esac\'\nUse pnpm instead\nnpm error code 1';
+    const info = describeImportError(raw);
+    expect(info.expected).toBe(true);
+    expect(info.message).toContain('pnpm');
+    expect(info.message).not.toContain('npm_config_user_agent');
+  });
+
+  it("maps gh's GraphQL repository 404 to a renamed/deleted/access hint (issue #733)", () => {
+    const raw =
+      "Process exited with code 1\n\nGraphQL: Could not resolve to a Repository with the name 'uxfold/fin-insight-tables'. (repository)";
+    const info = describeImportError(raw);
+    expect(info.expected).toBe(true);
+    expect(info.message).toContain('renamed');
+    expect(info.message).not.toContain('GraphQL');
+  });
+
+  it('delegates everything else to the shared classifier', () => {
+    // Recognized shared branch stays recognized…
+    expect(describeImportError('npm error code E401').expected).toBe(true);
+    // …and a genuinely unknown failure still reports as unexpected.
+    const unknown = describeImportError('Process exited with code 1\n\nsomething went sideways');
+    expect(unknown.expected).toBe(false);
+    expect(unknown.message).toContain('something went sideways');
+  });
+});

--- a/src/components/import-project/importErrors.ts
+++ b/src/components/import-project/importErrors.ts
@@ -1,0 +1,93 @@
+/**
+ * Import-specific failure classification for the GitHub import wizard.
+ *
+ * These are failure shapes that only the clone/install flow produces, and that
+ * the shared `describeProcessError` either doesn't recognize or (for `invalid
+ * path`) recognizes as the wrong thing. Each one is a repository or machine
+ * condition with a real next step — `expected: true` keeps them out of
+ * auto-filed bug reports, the same contract the shared classifier uses.
+ *
+ * @module components/import-project/importErrors
+ */
+
+import {
+  asCommandError,
+  describeProcessError,
+  formatCommandError,
+  type ProcessErrorInfo,
+} from '../../lib/errors';
+
+/**
+ * Classify a caught clone/install error, falling back to the shared
+ * {@link describeProcessError} for everything that isn't import-specific.
+ *
+ * Import branches run *first*: `error: invalid path` failures also carry the
+ * generic "unable to checkout working tree" wrapper text that the shared
+ * long-paths branch matches, so delegating first would hand the user the wrong
+ * remedy (issue #706).
+ */
+export function describeImportError(err: unknown): ProcessErrorInfo {
+  const msg =
+    err instanceof Error
+      ? err.message
+      : typeof err === 'string'
+        ? err
+        : formatCommandError(asCommandError(err));
+  const lower = msg.toLowerCase();
+
+  // Illegal filename characters during checkout: git-for-windows refuses to
+  // create files whose names contain " : < > | ? * with "error: invalid path
+  // '<file>'", then aborts with the same "unable to checkout working tree" /
+  // "Clone succeeded, but checkout failed." wrapper that a path-length failure
+  // produces. Long-path support can't fix this one — Windows rejects the name
+  // itself — so it needs its own message (issue #706, sibling of #701).
+  if (lower.includes('error: invalid path')) {
+    return {
+      expected: true,
+      message:
+        "The repository was downloaded, but some of its files have names containing characters Windows doesn't allow (such as \" : < > | ? *), so git couldn't check them out. Those files have to be renamed in the repository itself — or clone it on macOS, Linux, or WSL, where the names are valid.",
+    };
+  }
+
+  // pnpm/Yarn-only dependency protocols run through npm. `workspace:*` and
+  // pnpm's `catalog:` are rejected outright with EUNSUPPORTEDPROTOCOL — no
+  // retry helps, the project needs a different package manager (issues
+  // #707/#708).
+  if (
+    lower.includes('eunsupportedprotocol') ||
+    (lower.includes('unsupported url type') &&
+      (lower.includes('workspace:') || lower.includes('catalog:')))
+  ) {
+    return {
+      expected: true,
+      message:
+        "This project links its dependencies with pnpm's `workspace:`/`catalog:` protocol, which npm can't install. Install pnpm (`npm install -g pnpm`), then retry the install — or run `pnpm install` in the project folder yourself.",
+    };
+  }
+
+  // The other half of the same root cause: repos that guard against the wrong
+  // installer with a preinstall script inspecting `npm_config_user_agent`, and
+  // exit 1 with "Use pnpm instead". A project requirement, not an app bug
+  // (issue #707, second occurrence).
+  if (lower.includes('npm_config_user_agent') || /use (?:pnpm|yarn|bun) instead/.test(lower)) {
+    return {
+      expected: true,
+      message:
+        'This project refuses to install with npm — its own setup script requires pnpm (or Yarn). Install that package manager, then retry the install, or run its `install` command in the project folder yourself.',
+    };
+  }
+
+  // GitHub's GraphQL 404 for the repository query: `gh repo clone` exits with
+  // the generic code 1, so only the wording identifies it. The repo was
+  // renamed/deleted/transferred, or access was revoked, between listing it and
+  // importing it — a user/environment condition (issue #733).
+  if (lower.includes('could not resolve to a repository')) {
+    return {
+      expected: true,
+      message:
+        "GitHub couldn't find that repository. It may have been renamed, deleted, or transferred, or your access to it may have been removed. Go back, refresh the repository list, and check you picked the right account or organization.",
+    };
+  }
+
+  return describeProcessError(err);
+}

--- a/src/components/plugins/McpModal.test.tsx
+++ b/src/components/plugins/McpModal.test.tsx
@@ -27,8 +27,12 @@ vi.mock('../../lib/logger', () => ({
 vi.mock('../../contexts/ModalContext', () => ({
   useModal: () => ({ isOpen: true, close: vi.fn() }),
 }));
+const { showToast } = vi.hoisted(() => ({ showToast: vi.fn() }));
+vi.mock('../../contexts/ToastContext', () => ({
+  useOptionalToast: () => ({ showToast }),
+}));
 
-import { listMcpServers, addMcpServer } from '../../lib/mcp';
+import { listMcpServers, addMcpServer, removeMcpServer } from '../../lib/mcp';
 import { logger } from '../../lib/logger';
 
 type Fn = ReturnType<typeof vi.fn>;
@@ -208,5 +212,61 @@ describe('McpModal error flows', () => {
     expect(await screen.findByText(/something exploded/)).toBeInTheDocument();
     // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
     expect(logger.error as Fn).toHaveBeenCalled();
+  });
+
+  // #799/#800/#755/#763 — classify_mcp_failure marks these Expected on the
+  // backend and writes the guidance into the message; the modal's catch-alls
+  // still sent them to logger.error, auto-filing a bug report for an org
+  // policy, an unreachable gateway, the user's own agent config, or an
+  // upstream CLI regression.
+  it("logs the backend's Expected environment failures at warn, not error (#799/#800)", async () => {
+    vi.mocked(addMcpServer).mockRejectedValue({
+      type: 'Other',
+      message:
+        "Failed to add MCP server: Couldn't load settings from Cloud gateway gw.example.com.\n\nYour organization's agent gateway couldn't be reached. Check your network (or VPN) connection, or run `claude auth login` in a terminal to sign in again, then try again.",
+    });
+
+    render(<McpModal />);
+    const input = await openAddTab();
+
+    fireEvent.change(input, { target: { value: 'my-server -- npx -y @some/mcp-server' } });
+    clickAddSubmit();
+
+    expect(await screen.findByText(/agent gateway couldn't be reached/i)).toBeInTheDocument();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.warn as Fn).toHaveBeenCalledWith(
+      'Failed to add MCP server: environment or agent-config condition',
+      expect.objectContaining({ error: expect.stringContaining('Cloud gateway') as unknown })
+    );
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an Expected remove failure as an info toast at warn level (#755)', async () => {
+    vi.mocked(listMcpServers).mockResolvedValue([
+      {
+        name: 'sentry',
+        command_or_url: 'https://mcp.sentry.dev/mcp',
+        status: 'connected',
+        scope: 'user',
+      },
+    ]);
+    vi.mocked(removeMcpServer).mockRejectedValue({
+      type: 'Other',
+      message:
+        "Failed to remove MCP server: failed to load configuration\n\nThe agent CLI couldn't read its own config file — a setting in it (`service_tier`) has a value this version no longer accepts. Fix or remove that setting in the config file named above, then try again.",
+    });
+
+    render(<McpModal />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(
+        expect.stringContaining("couldn't read its own config file"),
+        'info'
+      );
+    });
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
   });
 });

--- a/src/components/plugins/McpModal.tsx
+++ b/src/components/plugins/McpModal.tsx
@@ -20,11 +20,13 @@ import {
   validateMcpAddCommand,
   isMcpUnsupportedCliError,
   isMcpInvalidInputError,
+  isMcpExpectedFailure,
 } from '../../lib/mcp';
 import { trackEvent, trackSearch } from '../../lib/analytics';
 import { logger } from '../../lib/logger';
 import { asCommandError, formatCommandError, isAgentNotInstalledError } from '../../lib/errors';
 import { useModal } from '../../contexts/ModalContext';
+import { useOptionalToast } from '../../contexts/ToastContext';
 
 type Tab = 'connected' | 'add';
 type ScopeFilter = 'all' | 'user' | 'project';
@@ -44,6 +46,7 @@ export function McpModal({
   agentBinaryName = 'claude',
 }: McpModalProps) {
   const { isOpen, close: onClose } = useModal('mcp');
+  const { showToast } = useOptionalToast();
   const [activeTab, setActiveTab] = useState<Tab>('connected');
   const [scopeFilter, setScopeFilter] = useState<ScopeFilter>('all');
   const [servers, setServers] = useState<McpServer[]>([]);
@@ -164,6 +167,16 @@ export function McpModal({
           error: message,
         });
         setAddError(message);
+      } else if (isMcpExpectedFailure(err)) {
+        // Enterprise policy, an unreachable org gateway, the agent CLI's own
+        // config, or an upstream `mcp add -e` parser bug — the backend already
+        // classified all of these Expected and wrote the guidance into the
+        // message. Nothing Ship Studio can fix, so don't auto-file a report
+        // (issues #755, #763, #799, #800).
+        logger.warn('Failed to add MCP server: environment or agent-config condition', {
+          error: message,
+        });
+        setAddError(message);
       } else {
         logger.error('Failed to add MCP server', { error: message });
         setAddError(message);
@@ -199,6 +212,18 @@ export function McpModal({
         logger.warn('Failed to remove MCP server: agent CLI lacks mcp subcommands', {
           error: message,
         });
+        showToast(
+          `Your ${agentDisplayName} CLI is too old to manage MCP servers — update it, then try again.`,
+          'info'
+        );
+      } else if (isMcpExpectedFailure(err)) {
+        // Same Expected shapes as the add path (#755, #763, #799, #800). The
+        // remove path had no user-facing feedback at all on failure, so the
+        // row simply stopped spinning — surface the backend's guidance.
+        logger.warn('Failed to remove MCP server: environment or agent-config condition', {
+          error: message,
+        });
+        showToast(message, 'info');
       } else {
         logger.error('Failed to remove MCP server', { error: message });
       }

--- a/src/components/plugins/PluginManager.registry.test.tsx
+++ b/src/components/plugins/PluginManager.registry.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * The plugin Library tab's empty-state copy must tell the truth about WHY the
+ * list is empty:
+ *
+ * - a reachability failure (offline, GitHub rate limit) keeps the "check your
+ *   connection" advice and logs at warn level (#713);
+ * - a malformed registry body is our bug, not the user's network — it gets its
+ *   own copy and stays a reportable `logger.error`;
+ * - a genuinely empty registry says so.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+vi.mock('../../lib/plugins', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/plugins')>()),
+  listPlugins: vi.fn(),
+  fetchPluginRegistry: vi.fn(),
+}));
+vi.mock('../../lib/analytics', () => ({ trackEvent: vi.fn(), trackError: vi.fn() }));
+vi.mock('../../lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../../contexts/ModalContext', () => ({
+  useModal: () => ({ isOpen: true, close: vi.fn() }),
+}));
+vi.mock('../../contexts/ToastContext', () => ({
+  useOptionalToast: () => ({ showToast: vi.fn() }),
+}));
+
+import { PluginManager } from './PluginManager';
+import { listPlugins, fetchPluginRegistry } from '../../lib/plugins';
+import { logger } from '../../lib/logger';
+
+async function openLibraryTab() {
+  // The installed-plugins fetch and the registry fetch both settle after the
+  // first paint — flush them inside act so React's warning stays off the output.
+  await act(async () => {
+    render(<PluginManager onPluginsChanged={vi.fn()} projectPath="/proj" />);
+    await Promise.resolve();
+  });
+  // "Library" also names the shortcut inside the installed-tab empty state —
+  // click the tab itself.
+  const tab = screen
+    .getAllByRole('button', { name: 'Library' })
+    .find((b) => b.className.includes('plugins-tab'));
+  expect(tab).toBeDefined();
+  await act(async () => {
+    fireEvent.click(tab!);
+    await Promise.resolve();
+  });
+}
+
+describe('PluginManager library empty states', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listPlugins).mockResolvedValue([]);
+  });
+
+  it('keeps the connection copy when the registry is unreachable (#713)', async () => {
+    vi.mocked(fetchPluginRegistry).mockRejectedValue(
+      new Error('Failed to fetch plugin registry: 429')
+    );
+    await openLibraryTab();
+
+    expect(await screen.findByText(/Check your connection/)).toBeTruthy();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the mock's calls, not invoking it bound
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      'Failed to fetch plugin registry',
+      expect.anything()
+    );
+  });
+
+  it('a malformed registry body gets its own copy, not "check your connection"', async () => {
+    vi.mocked(fetchPluginRegistry).mockRejectedValue(
+      new SyntaxError('Unexpected end of JSON input')
+    );
+    await openLibraryTab();
+
+    expect(await screen.findByText(/couldn't read it/)).toBeTruthy();
+    expect(screen.queryByText(/Check your connection/)).toBeNull();
+    // Still ours to fix — stays on the reportable error channel.
+    await waitFor(() => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the mock's calls, not invoking it bound
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        'Failed to fetch plugin registry',
+        expect.anything()
+      );
+    });
+  });
+
+  it('says the library is empty when the fetch succeeded with no entries', async () => {
+    vi.mocked(fetchPluginRegistry).mockResolvedValue([]);
+    await openLibraryTab();
+
+    expect(await screen.findByText(/library is empty right now/)).toBeTruthy();
+  });
+});

--- a/src/components/plugins/PluginManager.tsx
+++ b/src/components/plugins/PluginManager.tsx
@@ -62,9 +62,11 @@ export function PluginManager({
   // Library state
   const [registry, setRegistry] = useState<PluginRegistryEntry[]>([]);
   const [isLoadingRegistry, setIsLoadingRegistry] = useState(false);
-  /** Set when the library fetch failed, so an empty list isn't read as "the
-   *  library is empty" — it's usually rate limiting or no connection (#713). */
-  const [registryUnreachable, setRegistryUnreachable] = useState(false);
+  /** Why the library fetch failed, so an empty list isn't read as "the library
+   *  is empty" (#713). `unreachable` is the user's network or GitHub's rate
+   *  limiter; `malformed` is a registry body we couldn't parse — a different
+   *  problem, with a different fix, so it gets its own copy. */
+  const [registryFailure, setRegistryFailure] = useState<'unreachable' | 'malformed' | null>(null);
   const [installingId, setInstallingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showUrlInput, setShowUrlInput] = useState(false);
@@ -192,18 +194,18 @@ export function PluginManager({
     try {
       const result = await fetchPluginRegistry();
       setRegistry(result);
-      setRegistryUnreachable(false);
+      setRegistryFailure(null);
     } catch (err) {
       trackError('plugin_registry_load', err, 'Plugin Manager');
       // A reachability failure survived the retry/backoff (#713) — that's the
       // network or GitHub's rate limiter, not an app defect. A malformed
-      // registry body still errors: that one IS ours to fix.
+      // registry body still errors: that one IS ours to fix, and telling the
+      // user to check their connection would send them after the wrong thing.
       const msg = formatCommandError(asCommandError(err));
       const unreachable = isRegistryUnreachableError(err);
       logger[unreachable ? 'warn' : 'error']('Failed to fetch plugin registry', { error: msg });
       setRegistry([]);
-      // The user sees "couldn't load" either way — only the log level differs.
-      setRegistryUnreachable(true);
+      setRegistryFailure(unreachable ? 'unreachable' : 'malformed');
     } finally {
       setIsLoadingRegistry(false);
     }
@@ -576,15 +578,21 @@ export function PluginManager({
 
               {!isLoadingRegistry && registry.length === 0 && (
                 <div className="plugins-empty">
-                  {registryUnreachable ? (
+                  {registryFailure === 'unreachable' && (
                     <>
                       Couldn&apos;t reach the plugin library. Check your connection, or try again in
                       a minute — GitHub sometimes rate-limits this request. You can still install
                       from a URL below.
                     </>
-                  ) : (
-                    'The plugin library is empty right now. You can still install from a URL below.'
                   )}
+                  {registryFailure === 'malformed' && (
+                    <>
+                      The plugin library loaded but we couldn&apos;t read it — that&apos;s a problem
+                      on our side, not your connection. You can still install from a URL below.
+                    </>
+                  )}
+                  {registryFailure === null &&
+                    'The plugin library is empty right now. You can still install from a URL below.'}
                 </div>
               )}
 

--- a/src/components/plugins/PluginManager.tsx
+++ b/src/components/plugins/PluginManager.tsx
@@ -21,6 +21,8 @@ import {
   checkPluginUpdate,
   updatePlugin,
   fetchPluginRegistry,
+  isExpectedPluginFailure,
+  isRegistryUnreachableError,
   linkDevPlugin,
   unlinkDevPlugin,
   type PluginInfo,
@@ -60,6 +62,9 @@ export function PluginManager({
   // Library state
   const [registry, setRegistry] = useState<PluginRegistryEntry[]>([]);
   const [isLoadingRegistry, setIsLoadingRegistry] = useState(false);
+  /** Set when the library fetch failed, so an empty list isn't read as "the
+   *  library is empty" — it's usually rate limiting or no connection (#713). */
+  const [registryUnreachable, setRegistryUnreachable] = useState(false);
   const [installingId, setInstallingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showUrlInput, setShowUrlInput] = useState(false);
@@ -165,7 +170,9 @@ export function PluginManager({
       void autoCheckUpdates(result);
     } catch (err) {
       trackError('plugin_list_load', err, 'Plugin Manager');
-      logger.error('Failed to load plugins', {
+      // A vanished project folder / denied plugin registry is an environment
+      // state the backend classifies Expected (#831, #762) — warn, don't file.
+      logger[isExpectedPluginFailure(err) ? 'warn' : 'error']('Failed to load plugins', {
         error: formatCommandError(asCommandError(err)),
       });
       setPlugins([]);
@@ -185,12 +192,18 @@ export function PluginManager({
     try {
       const result = await fetchPluginRegistry();
       setRegistry(result);
+      setRegistryUnreachable(false);
     } catch (err) {
       trackError('plugin_registry_load', err, 'Plugin Manager');
-      logger.error('Failed to fetch plugin registry', {
-        error: formatCommandError(asCommandError(err)),
-      });
+      // A reachability failure survived the retry/backoff (#713) — that's the
+      // network or GitHub's rate limiter, not an app defect. A malformed
+      // registry body still errors: that one IS ours to fix.
+      const msg = formatCommandError(asCommandError(err));
+      const unreachable = isRegistryUnreachableError(err);
+      logger[unreachable ? 'warn' : 'error']('Failed to fetch plugin registry', { error: msg });
       setRegistry([]);
+      // The user sees "couldn't load" either way — only the log level differs.
+      setRegistryUnreachable(true);
     } finally {
       setIsLoadingRegistry(false);
     }
@@ -258,7 +271,8 @@ export function PluginManager({
       }));
     } catch (err) {
       trackError('plugin_update_check', err, 'Plugin Manager');
-      logger.error('Failed to check for update', {
+      // Offline / auth-walled / deleted remotes are Expected (#803, #732).
+      logger[isExpectedPluginFailure(err) ? 'warn' : 'error']('Failed to check for update', {
         error: formatCommandError(asCommandError(err)),
       });
       setUpdateStates((prev) => ({ ...prev, [pluginId]: 'idle' }));
@@ -277,7 +291,7 @@ export function PluginManager({
       setUpdateStates((prev) => ({ ...prev, [pluginId]: 'up_to_date' }));
     } catch (err) {
       trackError('plugin_update', err, 'Plugin Manager');
-      logger.error('Failed to update plugin', {
+      logger[isExpectedPluginFailure(err) ? 'warn' : 'error']('Failed to update plugin', {
         error: formatCommandError(asCommandError(err)),
       });
       setUpdateStates((prev) => ({ ...prev, [pluginId]: 'available' }));
@@ -303,14 +317,17 @@ export function PluginManager({
       setInstallingId(null);
     } catch (err) {
       trackError('plugin_install', err, 'Plugin Manager');
-      logger.error('Failed to install plugin', {
-        error: formatCommandError(asCommandError(err)),
-      });
       const msg = formatCommandError(asCommandError(err));
+      // A by-design refusal (bad manifest, unclonable URL, version mismatch…)
+      // is the app working correctly. logger.error files a bug report, and so
+      // does an 'error' toast — both had to be downgraded, since logger.error
+      // fires before the toast (issues #734, #833).
+      const expected = isExpectedPluginFailure(err);
+      logger[expected ? 'warn' : 'error']('Failed to install plugin', { error: msg });
       setError(msg);
       // Toast too — the inline error renders below the plugin list, off-screen
       // in a long library, so a failure otherwise looks like nothing happened.
-      showToast(msg, 'error');
+      showToast(msg, expected ? 'info' : 'error');
       setInstallingId(null);
     }
   };
@@ -334,12 +351,13 @@ export function PluginManager({
       onPluginsChanged();
     } catch (err) {
       trackError('plugin_install_url', err, 'Plugin Manager');
-      logger.error('Failed to install plugin from URL', {
-        error: formatCommandError(asCommandError(err)),
-      });
       const msg = formatCommandError(asCommandError(err));
+      // Same downgrade as handleLibraryInstall — a pasted URL that isn't a
+      // clonable repo is user input, not a defect (issues #734, #833, #803).
+      const expected = isExpectedPluginFailure(err);
+      logger[expected ? 'warn' : 'error']('Failed to install plugin from URL', { error: msg });
       setError(msg);
-      showToast(msg, 'error');
+      showToast(msg, expected ? 'info' : 'error');
     } finally {
       setIsInstallingUrl(false);
     }
@@ -363,7 +381,10 @@ export function PluginManager({
       }
     } catch (err) {
       trackError('plugin_dev_link', err, 'Plugin Manager');
-      logger.error('Failed to link dev plugin', {
+      // link_dev_plugin's manifest/bundle/id checks are by-design refusals of
+      // the folder the developer picked (issue #760) — the inline error still
+      // tells them what's wrong, but it isn't a bug to file.
+      logger[isExpectedPluginFailure(err) ? 'warn' : 'error']('Failed to link dev plugin', {
         error: formatCommandError(asCommandError(err)),
       });
       setError(formatCommandError(asCommandError(err)));
@@ -555,7 +576,15 @@ export function PluginManager({
 
               {!isLoadingRegistry && registry.length === 0 && (
                 <div className="plugins-empty">
-                  Could not load plugin library. Try installing from a URL below.
+                  {registryUnreachable ? (
+                    <>
+                      Couldn&apos;t reach the plugin library. Check your connection, or try again in
+                      a minute — GitHub sometimes rate-limits this request. You can still install
+                      from a URL below.
+                    </>
+                  ) : (
+                    'The plugin library is empty right now. You can still install from a URL below.'
+                  )}
                 </div>
               )}
 

--- a/src/components/plugins/PluginSlot.test.tsx
+++ b/src/components/plugins/PluginSlot.test.tsx
@@ -171,6 +171,52 @@ describe('buildContext failure reporting', () => {
     expect(showToast).toHaveBeenCalledTimes(1);
   });
 
+  it('routes a transient spawn-pressure failure to an info toast (#775)', async () => {
+    mockIPC(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- plain CommandError shape under test
+      throw {
+        type: 'Other',
+        message:
+          "Couldn't start `brew` — your system is temporarily low on process resources or open files. Close some apps or terminal tabs and try again.",
+      };
+    });
+    const { actions, showToast } = makeActions();
+    const ctx = buildContext('vercel', 'Vercel', project, actions, theme, []);
+
+    await expect(ctx.shell.exec('brew', ['list'])).rejects.toBeTruthy();
+    expect(showToast).toHaveBeenCalledTimes(1);
+    expect(showToast.mock.calls[0][0]).toContain('temporarily low on process resources');
+    // 'error' would re-report an environment state to telemetry.
+    expect(showToast.mock.calls[0][1]).toBe('info');
+  });
+
+  it('does not error-toast a bundled hosting plugin whose files vanished (#386)', async () => {
+    mockIPC(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- plain CommandError shape under test
+      throw { type: 'Other', message: "Plugin 'cloudflare' not found" };
+    });
+    const { actions, showToast } = makeActions();
+    const ctx = buildContext('cloudflare', 'Cloudflare Pages', project, actions, theme, []);
+
+    await expect(ctx.shell.exec('wrangler', ['whoami'])).rejects.toBeTruthy();
+    expect(showToast).toHaveBeenCalledTimes(1);
+    expect(showToast.mock.calls[0][0]).toContain('was deactivated');
+    expect(showToast.mock.calls[0][1]).toBe('info');
+  });
+
+  it('still error-toasts a user-installed plugin whose files vanished (#315)', async () => {
+    mockIPC(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- plain CommandError shape under test
+      throw { type: 'Other', message: "Plugin 'sanity' not found" };
+    });
+    const { actions, showToast } = makeActions();
+    const ctx = buildContext('sanity', 'Sanity', project, actions, theme, []);
+
+    await expect(ctx.shell.exec('sanity', ['deploy'])).rejects.toBeTruthy();
+    expect(showToast).toHaveBeenCalledTimes(1);
+    expect(showToast.mock.calls[0][1]).toBe('error');
+  });
+
   it('does not toast when the call succeeds', async () => {
     mockIPC((cmd) => {
       if (cmd === 'read_plugin_storage') return { key: 'value' };

--- a/src/components/plugins/PluginSlot.tsx
+++ b/src/components/plugins/PluginSlot.tsx
@@ -18,7 +18,12 @@ import {
   type PluginAppActions,
   type PluginThemeData,
 } from '../../contexts/PluginContext';
-import { execPluginShell, readPluginStorage, writePluginStorage } from '../../lib/plugins';
+import {
+  execPluginShell,
+  readPluginStorage,
+  writePluginStorage,
+  HOSTING_PLUGIN_IDS,
+} from '../../lib/plugins';
 import {
   markPluginCrashed,
   isPluginCrashed,
@@ -26,6 +31,7 @@ import {
   unloadPluginModule,
 } from '../../lib/plugin-loader';
 import { asCommandError, formatCommandError, isProjectFolderGoneError } from '../../lib/errors';
+import { isResourcePressureError } from '../../lib/errorReporting';
 import { logger } from '../../lib/logger';
 import { invoke } from '@tauri-apps/api/core';
 import { WarningIcon } from '../icons';
@@ -201,9 +207,21 @@ export function buildContext(
     // keeps making are suppressed instead of toasting every tick (issue #315).
     if (message.includes(`Plugin '${pluginId}' not found`)) {
       unloadPluginModule(projectPath, pluginId);
+      // A built-in hosting integration losing its files is a provisioning gap,
+      // not a user-visible bug the reporter can act on, and the user never
+      // "installed" it to reinstall — keep the notice but don't re-report it
+      // to telemetry via the 'error' toast path (issue #386, partial: the
+      // auto-reprovision half is still open).
+      const isBundled = HOSTING_PLUGIN_IDS.includes(pluginId);
+      if (isBundled) {
+        logger.warn(`Bundled plugin "${pluginId}" deactivated — its files are missing on disk`, {
+          projectPath,
+          error: message,
+        });
+      }
       actions.showToast(
         `Plugin "${pluginName}" was deactivated because its files are no longer on disk. Unlink or reinstall it from the Plugins menu.`,
-        'error'
+        isBundled ? 'info' : 'error'
       );
       throw e;
     }
@@ -237,6 +255,17 @@ export function buildContext(
       logger.warn(`Plugin "${pluginId}" shell command timed out — plugin handles this itself`, {
         error: message,
       });
+      throw e;
+    }
+    // The machine is transiently out of process slots / file descriptors, so
+    // `exec_plugin_shell`'s own EAGAIN retries gave up (issue #587). An
+    // environment state, not an app bug: the user still sees what happened,
+    // but an 'error' toast would re-report it to telemetry (issue #775).
+    if (isResourcePressureError(e)) {
+      logger.warn(`Plugin "${pluginId}" shell command hit system resource pressure`, {
+        error: message,
+      });
+      actions.showToast(`Plugin "${pluginName}": ${message}`, 'info');
       throw e;
     }
     actions.showToast(`Plugin "${pluginName}": ${message}`, 'error');

--- a/src/components/plugins/SkillsModal.tsx
+++ b/src/components/plugins/SkillsModal.tsx
@@ -55,6 +55,8 @@ export function SkillsModal({
   const [skills, setSkills] = useState<AgentSkill[]>([]);
   const [isLoadingSkills, setIsLoadingSkills] = useState(false);
   const [removingSkill, setRemovingSkill] = useState<string | null>(null);
+  /** Last removal failure, shown inline on the Installed tab (issue #720). */
+  const [removeError, setRemoveError] = useState<string | null>(null);
 
   // Installed tab search
   const [installedSearchQuery, setInstalledSearchQuery] = useState('');
@@ -103,8 +105,9 @@ export function SkillsModal({
       const result = await listAgentSkills(projectPath, agentId);
       setSkills(result);
     } catch (err) {
+      // Same "[object Object]" trap as handleRemove (issue #720).
       logger.error('Failed to load skills', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
       setSkills([]);
     } finally {
@@ -158,7 +161,7 @@ export function SkillsModal({
       setSearchResults(results);
     } catch (err) {
       logger.error('Failed to search skills', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
       setSearchError(formatCommandError(asCommandError(err)));
     } finally {
@@ -192,6 +195,7 @@ export function SkillsModal({
   const handleRemove = async (skill: AgentSkill) => {
     const skillKey = `${skill.plugin}-${skill.name}`;
     setRemovingSkill(skillKey);
+    setRemoveError(null);
     try {
       // Use the plugin as the package identifier
       await removeSkill(skill.plugin, skill.scope as 'user' | 'project', projectPath, agentId);
@@ -203,9 +207,12 @@ export function SkillsModal({
       // Refresh installed skills
       await fetchSkills();
     } catch (err) {
-      logger.error('Failed to remove skill', {
-        error: err instanceof Error ? err.message : String(err),
-      });
+      // A rejected Tauri command is a CommandError *object*, so String(err)
+      // logged "[object Object]" and the user saw nothing at all — the Remove
+      // button just stopped spinning (issue #720). Format it, and show it.
+      const msg = formatCommandError(asCommandError(err));
+      logger.error('Failed to remove skill', { error: msg });
+      setRemoveError(msg);
     } finally {
       setRemovingSkill(null);
     }
@@ -291,6 +298,8 @@ export function SkillsModal({
                   Loading skills...
                 </div>
               )}
+
+              {removeError && <div className="skills-error">{removeError}</div>}
 
               {!isLoadingSkills && filteredSkills.length === 0 && (
                 <div className="skills-empty">

--- a/src/components/preview/BrowserDropdown.tsx
+++ b/src/components/preview/BrowserDropdown.tsx
@@ -22,6 +22,8 @@ import {
 } from '../icons';
 import { BrowserInfo, checkBrowserAvailability, openUrlInBrowser } from '../../lib/browser';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
+import { isResourcePressureError } from '../../lib/errorReporting';
 
 interface BrowserDropdownProps {
   url: string;
@@ -126,7 +128,12 @@ export function BrowserDropdown({
       await openUrlInBrowser(url, browserId);
       setShowDropdown(false);
     } catch (e) {
-      logger.error(`Failed to open in ${browserId}`, { error: e });
+      // logger.error auto-files a bug report; a machine that's transiently out
+      // of process slots isn't one (issue #773). Also format the rejection —
+      // CommandError objects are plain objects, not Errors.
+      logger[isResourcePressureError(e) ? 'warn' : 'error'](`Failed to open in ${browserId}`, {
+        error: formatCommandError(asCommandError(e)),
+      });
     } finally {
       setOpeningBrowser(null);
     }

--- a/src/components/setup/OnboardingTerminal.tsx
+++ b/src/components/setup/OnboardingTerminal.tsx
@@ -19,6 +19,11 @@ import { loadNerdFonts } from '../../lib/fonts';
 import { isWindows, needsCmdExeWrapper, resolveCliPath, ResolvedCli } from '../../lib/setup';
 import { isPasteChord, readClipboardText } from '../../lib/clipboard';
 import { createPtyChunkDecoder, toPtyBytes, type PtyChunk } from '../../lib/terminalDiagnostics';
+import {
+  decideStartupTimeoutAction,
+  RESPAWN_GRACE_MS,
+  STARTUP_TIMEOUT_MS,
+} from '../terminal/startupWatchdog';
 import { logger } from '../../lib/logger';
 import { asCommandError, formatCommandError } from '../../lib/errors';
 import '@xterm/xterm/css/xterm.css';
@@ -447,13 +452,23 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
         // (Windows ConPTY especially, and occasionally macOS) — the main agent
         // terminal recovers from this by respawning (Terminal.tsx), but this
         // onboarding terminal previously just sat at "Starting…" forever with
-        // no feedback (issues #156, #164). If no output arrives within 10s,
-        // kill the silent PTY and respawn once; if the respawn is also silent,
-        // surface an actionable message instead of hanging.
+        // no feedback (issues #156, #164). If no output arrives within the
+        // startup window, kill the silent PTY and respawn once; if the respawn
+        // is also silent, surface an actionable message instead of hanging.
+        //
+        // The policy (one respawn per mount) and the timings are the SAME ones
+        // the workspace terminal uses — both read them from
+        // terminal/startupWatchdog.ts rather than keeping private copies, which
+        // is how these two watchdogs drifted apart (issues #245/#384).
         if (startupTimer) clearTimeout(startupTimer);
         startupTimer = setTimeout(() => {
-          if (!mounted || receivedOutput) return;
-          if (!autoRespawnUsed) {
+          const action = decideStartupTimeoutAction({
+            receivedOutput,
+            mounted,
+            autoRespawnUsed,
+          });
+          if (action === 'none') return;
+          if (action === 'respawn') {
             autoRespawnUsed = true;
             logger.warn('[OnboardingTerminal] No output after 10s — respawning', { command });
             terminalRef.current?.write('\r\n\x1b[33mNo output — restarting…\x1b[0m\r\n');
@@ -475,7 +490,7 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
             // Brief grace period so the killed PTY tears down before respawn.
             startupTimer = setTimeout(() => {
               if (mounted) void setupPty();
-            }, 500);
+            }, RESPAWN_GRACE_MS);
             return;
           }
           logger.error('[OnboardingTerminal] Still no output after respawn', { command });
@@ -496,7 +511,7 @@ export function OnboardingTerminal({ command, args, cwd, onExit }: OnboardingTer
           // without this the terminal showed the message but the wizard sat
           // in "connecting" forever (issue #245).
           onExitRef.current(1, failure);
-        }, 10_000);
+        }, STARTUP_TIMEOUT_MS);
 
         // Focus the terminal
         term.focus();

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -46,14 +46,18 @@ import { listen } from '@tauri-apps/api/event';
 import { homeDir } from '@tauri-apps/api/path';
 import { getShellPath, getSystemEnv } from '../../lib/project';
 import { loadNerdFonts } from '../../lib/fonts';
-import { isWindows, resolveCliPath } from '../../lib/setup';
+import { isWindows, needsCmdExeWrapper, resolveCliPath, type ResolvedCli } from '../../lib/setup';
 import { isPasteChord, readClipboardText, stageClipboardImage } from '../../lib/clipboard';
 import { logger } from '../../lib/logger';
 import { asCommandError, formatCommandError } from '../../lib/errors';
 import { isPointInRect, dropPointToLogical } from '../../lib/dropTarget';
 import { getTerminalGpuEnabled } from '../../lib/settings';
 import { attachedLibraryDirs } from '../../lib/attached-libraries';
-import { decideStartupTimeoutAction } from './startupWatchdog';
+import {
+  decideStartupTimeoutAction,
+  RESPAWN_GRACE_MS,
+  STARTUP_TIMEOUT_MS,
+} from './startupWatchdog';
 import type { AgentConfig } from '../../lib/agent';
 import '@xterm/xterm/css/xterm.css';
 
@@ -717,9 +721,12 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           }
         }
 
-        // On Windows, agent may be a .cmd script - must run through cmd.exe
-        let spawnCmd = isWin ? 'cmd.exe' : agent.binaryName;
-        const spawnArgs = isWin ? ['/C', agent.binaryName, ...agentArgs] : agentArgs;
+        // Placeholder — on Windows the real spawn shape (direct vs. wrapped
+        // in cmd.exe /C) is decided AFTER binary resolution below, because
+        // the decision depends on what the command resolves to (.cmd shim vs.
+        // real executable). See needsCmdExeWrapper in lib/setup.ts.
+        let spawnCmd = agent.binaryName;
+        let spawnArgs = agentArgs;
 
         // Resolve the bare binary name through the backend's thorough
         // discovery (every NVM version, ~/.<agent>/bin, npm prefix -g …) the
@@ -732,9 +739,10 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         // "binary" is an absolute path (/bin/zsh), which the backend rejects
         // with a validation error on every open (issue #303).
         const isBareName = !agent.binaryName.includes('/') && !agent.binaryName.includes('\\');
+        let resolved: ResolvedCli | null | undefined;
         if (isBareName) {
           try {
-            const resolved = await resolveCliPath(agent.binaryName);
+            resolved = await resolveCliPath(agent.binaryName);
             if (resolved) {
               const pathSep = isWin ? ';' : ':';
               if (!env.PATH.split(pathSep).includes(resolved.dir)) {
@@ -742,16 +750,41 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
               }
               if (!isWin) {
                 // Spawn the resolved absolute path — deterministic, no PATH
-                // shadowing. (Windows keeps the cmd.exe wrapper; the appended
-                // PATH dir makes the shim resolvable there.)
+                // shadowing. (The Windows equivalent happens in the
+                // spawn-shape block below, where wrapper-vs-direct is
+                // decided.)
                 spawnCmd = resolved.path;
               }
             }
           } catch (err) {
+            resolved = undefined;
             logger.warn('[Terminal] resolveCliPath failed — spawning bare name', {
               binary: agent.binaryName,
               error: String(err),
             });
+          }
+        }
+
+        if (isWin) {
+          // Windows spawn shape, same rule OnboardingTerminal already uses.
+          // Only .cmd/.bat shims need `cmd.exe /C` — they are batch scripts.
+          // Routing a REAL executable through cmd.exe adds a second parse
+          // layer (portable_pty composes one command line, then cmd re-parses
+          // it with its own quote rules) between us and the agent, which is
+          // what split a single `--session-id`/`--add-dir` value into several
+          // tokens and made Claude Code exit with "too many arguments"
+          // (issue #797). Unresolved names still wrap — needsCmdExeWrapper's
+          // conservative default — so nothing regresses when resolution
+          // fails open.
+          if (needsCmdExeWrapper(agent.binaryName, resolved?.path)) {
+            spawnCmd = 'cmd.exe';
+            spawnArgs = ['/C', agent.binaryName, ...agentArgs];
+          } else {
+            // Prefer the resolved absolute path (deterministic, no PATH
+            // shadowing); fall back to the bare name on the extended PATH
+            // when resolution failed open.
+            spawnCmd = resolved?.path ?? agent.binaryName;
+            spawnArgs = agentArgs;
           }
         }
 
@@ -974,12 +1007,13 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         gateOpen = true;
         gate.open(attach.endOffset);
 
-        // Startup watchdog: if no output is received within 10s, the agent
-        // likely failed to launch (binary not found, permission error, or a
-        // wedged first spawn — issue #158). The manual fix users found is
-        // "create a new agent tab", i.e. a fresh PTY — so kill the silent
-        // session and respawn once with the same config. Only if the
-        // respawn is also silent do we surface the error text.
+        // Startup watchdog: if no output is received within the startup
+        // window, the agent likely failed to launch (binary not found,
+        // permission error, or a wedged first spawn — issue #158). The manual
+        // fix users found is "create a new agent tab", i.e. a fresh PTY — so
+        // kill the silent session and respawn once with the same config. Only
+        // if the respawn is also silent do we surface the error text. Policy
+        // and timings are shared with the onboarding terminal (startupWatchdog.ts).
         startupTimeout = setTimeout(() => {
           const action = decideStartupTimeoutAction({ receivedOutput, mounted, autoRespawnUsed });
           if (action === 'none') return;
@@ -1016,7 +1050,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
                 // otherwise it would look like the new process exiting.
                 respawnTimer = setTimeout(() => {
                   if (mounted) void setupPty(0);
-                }, 500);
+                }, RESPAWN_GRACE_MS);
               });
             return;
           }
@@ -1029,7 +1063,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
             `\r\n\x1b[31m${agent.displayName} did not produce any output after 10 seconds.\x1b[0m\r\n` +
               `\x1b[33mThe process may have failed to start. Check that "${agent.binaryName}" is installed and accessible.\x1b[0m\r\n`
           );
-        }, 10_000);
+        }, STARTUP_TIMEOUT_MS);
         startupTimer = startupTimeout;
 
         if (pendingExit !== null) {

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -50,6 +50,7 @@ import { isWindows, resolveCliPath } from '../../lib/setup';
 import { isPasteChord, readClipboardText, stageClipboardImage } from '../../lib/clipboard';
 import { logger } from '../../lib/logger';
 import { asCommandError, formatCommandError } from '../../lib/errors';
+import { isResourcePressureError } from '../../lib/errorReporting';
 import { isPointInRect, dropPointToLogical } from '../../lib/dropTarget';
 import { getTerminalGpuEnabled } from '../../lib/settings';
 import { attachedLibraryDirs } from '../../lib/attached-libraries';
@@ -1175,7 +1176,10 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           lower.includes('no viable candidates found in path') ||
           lower.includes('does not exist') ||
           lower.includes('not executable');
-        logger[binaryNotFound ? 'warn' : 'error']('[Terminal] Failed to spawn PTY', {
+        // The second Expected spawn shape: the machine is transiently out of
+        // process slots / file descriptors (issues #587, #772).
+        const expectedSpawnFailure = binaryNotFound || isResourcePressureError(err);
+        logger[expectedSpawnFailure ? 'warn' : 'error']('[Terminal] Failed to spawn PTY', {
           agent: agent.id,
           binary: agent.binaryName,
           error: spawnError,

--- a/src/components/terminal/startupWatchdog.test.ts
+++ b/src/components/terminal/startupWatchdog.test.ts
@@ -1,13 +1,18 @@
 /**
- * Tests for the agent-terminal startup watchdog policy (issue #158).
+ * Tests for the PTY startup watchdog policy (issue #158).
  *
  * The behaviour that matters: a spawned-but-silent PTY gets exactly one
  * automatic respawn; a second silent run surfaces the error; output or
- * unmount disarms the watchdog entirely.
+ * unmount disarms the watchdog entirely. Both the workspace terminal
+ * (#384) and the onboarding terminal (#245) run on this one policy.
  */
 
 import { describe, it, expect } from 'vitest';
-import { decideStartupTimeoutAction } from './startupWatchdog';
+import {
+  decideStartupTimeoutAction,
+  RESPAWN_GRACE_MS,
+  STARTUP_TIMEOUT_MS,
+} from './startupWatchdog';
 
 describe('decideStartupTimeoutAction', () => {
   it('does nothing once output has been received', () => {
@@ -39,5 +44,15 @@ describe('decideStartupTimeoutAction', () => {
     expect(
       decideStartupTimeoutAction({ receivedOutput: false, mounted: true, autoRespawnUsed: true })
     ).toBe('error');
+  });
+});
+
+describe('watchdog timings', () => {
+  it('keeps the historical windows both terminals were built around', () => {
+    // Deliberately pinned: the setup commands are written to print
+    // immediately so 10s only trips a wedged spawn, and the user-facing
+    // messages in both terminals still say "10 seconds".
+    expect(STARTUP_TIMEOUT_MS).toBe(10_000);
+    expect(RESPAWN_GRACE_MS).toBe(500);
   });
 });

--- a/src/components/terminal/startupWatchdog.ts
+++ b/src/components/terminal/startupWatchdog.ts
@@ -1,17 +1,40 @@
 /**
- * Decision logic for the agent-terminal startup watchdog.
+ * Decision logic and timings for the PTY startup watchdog.
  *
  * When a PTY spawns but never produces output within the startup window,
- * the agent process is wedged (issue #158: seen on first app launch with
+ * the process is wedged (issue #158: seen on first app launch with
  * Claude Code on macOS and Codex on Windows). The manual workaround users
  * found — create a new agent tab, delete the old one — amounts to "kill
  * the silent PTY and spawn a fresh one". `decideStartupTimeoutAction`
  * drives the automatic version of that, capped at one respawn per
  * terminal mount so a genuinely-broken binary can't respawn in a loop.
  *
- * Kept as a pure function so the retry policy is unit-testable without
- * mounting the xterm-heavy Terminal component.
+ * This module is the single source of that policy for BOTH terminals that
+ * spawn a PTY — the workspace agent terminal (`Terminal.tsx`, issue #384)
+ * and the onboarding terminal (`setup/OnboardingTerminal.tsx`, issue #245).
+ * They previously carried separate copies of the same rule and the same
+ * magic numbers, which is how the two drifted into looking like unrelated
+ * bugs. Only the user-facing wording differs per terminal; the timings and
+ * the respawn cap live here.
+ *
+ * Kept as pure values/functions so the retry policy is unit-testable without
+ * mounting the xterm-heavy terminal components.
  */
+
+/**
+ * How long a freshly spawned PTY may stay silent before the watchdog acts.
+ * Every setup command is deliberately written to print something
+ * immediately (see the echoes in `getTerminalCommands`, lib/setup.ts) so
+ * this only fires on a genuinely wedged spawn.
+ */
+export const STARTUP_TIMEOUT_MS = 10_000;
+
+/**
+ * Pause between killing a silent PTY and respawning, so the dead PTY's exit
+ * event is delivered before the replacement subscribes — otherwise it looks
+ * like the new process exiting immediately.
+ */
+export const RESPAWN_GRACE_MS = 500;
 
 export interface StartupTimeoutState {
   /** True once any PTY output arrived for the current spawn. */

--- a/src/components/workspace/EnvEditor.tsx
+++ b/src/components/workspace/EnvEditor.tsx
@@ -18,6 +18,7 @@ import { useOptionalToast } from '../../contexts/ToastContext';
 import { useModal } from '../../contexts/ModalContext';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
+import type { ToastType } from '../../hooks/useToasts';
 
 /** Props for the EnvEditor component */
 interface EnvEditorProps {
@@ -28,7 +29,7 @@ interface EnvEditorProps {
 export function EnvEditor({ projectPath }: EnvEditorProps) {
   const { isOpen, close: onClose } = useModal('envEditor');
   const { showToast } = useOptionalToast();
-  const onToast = (message: string, type?: 'success' | 'error') => showToast(message, type);
+  const onToast = (message: string, type?: ToastType) => showToast(message, type);
   const {
     envFiles,
     selectedFile,
@@ -37,6 +38,7 @@ export function EnvEditor({ projectPath }: EnvEditorProps) {
     isLoading,
     isSaving,
     error,
+    keyNotice,
     showNewFileInput,
     setShowNewFileInput,
     newFileName,
@@ -348,6 +350,7 @@ export function EnvEditor({ projectPath }: EnvEditorProps) {
           </div>
         )}
 
+        {keyNotice && <div className="env-key-notice">{keyNotice}</div>}
         {error && <div className="env-error">{error}</div>}
       </div>
 

--- a/src/components/workspace/WorkspaceHeader.tsx
+++ b/src/components/workspace/WorkspaceHeader.tsx
@@ -32,7 +32,9 @@ import type { IntegrationState } from '../../hooks/useIntegrationStatus';
 import type { LoadedPlugin } from '../../hooks/usePlugins';
 import type { PluginThemeData } from '../../contexts/PluginContext';
 
-export const HOSTING_PLUGIN_IDS = ['vercel', 'cloudflare', 'netlify'];
+/** Re-exported from lib/plugins so non-UI code can share the list (issue #386). */
+export { HOSTING_PLUGIN_IDS } from '../../lib/plugins';
+import { HOSTING_PLUGIN_IDS } from '../../lib/plugins';
 
 export interface WorkspaceHeaderProps {
   // Project

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -1152,7 +1152,15 @@ export const WorkspaceView = memo(function WorkspaceView({
               {(currentBranch === 'main' || currentBranch === 'master') && (
                 <MainBranchBanner
                   projectPath={currentProject.path}
-                  onCreateBranch={() => setWorkspaceTab('branches')}
+                  onCreateBranch={() => {
+                    setIsPreviewHidden(false);
+                    setWorkspaceTab('branches');
+                  }}
+                  createBranchDisabledReason={
+                    integrations.projectGithub?.status === 'connected'
+                      ? undefined
+                      : 'Connect this project to GitHub to create and switch branches'
+                  }
                 />
               )}
 

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -1156,11 +1156,7 @@ export const WorkspaceView = memo(function WorkspaceView({
                     setIsPreviewHidden(false);
                     setWorkspaceTab('branches');
                   }}
-                  createBranchDisabledReason={
-                    integrations.projectGithub?.status === 'connected'
-                      ? undefined
-                      : 'Connect this project to GitHub to create and switch branches'
-                  }
+                  isGitHubConnected={integrations.projectGithub?.status === 'connected'}
                 />
               )}
 

--- a/src/hooks/useBranchManagement.test.ts
+++ b/src/hooks/useBranchManagement.test.ts
@@ -530,10 +530,33 @@ describe('useBranchManagement', () => {
       });
 
       const [message, type] = vi.mocked(params.showToast).mock.calls[1]; // [0] is the "Preparing..." toast
-      expect(type).toBe('error');
+      // A worktree collision is a recognized, by-design git refusal — 'info',
+      // not the 'error' channel that auto-files a bug report (issue #843).
+      expect(type).toBe('info');
       expect(message).toContain('already checked out in another worktree');
       expect(message).not.toContain('fatal:');
       expect(message).not.toContain('/private/tmp');
+    });
+
+    it('keeps a gone head branch out of the error channel (issue #843)', async () => {
+      vi.mocked(branches.switchBranch).mockResolvedValue({
+        success: false,
+        stashedChanges: false,
+        pendingStashFrom: null,
+        stashApplied: false,
+        error: "error: pathspec 'feature/gone' did not match any file(s) known to git",
+      });
+      const params = createParams();
+      const { result } = renderHook(() => useBranchManagement(params));
+
+      await act(async () => {
+        await result.current.handleResolveConflicts('feature/gone', 'main');
+      });
+
+      const [message, type] = vi.mocked(params.showToast).mock.calls[1];
+      expect(type).toBe('info');
+      expect(message).toContain('no longer exists');
+      expect(message).not.toContain('pathspec');
     });
 
     it('explains when git reported a switch failure with no detail', async () => {

--- a/src/hooks/useBranchManagement.ts
+++ b/src/hooks/useBranchManagement.ts
@@ -331,7 +331,23 @@ export function useBranchManagement({
             const detail = switchResult.error
               ? humanizeGitError(switchResult.error, { branch: headBranch })
               : '(git reported failure with no detail — check for uncommitted changes)';
-            showToast(`Couldn't switch to "${headBranch}": ${detail}`, 'error');
+            // Recognized states (the PR's head branch deleted on GitHub, a
+            // worktree collision, unsaved changes) are anticipated conditions
+            // the backend already classified Expected — an 'error' toast here
+            // re-reports them through toast telemetry (issue #843). Mirror the
+            // merge-failure branch below: info + warn for recognized causes.
+            const recognized =
+              !!switchResult.error &&
+              isRecognizedGitFailure(switchResult.error, { branch: headBranch });
+            if (recognized) {
+              logger.warn('Switch for conflict resolution refused for a recognized reason', {
+                message: switchResult.error,
+              });
+            }
+            showToast(
+              `Couldn't switch to "${headBranch}": ${detail}`,
+              recognized ? 'info' : 'error'
+            );
             return;
           }
 

--- a/src/hooks/useBranchManagement.ts
+++ b/src/hooks/useBranchManagement.ts
@@ -25,6 +25,7 @@ import {
   asCommandError,
   formatCommandError,
   humanizeGitError,
+  isMissingUpstreamError,
   isRecognizedGitFailure,
 } from '../lib/errors';
 import { trackEvent, trackError } from '../lib/analytics';
@@ -265,7 +266,7 @@ export function useBranchManagement({
         void trackEvent('git_pulled', { result: 'merge_conflict', $screen_name: 'Workspace' });
         logger.warn('Pull produced merge conflicts', { message });
         setShowConflictResolution(true);
-      } else if (/no tracking information|no such ref was fetched/i.test(message)) {
+      } else if (isMissingUpstreamError(e)) {
         // Expected, by-design refusal (unpushed branch) — info toast + warn
         // log, NOT the error channels: error toasts and logger.error both
         // auto-file bug reports, and this isn't a bug (issue #600).

--- a/src/hooks/useCodeHealth.ts
+++ b/src/hooks/useCodeHealth.ts
@@ -40,7 +40,7 @@ const AUTO_RUN_INTERVAL_SECONDS = 15 * 60;
 
 interface UseCodeHealthParams {
   projectPath: string;
-  onToast?: (message: string, type?: 'success' | 'error') => void;
+  onToast?: (message: string, type?: 'success' | 'error' | 'info') => void;
   onAskClaude?: (prompt: string) => void;
   onHealthOutput?: (output: string) => void;
 }
@@ -128,8 +128,10 @@ export function useCodeHealth({
 
       setCheckStates(newStates);
     } catch (e) {
+      // CommandError rejections are plain objects — String() renders
+      // "[object Object]" (issue #830); format to the real message.
       logger.error('Failed to detect health scripts', {
-        error: e instanceof Error ? e.message : String(e),
+        error: formatCommandError(asCommandError(e)),
       });
     }
   }, [projectPath]);
@@ -194,7 +196,11 @@ export function useCodeHealth({
             }
             emitOutput(`\x1b[90m───────────────────────────────────────\x1b[0m\r\n`);
           }
-          onToast?.(`${CATEGORY_LABELS[category]} failed`, 'error');
+          // The script ran and reported violations — that's the check doing its
+          // job, not an app malfunction. An 'error' toast re-reports to
+          // telemetry (see useToasts), so use 'info' here (issue #761); the
+          // catch block below keeps 'error' for a script that couldn't run.
+          onToast?.(`${CATEGORY_LABELS[category]} failed`, 'info');
           return 'fail';
         }
       } catch (e) {
@@ -359,7 +365,7 @@ export function useCodeHealth({
       setPackageJsonContent(content);
       setShowPackageJson(true);
     } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
+      const message = formatCommandError(asCommandError(e));
       onToast?.(`Failed to load package.json: ${message}`, 'error');
     } finally {
       setIsLoadingPackageJson(false);

--- a/src/hooks/useElementSettings.test.ts
+++ b/src/hooks/useElementSettings.test.ts
@@ -131,16 +131,23 @@ describe('useElementSettings addClass', () => {
 
     await add(result, 'mt-4');
 
+    // A by-design refusal: the backend declining to guess which of several
+    // look-alike tags was clicked. The user still gets the specific reason, but
+    // as 'info' — an 'error' toast re-files it as a bug on every occurrence
+    // through useToasts' `source: 'toast'` reporting (issue #818).
     expect(onToast).toHaveBeenCalledWith(
       expect.stringContaining("Couldn't tell which <div> in source"),
-      'error'
+      'info'
     );
-    // The log carries the same formatted message — a plain CommandError object
-    // through String(err) would log "[object Object]" (issues #516/#517).
     // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
     const errorLog = logger.error as Fn;
-    const logged = (errorLog.mock.calls as Array<[string, { error: string }]>).find(
-      ([msg]) => msg === '[ElementSettings] add class failed'
+    expect(errorLog).not.toHaveBeenCalled();
+    // The warn log carries the same formatted message — a plain CommandError
+    // object through String(err) would log "[object Object]" (issues #516/#517).
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    const warnLog = logger.warn as Fn;
+    const logged = (warnLog.mock.calls as Array<[string, { error: string }]>).find(
+      ([msg]) => msg === '[ElementSettings] add class refused'
     );
     expect(logged?.[1].error).toContain("Couldn't tell which <div>");
     // Nothing was written — the class list stays empty.

--- a/src/hooks/useElementSettings.ts
+++ b/src/hooks/useElementSettings.ts
@@ -29,9 +29,35 @@ import { setAttribute as setAttrInHtml } from '../lib/htmlAttrs';
 import { logger } from '../lib/logger';
 import { trackEvent } from '../lib/analytics';
 import { asCommandError, formatCommandError } from '../lib/errors';
+import { isExpectedStructuralRefusal } from './useElementStructure';
 
 function toastText(err: unknown): string {
   return formatCommandError(asCommandError(err));
+}
+
+/**
+ * Log a settings-write failure at the right level, then toast it.
+ *
+ * The backend refuses by design when it can't tell which element in source the
+ * user clicked (`edit.rs`'s classname-resolution ladder: "Couldn't tell which
+ * <img> in source to add the class to…"). Those messages are already accurate
+ * and actionable, so they must not reach the bug pipeline — `logger.error` and
+ * an 'error' toast would both file one on every occurrence (issue #818, same
+ * distinction `useElementStructure` makes in #402/#723).
+ */
+function reportSettingsFailure(
+  what: string,
+  err: unknown,
+  onToast: (message: string, type?: 'success' | 'error' | 'info') => void
+): void {
+  const message = toastText(err);
+  const expected = isExpectedStructuralRefusal(message);
+  if (expected) {
+    logger.warn(`[ElementSettings] ${what} refused`, { error: message });
+  } else {
+    logger.error(`[ElementSettings] ${what} failed`, { error: message });
+  }
+  onToast(message, expected ? 'info' : 'error');
 }
 
 export interface ElementAttr {
@@ -79,7 +105,7 @@ interface Params {
   projectPath: string;
   enabled: boolean;
   signature: ElementSignature | null;
-  onToast: (message: string, type?: 'success' | 'error') => void;
+  onToast: (message: string, type?: 'success' | 'error' | 'info') => void;
 }
 
 export function useElementSettings({
@@ -158,8 +184,7 @@ export function useElementSettings({
         setAttributes(parseAttributes(newHtml));
         void trackEvent('visual_style_saved', { mode: 'css-code', attr_edit: true });
       } catch (err) {
-        logger.error('[ElementSettings] attribute edit failed', { error: toastText(err) });
-        onToast(toastText(err), 'error');
+        reportSettingsFailure('attribute edit', err, onToast);
       } finally {
         setBusy(false);
       }
@@ -189,8 +214,7 @@ export function useElementSettings({
         setAttributes(parseAttributes(newHtml));
         void trackEvent('visual_style_saved', { mode: 'css-code', attr_edit: true });
       } catch (err) {
-        logger.error('[ElementSettings] attribute rename failed', { error: toastText(err) });
-        onToast(toastText(err), 'error');
+        reportSettingsFailure('attribute rename', err, onToast);
       } finally {
         setBusy(false);
       }
@@ -259,8 +283,7 @@ export function useElementSettings({
           void trackEvent('visual_class_added', { mode: 'css-code' });
         }
       } catch (err) {
-        logger.error('[ElementSettings] add class failed', { error: toastText(err) });
-        onToast(toastText(err), 'error');
+        reportSettingsFailure('add class', err, onToast);
       } finally {
         setBusy(false);
       }
@@ -278,8 +301,7 @@ export function useElementSettings({
           void trackEvent('visual_class_removed', { mode: 'css-code' });
         }
       } catch (err) {
-        logger.error('[ElementSettings] remove class failed', { error: toastText(err) });
-        onToast(toastText(err), 'error');
+        reportSettingsFailure('remove class', err, onToast);
       } finally {
         setBusy(false);
       }

--- a/src/hooks/useElementStructure.test.ts
+++ b/src/hooks/useElementStructure.test.ts
@@ -26,7 +26,11 @@ vi.mock('../lib/edit-html', () => ({
 // trackEvent would otherwise reach for a real Tauri IPC on a saved edit.
 vi.mock('../lib/analytics', () => ({ trackEvent: vi.fn().mockResolvedValue(undefined) }));
 
-import { useElementStructure, structuralEditMessage } from './useElementStructure';
+import {
+  useElementStructure,
+  structuralEditMessage,
+  isExpectedStructuralRefusal,
+} from './useElementStructure';
 import { insertElement, duplicateElement, deleteElement } from '../lib/edit-structure';
 import { resolveElementHtml } from '../lib/edit-html';
 
@@ -214,6 +218,28 @@ describe('useElementStructure', () => {
     vi.useRealTimers();
   });
 
+  it('the structural-tag guard toasts friendly wording as info, not a bug', async () => {
+    const { result, iframeRef, onToast } = setup();
+    const source = iframeRef.current!.contentWindow as unknown as MessageEventSource;
+    await dispatch({ type: 'ss:select', signature: { ...SIG, tagName: 'body' }, count: 1 }, source);
+    // The backend refuses by design; the raw wording used to reach the user
+    // verbatim AND file a bug on every occurrence (issues #723/#740).
+    (deleteElement as Fn).mockRejectedValue({
+      type: 'Validation',
+      field: 'element',
+      reason: "<body> can't be deleted.",
+    });
+
+    await act(async () => {
+      await result.current.remove();
+    });
+    expect(onToast).toHaveBeenCalledWith(
+      expect.stringContaining('part of the page itself'),
+      'info'
+    );
+    expect(onToast).not.toHaveBeenCalledWith(expect.stringContaining("can't be deleted."), 'error');
+  });
+
   it('an unrecognized failure keeps the reportable error toast type', async () => {
     const { result, iframeRef, onToast } = setup();
     const source = iframeRef.current!.contentWindow as unknown as MessageEventSource;
@@ -279,5 +305,48 @@ describe('structuralEditMessage', () => {
       )
     ).toContain('generated dynamically');
     expect(structuralEditMessage('disk full')).toBe('disk full');
+  });
+
+  // The STRUCTURAL_TAGS guard in edit_structure.rs (issues #723/#740).
+  it('rephrases the html/head/body structural-tag guard', () => {
+    expect(structuralEditMessage("<body> can't be deleted.")).toBe(
+      "<body> is part of the page itself, so it can't be deleted. Pick an element inside it instead."
+    );
+    expect(structuralEditMessage("<html> can't be duplicated.")).toContain("can't be duplicated");
+    expect(
+      structuralEditMessage("Can't insert next to <head> — insert inside it instead.")
+    ).toContain('Nothing can sit beside <head>');
+  });
+
+  // Issue #789: raw internal wording reached the toast verbatim.
+  it('rephrases the span-mapping failure but keeps it reportable', () => {
+    const raw = "couldn't map this element to its source markup";
+    expect(structuralEditMessage(raw)).toContain("couldn't read this element's full markup");
+    expect(isExpectedStructuralRefusal(raw)).toBe(false);
+  });
+});
+
+describe('isExpectedStructuralRefusal', () => {
+  it('recognizes the by-design refusals, including the structural-tag guard', () => {
+    for (const raw of [
+      'This element has no class in source to anchor its markup on.',
+      'This element appears in several places whose markup differs',
+      'This element appears in several identical places',
+      "This element can't be matched to its source markup",
+      "Couldn't tell which <img> in source to add the class to \u2014 7 classless <img> tag(s) matched",
+      "Couldn't find a <div> without a class in source to add a class to",
+      "<body> can't be deleted.",
+      "<html> can't be duplicated.",
+      "Can't insert next to <body>",
+    ]) {
+      expect(isExpectedStructuralRefusal(raw)).toBe(true);
+    }
+  });
+
+  it('does not swallow genuine failures', () => {
+    expect(isExpectedStructuralRefusal('I/O error: disk full')).toBe(false);
+    expect(isExpectedStructuralRefusal("couldn't map this element to its source markup")).toBe(
+      false
+    );
   });
 });

--- a/src/hooks/useElementStructure.ts
+++ b/src/hooks/useElementStructure.ts
@@ -85,7 +85,47 @@ export function structuralEditMessage(message: string): string {
   if (message.includes("can't be matched to its source markup")) {
     return "This element can't be matched to its source code (its classes are generated dynamically). Ask your agent to make this change instead.";
   }
+  // STRUCTURAL_TAGS guard (edit_structure.rs): the document's own <html>/<head>/
+  // <body> can't be removed or displaced. A by-design refusal, but the raw
+  // wording reads like an internal rule (issues #723/#740).
+  const structural = /<(html|head|body)> can't be (deleted|duplicated)\./.exec(message);
+  if (structural) {
+    return `<${structural[1]}> is part of the page itself, so it can't be ${structural[2]}. Pick an element inside it instead.`;
+  }
+  const insertNextTo = /Can't insert next to <(html|head|body)>/.exec(message);
+  if (insertNextTo) {
+    return `Nothing can sit beside <${insertNextTo[1]}> — it's part of the page itself. Use "Insert inside" instead.`;
+  }
+  // `element_span` walked off the end of the file looking for this element's
+  // closing tag — raw internal wording that meant nothing to the user (issue
+  // #789). Rephrased, but NOT treated as expected below: it still points at
+  // markup the span mapper can't read, which is worth a report.
+  if (message.includes("couldn't map this element to its source markup")) {
+    return "Ship Studio couldn't read this element's full markup in your code. Select a more specific element, or ask your agent to make this change.";
+  }
   return message;
+}
+
+/**
+ * Whether a structural-edit failure is a by-design refusal rather than a bug:
+ * the backend declining to guess (ambiguous/unanchorable element) or the
+ * structural-tag guard. These already give the user an accurate, actionable
+ * message, so they route to `logger.warn` + a non-'error' toast instead of the
+ * bug pipeline (issues #402/#515/#723/#740).
+ */
+export function isExpectedStructuralRefusal(message: string): boolean {
+  return (
+    message.includes('no class in source to anchor') ||
+    message.includes('several places whose markup differs') ||
+    message.includes('several identical places') ||
+    message.includes("can't be matched to its source markup") ||
+    // The classless-anchor ladder refusing to pick among look-alike tags — its
+    // own wording is already user-facing and names what it searched (#318/#818).
+    message.includes("Couldn't tell which <") ||
+    message.includes('without a class in source') ||
+    /<(html|head|body)> can't be (deleted|duplicated)\./.test(message) ||
+    /Can't insert next to <(html|head|body)>/.test(message)
+  );
 }
 
 export function useElementStructure({ iframeRef, projectPath, enabled, onToast }: Params) {
@@ -198,23 +238,26 @@ export function useElementStructure({ iframeRef, projectPath, enabled, onToast }
         await action();
       } catch (err) {
         const message = formatCommandError(asCommandError(err));
+        // Wording and reportability are decided separately: a failure can
+        // deserve better phrasing AND still be a bug worth filing (issue #789).
         const friendly = structuralEditMessage(message);
-        if (friendly === message) {
-          // Unrecognized failure — a genuine bug candidate, report it.
-          logger.error('[ElementStructure] structural edit failed', { error: message });
-        } else {
-          // A known by-design refusal (ambiguous/unanchorable element). The
-          // user already gets an accurate toast; logger.error would ship it
-          // to the bug pipeline on every occurrence even though #299 already
-          // classified these as non-reportable on the Rust side (issue #402).
+        const expected = isExpectedStructuralRefusal(message);
+        if (expected) {
+          // A known by-design refusal (ambiguous/unanchorable element, or the
+          // structural-tag guard). The user already gets an accurate toast;
+          // logger.error would ship it to the bug pipeline on every occurrence
+          // even though #299 already classified these as non-reportable on the
+          // Rust side (issues #402/#723/#740).
           logger.warn('[ElementStructure] structural edit refused', { error: message });
+        } else {
+          logger.error('[ElementStructure] structural edit failed', { error: message });
         }
         // Recognized refusals also skip the 'error' toast type: error toasts
         // re-enter telemetry through useToasts' `source: 'toast'` reporting
         // path, re-reporting what the logger.warn branch above deliberately
         // kept out (issues #437/#515). 'info' keeps the toast visible without
         // filing a bug.
-        onToast?.(friendly, friendly === message ? 'error' : 'info');
+        onToast?.(friendly, expected ? 'info' : 'error');
       } finally {
         busyRef.current = false;
         setBusy(false);

--- a/src/hooks/useEnvEditor.test.ts
+++ b/src/hooks/useEnvEditor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { useEnvEditor } from './useEnvEditor';
+import { describeInvalidEnvKey, splitEnvEntry, useEnvEditor } from './useEnvEditor';
 
 // Mock external dependencies
 vi.mock('@tauri-apps/api/core', () => ({
@@ -91,5 +91,102 @@ describe('useEnvEditor', () => {
 
       expect(result.current.error).toBe('file already exists');
     });
+  });
+
+  describe('variable name field (issue #824)', () => {
+    /** Render with one loaded .env.local holding a single variable. */
+    async function renderWithVar() {
+      vi.mocked(core.invoke).mockImplementation((cmd: string) => {
+        if (cmd === 'list_env_files')
+          return Promise.resolve([{ name: '.env.local', path: '/test/project/.env.local' }]);
+        if (cmd === 'read_env_file') return Promise.resolve([{ key: 'FOO', value: 'bar' }]);
+        return Promise.resolve(undefined);
+      });
+      const rendered = renderEnvEditor();
+      await waitFor(() => expect(rendered.result.current.vars).toHaveLength(1));
+      return rendered;
+    }
+
+    it('splits a pasted KEY=value into both fields and explains what happened', async () => {
+      const { result } = await renderWithVar();
+
+      act(() => {
+        result.current.handleUpdateVar(0, 'key', 'API_KEY=sk-123');
+      });
+
+      expect(result.current.vars[0]).toEqual({ key: 'API_KEY', value: 'sk-123' });
+      expect(result.current.keyNotice).toContain('name and value fields');
+    });
+
+    it('strips quotes from the split value, like the bulk paste flow', async () => {
+      const { result } = await renderWithVar();
+
+      act(() => {
+        result.current.handleUpdateVar(0, 'key', 'GREETING="hello world"');
+      });
+
+      expect(result.current.vars[0]).toEqual({ key: 'GREETING', value: 'hello world' });
+    });
+
+    it('refuses to save an invalid name inline instead of letting the backend reject it', async () => {
+      const { result } = await renderWithVar();
+      act(() => {
+        result.current.handleUpdateVar(0, 'key', 'my key');
+      });
+
+      await act(async () => {
+        await result.current.handleSave();
+      });
+
+      expect(result.current.error).toContain('valid variable name');
+      expect(core.invoke).not.toHaveBeenCalledWith('write_env_file', expect.anything());
+    });
+
+    it('still saves a valid name', async () => {
+      const { result } = await renderWithVar();
+      act(() => {
+        result.current.handleUpdateVar(0, 'key', 'FOO_2');
+      });
+
+      await act(async () => {
+        await result.current.handleSave();
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(core.invoke).toHaveBeenCalledWith('write_env_file', expect.anything());
+    });
+  });
+});
+
+describe('splitEnvEntry', () => {
+  it('splits at the first "=" and trims both halves', () => {
+    expect(splitEnvEntry(' API_KEY = sk-1=2 ')).toEqual({ key: 'API_KEY', value: 'sk-1=2' });
+  });
+
+  it('leaves the value untouched (null) when there is no "="', () => {
+    expect(splitEnvEntry('  API_KEY ')).toEqual({ key: 'API_KEY', value: null });
+  });
+
+  it('keeps a lone quote character as-is', () => {
+    expect(splitEnvEntry('K="')).toEqual({ key: 'K', value: '"' });
+  });
+});
+
+describe('describeInvalidEnvKey', () => {
+  it('accepts names write_env_file accepts', () => {
+    for (const key of ['FOO', '_private', 'A1_b2']) {
+      expect(describeInvalidEnvKey(key)).toBeNull();
+    }
+  });
+
+  it('explains empty, leading-digit and illegal-character names', () => {
+    expect(describeInvalidEnvKey('   ')).toContain('needs a name');
+    expect(describeInvalidEnvKey('1FOO')).toContain("can't start with a number");
+    expect(describeInvalidEnvKey('MY KEY')).toContain('valid variable name');
+    expect(describeInvalidEnvKey('KEY=value')).toContain('valid variable name');
+  });
+
+  it('rejects a name longer than the backend limit', () => {
+    expect(describeInvalidEnvKey('A'.repeat(257))).toContain('too long');
   });
 });

--- a/src/hooks/useEnvEditor.test.ts
+++ b/src/hooks/useEnvEditor.test.ts
@@ -128,6 +128,27 @@ describe('useEnvEditor', () => {
       expect(result.current.vars[0]).toEqual({ key: 'GREETING', value: 'hello world' });
     });
 
+    it('a trailing "=" (a .env.example line) never wipes the row\'s existing value', async () => {
+      // `API_KEY=` carries a name and NO value. Treating the empty half as a
+      // real value overwrote the stored secret with '', and Save destroyed it.
+      const { result } = await renderWithVar();
+
+      act(() => {
+        result.current.handleUpdateVar(0, 'key', 'API_KEY=');
+      });
+
+      expect(result.current.vars[0]).toEqual({ key: 'API_KEY', value: 'bar' });
+      expect(result.current.keyNotice).toContain('left as it was');
+
+      await act(async () => {
+        await result.current.handleSave();
+      });
+      expect(core.invoke).toHaveBeenCalledWith('write_env_file', {
+        filePath: '/test/project/.env.local',
+        vars: [{ key: 'API_KEY', value: 'bar' }],
+      });
+    });
+
     it('refuses to save an invalid name inline instead of letting the backend reject it', async () => {
       const { result } = await renderWithVar();
       act(() => {
@@ -169,6 +190,12 @@ describe('splitEnvEntry', () => {
 
   it('keeps a lone quote character as-is', () => {
     expect(splitEnvEntry('K="')).toEqual({ key: 'K', value: '"' });
+  });
+
+  it('reports a trailing "=" as no value at all, so callers keep the existing one', () => {
+    expect(splitEnvEntry('API_KEY=')).toEqual({ key: 'API_KEY', value: null });
+    expect(splitEnvEntry('API_KEY=   ')).toEqual({ key: 'API_KEY', value: null });
+    expect(splitEnvEntry('API_KEY=""')).toEqual({ key: 'API_KEY', value: null });
   });
 });
 

--- a/src/hooks/useEnvEditor.ts
+++ b/src/hooks/useEnvEditor.ts
@@ -13,6 +13,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { trackEvent, trackError } from '../lib/analytics';
 import { asCommandError, formatCommandError } from '../lib/errors';
 import { logger } from '../lib/logger';
+import type { ToastType } from './useToasts';
 
 /** Represents an environment file in the project */
 export interface EnvFile {
@@ -30,6 +31,56 @@ export interface EnvVar {
   value: string;
 }
 
+/**
+ * What `write_env_file` (src-tauri/src/commands/env.rs) accepts as a variable
+ * name: ASCII letters, digits and underscores, never leading with a digit.
+ * Mirrored here so the editor can refuse a bad name inline instead of letting
+ * the save fail with the backend's raw validation string (issue #824).
+ */
+const VALID_ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Matches `MAX_ENV_KEY_LENGTH` in src-tauri/src/commands/env.rs. */
+const MAX_ENV_KEY_LENGTH = 256;
+
+/**
+ * Split a pasted `KEY=value` entry into its two halves (surrounding quotes
+ * stripped from the value, as {@link parseEnvContent} does). Returns a null
+ * value when the text carries no `=` at all, so callers can leave the
+ * existing value alone.
+ */
+export function splitEnvEntry(raw: string): { key: string; value: string | null } {
+  const eq = raw.indexOf('=');
+  if (eq === -1) return { key: raw.trim(), value: null };
+  const key = raw.slice(0, eq).trim();
+  let value = raw.slice(eq + 1).trim();
+  if (
+    value.length >= 2 &&
+    ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'")))
+  ) {
+    value = value.slice(1, -1);
+  }
+  return { key, value };
+}
+
+/**
+ * Plain-language reason a variable name would be rejected, or null when it's
+ * fine. Keeps the backend's raw "Invalid environment variable name: …" string
+ * (which reads like an app malfunction) off the save path (issue #824).
+ */
+export function describeInvalidEnvKey(key: string): string | null {
+  if (key.trim().length === 0) return 'Every variable needs a name.';
+  if (key.length > MAX_ENV_KEY_LENGTH) {
+    return `"${key.slice(0, 40)}…" is too long for a variable name (max ${MAX_ENV_KEY_LENGTH} characters).`;
+  }
+  if (/^[0-9]/.test(key))
+    return `"${key}" can't be used — a variable name can't start with a number.`;
+  if (!VALID_ENV_KEY_PATTERN.test(key)) {
+    return `"${key}" isn't a valid variable name. Use letters, numbers and underscores only — no spaces, quotes or "=".`;
+  }
+  return null;
+}
+
 /** Params for the useEnvEditor hook */
 interface UseEnvEditorParams {
   /** Absolute path to the project directory */
@@ -39,7 +90,7 @@ interface UseEnvEditorParams {
   /** Callback to close the editor */
   onClose: () => void;
   /** Optional callback to show toast notifications */
-  onToast?: (message: string, type?: 'success' | 'error') => void;
+  onToast?: (message: string, type?: ToastType) => void;
 }
 
 /** Sync status between .env.local and .env.example */
@@ -57,6 +108,8 @@ export interface UseEnvEditorReturn {
   isLoading: boolean;
   isSaving: boolean;
   error: string | null;
+  /** Friendly inline note about the variable-name field (issue #824). */
+  keyNotice: string | null;
   showNewFileInput: boolean;
   setShowNewFileInput: React.Dispatch<React.SetStateAction<boolean>>;
   newFileName: string;
@@ -106,6 +159,7 @@ export function useEnvEditor({
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [keyNotice, setKeyNotice] = useState<string | null>(null);
   const [showNewFileInput, setShowNewFileInput] = useState(false);
   const [newFileName, setNewFileName] = useState('.env.local');
   const [editingKey, setEditingKey] = useState<string | null>(null);
@@ -208,8 +262,23 @@ export function useEnvEditor({
   const handleSave = async () => {
     if (!selectedFile) return;
 
+    // Catch a name the backend would reject before the write, so the user
+    // gets an inline explanation instead of write_env_file's raw validation
+    // string in an error toast (which also auto-files a bug report — this is
+    // a typo, not a malfunction; issue #824).
+    for (const v of vars) {
+      const reason = describeInvalidEnvKey(v.key);
+      if (reason) {
+        setError(reason);
+        setKeyNotice(null);
+        onToast?.(reason, 'info');
+        return;
+      }
+    }
+
     setIsSaving(true);
     setError(null);
+    setKeyNotice(null);
     try {
       await invoke('write_env_file', { filePath: selectedFile.path, vars });
       setHasChanges(false);
@@ -301,7 +370,21 @@ export function useEnvEditor({
 
   const handleUpdateVar = (index: number, field: 'key' | 'value', newValue: string) => {
     const updated = [...vars];
-    updated[index] = { ...updated[index], [field]: newValue };
+    if (field === 'key' && newValue.includes('=')) {
+      // Pasting a whole `KEY=value` line into the name field is the obvious
+      // thing to try, and it used to be accepted silently — then the save
+      // failed with write_env_file's raw "Invalid environment variable name"
+      // string, which reads like an app bug (issue #824). Split it the same
+      // way the bulk-paste flow does and say what happened.
+      const { key, value } = splitEnvEntry(newValue);
+      updated[index] = { key, value: value ?? updated[index].value };
+      setKeyNotice(
+        `Split "${newValue.trim()}" into the name and value fields — the name field takes just the variable name.`
+      );
+    } else {
+      updated[index] = { ...updated[index], [field]: newValue };
+      if (field === 'key') setKeyNotice(null);
+    }
     setVars(updated);
     setHasChanges(true);
   };
@@ -474,6 +557,7 @@ export function useEnvEditor({
     isLoading,
     isSaving,
     error,
+    keyNotice,
     showNewFileInput,
     setShowNewFileInput,
     newFileName,

--- a/src/hooks/useEnvEditor.ts
+++ b/src/hooks/useEnvEditor.ts
@@ -44,9 +44,13 @@ const MAX_ENV_KEY_LENGTH = 256;
 
 /**
  * Split a pasted `KEY=value` entry into its two halves (surrounding quotes
- * stripped from the value, as {@link parseEnvContent} does). Returns a null
- * value when the text carries no `=` at all, so callers can leave the
- * existing value alone.
+ * stripped from the value, as {@link parseEnvContent} does).
+ *
+ * The value is null when the text carries NO value to apply — either no `=` at
+ * all, or a trailing `=` with nothing after it (the `.env.example` shape,
+ * `API_KEY=`). Both mean "the name is all that was typed", so callers keep the
+ * row's existing value instead of overwriting a stored secret with an empty
+ * string.
  */
 export function splitEnvEntry(raw: string): { key: string; value: string | null } {
   const eq = raw.indexOf('=');
@@ -60,7 +64,7 @@ export function splitEnvEntry(raw: string): { key: string; value: string | null 
   ) {
     value = value.slice(1, -1);
   }
-  return { key, value };
+  return { key, value: value === '' ? null : value };
 }
 
 /**
@@ -377,9 +381,14 @@ export function useEnvEditor({
       // string, which reads like an app bug (issue #824). Split it the same
       // way the bulk-paste flow does and say what happened.
       const { key, value } = splitEnvEntry(newValue);
+      // A null value means the text carried no value to apply (a bare
+      // `.env.example`-style `API_KEY=`). Keep the row's existing value — an
+      // empty string here would silently wipe a stored secret on the next Save.
       updated[index] = { key, value: value ?? updated[index].value };
       setKeyNotice(
-        `Split "${newValue.trim()}" into the name and value fields — the name field takes just the variable name.`
+        value === null
+          ? `Took "${key}" as the variable name — the name field takes just the name, so the value was left as it was.`
+          : `Split "${newValue.trim()}" into the name and value fields — the name field takes just the variable name.`
       );
     } else {
       updated[index] = { ...updated[index], [field]: newValue };

--- a/src/hooks/useFileTree.test.ts
+++ b/src/hooks/useFileTree.test.ts
@@ -32,6 +32,7 @@ vi.mock('../lib/analytics', () => ({ trackEvent: vi.fn().mockResolvedValue(undef
 
 import { useFileTree } from './useFileTree';
 import { readProjectFile, saveProjectFile } from '../lib/code';
+import { logger } from '../lib/logger';
 
 type Fn = ReturnType<typeof vi.fn>;
 const EDIT_KEY = 'shipstudio:code-edit-mode';
@@ -261,5 +262,42 @@ describe('useFileTree — discard-confirmation guard', () => {
     expect(result.current.pendingAction).toBeNull();
     expect(result.current.selectedFilePath).toBe('b.ts');
     expect(result.current.draft).toBe('bbb');
+  });
+});
+
+describe('useFileTree — read-failure log level', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  /** Select a file whose read rejects with a plain CommandError (the IPC shape). */
+  async function openFailing(message: string) {
+    (readProjectFile as Fn).mockRejectedValue({ type: 'Other', message });
+    const { result } = await setup();
+    await act(async () => {
+      result.current.selectFile('a.ts');
+      await flush();
+    });
+  }
+
+  it('warns (not errors) when the file vanished under a stale tab (#834)', async () => {
+    await openFailing('File not found: a.ts');
+    expect(logger.warn).toHaveBeenCalledWith('Failed to read file', {
+      path: 'a.ts',
+      error: 'File not found: a.ts',
+    });
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('warns when the OS denies access to the file (#837)', async () => {
+    await openFailing("Can't read a.ts — permission denied. It may be locked by another program.");
+    expect(logger.warn).toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('still errors on a genuine read failure', async () => {
+    await openFailing("Failed to resolve file 'a.ts': something unexpected");
+    expect(logger.error).toHaveBeenCalled();
   });
 });

--- a/src/hooks/useFileTree.test.ts
+++ b/src/hooks/useFileTree.test.ts
@@ -283,21 +283,26 @@ describe('useFileTree — read-failure log level', () => {
 
   it('warns (not errors) when the file vanished under a stale tab (#834)', async () => {
     await openFailing('File not found: a.ts');
-    expect(logger.warn).toHaveBeenCalledWith('Failed to read file', {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.warn as Fn).toHaveBeenCalledWith('Failed to read file', {
       path: 'a.ts',
       error: 'File not found: a.ts',
     });
-    expect(logger.error).not.toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
   });
 
   it('warns when the OS denies access to the file (#837)', async () => {
     await openFailing("Can't read a.ts — permission denied. It may be locked by another program.");
-    expect(logger.warn).toHaveBeenCalled();
-    expect(logger.error).not.toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.warn as Fn).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
   });
 
   it('still errors on a genuine read failure', async () => {
     await openFailing("Failed to resolve file 'a.ts': something unexpected");
-    expect(logger.error).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).toHaveBeenCalled();
   });
 });

--- a/src/hooks/useFileTree.ts
+++ b/src/hooks/useFileTree.ts
@@ -32,6 +32,25 @@ import { useAsyncState } from './useAsyncState';
 const CODE_EDIT_MODE_KEY = 'shipstudio:code-edit-mode';
 
 /**
+ * True when a failed file read is an environment state rather than an app bug:
+ * the file vanished under a stale tab / tree entry (build tool, branch switch,
+ * external editor — `resolve_error`'s NotFound branch in `code.rs`, issue
+ * #834), or the OS refused access because another program holds a lock or the
+ * ACL denies us (issue #837). The backend classifies both
+ * `CommandError::Expected`, but Expected serializes identically to Other
+ * across IPC, so the message shape is re-checked here.
+ */
+function isExpectedFileAccessError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('file not found:') ||
+    lower.includes('locked by another program') ||
+    lower.includes('permission denied') ||
+    lower.includes("doesn't have permission")
+  );
+}
+
+/**
  * A pending action that would discard the current edit buffer and so needs a
  * discard confirmation first: switching to `path`, or turning Edit mode off.
  */
@@ -112,7 +131,11 @@ export function useFileTree(projectPath: string): UseFileTreeResult {
       // CommandError rejections are plain objects — String() renders
       // "[object Object]" (issue #396); format to the real message.
       const msg = formatCommandError(asCommandError(err));
-      logger.error('Failed to read file', { path, error: msg });
+      // logger.error auto-files a bug report; a gone or locked file isn't one.
+      logger[isExpectedFileAccessError(msg) ? 'warn' : 'error']('Failed to read file', {
+        path,
+        error: msg,
+      });
       throw err;
     }
   }, []);

--- a/src/hooks/usePlugins.ts
+++ b/src/hooks/usePlugins.ts
@@ -13,7 +13,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { listPlugins, updatePlugin, PluginInfo } from '../lib/plugins';
+import { listPlugins, updatePlugin, isExpectedPluginFailure, PluginInfo } from '../lib/plugins';
 import { loadPluginModule, unloadPluginModule, PluginModule } from '../lib/plugin-loader';
 import { asCommandError, formatCommandError } from '../lib/errors';
 import { logger } from '../lib/logger';
@@ -217,7 +217,11 @@ export function usePlugins(
           setFailures(failed);
         }
       } catch (e) {
-        logger.error('Failed to list plugins', {
+        // Full Disk Access / read-only volume / a project folder that's gone
+        // are environment states the backend classifies Expected — the UI
+        // already surfaces them in `failures`, so logger.error would file a
+        // bug report for the app behaving correctly (issue #762).
+        logger[isExpectedPluginFailure(e) ? 'warn' : 'error']('Failed to list plugins', {
           error: formatCommandError(asCommandError(e)),
         });
         if (mountedRef.current && currentPathRef.current === path) {

--- a/src/hooks/useProjectCreation.ts
+++ b/src/hooks/useProjectCreation.ts
@@ -17,7 +17,8 @@
  * Consumed solely by `components/dashboard/CreateProject.tsx`.
  *
  * Boundaries: `spawn_pty` + the `pty-output`/`pty-exit` events (exit codes
- * mapped to friendly errors: 243 npm cache, 128 git auth, 69 Xcode license),
+ * mapped to friendly errors: 243 npm cache, 128 fatal git failure, 69 Xcode
+ * license),
  * `list_projects` (duplicate-name check), `ensure_shipstudio_dir`,
  * lib/setup (`checkNpmCachePermissions`), lib/plugins.
  *
@@ -49,6 +50,15 @@ import { basename } from '../lib/paths';
 /** Extra PTY exit-code mappings specific to the creation flow (template scaffolds). */
 const CREATE_FLOW_EXIT_MESSAGES: Record<number, string> = {
   69: 'Xcode Command Line Tools license has not been accepted. Open Terminal and run:\nsudo xcodebuild -license accept\n\nThen try creating the project again.',
+  // Git exits 128 for many fatal reasons. The shared table maps it to "Git
+  // authentication failed. Make sure you're signed into GitHub." — true for
+  // the import flow's private-repo clones, but wrong here: every template is
+  // a public repo cloned anonymously, so no GitHub sign-in is involved and
+  // that advice sent a reporter chasing re-auth instead of the real (NAS)
+  // problem (issue #841). describeProcessError recognizes the specific
+  // filesystem/ownership causes before this; this is the honest fallback for
+  // everything it couldn't name.
+  128: "The template couldn't be downloaded — git stopped with a fatal error. Check that your projects folder is on a connected, writable drive and that this computer can reach github.com, then try again.",
 };
 
 /** Grouping for the template picker, so the grid isn't an undifferentiated list. */

--- a/src/hooks/useProjectLifecycle.test.ts
+++ b/src/hooks/useProjectLifecycle.test.ts
@@ -215,6 +215,27 @@ describe('handleSelectProject — folder-gone toast routing (#640)', () => {
     expect(logger.error as Fn).not.toHaveBeenCalled();
   });
 
+  it('shows the by-design auto-register refusal as an info toast (#752)', async () => {
+    rejectRegistration(
+      "Refusing to auto-register '/x/notes': it does not look like a project directory. Add it via the folder picker instead."
+    );
+    const params = createParams();
+    const { result } = renderHook(() => useProjectLifecycle(params));
+
+    await act(async () => {
+      await result.current.handleSelectProject({
+        name: 'notes',
+        path: '/x/notes',
+        thumbnail: null,
+      });
+    });
+
+    const [message, type] = vi.mocked(params.showToast).mock.calls[0];
+    expect(message).toContain("isn't a recognized project location");
+    // 'error' toasts auto-file a bug report; this refusal is the guard working.
+    expect(type).toBe('info');
+  });
+
   it('keeps the unrecognized-location refusal as an error toast', async () => {
     rejectRegistration('Invalid path in validate_project_path: /x/elsewhere');
     const params = createParams();

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -322,15 +322,21 @@ export function useProjectLifecycle({
       // Distinguish "the folder is gone" (moved/renamed/deleted outside the
       // app — issue #365) from "the path isn't in an allowed location"; the
       // "re-add via Select Project Folder" advice only fits the latter.
-      const folderGone = formatCommandError(asCommandError(e)).includes('no longer exists');
+      const errorMessage = formatCommandError(asCommandError(e));
+      const folderGone = errorMessage.includes('no longer exists');
+      // `ensure_external_project_registered` refuses paths that don't look like
+      // a project root — a by-design security guard the backend classifies
+      // Expected (issue #598).
+      const notAProject = errorMessage.includes('does not look like a project directory');
       const message = folderGone
         ? `Can't open "${project.name}" — its folder no longer exists. It may have been moved, renamed, or deleted outside Ship Studio.`
         : `Can't open "${project.name}" — its folder isn't a recognized project location. Re-add it via "Select Project Folder".`;
-      // A folder deleted/moved outside the app is a user-caused environment
-      // change the backend already classifies Expected — info toast, NOT
-      // 'error': error toasts auto-file bug reports (issue #640, same
-      // pattern as #535's import-refusal gating below).
-      showToast(message, folderGone ? 'info' : 'error');
+      // A folder deleted/moved outside the app, or a path the auto-register
+      // guard declines, is a user-caused environment state the backend already
+      // classifies Expected — info toast, NOT 'error': error toasts auto-file
+      // bug reports (issues #640/#752, same pattern as #535's import-refusal
+      // gating below). 'error' stays for genuine I/O failures.
+      showToast(message, folderGone || notAProject ? 'info' : 'error');
       return;
     }
 

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -68,7 +68,12 @@ import {
 import { invoke } from '@tauri-apps/api/core';
 import { logger } from '../lib/logger';
 import { trackEvent, trackError, setActiveProject } from '../lib/analytics';
-import { asCommandError, formatCommandError, isExpectedProjectImportRefusal } from '../lib/errors';
+import {
+  asCommandError,
+  describeProcessError,
+  formatCommandError,
+  isExpectedProjectImportRefusal,
+} from '../lib/errors';
 import { describeExitStatus, extractTerminalError } from '../lib/terminalDiagnostics';
 import { getProjectId } from '../lib/projectIdentity';
 import { startProjectSession, endProjectSession } from '../lib/session';
@@ -822,6 +827,25 @@ export function useProjectLifecycle({
       // libuv codes, or their huge u32 wraps from older backends) render as
       // hex instead of a nonsense number like 4294963238 (issue #622).
       const exitDesc = describeExitStatus(exitCode);
+      // Classify the raw tail the same way the import/create flows classify
+      // their install failures. Recognized package-manager conditions (npm's
+      // ERESOLVE peer conflict, a corrupted pnpm store, pnpm's build-script
+      // gate, an expired npm login…) are properties of the project or the
+      // machine, not app bugs — an unconditional 'error' toast auto-files a
+      // bug report for every one of them (issues #717/#788).
+      const classified = describeProcessError(outputTail);
+      if (classified.expected) {
+        logger.warn('[Install] Install failed for a recognized reason', {
+          packageManager: cfg.packageManager,
+          exitCode,
+          detail: scrubbedDetail,
+        });
+        showToast(
+          `${classified.message} (Install exited with ${exitDesc} — the terminal has the full output.)`,
+          'info'
+        );
+        return; // keep overlay open so user can read stderr + close manually
+      }
       showToast(
         detail
           ? `Install exited with ${exitDesc}: ${detail} — check the terminal for the full output.`

--- a/src/hooks/useScreenshotManagement.test.ts
+++ b/src/hooks/useScreenshotManagement.test.ts
@@ -229,4 +229,23 @@ describe('useScreenshotManagement auto-capture consent gate', () => {
     expect(invokeMock).toHaveBeenCalledTimes(2);
     expect(setThumbnailsEnabled).not.toHaveBeenCalled();
   });
+
+  it('missing project folder: stops retrying on the NotFound wording too', async () => {
+    // Issue #750: the backend reports a vanished project folder with this
+    // message, not only the validate_project_path one — retrying it can never
+    // succeed, so the schedule must stop instead of burning all five attempts.
+    vi.mocked(getThumbnailsEnabled).mockResolvedValue(true);
+    invokeMock.mockRejectedValue(
+      "The folder '/Users/test/ShipStudio/demo' no longer exists — it may have been moved, renamed, or deleted outside Ship Studio"
+    );
+    const { result } = renderHook(() => useScreenshotManagement(makeParams()));
+
+    await triggerAutoCapture(result);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/hooks/useScreenshotManagement.ts
+++ b/src/hooks/useScreenshotManagement.ts
@@ -12,17 +12,8 @@ import { logger } from '../lib/logger';
 import { trackEvent } from '../lib/analytics';
 import { getThumbnailsEnabled, setThumbnailsEnabled } from '../lib/settings';
 import { decideAutoCapture, isPermissionDenialError } from '../lib/thumbnailGate';
-import { asCommandError, formatCommandError } from '../lib/errors';
+import { asCommandError, formatCommandError, isProjectFolderGoneError } from '../lib/errors';
 import { captureThumbnailFromPreview } from '../lib/previewSnapshot';
-
-/** Backend rejection meaning the project's root directory no longer exists
- *  (deleted, renamed, or moved while its session stayed hot). Permanent for
- *  this path — retrying can never succeed. */
-function isProjectGoneError(error: unknown): boolean {
-  return formatCommandError(asCommandError(error)).includes(
-    'Invalid path in validate_project_path'
-  );
-}
 
 /** Backend rejection meaning a capture for this project is already running
  *  (the backend's per-project in-flight guard, issue #387). Not a failure —
@@ -225,7 +216,7 @@ export function useScreenshotManagement({
           void setThumbnailsEnabled(false);
           return;
         }
-        if (isProjectGoneError(error)) {
+        if (isProjectFolderGoneError(error)) {
           // The project's folder vanished while its session stayed hot —
           // retrying can't succeed, and the 5-minute interval would re-burn
           // 5 attempts forever with no user-facing signal (issue #300).

--- a/src/hooks/useTextEditing.test.ts
+++ b/src/hooks/useTextEditing.test.ts
@@ -254,9 +254,33 @@ describe('useTextEditing', () => {
       expect(logger.error).not.toHaveBeenCalled();
     });
 
-    it('does not retry when the source has not actually drifted (identical re-resolve)', async () => {
-      // A Validation rejection whose re-resolve returns the SAME target would
-      // fail identically — the hook must not write the same thing twice.
+    it('retries even when the re-resolve matches the stale baseline exactly', async () => {
+      // The rejection came from the backend's own read a moment earlier, so an
+      // identical re-resolve means the transient writer (formatter, HMR) has
+      // already settled back — the same write plausibly succeeds now. Giving up
+      // here threw away saves that could have landed (issue #769).
+      (applyTextEdit as Fn).mockRejectedValueOnce(DRIFT_REJECTION);
+      (resolveTextSource as Fn).mockResolvedValue({
+        status: 'resolved',
+        file: 'src/pages/index.astro',
+        line: 7,
+        column: 3,
+        text: 'Old copy',
+      });
+      const { iframeRef, onToast } = setup();
+      const src = iframeRef.current!.contentWindow!;
+      await dispatch({ type: 'ss:select', signature: SIG, leafText: true }, src);
+      await dispatch({ type: 'ss:textCommit', text: 'New copy' }, src);
+      await settle();
+
+      expect(applyTextEdit).toHaveBeenCalledTimes(2);
+      expect(posts(iframeRef)).not.toContainEqual({ type: 'ss:textRevert' });
+      expect(onToast).toHaveBeenCalledWith('Saved to source', 'success');
+    });
+
+    it('still reverts when the retry is rejected too', async () => {
+      // The retry is an extra chance, not a way around the guard: a second
+      // rejection still explains, reverts, and stays out of the bug pipeline.
       (applyTextEdit as Fn).mockRejectedValue(DRIFT_REJECTION);
       (resolveTextSource as Fn).mockResolvedValue({
         status: 'resolved',
@@ -271,9 +295,14 @@ describe('useTextEditing', () => {
       await dispatch({ type: 'ss:textCommit', text: 'New copy' }, src);
       await settle();
 
-      expect(applyTextEdit).toHaveBeenCalledTimes(1);
+      expect(applyTextEdit).toHaveBeenCalledTimes(2);
       expect(posts(iframeRef)).toContainEqual({ type: 'ss:textRevert' });
-      expect(onToast).toHaveBeenCalledWith(expect.any(String), 'error');
+      expect(onToast).toHaveBeenCalledWith(
+        expect.stringContaining("Couldn't save your text"),
+        'error'
+      );
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- asserting on the mock, not invoking it bound
+      expect(logger.error).not.toHaveBeenCalled();
     });
   });
 

--- a/src/hooks/useTextEditing.ts
+++ b/src/hooks/useTextEditing.ts
@@ -166,17 +166,15 @@ export function useTextEditing({ iframeRef, projectPath, enabled, onToast }: Par
             if (isDrift && sig) {
               try {
                 const res = await resolveTextSource(projectPath, sig);
-                const stale = textTargetRef.current;
-                const sameTarget =
-                  res.status === 'resolved' &&
-                  stale != null &&
-                  res.file === stale.file &&
-                  res.line === stale.line &&
-                  res.column === stale.column &&
-                  res.text === stale.text;
-                // An identical re-resolve would just fail the same way — only
-                // retry when the fresh source actually differs.
-                if (res.status === 'resolved' && !sameTarget) {
+                // Retry whenever the element still resolves, even when the fresh
+                // read matches the stale baseline byte-for-byte. That used to be
+                // treated as "would just fail again", but the rejection came from
+                // the backend's own read a moment earlier: if whatever touched
+                // the file (formatter, HMR rewrite) has already settled back, the
+                // same write now succeeds and the user keeps their copy (#769).
+                // Only the resolver genuinely losing the element (status !==
+                // 'resolved') makes a retry pointless.
+                if (res.status === 'resolved') {
                   if (res.text !== next) {
                     await applyTextEdit(
                       projectPath,

--- a/src/hooks/useVisualEditor.test.ts
+++ b/src/hooks/useVisualEditor.test.ts
@@ -361,6 +361,78 @@ describe('useVisualEditor class drift recovery (issue #739)', () => {
     expect(applyClassnameEdit).toHaveBeenCalledTimes(1);
     expect(onToast).toHaveBeenCalledWith(expect.stringContaining('disk full'), 'error');
   });
+
+  it('refuses the retry when the drift added instances the picker never showed', async () => {
+    // Selected as a SINGLE-location element, so no multi picker was ever shown.
+    // The drift then turns it into a 3-location multi; multiTarget is still its
+    // 'all' default, so a naive retry would rewrite two spots the user never
+    // chose. It must fail loudly instead.
+    (applyClassnameEdit as Fn).mockRejectedValueOnce({
+      type: 'Validation',
+      field: 'old_class',
+      reason: 'source no longer matches — reselect the element',
+    });
+    const { result, iframeRef, onToast } = setup();
+    act(() => result.current.toggleEditMode());
+    await select('p-3', iframeRef.current!.contentWindow!);
+
+    (resolveClassnameSource as Fn).mockResolvedValue({
+      status: 'multi',
+      class_name: 'p-3',
+      locations: [
+        { file: 'app/page.tsx', line: 9, column: 1 },
+        { file: 'app/page.tsx', line: 20, column: 1 },
+        { file: 'components/card.tsx', line: 4, column: 1 },
+      ],
+      confidence: 'ambiguous',
+    });
+
+    act(() => result.current.applyEnum('p-8', { padding: '2rem' }));
+    await act(async () => {
+      await result.current.commit();
+    });
+
+    // The original (failed) write only; nothing was written to the new spots.
+    expect(applyClassnameEdit).toHaveBeenCalledTimes(1);
+    expect(applyClassnameEditMulti).not.toHaveBeenCalled();
+    expect(onToast).toHaveBeenCalledWith(
+      expect.stringContaining('more places in the source'),
+      'error'
+    );
+  });
+
+  it('still retries when the drift did not widen the write', async () => {
+    // Same multi shape at selection AND after the drift — the user's 'all' pick
+    // still covers exactly what they saw, so the recovery runs as before.
+    const multi = {
+      status: 'multi',
+      class_name: 'p-3',
+      locations: [
+        { file: 'app/page.tsx', line: 9, column: 1 },
+        { file: 'app/page.tsx', line: 20, column: 1 },
+      ],
+      confidence: 'ambiguous',
+    };
+    (resolveClassnameSource as Fn).mockResolvedValue(multi);
+    (applyClassnameEditMulti as Fn)
+      .mockRejectedValueOnce({
+        type: 'Validation',
+        field: 'old_class',
+        reason: 'source no longer matches — reselect the element',
+      })
+      .mockResolvedValue(undefined);
+    const { result, iframeRef, onToast } = setup();
+    act(() => result.current.toggleEditMode());
+    await select('p-3', iframeRef.current!.contentWindow!);
+
+    act(() => result.current.applyEnum('p-8', { padding: '2rem' }));
+    await act(async () => {
+      await result.current.commit();
+    });
+
+    expect(applyClassnameEditMulti).toHaveBeenCalledTimes(2);
+    expect(onToast).toHaveBeenCalledWith('Saved to source', 'success');
+  });
 });
 
 describe('useVisualEditor custom classes', () => {

--- a/src/hooks/useVisualEditor.test.ts
+++ b/src/hooks/useVisualEditor.test.ts
@@ -72,6 +72,7 @@ function fakeIframeRef() {
 
 function setup() {
   const iframeRef = fakeIframeRef();
+  const onToast = vi.fn();
   const hook = renderHook(() =>
     useVisualEditor({
       iframeRef,
@@ -79,9 +80,10 @@ function setup() {
       enabled: true,
       activeBreakpoint: BASE_BREAKPOINT,
       breakpoints: BREAKPOINTS,
+      onToast,
     })
   );
-  return { ...hook, iframeRef };
+  return { ...hook, iframeRef, onToast };
 }
 
 /** Flush pending microtasks (e.g. the async resolve) under act. */
@@ -299,6 +301,65 @@ describe('useVisualEditor failure logging (issues #543/#544)', () => {
       error: 'Validation failed for `element`: could not anchor the open tag',
     });
     expect(JSON.stringify(errorLogs())).not.toContain('[object Object]');
+  });
+});
+
+describe('useVisualEditor class drift recovery (issue #739)', () => {
+  it('re-resolves and retries a class write the drift guard rejected', async () => {
+    // The file moved under us between selection and save (a formatter, HMR, an
+    // agent edit). Text edits have recovered from this since #557; class/style
+    // edits used to just lose the user's work.
+    (applyClassnameEdit as Fn).mockRejectedValueOnce({
+      type: 'Validation',
+      field: 'old_class',
+      reason: 'source no longer matches — reselect the element',
+    });
+    const { result, iframeRef, onToast } = setup();
+    act(() => result.current.toggleEditMode());
+    await select('p-3', iframeRef.current!.contentWindow!);
+
+    // The re-resolve sees the element at a NEW line with a drifted baseline.
+    (resolveClassnameSource as Fn).mockResolvedValue({
+      status: 'resolved',
+      file: 'app/page.tsx',
+      line: 9,
+      column: 1,
+      class_name: 'p-3 text-sm',
+      confidence: 'unique',
+    });
+
+    act(() => result.current.applyEnum('p-8', { padding: '2rem' }));
+    await act(async () => {
+      await result.current.commit();
+    });
+
+    const calls = (applyClassnameEdit as Fn).mock.calls as Array<
+      [string, string, number, string, string]
+    >;
+    expect(calls).toHaveLength(2);
+    // The retry writes against the FRESH baseline at the FRESH location — the
+    // guard is honored, not bypassed.
+    expect(calls[1][2]).toBe(9);
+    expect(calls[1][3]).toBe('p-3 text-sm');
+    // Recovered drift is an expected environment state, not a bug.
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the mock's calls, not invoking it bound
+    expect(vi.mocked(logger.error)).not.toHaveBeenCalled();
+    expect(onToast).toHaveBeenCalledWith('Saved to source', 'success');
+  });
+
+  it('a non-drift rejection is not retried', async () => {
+    (applyClassnameEdit as Fn).mockRejectedValue({ type: 'Io', message: 'disk full' });
+    const { result, iframeRef, onToast } = setup();
+    act(() => result.current.toggleEditMode());
+    await select('p-3', iframeRef.current!.contentWindow!);
+
+    act(() => result.current.applyEnum('p-8', { padding: '2rem' }));
+    await act(async () => {
+      await result.current.commit();
+    });
+
+    expect(applyClassnameEdit).toHaveBeenCalledTimes(1);
+    expect(onToast).toHaveBeenCalledWith(expect.stringContaining('disk full'), 'error');
   });
 });
 

--- a/src/hooks/useVisualEditor.ts
+++ b/src/hooks/useVisualEditor.ts
@@ -92,6 +92,11 @@ export type EditTarget = { kind: 'element' } | { kind: 'class'; name: string; ba
  *  `read_only` elements are never written to). */
 type WritableResolution = Extract<Resolution, { status: 'resolved' | 'multi' }>;
 
+/** How many source spots a writable resolution covers (1 for a single location). */
+function locationCount(res: WritableResolution): number {
+  return res.status === 'multi' ? res.locations.length : 1;
+}
+
 /** A breakpoint-scoped slice of the live-preview stylesheet: `decls` applied at
  *  `minPx` and up (0 = base, all widths). A null value deletes that property from
  *  the preview (Reset). Mirrors `select_script.html`'s contract. */
@@ -525,7 +530,10 @@ export function useVisualEditor({
    *  fresh baseline rather than dropping the user's styling. That's the recovery
    *  inline text edits have had since #557, extended to class/style writes
    *  (#739); the guard itself stays intact, since the retry writes against a
-   *  just-read baseline and never forces a stale one through.
+   *  just-read baseline and never forces a stale one through. The retry also
+   *  refuses to widen the blast radius: if the fresh resolve covers MORE source
+   *  spots than the one the user picked against, it fails instead of letting the
+   *  default 'all' write to instances the picker never showed.
    *
    *  Returns the resolution the write actually landed on, so callers advance
    *  their drift baseline to where the element really is now. */
@@ -554,6 +562,17 @@ export function useVisualEditor({
         if (!(cmdErr.type === 'Validation' && cmdErr.field === 'old_class')) throw err;
         const fresh = await resolveClassnameSource(projectPath, sig);
         if (fresh.status !== 'resolved' && fresh.status !== 'multi') throw err;
+        // The multi-location pick ('all' by default) was made against the
+        // locations resolved at SELECTION time. If the re-resolve now finds MORE
+        // of them, the drift added instances the user never saw in the picker —
+        // silently writing to all of them (or to a shifted index) would edit
+        // markup they never chose. Fail the retry instead and let the caller's
+        // revert+toast path run.
+        if (locationCount(fresh) > locationCount(res)) {
+          throw new Error(
+            "Couldn't save — this element now appears in more places in the source than when you selected it. Reselect it and choose which one to edit."
+          );
+        }
         // Already carrying the class we wanted (someone else's write beat us to
         // the same result) — nothing left to do.
         if (fresh.class_name !== next) await write(fresh, fresh.class_name);

--- a/src/hooks/useVisualEditor.ts
+++ b/src/hooks/useVisualEditor.ts
@@ -88,6 +88,10 @@ import { asCommandError, formatCommandError } from '../lib/errors';
  */
 export type EditTarget = { kind: 'element' } | { kind: 'class'; name: string; baseline: string };
 
+/** The resolutions that have a class literal to write over (`no_class` /
+ *  `read_only` elements are never written to). */
+type WritableResolution = Extract<Resolution, { status: 'resolved' | 'multi' }>;
+
 /** A breakpoint-scoped slice of the live-preview stylesheet: `decls` applied at
  *  `minPx` and up (0 = base, all widths). A null value deletes that property from
  *  the preview (Reset). Mirrors `select_script.html`'s contract. */
@@ -513,6 +517,56 @@ export function useVisualEditor({
     [postMutate, setLiveClass, activeBreakpoint, known]
   );
 
+  /** Write `next` over `prev` at the element's resolved source location(s).
+   *
+   *  On an `old_class` drift rejection — the file changed between selection and
+   *  save (a formatter, HMR, an agent edit), so the baseline no longer matches —
+   *  re-resolve the element against the CURRENT source and re-apply against the
+   *  fresh baseline rather than dropping the user's styling. That's the recovery
+   *  inline text edits have had since #557, extended to class/style writes
+   *  (#739); the guard itself stays intact, since the retry writes against a
+   *  just-read baseline and never forces a stale one through.
+   *
+   *  Returns the resolution the write actually landed on, so callers advance
+   *  their drift baseline to where the element really is now. */
+  const writeClassToSource = useCallback(
+    async (
+      sig: ElementSignature,
+      res: WritableResolution,
+      prev: string,
+      next: string
+    ): Promise<WritableResolution> => {
+      const write = async (r: WritableResolution, oldClass: string) => {
+        if (r.status === 'resolved') {
+          await applyClassnameEdit(projectPath, r.file, r.line, oldClass, next);
+        } else {
+          // Honor the user's multi-location pick ('all' vs one index).
+          const mt = multiTargetRef.current;
+          const edits = mt === 'all' ? r.locations : r.locations.filter((_, i) => i === mt);
+          await applyClassnameEditMulti(projectPath, edits, oldClass, next);
+        }
+      };
+      try {
+        await write(res, prev);
+        return res;
+      } catch (err) {
+        const cmdErr = asCommandError(err);
+        if (!(cmdErr.type === 'Validation' && cmdErr.field === 'old_class')) throw err;
+        const fresh = await resolveClassnameSource(projectPath, sig);
+        if (fresh.status !== 'resolved' && fresh.status !== 'multi') throw err;
+        // Already carrying the class we wanted (someone else's write beat us to
+        // the same result) — nothing left to do.
+        if (fresh.class_name !== next) await write(fresh, fresh.class_name);
+        // Recovered drift is an expected environment state, not a bug.
+        logger.warn('[VisualEditor] stale class save recovered by re-resolving', {
+          error: formatCommandError(cmdErr),
+        });
+        return fresh;
+      }
+    },
+    [projectPath]
+  );
+
   /** Persist the current live class to source. `silent` suppresses the success
    *  toast (used by auto-save, which shouldn't toast on every debounced write —
    *  errors still surface). */
@@ -567,19 +621,11 @@ export function useVisualEditor({
       // live preview doesn't briefly revert), while agent edits still reload.
       post({ type: 'ss:suppressReload' });
       try {
-        if (res.status === 'resolved') {
-          await applyClassnameEdit(projectPath, res.file, res.line, prev, next);
-        } else {
-          // Multi: write to all matching source spots, or the one the user picked.
-          const target = multiTargetRef.current;
-          const edits =
-            target === 'all' ? res.locations : res.locations.filter((_, i) => i === target);
-          await applyClassnameEditMulti(projectPath, edits, prev, next);
-        }
+        const landed = await writeClassToSource(sel.signature, res, prev, next);
         // Advance the drift baseline so consecutive edits keep working. Keep
         // selectedSigRef in lockstep — the structural gestures use it as the live
         // source-className baseline, so it must reflect saved style edits too.
-        setSelection({ ...sel, resolution: { ...res, class_name: next } });
+        setSelection({ ...sel, resolution: { ...landed, class_name: next } });
         if (selectedSigRef.current) {
           selectedSigRef.current = { ...selectedSigRef.current, className: next };
         }
@@ -599,7 +645,7 @@ export function useVisualEditor({
         onToast?.(formatCommandError(asCommandError(err)), 'error');
       }
     },
-    [selection, projectPath, onToast, post, setEditTarget, recordCommit]
+    [selection, projectPath, onToast, post, setEditTarget, recordCommit, writeClassToSource]
   );
 
   /** Rewrite the selected element's className in source to `next` (single or
@@ -619,18 +665,11 @@ export function useVisualEditor({
       const prev = selectedSigRef.current?.className ?? res.class_name;
       if (next === prev) return true;
       post({ type: 'ss:suppressReload' });
-      if (res.status === 'resolved') {
-        await applyClassnameEdit(projectPath, res.file, res.line, prev, next);
-      } else {
-        // Honor the user's multi-location pick ('all' vs one index), same as commit().
-        const mt = multiTargetRef.current;
-        const edits = mt === 'all' ? res.locations : res.locations.filter((_, i) => i === mt);
-        await applyClassnameEditMulti(projectPath, edits, prev, next);
-      }
+      const landed = await writeClassToSource(sel.signature, res, prev, next);
       // Keep BOTH the selection signature (drives the class-bar chips) and the
       // resolution baseline (drift guard) in sync with the element's new class.
       const nextSig = { ...sel.signature, className: next };
-      setSelection({ ...sel, signature: nextSig, resolution: { ...res, class_name: next } });
+      setSelection({ ...sel, signature: nextSig, resolution: { ...landed, class_name: next } });
       selectedSigRef.current = nextSig;
       // Reflect on the element itself (in element mode the live class is the element).
       if (editTargetRef.current.kind === 'element') setLiveClass(next);
@@ -638,7 +677,7 @@ export function useVisualEditor({
       post({ type: 'ss:commit' });
       return true;
     },
-    [selection, projectPath, onToast, post, setLiveClass]
+    [selection, onToast, post, setLiveClass, writeClassToSource]
   );
 
   /** Add the FIRST class to a class-less element (a `no_class` resolution): the

--- a/src/lib/agentBridge.test.ts
+++ b/src/lib/agentBridge.test.ts
@@ -164,6 +164,45 @@ describe('executeBridgeTool', () => {
     );
   });
 
+  it('warns instead of erroring when a capture races a dev-server restart (#735)', async () => {
+    vi.mocked(logger.warn).mockClear();
+    vi.mocked(logger.error).mockClear();
+    invokeMock.mockRejectedValue({
+      type: 'Other',
+      message:
+        'The dev server at http://localhost:4173/ stopped responding while the screenshot was being captured. Wait for the preview to finish reloading, then try again.',
+    });
+    const result = await executeBridgeTool(
+      { requestId: 40, tool: 'preview_screenshot' },
+      makeCtx()
+    );
+
+    // The agent still sees the failure…
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('stopped responding');
+    // …but logger.error would auto-file a bug report for an Expected race.
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[AgentBridge] Tool execution failed',
+      expect.objectContaining({ tool: 'preview_screenshot' })
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('still errors on an unclassified tool failure', async () => {
+    vi.mocked(logger.error).mockClear();
+    invokeMock.mockRejectedValue(new Error('kaboom'));
+    const result = await executeBridgeTool(
+      { requestId: 41, tool: 'preview_screenshot' },
+      makeCtx()
+    );
+
+    expect(result.isError).toBe(true);
+    expect(logger.error).toHaveBeenCalledWith(
+      '[AgentBridge] Tool execution failed',
+      expect.objectContaining({ tool: 'preview_screenshot' })
+    );
+  });
+
   it('returns an isError result for unknown tools', async () => {
     const result = await executeBridgeTool({ requestId: 6, tool: 'preview_dance' }, makeCtx());
     expect(result.isError).toBe(true);

--- a/src/lib/agentBridge.test.ts
+++ b/src/lib/agentBridge.test.ts
@@ -17,6 +17,8 @@ import {
 } from './agentBridge';
 import { logger } from './logger';
 
+type Fn = ReturnType<typeof vi.fn>;
+
 const makeCtx = (overrides: Partial<BridgeToolContext> = {}): BridgeToolContext => ({
   projectPath: '/Users/me/ShipStudio/site',
   getCurrentUrl: () => 'http://localhost:4173/',
@@ -165,8 +167,8 @@ describe('executeBridgeTool', () => {
   });
 
   it('warns instead of erroring when a capture races a dev-server restart (#735)', async () => {
-    vi.mocked(logger.warn).mockClear();
-    vi.mocked(logger.error).mockClear();
+    (logger.warn as Fn).mockClear();
+    (logger.error as Fn).mockClear();
     invokeMock.mockRejectedValue({
       type: 'Other',
       message:
@@ -181,15 +183,17 @@ describe('executeBridgeTool', () => {
     expect(result.isError).toBe(true);
     expect((result.content[0] as { text: string }).text).toContain('stopped responding');
     // …but logger.error would auto-file a bug report for an Expected race.
-    expect(logger.warn).toHaveBeenCalledWith(
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.warn as Fn).toHaveBeenCalledWith(
       '[AgentBridge] Tool execution failed',
       expect.objectContaining({ tool: 'preview_screenshot' })
     );
-    expect(logger.error).not.toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).not.toHaveBeenCalled();
   });
 
   it('still errors on an unclassified tool failure', async () => {
-    vi.mocked(logger.error).mockClear();
+    (logger.error as Fn).mockClear();
     invokeMock.mockRejectedValue(new Error('kaboom'));
     const result = await executeBridgeTool(
       { requestId: 41, tool: 'preview_screenshot' },
@@ -197,7 +201,8 @@ describe('executeBridgeTool', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(logger.error).toHaveBeenCalledWith(
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- inspecting the logger mock's calls, not invoking it bound
+    expect(logger.error as Fn).toHaveBeenCalledWith(
       '[AgentBridge] Tool execution failed',
       expect.objectContaining({ tool: 'preview_screenshot' })
     );
@@ -304,7 +309,7 @@ describe('registerPreviewMcpServer', () => {
       registerPreviewMcpServer('http://127.0.0.1:4123/mcp/abc', '/policy-blocked')
     ).resolves.toBe(false);
     // eslint-disable-next-line @typescript-eslint/unbound-method -- asserting on the mock, not invoking it bound
-    expect(logger.warn).toHaveBeenCalledWith(
+    expect(logger.warn as Fn).toHaveBeenCalledWith(
       expect.stringContaining('enterprise policy'),
       expect.anything()
     );

--- a/src/lib/agentBridge.ts
+++ b/src/lib/agentBridge.ts
@@ -18,7 +18,8 @@ import {
   formatElementsForAgent,
 } from './inspectFormat';
 import { addMcpServer, removeMcpServer } from './mcp';
-import { asCommandError, formatCommandError } from './errors';
+import { asCommandError, formatCommandError, isProjectFolderGoneError } from './errors';
+import { isResourcePressureError } from './errorReporting';
 import { execPreviewAction, type PreviewActionResult } from './previewActions';
 import { agentCursorAt } from './agentActivityStore';
 import { logger } from './logger';
@@ -427,6 +428,24 @@ async function captureScreenshot(
 }
 
 /**
+ * True when a bridge tool's rejection is one of the backend's deliberately
+ * `CommandError::Expected` states rather than an app defect. Expected
+ * serializes identically to Other across IPC, so the message shape is
+ * re-checked here (issue #735).
+ *
+ * Kept deliberately narrow: the dev-server-restart race that
+ * `capture_script_error` classifies Expected (issues #514/#703), plus the two
+ * environment states with shared recognizers.
+ */
+function isExpectedBridgeFailure(detail: string, err: unknown): boolean {
+  return (
+    detail.includes('stopped responding while the screenshot was being captured') ||
+    isProjectFolderGoneError(err) ||
+    isResourcePressureError(err)
+  );
+}
+
+/**
  * Execute one bridge tool call. Never throws — failures come back as
  * `isError` results so the agent can read what went wrong.
  */
@@ -556,7 +575,13 @@ export async function executeBridgeTool(
     // the detail as "[object Object]". Surface the real message to both the
     // agent and the logs.
     const detail = err instanceof Error ? err.message : formatCommandError(asCommandError(err));
-    logger.error('[AgentBridge] Tool execution failed', {
+    // This catch covers every bridge tool, so it must not turn the backend's
+    // deliberately-Expected states (a dev-server restart racing a capture, a
+    // project folder that's gone, transient spawn pressure) into bug reports —
+    // logger.error auto-files one. The agent still gets the same errorResult
+    // either way; only the log severity changes (issue #735).
+    const expected = isExpectedBridgeFailure(detail, err);
+    logger[expected ? 'warn' : 'error']('[AgentBridge] Tool execution failed', {
       tool: request.tool,
       error: detail,
     });

--- a/src/lib/edit-structure.ts
+++ b/src/lib/edit-structure.ts
@@ -71,6 +71,12 @@ export const VOID_ELEMENTS = new Set([
   'wbr',
 ]);
 
+/** Tags that ARE the document — mirrors `STRUCTURAL_TAGS` in `edit_structure.rs`.
+ *  Deleting, duplicating, or inserting beside one would break the page, so the
+ *  backend refuses; the UI disables those actions rather than round-tripping to
+ *  a refusal (issues #723/#740). */
+export const STRUCTURAL_ELEMENTS = new Set(['html', 'head', 'body']);
+
 /** Insert a new `elementKind` before/after/inside the selected element. */
 export function insertElement(
   projectPath: string,

--- a/src/lib/errorReporting.test.ts
+++ b/src/lib/errorReporting.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { mockIPC, clearMocks } from '@tauri-apps/api/mocks';
-import { dedupeKey, shouldReport, reportError } from './errorReporting';
+import { dedupeKey, shouldReport, reportError, isResourcePressureError } from './errorReporting';
 
 afterEach(() => {
   clearMocks();
@@ -33,6 +33,27 @@ describe('shouldReport', () => {
   it('treats different fingerprints independently', () => {
     expect(shouldReport({ message: 'a', fingerprint: 'independent-test-a' })).toBe(true);
     expect(shouldReport({ message: 'a', fingerprint: 'independent-test-b' })).toBe(true);
+  });
+});
+
+describe('isResourcePressureError', () => {
+  const message =
+    "Couldn't start `opencode` — your system is temporarily low on process resources or open files. Close some apps or terminal tabs and try again.";
+
+  it('recognizes spawn_resource_pressure_error as a CommandError object (#772/#773/#775)', () => {
+    expect(isResourcePressureError({ type: 'Other', message })).toBe(true);
+  });
+
+  it('recognizes it as a plain string or Error', () => {
+    expect(isResourcePressureError(message)).toBe(true);
+    expect(isResourcePressureError(new Error(message))).toBe(true);
+  });
+
+  it('leaves genuine spawn failures reporting as bugs', () => {
+    expect(isResourcePressureError('binary not found: no viable candidates found in PATH')).toBe(
+      false
+    );
+    expect(isResourcePressureError(undefined)).toBe(false);
   });
 });
 

--- a/src/lib/errorReporting.ts
+++ b/src/lib/errorReporting.ts
@@ -16,26 +16,10 @@
  */
 
 import { invoke } from '@tauri-apps/api/core';
-import { asCommandError, formatCommandError } from './errors';
 
-/**
- * True when a caught backend error is the transient EAGAIN / "too many open
- * files" spawn failure the Rust side reports via `spawn_resource_pressure_error`
- * (`src-tauri/src/external_command.rs`, issue #587) after its own retries are
- * exhausted. That's a machine state — too many processes or file descriptors
- * right now — not an app bug, so callers must route it to `logger.warn` and a
- * non-`'error'` toast: both `logger.error` and `'error'` toasts auto-file bug
- * reports. The backend classifies it `CommandError::Expected`, but Expected
- * serializes identically to Other across IPC, so the message shape is
- * re-checked here (issues #772/#773/#775).
- */
-export function isResourcePressureError(value: unknown): boolean {
-  const message = formatCommandError(asCommandError(value)).toLowerCase();
-  return (
-    message.includes('temporarily low on process resources') ||
-    message.includes('close some apps or terminal tabs')
-  );
-}
+// Re-exported so telemetry-adjacent call sites (#772/#773/#775) can import it
+// alongside the reporting pipeline; the canonical definition lives in errors.ts.
+export { isResourcePressureError } from './errors';
 
 export interface ErrorReport {
   message: string;

--- a/src/lib/errorReporting.ts
+++ b/src/lib/errorReporting.ts
@@ -16,6 +16,26 @@
  */
 
 import { invoke } from '@tauri-apps/api/core';
+import { asCommandError, formatCommandError } from './errors';
+
+/**
+ * True when a caught backend error is the transient EAGAIN / "too many open
+ * files" spawn failure the Rust side reports via `spawn_resource_pressure_error`
+ * (`src-tauri/src/external_command.rs`, issue #587) after its own retries are
+ * exhausted. That's a machine state — too many processes or file descriptors
+ * right now — not an app bug, so callers must route it to `logger.warn` and a
+ * non-`'error'` toast: both `logger.error` and `'error'` toasts auto-file bug
+ * reports. The backend classifies it `CommandError::Expected`, but Expected
+ * serializes identically to Other across IPC, so the message shape is
+ * re-checked here (issues #772/#773/#775).
+ */
+export function isResourcePressureError(value: unknown): boolean {
+  const message = formatCommandError(asCommandError(value)).toLowerCase();
+  return (
+    message.includes('temporarily low on process resources') ||
+    message.includes('close some apps or terminal tabs')
+  );
+}
 
 export interface ErrorReport {
   message: string;

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -11,6 +11,7 @@ import {
   isMergeConflictError,
   isProjectFolderGoneError,
   isRecognizedGitFailure,
+  isResourcePressureError,
   type CommandError,
 } from './errors';
 
@@ -566,5 +567,82 @@ describe('describeAccountsLoadError (issue #686)', () => {
   it('keeps sign-out advice for non-timeout failures', () => {
     const msg = describeAccountsLoadError({ type: 'Other', message: 'HTTP 401 bad credentials' });
     expect(msg).toContain('Try signing out and back into GitHub.');
+  });
+});
+
+describe('asCommandError fallback (issue #790)', () => {
+  it('serializes a plain non-CommandError object instead of "[object Object]"', () => {
+    const err = asCommandError({ code: 'ENOENT', path: '/tmp/x' });
+    expect(err.type).toBe('Other');
+    expect(formatCommandError(err)).toBe('{"code":"ENOENT","path":"/tmp/x"}');
+    expect(formatCommandError(err)).not.toContain('[object Object]');
+  });
+
+  it('falls back to String() for values JSON cannot serialize', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(formatCommandError(asCommandError(circular))).toBe('[object Object]');
+    expect(asCommandError(undefined)).toEqual({ type: 'Other', message: 'undefined' });
+  });
+});
+
+describe('isRecognizedGitFailure — pre-commit hook refusal (issue #766)', () => {
+  it("recognizes git_stage_and_commit's Expected hook message", () => {
+    const message =
+      "This project's pre-commit checks blocked the commit — they run the project's own " +
+      'lint/tests before every commit. Fix what they reported (the end of their output is ' +
+      'below), then try again.\n\nhusky - pre-commit script failed (code 1)';
+    expect(isRecognizedGitFailure({ type: 'Other', message })).toBe(true);
+  });
+});
+
+describe('describeProcessError — npm ERESOLVE (issues #781/#788)', () => {
+  const raw = [
+    'npm error code ERESOLVE',
+    'npm error ERESOLVE unable to resolve dependency tree',
+    'npm error Found: astro@7.1.3',
+    'npm error peer astro@"^7.2.0" from @astrojs/cloudflare@14.2.3',
+  ].join('\n');
+
+  it('classifies a peer-dependency conflict as expected with actionable guidance', () => {
+    const info = describeProcessError(raw);
+    expect(info.expected).toBe(true);
+    expect(info.message).toContain('--legacy-peer-deps');
+    expect(info.message).not.toContain('npm error code');
+  });
+
+  it('matches the wording alone, without the ERESOLVE code', () => {
+    expect(describeProcessError('ERESOLVE unable to resolve dependency tree').expected).toBe(true);
+  });
+});
+
+describe('describeProcessError — GitHub HTTP 499 (issue #806)', () => {
+  it('classifies a 499 the same way as a 5xx', () => {
+    const info = describeProcessError('HTTP 499: 499  (https://api.github.com/graphql)');
+    expect(info.expected).toBe(true);
+    expect(info.message).toContain("GitHub's API is temporarily unavailable");
+  });
+
+  it('still classifies the 5xx family', () => {
+    expect(describeProcessError('HTTP 503: Service Unavailable').expected).toBe(true);
+  });
+
+  it('does not swallow unrelated status codes', () => {
+    expect(describeProcessError('HTTP 404: Not Found').expected).toBe(false);
+  });
+});
+
+describe('isResourcePressureError', () => {
+  it('recognizes the backend spawn_resource_pressure_error wording', () => {
+    const message =
+      "Couldn't start `git` — your system is temporarily low on process resources or " +
+      'open files. Close some apps or terminal tabs and try again.';
+    expect(isResourcePressureError({ type: 'Other', message })).toBe(true);
+    expect(isResourcePressureError(message)).toBe(true);
+  });
+
+  it('is false for unrelated failures', () => {
+    expect(isResourcePressureError('fatal: not a git repository')).toBe(false);
+    expect(isResourcePressureError(null)).toBe(false);
   });
 });

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -9,6 +9,7 @@ import {
   isAgentNotInstalledError,
   isExpectedProjectImportRefusal,
   isMergeConflictError,
+  isMissingUpstreamError,
   isProjectFolderGoneError,
   isRecognizedGitFailure,
   isResourcePressureError,
@@ -480,6 +481,41 @@ describe('humanizeGitError', () => {
     } as unknown as CommandError;
     // Timeout formats to a "timed out" message → the network case.
     expect(humanizeGitError(err)).toMatch(/couldn't reach GitHub/i);
+  });
+});
+
+describe('isMissingUpstreamError', () => {
+  // One signature shared by Revert-to-GitHub (BranchesTab) and Pull latest
+  // (useBranchManagement) — they used to carry their own copy of this regex.
+  it('matches both of git\'s "nothing on GitHub to pull" refusals (#600/#809)', () => {
+    expect(
+      isMissingUpstreamError(
+        'Failed to pull: There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.'
+      )
+    ).toBe(true);
+    expect(
+      isMissingUpstreamError(
+        "Failed to pull: Your configuration specifies to merge with the ref 'refs/heads/feat/unpushed'\nfrom the remote, but no such ref was fetched."
+      )
+    ).toBe(true);
+  });
+
+  it('reads a CommandError object, not just a string', () => {
+    expect(
+      isMissingUpstreamError({
+        type: 'Process',
+        cmd: 'git',
+        exit_code: 1,
+        stderr: 'There is no tracking information for the current branch.',
+      })
+    ).toBe(true);
+  });
+
+  it('does not match unrelated git failures', () => {
+    expect(isMissingUpstreamError('error: your local changes would be overwritten by merge')).toBe(
+      false
+    );
+    expect(isMissingUpstreamError(new Error('fatal: not a git repository'))).toBe(false);
   });
 });
 

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -646,3 +646,139 @@ describe('isResourcePressureError', () => {
     expect(isResourcePressureError(null)).toBe(false);
   });
 });
+
+// Wave-2 recognition of wordings the wave-1 backend fixes introduced. Each
+// literal below is copied byte-for-byte from the Rust
+// `CommandError::expected(...)` string it mirrors — if one drifts, the
+// frontend silently starts auto-filing bug reports for a condition the backend
+// deliberately kept out of telemetry.
+describe('isRecognizedGitFailure — backend wordings added in sweep 18', () => {
+  const backendMessages: [string, string][] = [
+    [
+      '#838 pr_create_refusal (unrelated histories)',
+      'This branch shares no history with "main", so GitHub can\'t compare them for a pull request. It was most likely started separately instead of from "main".',
+    ],
+    [
+      '#779 push_to_github (origin points elsewhere)',
+      'This project is already connected to a different GitHub repository (git@github.com:me/other.git). Publish to that repository, or remove the existing remote (`git remote remove origin`) before creating a new one.',
+    ],
+    [
+      '#779 push_to_github (repo created, remote-add lost the race)',
+      'The repository "my-app" was created on GitHub, but this project couldn\'t be connected to it because it already has a remote named "origin". Point that remote at the new repository (`git remote set-url origin <url>`) and push, or remove it and try again.',
+    ],
+    [
+      "#737 gh_shadowed_binary_error (PATH found something that isn't gh)",
+      'The program named `gh` on this computer isn\'t GitHub\'s CLI — something else (most often an unrelated global npm package called "gh") is being found first. Remove it (`npm uninstall -g gh`) or reinstall the GitHub CLI, then try again.',
+    ],
+    [
+      '#792 delete_branch (GitHub refuses to delete the default branch)',
+      "'trunk' is this repository's default branch on GitHub, so GitHub won't let it be deleted. The local copy has been removed; change the default branch in the repository's GitHub settings if you also want the remote one gone.",
+    ],
+    [
+      '#791 create_branch (name taken)',
+      "A branch named 'feature/x' already exists. Pick a different name, or switch to the existing branch.",
+    ],
+    ['#317 get_current_branch (detached HEAD)', 'Detached HEAD state'],
+    [
+      '#794 publish_branch (detached HEAD)',
+      "This project isn't on a branch right now (git calls this a detached HEAD — it happens mid-rebase or after checking out a specific commit or tag). Switch to a branch first, then publish.",
+    ],
+    [
+      '#819 push_branch timeout',
+      "Publishing took too long — GitHub didn't respond in time. Check your internet connection and try again.",
+    ],
+    [
+      '#771 gh repo create --push timeout',
+      'Creating the repository on GitHub took too long and timed out. Larger projects can take a while to upload — check your internet connection and try again.',
+    ],
+    [
+      '#819 sibling: delete_branch remote-delete timeout',
+      "GitHub didn't respond in time while deleting the remote branch. The local branch is gone — check your connection and try deleting the remote copy again.",
+    ],
+    [
+      '#798 close_pull_request (already merged)',
+      "This pull request was already merged, so there's nothing to close. Refresh to see its current state.",
+    ],
+  ];
+
+  it.each(backendMessages)('recognizes %s', (_label, message) => {
+    expect(isRecognizedGitFailure(message)).toBe(true);
+    expect(isRecognizedGitFailure({ type: 'Other', message })).toBe(true);
+  });
+
+  it('still reports genuinely unknown git failures', () => {
+    expect(isRecognizedGitFailure('fatal: bad object 0000000')).toBe(false);
+  });
+});
+
+describe('humanizeGitError — raw-git cases added in sweep 18', () => {
+  it("rephrases git's taken-branch-name refusal and names the branch (#791)", () => {
+    const message = humanizeGitError("fatal: a branch named 'feature/x' already exists");
+    expect(message).toContain("'feature/x'");
+    expect(message).toMatch(/pick a different name/i);
+    // Must not be mistaken for the open-PR collision, which also says
+    // "already exists".
+    expect(message).not.toMatch(/pull request/i);
+  });
+
+  it('still recognizes the open-PR collision (#428)', () => {
+    expect(
+      humanizeGitError('a pull request for branch "feature/x" already exists', {
+        branch: 'feature/x',
+      })
+    ).toMatch(/already an open pull request/i);
+  });
+
+  it("explains git's multi-remote checkout refusal (#729 residual)", () => {
+    const raw = "fatal: 'shared' matched multiple (2) remote tracking branches";
+    const message = humanizeGitError(raw, { branch: 'shared' });
+    expect(message).toMatch(/more than one remote/i);
+    expect(message).toContain('git checkout -b');
+    expect(isRecognizedGitFailure(raw)).toBe(true);
+  });
+});
+
+describe('describeProcessError — git exit-128 causes that are not auth (issue #841)', () => {
+  // The templates the creation flow clones are public repos fetched
+  // anonymously, so "make sure you're signed into GitHub" is always wrong
+  // advice for them. Each of these must be named before the exit-code table.
+  const clone = (stderr: string) =>
+    describeProcessError(`Process exited with code 128\n\n${stderr}`);
+
+  it('names the dubious-ownership check instead of blaming GitHub auth', () => {
+    const info = clone(
+      "fatal: detected dubious ownership in repository at '/Volumes/nas/Projects'"
+    );
+    expect(info.expected).toBe(true);
+    expect(info.message).toMatch(/safe\.directory/);
+    expect(info.message).not.toMatch(/signed into GitHub/i);
+  });
+
+  it('names an unwritable projects folder instead of blaming GitHub auth', () => {
+    for (const stderr of [
+      "fatal: could not create work tree dir 'uicpick': Permission denied",
+      "fatal: could not create leading directories of 'Z:/mainframe/Projects/uicpick'",
+      'error: unable to create directory for .git/objects: Input/output error',
+      'fatal: Unable to write new index file',
+      'error: copy-fd: write returned: Read-only file system',
+    ]) {
+      const info = clone(stderr);
+      expect(info.expected, stderr).toBe(true);
+      expect(info.message, stderr).toMatch(/NAS, network, or external drive/);
+      expect(info.message, stderr).not.toMatch(/signed into GitHub/i);
+    }
+  });
+
+  it('names a full disk', () => {
+    const info = clone('fatal: write error: No space left on device');
+    expect(info.expected).toBe(true);
+    expect(info.message).toMatch(/run out of space/i);
+  });
+
+  it('still falls back to the caller-supplied 128 message when nothing is recognized', () => {
+    const info = describeProcessError('Process exited with code 128', {
+      128: 'creation-flow fallback',
+    });
+    expect(info).toEqual({ expected: true, message: 'creation-flow fallback' });
+  });
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -120,6 +120,35 @@ const BACKEND_HUMANIZED_GIT_PHRASES = [
   // project's own husky/lint-staged/test chain rejecting the commit is the
   // project working as configured, not an app malfunction.
   'pre-commit checks blocked the commit',
+  // create_branch's taken-name refusal (issue #791). Paired with the raw-git
+  // case in humanizeGitError below: because that case reconstructs this exact
+  // sentence, the inequality test alone can't see it.
+  'already exists. pick a different name',
+  // delete_branch's default-branch refusal (issue #792). GitHub's own
+  // pre-receive rejection wording never reaches the frontend, and the
+  // friendly replacement contains none of the network/auth/"rejected"
+  // substrings humanizeGitError keys on.
+  'default branch on github',
+  // pr_create_refusal's unrelated-histories case (issue #838)
+  'shares no history with',
+  // push_to_github's existing-origin refusals (issue #779) — the project is
+  // already wired to another repo, or gh created the repo but couldn't add
+  // the remote. Both are user-side git state, not a malfunction.
+  'already connected to a different github repository',
+  "was created on github, but this project couldn't be connected",
+  // gh_shadowed_binary_error: PATH resolved something that isn't the GitHub
+  // CLI (issue #737)
+  "isn't github's cli",
+  // publish_branch / get_current_branch's detached-HEAD guard (issues
+  // #317/#794) — a normal git state with a user-side fix.
+  'detached head',
+  // delete_branch's remote-delete timeout (issue #819's sibling): the other
+  // push/create timeouts already say "check your internet connection", but
+  // this one says "check your connection".
+  "didn't respond in time",
+  // close_pull_request's already-merged refusal (issue #798) — the PR list
+  // the Close button was clicked from went stale, an anticipated race.
+  "already merged, so there's nothing to close",
 ];
 
 /** True when a message is one the backend already humanized (see
@@ -254,6 +283,24 @@ export function humanizeGitError(value: unknown, ctx: GitErrorContext = {}): str
   // A PR is already open for this branch.
   if (m.includes('already exists') && m.includes('pull request')) {
     return `There's already an open pull request for ${branch}.`;
+  }
+
+  // Creating a branch under a name that's taken — "fatal: a branch named 'X'
+  // already exists" (issue #791). create_branch classifies its own hit
+  // Expected with this same wording (see BACKEND_HUMANIZED_GIT_PHRASES); this
+  // covers git's raw phrasing on any path that misses that classification.
+  if (m.includes('a branch named') && m.includes('already exists')) {
+    const taken = raw.match(/a branch named '([^']+)' already exists/i)?.[1];
+    return `A branch named ${taken ? `'${taken}'` : 'that'} already exists. Pick a different name, or switch to the existing branch.`;
+  }
+
+  // The branch name exists on several remotes and nowhere locally, so git's
+  // DWIM checkout refuses to guess: "fatal: 'X' matched multiple (2) remote
+  // tracking branches". switch_branch qualifies against origin when origin
+  // has it (issue #729), so this is the residual case — the branch is on
+  // other remotes but not origin.
+  if (m.includes('matched multiple') && m.includes('remote tracking branches')) {
+    return `${branch} exists on more than one remote and not on origin, so git can't tell which copy to check out. In a terminal, create a local branch from the remote you want (\`git checkout -b <name> <remote>/<name>\`), then switch to it here.`;
   }
 
   // A checkout would clobber unsaved work.
@@ -561,6 +608,42 @@ export function describeProcessError(
       expected: true,
       message:
         'pnpm blocked dependency build scripts pending your approval. In a terminal, run `pnpm approve-builds` in the project folder, approve the listed packages, then retry the install.',
+    };
+  }
+  // Git exits 128 for many fatal, non-auth reasons, but the exit-code table
+  // below maps every 128 to "Git authentication failed" — actively wrong for
+  // the project-creation clone, whose templates are public repos fetched
+  // anonymously with no GitHub sign-in involved at all. The reported cases
+  // were a NAS / mapped network drive: git couldn't create or write the
+  // destination, or its dubious-ownership check tripped on a share reporting
+  // foreign owner metadata (issue #841). Named causes first, so the blanket
+  // mapping only ever sees what none of these explain.
+  if (lower.includes('detected dubious ownership')) {
+    return {
+      expected: true,
+      message:
+        "Git refused to use this folder because the operating system reports it as owned by a different user — common on NAS, network, and external drives. Open a terminal and run `git config --global --add safe.directory '<the project folder>'`, or move your projects folder to a local disk, then try again.",
+    };
+  }
+  if (
+    lower.includes('could not create work tree dir') ||
+    lower.includes('could not create leading directories') ||
+    lower.includes('unable to create directory') ||
+    lower.includes('unable to write new index file') ||
+    lower.includes('read-only file system') ||
+    lower.includes('input/output error')
+  ) {
+    return {
+      expected: true,
+      message:
+        "Git couldn't write to your projects folder. That usually means it's on a NAS, network, or external drive that dropped out or won't accept the write — this isn't a GitHub sign-in problem. Check the drive is connected and writable, or move your projects folder to a local disk, then try again.",
+    };
+  }
+  if (lower.includes('no space left on device')) {
+    return {
+      expected: true,
+      message:
+        'The drive your projects folder is on has run out of space. Free some up, then try again.',
     };
   }
   // The tool itself is missing: Windows' cmd.exe says "'bun' is not

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -440,7 +440,11 @@ export function isProjectFolderGoneError(value: unknown): boolean {
  * instead of the channels that auto-file bug reports.
  */
 export function isResourcePressureError(value: unknown): boolean {
-  return /temporarily low on process resources/i.test(formatCommandError(asCommandError(value)));
+  const message = formatCommandError(asCommandError(value)).toLowerCase();
+  return (
+    message.includes('temporarily low on process resources') ||
+    message.includes('close some apps or terminal tabs')
+  );
 }
 
 /**

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -32,6 +32,21 @@ export function asCommandError(value: unknown): CommandError {
   if (value instanceof Error) {
     return { type: 'Other', message: value.message };
   }
+  // Anything else that reaches here is a plain object with no `type` tag (a
+  // rejected non-CommandError payload, a DOM/plugin error bag, …). `String()`
+  // renders those as the literal "[object Object]", which defeats every call
+  // site that dutifully routes through this helper — the real cause becomes
+  // unrecoverable from telemetry (issue #790). Serialize instead, falling
+  // back to String() for values JSON can't represent (undefined, symbols,
+  // functions) or refuses to walk (circular refs, throwing getters).
+  try {
+    const serialized = JSON.stringify(value);
+    if (typeof serialized === 'string') {
+      return { type: 'Other', message: serialized };
+    }
+  } catch {
+    // fall through to String()
+  }
   return { type: 'Other', message: String(value) };
 }
 
@@ -101,6 +116,10 @@ const BACKEND_HUMANIZED_GIT_PHRASES = [
   "couldn't start because the system is low on memory",
   // create_branch's vanished base ref (issue #692)
   'no longer exists on github',
+  // git_stage_and_commit's pre-commit hook refusal (issues #604/#766) — the
+  // project's own husky/lint-staged/test chain rejecting the commit is the
+  // project working as configured, not an app malfunction.
+  'pre-commit checks blocked the commit',
 ];
 
 /** True when a message is one the backend already humanized (see
@@ -362,6 +381,22 @@ export function isProjectFolderGoneError(value: unknown): boolean {
 }
 
 /**
+ * True when a caught backend error is the spawn-time resource-pressure
+ * refusal — `spawn_resource_pressure_error` in
+ * `src-tauri/src/external_command.rs` ("Couldn't start `<cmd>` — your system
+ * is temporarily low on process resources or open files…"), raised when the
+ * OS can't fork/exec because the machine is out of PIDs or file descriptors.
+ *
+ * The backend classifies it `CommandError::expected`, but Expected serializes
+ * identically to Other across IPC, so callers re-check the wording. It's a
+ * transient machine state, not a bug: route it to warn logs / info toasts
+ * instead of the channels that auto-file bug reports.
+ */
+export function isResourcePressureError(value: unknown): boolean {
+  return /temporarily low on process resources/i.test(formatCommandError(asCommandError(value)));
+}
+
+/**
  * Exit-code → actionable-message mappings shared by the PTY-driven flows
  * (project creation, GitHub import) that run `git clone` / package installs.
  */
@@ -457,9 +492,12 @@ export function describeProcessError(
   // respond to your request in time…" from api.github.com/graphql during
   // `gh repo clone`). gh exits with the generic code 1, so only the wording
   // identifies it — a GitHub-side blip with a built-in retry suggestion, not
-  // an app bug (issue #620).
+  // an app bug (issue #620). HTTP 499 ("Client Closed Request", nginx's code
+  // for a request GitHub's edge abandoned before responding) is the same
+  // class of transient, GitHub-side blip despite not being a 5xx — it fell
+  // through the `5\d\d` regex and reached telemetry unclassified (issue #806).
   if (
-    /http 5\d\d/.test(lower) ||
+    /http (?:499|5\d\d)/.test(lower) ||
     lower.includes('respond to your request in time') ||
     lower.includes('gateway timeout') ||
     lower.includes('service unavailable') ||
@@ -484,6 +522,18 @@ export function describeProcessError(
       expected: true,
       message:
         "npm couldn't sign in to the package registry — your saved npm login or token is expired or incorrect. Open a terminal and run `npm login` (or refresh the token in your .npmrc if this project uses a private registry), then try again.",
+    };
+  }
+  // npm refusing a peer-dependency conflict declared by the project itself
+  // ("npm error code ERESOLVE" / "unable to resolve dependency tree"). npm
+  // exits with the generic code 1, so only the wording identifies it — a
+  // property of the target repo's own package.json, not an app bug, and the
+  // raw multi-line dump gave the user nothing to act on (issues #781/#788).
+  if (lower.includes('eresolve') || lower.includes('unable to resolve dependency tree')) {
+    return {
+      expected: true,
+      message:
+        "This project's dependencies have a version conflict npm won't resolve on its own (see the peer dependency mismatch in the output). Update the conflicting package to a version they agree on, or re-run the install with `--legacy-peer-deps` if that's safe for this project.",
     };
   }
   // Corrupted pnpm store: the content-addressable cache has dangling links,

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -378,6 +378,23 @@ export function isRecognizedGitFailure(value: unknown, ctx: GitErrorContext = {}
 }
 
 /**
+ * True when a git failure means there is nothing on GitHub for this branch to
+ * pull. Two refusals say the same thing: "no tracking information" is the
+ * never-pushed branch (issue #600), and "no such ref was fetched" is a
+ * configured upstream whose remote ref is gone — deleted or renamed on GitHub
+ * (issue #809). Both are git's normal, by-design refusals rather than app
+ * malfunctions, so callers route them to an info toast + `logger.warn` instead
+ * of the error channels that auto-file a bug report.
+ *
+ * Shared by the Revert-to-GitHub flow (`BranchesTab`) and Pull latest
+ * (`useBranchManagement`) so the two can't drift apart.
+ */
+export function isMissingUpstreamError(value: unknown): boolean {
+  const message = formatCommandError(asCommandError(value));
+  return /no tracking information|no such ref was fetched/i.test(message);
+}
+
+/**
  * Phrases from `register_external_project`'s by-design refusals of a folder
  * pick (backend returns `CommandError::expected` for them, issue #416 — but
  * Expected serializes identically to Other across IPC, so the frontend

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -133,7 +133,9 @@ export async function listCollaboratorRepos(): Promise<GitHubRepo[]> {
 
 /**
  * Detect the package manager used in a project.
- * Checks for lock files in the following order: pnpm, yarn, bun, npm (default).
+ * Checks lock files first (pnpm, yarn, bun); with none committed, falls back to
+ * what package.json declares (`packageManager`, `workspace:`/`catalog:` deps) or
+ * a pnpm-workspace.yaml, then npm.
  * @param projectPath - Absolute path to the project directory
  * @returns Package manager name ("pnpm", "yarn", "bun", or "npm")
  */

--- a/src/lib/mcp.test.ts
+++ b/src/lib/mcp.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { validateMcpAddCommand, isMcpUnsupportedCliError, isMcpInvalidInputError } from './mcp';
+import {
+  validateMcpAddCommand,
+  isMcpUnsupportedCliError,
+  isMcpInvalidInputError,
+  isMcpExpectedFailure,
+} from './mcp';
 
 describe('validateMcpAddCommand (#588)', () => {
   const validInputs = [
@@ -134,5 +139,43 @@ describe('isMcpUnsupportedCliError (#550)', () => {
     expect(isMcpUnsupportedCliError('Codex binary not found')).toBe(false);
     // The CLI's *own* argument validation for a user typo is not a version gap.
     expect(isMcpUnsupportedCliError("error: missing required argument 'commandOrUrl'")).toBe(false);
+  });
+});
+
+describe('isMcpExpectedFailure', () => {
+  // Guidance sentences authored by classify_mcp_failure
+  // (src-tauri/src/commands/mcp.rs) — kept byte-identical to the Rust strings.
+  const expectedFailures: [string, string][] = [
+    [
+      '#675 enterprise MCP allowlist',
+      'Failed to add MCP server: Cannot add MCP server "x": not allowed by enterprise policy\n\nYour organization\'s managed agent settings block this MCP server. Ask your admin to allowlist it, then try again.',
+    ],
+    [
+      '#799/#800 org Cloud gateway unreachable',
+      "Failed to list MCP servers: Couldn't load settings from Cloud gateway gw.example.com.\n\nYour organization's agent gateway couldn't be reached. Check your network (or VPN) connection, or run `claude auth login` in a terminal to sign in again, then try again.",
+    ],
+    [
+      '#763 upstream `mcp add -e` parser bug',
+      "Failed to add MCP server: Invalid environment variable format\n\nThis is a known bug in recent Claude Code CLI versions — its `mcp add` parser mishandles `-e` environment variables (anthropics/claude-code#23365). Add the server without its `-e` flags for now (set those variables in the server's own config instead), or update Claude Code once the fix ships.",
+    ],
+    [
+      "#755 the agent CLI's own config has an unusable value",
+      "Failed to remove MCP server: failed to load configuration\n\nThe agent CLI couldn't read its own config file — a setting in it (`service_tier`) has a value this version no longer accepts. Fix or remove that setting in the config file named above, then try again.",
+    ],
+    [
+      "#471/#677 the OS denied the agent's config write",
+      "Failed to add MCP server: Access is denied. (os error 5)\n\nThe agent couldn't write its own config file — the OS denied access. Check that the file isn't read-only or locked by another program (antivirus, OneDrive/cloud sync), and that its folder is owned by your user account, then try again.",
+    ],
+  ];
+
+  it.each(expectedFailures)('recognizes %s', (_label, message) => {
+    expect(isMcpExpectedFailure(message)).toBe(true);
+    expect(isMcpExpectedFailure({ type: 'Other', message })).toBe(true);
+  });
+
+  it('does not swallow failures that could be app defects', () => {
+    expect(isMcpExpectedFailure('Failed to add MCP server: connection refused')).toBe(false);
+    expect(isMcpExpectedFailure('Failed to list MCP servers: unexpected panic')).toBe(false);
+    expect(isMcpExpectedFailure(null)).toBe(false);
   });
 });

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -84,6 +84,42 @@ export function isMcpInvalidInputError(value: unknown): boolean {
 }
 
 /**
+ * Wording of the guidance sentences `classify_mcp_failure`
+ * (src-tauri/src/commands/mcp.rs) appends when an `<agent> mcp add|remove|list`
+ * failure reflects machine state, org policy, the user's own agent config, or
+ * an upstream CLI bug — never a Ship Studio defect. The backend returns those
+ * as `CommandError::Expected`, but Expected serializes identically to Other
+ * across IPC, so the wording is the only signal left by the time the modal
+ * catches it. Keep these in sync with the Rust strings byte-for-byte.
+ */
+const MCP_EXPECTED_FAILURE_PHRASES = [
+  // Enterprise MCP allowlist (issue #675)
+  "your organization's managed agent settings block this mcp server",
+  // Org-managed Cloud gateway unreachable / session expired (issues #799, #800)
+  "your organization's agent gateway couldn't be reached",
+  // Upstream `mcp add -e` parser regression (issue #763)
+  'this is a known bug in recent claude code cli versions',
+  // The agent CLI's own config file has a value it no longer accepts (#755)
+  "the agent cli couldn't read its own config file",
+  // The OS denied the agent's config write (issues #471, #677)
+  "the agent couldn't write its own config file",
+];
+
+/**
+ * True when an `mcp add/remove/list` failure is one the backend already
+ * classified `Expected` with its own guidance (see
+ * {@link MCP_EXPECTED_FAILURE_PHRASES}). These are the user's environment,
+ * organization, or agent CLI — routing them to `logger.error` auto-files a bug
+ * report for something Ship Studio can't fix (issues #755, #763, #799, #800),
+ * so callers log them at warn level and surface them as information, following
+ * the #655 precedent above.
+ */
+export function isMcpExpectedFailure(value: unknown): boolean {
+  const message = formatCommandError(asCommandError(value)).toLowerCase();
+  return MCP_EXPECTED_FAILURE_PHRASES.some((phrase) => message.includes(phrase));
+}
+
+/**
  * Split a raw `mcp add` argument string like a shell would — whitespace
  * separates tokens, single/double quotes group, `\"` and `\\` escape inside
  * double quotes. Mirrors the backend's `shell_split`

--- a/src/lib/plugins.test.ts
+++ b/src/lib/plugins.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for the plugin library fetch (retry/backoff) and the expected-failure
+ * classifier both the Plugin Manager and usePlugins use to decide between
+ * logger.warn/info-toast and logger.error/error-toast.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+type PluginsModule = typeof import('./plugins');
+
+/** Fresh module instance per test — `fetchPluginRegistry` memoizes globally. */
+async function loadPlugins(): Promise<PluginsModule> {
+  vi.resetModules();
+  return import('./plugins');
+}
+
+function jsonResponse(plugins: unknown[]): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: () => Promise.resolve({ plugins }),
+  } as unknown as Response;
+}
+
+function errorResponse(status: number, retryAfter?: string): Response {
+  return {
+    ok: false,
+    status,
+    headers: { get: (name: string) => (name === 'Retry-After' ? (retryAfter ?? null) : null) },
+    json: () => Promise.reject(new Error('no body')),
+  } as unknown as Response;
+}
+
+describe('fetchPluginRegistry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('retries a 429 and returns the registry on a later attempt (issue #713)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse(429))
+      .mockResolvedValueOnce(jsonResponse([{ id: 'vercel' }]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchPluginRegistry } = await loadPlugins();
+    const promise = fetchPluginRegistry();
+    await vi.runAllTimersAsync();
+
+    expect(await promise).toEqual([{ id: 'vercel' }]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('honors Retry-After instead of its own backoff', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse(429, '2'))
+      .mockResolvedValueOnce(jsonResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchPluginRegistry } = await loadPlugins();
+    const promise = fetchPluginRegistry();
+
+    // The default backoff is 500ms; Retry-After: 2 must hold it longer.
+    await vi.advanceTimersByTimeAsync(600);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1500);
+    await promise;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up after the attempt budget and rethrows the status error', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(errorResponse(429));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchPluginRegistry } = await loadPlugins();
+    const promise = fetchPluginRegistry();
+    const assertion = expect(promise).rejects.toThrow('Failed to fetch plugin registry: 429');
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry a 404 — that is a real answer, not a blip', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(errorResponse(404));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchPluginRegistry } = await loadPlugins();
+    await expect(fetchPluginRegistry()).rejects.toThrow('Failed to fetch plugin registry: 404');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a network-level failure', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(jsonResponse([{ id: 'figma' }]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchPluginRegistry } = await loadPlugins();
+    const promise = fetchPluginRegistry();
+    await vi.runAllTimersAsync();
+
+    expect(await promise).toEqual([{ id: 'figma' }]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('isRegistryUnreachableError', () => {
+  it('separates reachability failures from a malformed registry body', async () => {
+    const { isRegistryUnreachableError } = await loadPlugins();
+    expect(isRegistryUnreachableError(new Error('Failed to fetch plugin registry: 429'))).toBe(
+      true
+    );
+    expect(isRegistryUnreachableError(new TypeError('Failed to fetch'))).toBe(true);
+    // A broken registry JSON is Ship Studio's own problem — keep reporting it.
+    expect(isRegistryUnreachableError(new SyntaxError('Unexpected end of JSON input'))).toBe(false);
+  });
+});
+
+describe('isExpectedPluginFailure', () => {
+  it('recognizes the backend by-design install refusals (issues #734/#833)', async () => {
+    const { isExpectedPluginFailure } = await loadPlugins();
+    for (const message of [
+      'Invalid plugin: No plugin.json found in /tmp/x',
+      "Plugin manifest must have 'id' and 'name' fields",
+      'Plugin ID contains invalid characters',
+      "This plugin can't be installed: its repository has no built bundle (dist/index.js). …",
+      "Plugin 'Figma' requires Ship Studio v9.0.0 or later (current: v0.18.6). Please update Ship Studio.",
+      "Plugin 'x' requests commands that are not available to plugins: rm_rf",
+      "A non-dev plugin 'vercel' is already installed. Uninstall it first.",
+    ]) {
+      expect(isExpectedPluginFailure({ type: 'Other', message })).toBe(true);
+    }
+  });
+
+  it('recognizes unclonable/unreachable repository failures (issues #803/#732)', async () => {
+    const { isExpectedPluginFailure } = await loadPlugins();
+    for (const message of [
+      "Couldn't find a git repository at that URL. Double-check the plugin's repository link …",
+      "This plugin's repository requires sign-in, and Ship Studio can't authenticate to it …",
+      "Couldn't reach the plugin's repository — check your internet connection and try again.",
+      'That link points at a page inside a repository, not the repository itself. …',
+      'Plugin repository URL must be an https://, ssh://, git:// or git@ remote',
+    ]) {
+      expect(isExpectedPluginFailure({ type: 'Other', message })).toBe(true);
+    }
+  });
+
+  it('recognizes filesystem/project environment states (issues #762/#831/#770)', async () => {
+    const { isExpectedPluginFailure } = await loadPlugins();
+    for (const message of [
+      "Ship Studio isn't allowed to read this project's plugin registry (/x). Grant access in System Settings → Privacy & Security → Files & Folders (or Full Disk Access), then try again.",
+      "The folder '/x' no longer exists — it may have been moved, renamed, or deleted outside Ship Studio",
+      'Plugin bundle not found: /x/.shipstudio/plugins/vercel/dist/index.js',
+    ]) {
+      expect(isExpectedPluginFailure({ type: 'Other', message })).toBe(true);
+    }
+  });
+
+  it('leaves genuine defects reportable', async () => {
+    const { isExpectedPluginFailure } = await loadPlugins();
+    expect(
+      isExpectedPluginFailure({ type: 'Other', message: 'Failed to parse registry: eof' })
+    ).toBe(false);
+    expect(
+      isExpectedPluginFailure({ type: 'Io', message: 'Failed to read plugin bundle: EIO' })
+    ).toBe(false);
+    expect(isExpectedPluginFailure(new Error('Git clone failed: object file is empty'))).toBe(
+      false
+    );
+  });
+});

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -8,6 +8,8 @@
  */
 
 import { invoke } from '@tauri-apps/api/core';
+import { asCommandError, formatCommandError } from './errors';
+import { logger } from './logger';
 
 /** Setup item contributed by a plugin */
 export interface PluginSetupItem {
@@ -73,22 +75,153 @@ const REGISTRY_URL =
 let registryCache: { plugins: PluginRegistryEntry[]; fetchedAt: number } | null = null;
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
+/** Attempts (including the first) for a retryable registry fetch failure. */
+const REGISTRY_FETCH_ATTEMPTS = 3;
+/** First backoff step; doubled per retry. */
+const REGISTRY_RETRY_BASE_MS = 500;
+/** Ceiling on an honored `Retry-After`, so a rude header can't stall the modal. */
+const REGISTRY_MAX_RETRY_WAIT_MS = 5000;
+
+/**
+ * Statuses worth a retry: raw.githubusercontent.com rate-limits shared egress
+ * IPs with 429 (issue #713), and 5xx/408 are transient by definition. A 404 or
+ * other 4xx is a real answer — retrying it just wastes the user's time.
+ */
+function isRetryableRegistryStatus(status: number): boolean {
+  return status === 429 || status === 408 || status >= 500;
+}
+
+/** `Retry-After` in ms (delta-seconds or HTTP-date), clamped, or null. */
+function parseRetryAfter(header: string | null): number | null {
+  if (!header) return null;
+  const seconds = Number(header.trim());
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(seconds * 1000, REGISTRY_MAX_RETRY_WAIT_MS);
+  }
+  const date = Date.parse(header);
+  if (Number.isNaN(date)) return null;
+  return Math.min(Math.max(date - Date.now(), 0), REGISTRY_MAX_RETRY_WAIT_MS);
+}
+
+type RegistryFetchOutcome =
+  | { kind: 'ok'; plugins: PluginRegistryEntry[] }
+  /** Worth another attempt. `waitMs` is the server's `Retry-After`, if any. */
+  | { kind: 'retry'; waitMs: number | null; error: Error }
+  | { kind: 'fail'; error: Error };
+
+async function attemptRegistryFetch(): Promise<RegistryFetchOutcome> {
+  let response: Response;
+  try {
+    response = await fetch(REGISTRY_URL);
+  } catch (err) {
+    // Network-level failure (offline, DNS, TLS handshake) — often a blip.
+    return {
+      kind: 'retry',
+      waitMs: null,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+  if (response.ok) {
+    const data = (await response.json()) as { plugins: PluginRegistryEntry[] };
+    return { kind: 'ok', plugins: data.plugins };
+  }
+  const error = new Error(`Failed to fetch plugin registry: ${response.status}`);
+  if (!isRetryableRegistryStatus(response.status)) {
+    return { kind: 'fail', error };
+  }
+  return { kind: 'retry', waitMs: parseRetryAfter(response.headers.get('Retry-After')), error };
+}
+
 /**
  * Fetch the plugin library from the remote registry.
+ *
+ * Retries rate-limited (429), transient-server, and network failures with
+ * backoff, honoring `Retry-After` when the server sends one — a single 429
+ * from raw.githubusercontent.com used to empty the Library tab outright
+ * (issue #713).
  */
 export async function fetchPluginRegistry(): Promise<PluginRegistryEntry[]> {
   if (registryCache && Date.now() - registryCache.fetchedAt < CACHE_TTL) {
     return registryCache.plugins;
   }
 
-  const response = await fetch(REGISTRY_URL);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch plugin registry: ${response.status}`);
+  let backoff = REGISTRY_RETRY_BASE_MS;
+  for (let attempt = 1; ; attempt++) {
+    const outcome = await attemptRegistryFetch();
+    if (outcome.kind === 'ok') {
+      registryCache = { plugins: outcome.plugins, fetchedAt: Date.now() };
+      return outcome.plugins;
+    }
+    if (outcome.kind === 'fail' || attempt >= REGISTRY_FETCH_ATTEMPTS) {
+      throw outcome.error;
+    }
+    const waitMs = outcome.waitMs ?? backoff;
+    logger.warn('Plugin registry fetch failed; retrying', {
+      attempt,
+      waitMs,
+      error: outcome.error.message,
+    });
+    await new Promise((resolve) => setTimeout(resolve, waitMs));
+    backoff = Math.min(backoff * 2, REGISTRY_MAX_RETRY_WAIT_MS);
   }
+}
 
-  const data = (await response.json()) as { plugins: PluginRegistryEntry[] };
-  registryCache = { plugins: data.plugins, fetchedAt: Date.now() };
-  return data.plugins;
+/**
+ * True when a {@link fetchPluginRegistry} rejection means we couldn't reach or
+ * read a response from the registry host (offline, DNS, TLS, a rate-limit or
+ * server status that survived the retries) rather than the registry being
+ * malformed. Reachability is the user's network; a broken body is ours to fix,
+ * so only the former is downgraded out of telemetry (issue #713).
+ */
+export function isRegistryUnreachableError(value: unknown): boolean {
+  if (!(value instanceof Error)) return false;
+  return value.message.startsWith('Failed to fetch plugin registry:') || value instanceof TypeError;
+}
+
+/**
+ * Backend plugin failures that are by-design refusals or user-environment
+ * states, not app defects: manifest/bundle/id validation (issue #472), version
+ * and command-permission checks, unclonable or unreachable repository URLs
+ * (#803/#732), a missing bundle the self-heal couldn't repair (#770), and the
+ * filesystem-permission classifications (#762).
+ *
+ * The backend already marks these `CommandError::expected`, but `Expected`
+ * serializes across IPC identically to `Other`, so the frontend re-checks the
+ * wording — exactly like `isExpectedProjectImportRefusal` in `lib/errors`.
+ * Callers use it to pick `logger.warn` over `logger.error` and an `'info'`
+ * toast over `'error'`; both of those otherwise auto-file a bug report for the
+ * app behaving correctly (issues #734, #833, #762).
+ */
+const EXPECTED_PLUGIN_FAILURE_PHRASES = [
+  // Manifest / bundle / id validation (install, update, dev-link)
+  'Invalid plugin:',
+  "Plugin manifest must have 'id' and 'name' fields",
+  'Plugin ID contains invalid characters',
+  'has no built bundle (dist/index.js)',
+  'Plugin bundle not found',
+  'requires Ship Studio v',
+  'requests commands that are not available to plugins',
+  'is already installed. Uninstall it first',
+  // Repository URL refusals and remote-git classifications
+  'Plugin repository URL',
+  'points at a page inside a repository',
+  "Couldn't find a git repository at that URL",
+  "Couldn't reach the plugin's repository",
+  'repository requires sign-in',
+  "Git isn't installed or couldn't be located",
+  // Filesystem / project-folder environment states (classify_fs_error,
+  // validate_project_path)
+  'Grant access in System Settings',
+  'Windows denied access',
+  'the disk or volume is read-only',
+  'no longer exists — it may have been moved',
+];
+
+/** True when a plugin-command failure is one of the backend's by-design
+ *  refusals or environment states (see {@link EXPECTED_PLUGIN_FAILURE_PHRASES}). */
+export function isExpectedPluginFailure(value: unknown): boolean {
+  const message = formatCommandError(asCommandError(value));
+  return EXPECTED_PLUGIN_FAILURE_PHRASES.some((phrase) => message.includes(phrase));
 }
 
 /** Result of a plugin shell command */

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -66,6 +66,16 @@ export interface PluginRegistryEntry {
 /** Official Vercel plugin repository URL */
 export const VERCEL_PLUGIN_REPO = 'https://github.com/ship-studio/plugin-vercel';
 
+/**
+ * Built-in hosting integrations. They install like any other plugin (cloned
+ * into `.shipstudio/plugins/<id>`) but the app renders them in a dedicated
+ * header slot and the user never chose to add them — so a missing-on-disk
+ * deactivation is an app-provisioning gap, not something the user did (issue
+ * #386). Lives here rather than in a component so non-UI code can check it
+ * without importing the workspace header.
+ */
+export const HOSTING_PLUGIN_IDS = ['vercel', 'cloudflare', 'netlify'];
+
 const REGISTRY_URL =
   'https://raw.githubusercontent.com/ship-studio/plugin-registry/main/registry.json';
 

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -15,7 +15,7 @@ import { listen, UnlistenFn } from '@tauri-apps/api/event';
 import { homeDir } from '@tauri-apps/api/path';
 import { logger } from './logger';
 import { readProjectFile } from './code';
-import { asCommandError, formatCommandError } from './errors';
+import { asCommandError, formatCommandError, isProjectFolderGoneError } from './errors';
 import { trackError } from './analytics';
 import { isWindows } from './setup';
 
@@ -423,6 +423,13 @@ export async function startDevServer(
         // useDevServer skips the spawn for the common case (issue #593), and
         // remaining paths (restarts, monorepo cwd) must not page telemetry.
         logger.warn('[DevServer] No package.json found; falling back to npm run dev', {
+          projectPath,
+        });
+      } else if (isProjectFolderGoneError(e)) {
+        // The project folder was moved, renamed, or deleted outside Ship Studio
+        // while its session stayed open — an environment state, not an app bug
+        // (issue #822). Same treatment as the missing-package.json case.
+        logger.warn('[DevServer] Project folder is gone; falling back to npm run dev', {
           projectPath,
         });
       } else {

--- a/src/lib/terminalDiagnostics.test.ts
+++ b/src/lib/terminalDiagnostics.test.ts
@@ -107,6 +107,35 @@ describe('extractTerminalError', () => {
     expect(extractTerminalError(tail)).toBe('error: could not connect to registry');
   });
 
+  it("skips npm's bug-report boilerplate footer for the real cause (issue #717)", () => {
+    const tail = [
+      'npm error code ETARGET',
+      'npm error notarget No matching version found for left-pad@9.9.9',
+      'npm error This is an error with npm itself. Please report this error at:',
+      'npm error   <https://github.com/npm/cli/issues>',
+    ].join('\n');
+    expect(extractTerminalError(tail)).toBe(
+      'npm error notarget No matching version found for left-pad@9.9.9'
+    );
+  });
+
+  it('explains an npm ERESOLVE peer conflict instead of echoing the tail (issue #781)', () => {
+    const tail = [
+      'npm error code ERESOLVE',
+      'npm error ERESOLVE unable to resolve dependency tree',
+      'npm error peer astro@"^7.2.0" from @astrojs/cloudflare@14.2.3',
+    ].join('\n');
+    const result = extractTerminalError(tail);
+    expect(result).toContain('--legacy-peer-deps');
+    expect(result).not.toContain('npm error');
+  });
+
+  it("recognizes ERESOLVE from npm's debug-log filename alone (issue #788)", () => {
+    const tail =
+      'npm error C:\\Users\\me\\AppData\\Local\\npm-cache\\_logs\\2026-08-21T13_59_11_384Z-eresolve-report.txt';
+    expect(extractTerminalError(tail)).toContain('version conflict');
+  });
+
   it('caps very long lines at 200 characters', () => {
     const longLine = `npm ERR! ${'x'.repeat(400)}`;
     const result = extractTerminalError(longLine);

--- a/src/lib/terminalDiagnostics.ts
+++ b/src/lib/terminalDiagnostics.ts
@@ -52,11 +52,15 @@ export function createPtyChunkDecoder(): (data: PtyChunk) => string {
 const ERROR_LINE_PATTERN = /error|not recognized|not found|EACCES|EPERM|EEXIST|ENOENT|npm ERR!/i;
 
 /**
- * npm's trailing pointer at its debug log (the sentence and the log-file path
- * line that follows it) — present on every failure and says nothing about the
- * cause, so never pick it as "the" error line.
+ * npm's boilerplate footer — the pointer at its debug log (the sentence and
+ * the log-file path line that follows it) and the "report this to npm"
+ * blurb. Both are printed on failures regardless of cause, and both match
+ * {@link ERROR_LINE_PATTERN}, so without this filter the last "error" line is
+ * a log path or a bug-tracker URL instead of what actually broke (issue
+ * #717).
  */
-const NOISE_LINE_PATTERN = /complete log of this run|[\\/]_logs[\\/].*\.log\b/i;
+const NOISE_LINE_PATTERN =
+  /complete log of this run|[\\/]_logs[\\/].*\.log\b|report this error at|this is an error with npm itself|github\.com[\\/]npm[\\/]cli[\\/]issues/i;
 
 /**
  * "npm/node isn't on PATH" — cmd.exe ("'npm' is not recognized as an internal
@@ -65,6 +69,12 @@ const NOISE_LINE_PATTERN = /complete log of this run|[\\/]_logs[\\/].*\.log\b/i;
  */
 const NODE_MISSING_PATTERN =
   /'(npm|node)(\.cmd|\.exe)?' is not recognized|\b(npm|node): (command )?not found/i;
+
+/**
+ * npm's peer-dependency conflict refusal: "npm error code ERESOLVE" /
+ * "ERESOLVE unable to resolve dependency tree" (issues #781/#788).
+ */
+const ERESOLVE_PATTERN = /\bERESOLVE\b|unable to resolve dependency tree/i;
 
 /** Maximum length of an extracted error message shown in the UI / telemetry. */
 const MAX_ERROR_LENGTH = 200;
@@ -100,6 +110,14 @@ export function extractTerminalError(tail: string): string | null {
   // with no next step left users stuck (issue #469) — say what to actually do.
   if (lines.some((line) => line.includes('approve-builds'))) {
     return 'pnpm blocked dependency build scripts pending your approval. In the terminal, run `pnpm approve-builds`, approve the listed packages, then retry the install';
+  }
+
+  // npm refusing a peer-dependency conflict the project itself declares. The
+  // raw tail is npm's debug-log filename (which merely *ends* in "-eresolve")
+  // or a fragment of the conflict tree — neither says what to do, and both
+  // read like an app failure (issues #781/#788).
+  if (lines.some((line) => ERESOLVE_PATTERN.test(line))) {
+    return "This project's dependencies have a version conflict npm won't resolve on its own. Update the conflicting package to a version they agree on, or re-run the install with `--legacy-peer-deps` if that's safe for this project";
   }
 
   const errorLines = lines.filter(

--- a/src/lib/terminalWebgl.test.ts
+++ b/src/lib/terminalWebgl.test.ts
@@ -44,16 +44,30 @@ class ResizeObserverStub {
 interface FakeContainer {
   offsetWidth: number;
   offsetHeight: number;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
 }
 
 function makeFixture(width: number, height: number) {
-  const container: FakeContainer = { offsetWidth: width, offsetHeight: height };
+  const container: FakeContainer = {
+    offsetWidth: width,
+    offsetHeight: height,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
   const term = { loadAddon: vi.fn() };
   const dispose = attachWebglRenderer(
     term as unknown as Terminal,
     container as unknown as HTMLElement
   );
-  return { container, term, dispose };
+  /** Fire the capture-phase `webglcontextlost` listener the loader registered. */
+  const fireContextLost = () => {
+    const call = container.addEventListener.mock.calls.find(
+      ([type]) => type === 'webglcontextlost'
+    );
+    (call?.[1] as () => void)();
+  };
+  return { container, term, dispose, fireContextLost };
 }
 
 beforeEach(() => {
@@ -107,9 +121,36 @@ describe('attachWebglRenderer', () => {
     expect(addonInstances).toHaveLength(1);
   });
 
+  it('drops the addon on webglcontextlost instead of waiting for a restore', () => {
+    // The addon's restore path re-runs _initializeWebGLState() from a native
+    // event listener and can throw uncaught there (issue #716) — so the
+    // capture-phase listener must dispose before the addon schedules it.
+    const { container, fireContextLost } = makeFixture(800, 600);
+    const [addon] = addonInstances;
+    expect(container.addEventListener).toHaveBeenCalledWith(
+      'webglcontextlost',
+      expect.any(Function),
+      true
+    );
+
+    fireContextLost();
+    expect(addon.dispose).toHaveBeenCalledTimes(1);
+    expect(disconnectSpy).toHaveBeenCalled();
+
+    // Permanent fallback — layout changes never bring WebGL back.
+    container.offsetWidth = 1000;
+    fireResize();
+    expect(addonInstances).toHaveLength(1);
+  });
+
   it('cleanup disconnects the observer and disposes the loaded addon', () => {
-    const { dispose } = makeFixture(800, 600);
+    const { container, dispose } = makeFixture(800, 600);
     dispose();
+    expect(container.removeEventListener).toHaveBeenCalledWith(
+      'webglcontextlost',
+      expect.any(Function),
+      true
+    );
     expect(disconnectSpy).toHaveBeenCalled();
     expect(addonInstances[0].dispose).toHaveBeenCalledTimes(1);
 

--- a/src/lib/terminalWebgl.ts
+++ b/src/lib/terminalWebgl.ts
@@ -15,7 +15,9 @@
  * renderer) whenever the container collapses to zero, and reloads it when
  * layout returns. WebGL being unavailable, or a GPU context loss, falls back
  * to the non-WebGL renderer permanently — same behavior the call sites had
- * before this guard existed.
+ * before this guard existed. Context loss drops the addon immediately rather
+ * than riding out the addon's restore attempt, whose re-initialization can
+ * throw uncaught from a native event listener (issue #716).
  */
 
 import type { Terminal } from '@xterm/xterm';
@@ -74,11 +76,38 @@ export function attachWebglRenderer(term: Terminal, container: HTMLElement): () 
   };
 
   const observer = new ResizeObserver(sync);
+
+  // GPU context loss: fall back to the DOM renderer the moment the context
+  // goes away, instead of letting the addon try to restore it.
+  //
+  // `@xterm/addon-webgl` answers `webglcontextlost` by scheduling a restore,
+  // and its `webglcontextrestored` listener calls `_initializeWebGLState()`
+  // again. That runs inside a native event dispatch — outside any call stack
+  // this module controls — so when a driver hiccup makes one of the WebGL
+  // program/uniform lookups come back null, xterm's `throwIfFalsy` throws
+  // "value must not be falsy" uncaught, straight into the global error
+  // handler (issue #716). Disposing on loss removes the addon's own restore
+  // listener, so that path can never run.
+  //
+  // The listener sits on the container in CAPTURE phase: `webglcontextlost`
+  // is dispatched on the addon's canvas and does not bubble, but capturing
+  // ancestors still see it — and see it BEFORE the addon's own target-phase
+  // listener, which is the one that schedules the restore.
+  const onContextLost = () => {
+    if (unavailable) return;
+    unavailable = true;
+    observer.disconnect();
+    disposeAddon();
+    logger.warn('[Terminal] WebGL context lost, using canvas renderer');
+  };
+  container.addEventListener('webglcontextlost', onContextLost, true);
+
   observer.observe(container);
   sync();
 
   return () => {
     disposed = true;
+    container.removeEventListener('webglcontextlost', onContextLost, true);
     observer.disconnect();
     disposeAddon();
   };

--- a/src/styles/features/create-project.css
+++ b/src/styles/features/create-project.css
@@ -800,3 +800,27 @@
   color: var(--text-muted);
   font-size: var(--font-size-md);
 }
+
+/* Fetch failed — distinct from "no results" so the user knows to retry (#754) */
+.tg-error {
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: 0 var(--spacing-lg);
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.tg-retry {
+  padding: var(--spacing-xs) var(--spacing-md);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: var(--font-size-base);
+  cursor: pointer;
+  transition: background var(--transition);
+}
+
+.tg-retry:hover {
+  background: var(--bg-secondary);
+}

--- a/src/styles/features/create-project.css
+++ b/src/styles/features/create-project.css
@@ -809,18 +809,3 @@
   text-align: center;
   color: var(--text-secondary);
 }
-
-.tg-retry {
-  padding: var(--spacing-xs) var(--spacing-md);
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  color: var(--text-primary);
-  font-size: var(--font-size-base);
-  cursor: pointer;
-  transition: background var(--transition);
-}
-
-.tg-retry:hover {
-  background: var(--bg-secondary);
-}

--- a/src/styles/features/env-editor.css
+++ b/src/styles/features/env-editor.css
@@ -283,6 +283,16 @@
   color: var(--text-muted);
 }
 
+/* Neutral inline note, not a failure — e.g. a pasted KEY=value entry that was
+   split into the name and value fields. */
+.env-key-notice {
+  color: var(--text-secondary);
+  font-size: var(--font-size-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--bg-tertiary);
+  border-radius: var(--radius);
+}
+
 .env-error {
   color: var(--error);
   font-size: var(--font-size-md);

--- a/src/styles/features/main-branch-banner.css
+++ b/src/styles/features/main-branch-banner.css
@@ -77,10 +77,17 @@
   white-space: nowrap;
 }
 
-.main-branch-banner-action:hover {
+.main-branch-banner-action:hover:not(:disabled) {
   background: rgba(var(--warning-rgb), 0.3);
   border-color: rgba(var(--warning-rgb), 0.5);
   color: var(--banner-amber-bright);
+}
+
+/* Branches live behind a connected GitHub repo (issue #612) — the button stays
+   visible so the offered fix is still discoverable, with the reason on hover. */
+.main-branch-banner-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .main-branch-banner-checkbox {


### PR DESCRIPTION
Sweep 18: ~118 auto-reported issues fixed across the whole app, prepared for release v0.18.7.

## Scope
- **Git/GitHub/PRs**: classification for corrupted repos, pagefile/fork-bomb/CLT gaps, localized git output, empty-stderr failures; detached-HEAD publish guard; existing-origin reuse; index.lock retries for stash/undo; centralized push-timeout mapping in `run_git_net`; "no history in common", HTTP 499, already-merged-close handling
- **MCP**: remove/list paths get the same failure classifier as add (gateway/auth, broken agent configs, invalid `service_tier`, upstream env-var CLI bug); empty errors carry exit codes
- **Plugins/skills**: `Expected` classification survives the plugin command helpers; clone retry + `GIT_TERMINAL_PROMPT=0` + bounded network timeouts; registry 429 backoff; stale `.tmp-install` cleanup; readable skill errors
- **Capture**: Playwright (`ERR_ABORTED` retry, download endpoints, closed-target, silent exits, node-missing guidance) and thumbnail fallback (disk-full, pagefile, Crashpad/NTSTATUS crash codes, PDH/CVDisplayLink noise)
- **Visual editor**: classless elements insert/duplicate/delete (#318); JSX handler props no longer break span mapping (#789); class/style drift-guard retry; structural-tag guard UX
- **Windows**: agent terminal spawn (`needsCmdExeWrapper`), npm-shadowed `gh` detection, npx/uninstall PATH resolution, winget error surfacing
- **Crashes**: disk-full startup (#827), empty contribution calendar (#721), terminal WebGL context loss (#716)
- **Imports**: pnpm/yarn-workspace detection (incl. Yarn berry), EUNSUPPORTEDPROTOCOL/illegal-filename/GraphQL messaging
- **Telemetry hygiene**: ~50 toast/logger paths stop auto-filing bug reports for environmental states; frontend recognition synced byte-for-byte with new backend wordings

## Verification
- cargo: 1055 passed (baseline 969); vitest: 1640 passed (baseline 1528); tsc, check:patterns, check:loc, production build all clean
- Adversarial code review over the full diff surfaced 10 verified regressions (incl. two data-loss bugs) — all fixed and re-verified
- Windows-specific paths are unit-tested but not compile-verified/run on Windows

Issue list (not auto-closed; see the sweep report for per-issue detail): #705–#845 range majority, plus #318 #612 #694-adjacent #716 #721. Full triage: 160 open issues → ~118 fixed, ~42 skipped for cause (upstream crates, separate plugin repos, hardware-only repros, stripped proprietary code, questions/enhancements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181KkoiaeqnxXT1cucMLNF8
