### PR TITLE
Fix breakpoint canvas clipping content loaded after startup

### DIFF
--- a/src-tauri/src/proxy/select_script.html
+++ b/src-tauri/src/proxy/select_script.html
@@ -1198,7 +1198,7 @@ function ssSyncPage(){
     ssVHTimer=0;ssPinRootHeight();ssRewriteViewportUnits();ssLoadEverything();ssReportPage();
   },200);
 }
-/* Watch for STYLESHEETS arriving, not for the page living its life. A canvas
+/* Watch for STYLESHEETS arriving without observing attribute changes. A canvas
    holds four of these pages at once; an observer over the whole document with
    attributes on fires on every class toggle a scroll animation makes, in every
    frame, and each firing schedules a walk of the CSSOM and a forced layout.
@@ -1206,6 +1206,34 @@ function ssSyncPage(){
    all this needs to see. NB: no literal opening head/html tag may appear
    anywhere in this file, comments included — the proxy splices its head-start
    snippet at the first such string it finds in the whole response. */
+/* Content can arrive after the initial settle window (async data, expanded
+   sections, images). Measure twice after actual content changes, then stop.
+   Ignore animation-related attribute churn and Ship Studio's own overlays. */
+var ssContentTimer=0;
+function ssSyncContent(){
+  if(!ssCanvas)return;
+  if(ssContentTimer)clearTimeout(ssContentTimer);
+  ssContentTimer=setTimeout(function(){
+    ssContentTimer=0;
+    if(!ssCanvas)return;
+    ssPageSeen=0;ssPageAgreed=0;ssPageWrites=0;ssPageCommitted=[];ssPageLocked=false;
+    ssReportPage();
+    ssContentTimer=setTimeout(function(){ssContentTimer=0;ssReportPage();},200);
+  },200);
+}
+function ssContentOwn(node){
+  var el=node.nodeType===1?node:node.parentElement;
+  return !!(el&&el.closest&&el.closest('[data-ss-overlay],[id^="ss-"]'));
+}
+function ssOnContentMutations(records){
+  for(var i=0;i<records.length;i++){
+    var r=records[i];
+    if(ssContentOwn(r.target))continue;
+    if(r.type==='characterData'){ssSyncContent();return;}
+    var nodes=Array.prototype.slice.call(r.addedNodes).concat(Array.prototype.slice.call(r.removedNodes));
+    for(var j=0;j<nodes.length;j++)if(!ssContentOwn(nodes[j])){ssSyncContent();return;}
+  }
+}
 /* Started only when a canvas takes this frame over, and never otherwise: the
    ordinary single-frame preview must cost exactly what it cost before this
    feature existed. */
@@ -1217,10 +1245,13 @@ function ssWatchPage(){
     new MutationObserver(ssOnHeadMutations).observe(document.head||document.documentElement,
       {childList:true,subtree:true});
   }
+  if(window.MutationObserver&&document.body){
+    new MutationObserver(ssOnContentMutations).observe(document.body,{childList:true,subtree:true,characterData:true});
+    document.body.addEventListener('load',ssSyncContent,true);
+  }
   window.addEventListener('load',ssSyncPage);
-  /* Everything else that changes a page's length — fonts landing, images
-     sizing, content revealed on load — happens early and then stops. A few
-     checks over the first few seconds cover it without watching forever. */
+  /* Cover startup layout and fonts with a bounded settle window. Later
+     content and image loads are handled by the debounced content watcher. */
   var ticks=0;
   var settle=setInterval(function(){
     if(++ticks>24){clearInterval(settle);return;}

--- a/src/components/edit/selectScriptCanvas.test.ts
+++ b/src/components/edit/selectScriptCanvas.test.ts
@@ -58,3 +58,31 @@ it('pins the root height for a canvas without touching the site around it', asyn
   observer.disconnect();
   expect(mutations).toEqual([]);
 });
+
+it('remeasures late content after settling and shrinks again without idle polling', async () => {
+  document.body.innerHTML = '<main></main>';
+  window.dispatchEvent(
+    new MessageEvent('message', { data: { type: 'ss:canvas', on: true, vh: 700 } })
+  );
+  document.body.style.margin = '0';
+  const main = document.querySelector('main')!;
+  vi.spyOn(main, 'getBoundingClientRect').mockReturnValue({ bottom: 900 } as DOMRect);
+  await vi.advanceTimersByTimeAsync(11000);
+  const post = vi.spyOn(window.parent, 'postMessage');
+  const extra = document.createElement('section');
+  vi.spyOn(extra, 'getBoundingClientRect').mockReturnValue({ bottom: 2800 } as DOMRect);
+  document.body.appendChild(extra);
+  await vi.advanceTimersByTimeAsync(800);
+  expect(post).toHaveBeenCalledWith({ type: 'ss:pageHeight', height: 2800 }, '*');
+  extra.remove();
+  await vi.advanceTimersByTimeAsync(800);
+  expect(post).toHaveBeenCalledWith({ type: 'ss:pageHeight', height: 900 }, '*');
+  const count = post.mock.calls.filter(
+    ([d]) => (d as { type?: string }).type === 'ss:pageHeight'
+  ).length;
+  await vi.advanceTimersByTimeAsync(12000);
+  expect(
+    post.mock.calls.filter(([d]) => (d as { type?: string }).type === 'ss:pageHeight')
+  ).toHaveLength(count);
+  post.mockRestore();
+});


### PR DESCRIPTION
## Summary

Fixes late content being clipped in the breakpoint canvas. After the initial roughly 10-second settling window, adding page content leaves the iframe at its previous height. Removing content can similarly leave excess space.

Watch body content changes and image loads, debounce two height measurements, and reset the sizing agreement state when content changes. Attribute mutations and Ship Studio overlays are ignored to avoid measuring on animation-related style changes. No continuous polling is added.

This PR targets `worktree-breakpoint-canvas` and changes only the injected sizing script and its regression test. It is independent of the canvas comments feature.

## Reproduction

1. Open Every breakpoint and wait longer than 10 seconds.
2. Append a 1,600px section to the page.
3. Before: each iframe keeps its old height and cuts off the added section.
4. After: all four frames expand; removing content lets them shrink again.

## Test plan

- [x] Regression test covers content arriving after settling, removal, and no further height messages while idle.
- [x] Live four-frame fixture: heights grew from 3600 / 2800 / 4096 / 3248 to 5200 / 4400 / 5696 / 4848. The 100vh hero remained at device heights 900 / 700 / 1024 / 812.
- [x] In a settled 43-second fixture sample, canvas render counts and height-message counts stayed unchanged; inactive frame animation counters were also stable. This is a focused regression check, not a full performance sign-off for large sites.
- [x] Frontend suite: 2,176 passed, 4 skipped.

## CI gates

- [x] `pnpm check:all && pnpm test:run && pnpm rust:test` passed locally on this isolated branch.
- Backend suite: 1,176 passed, 2 ignored; documentation test ignored.

## Patterns checklist

- [x] Added a regression test for non-trivial sizing behavior.
- No new UI, CSS, Rust command, or continuous polling loop is introduced.
