### PR TITLE
Move the Spotify toggle out of Appearance into a new Experimental tab

### DIFF
--- a/src/components/dashboard/SettingsModal.tsx
+++ b/src/components/dashboard/SettingsModal.tsx
@@ -4,6 +4,8 @@
  * Contains:
  * - Projects folder (where projects are listed/created), with an optional move
  * - General settings and Appearance settings, including workspace layout and icon selection
+ * - Experimental: opt-in toys and half-finished ideas, kept out of Appearance so
+ *   that tab stays about how the app looks
  * - Analytics opt-out toggle
  *
  * @module components/SettingsModal
@@ -71,7 +73,7 @@ interface MovePrompt {
   info: MovableProjects;
 }
 
-type SettingsTab = 'general' | 'appearance';
+type SettingsTab = 'general' | 'appearance' | 'experimental';
 
 export function SettingsModal({
   isOpen,
@@ -398,6 +400,9 @@ export function SettingsModal({
             <TabsTab value="appearance" width="fill" className="command-palette-tab">
               Appearance
             </TabsTab>
+            <TabsTab value="experimental" width="fill" className="command-palette-tab">
+              Experimental
+            </TabsTab>
           </TabsList>
 
           <TabsPanel value="general" className="settings-tab-panel">
@@ -598,29 +603,6 @@ export function SettingsModal({
                       </span>
                     </button>
                   </div>
-                  {isMac() && (
-                    <div className="settings-row">
-                      <div className="settings-row-info">
-                        <span className="settings-row-label">Spotify controls</span>
-                        <span className="settings-row-description">
-                          Show what's playing in Spotify in the sidebar, with play/pause and skip
-                          controls. macOS will ask permission to control Spotify the first time.
-                        </span>
-                      </div>
-                      <button
-                        className={`settings-toggle ${spotifyWidgetEnabled ? 'on' : 'off'}`}
-                        onClick={handleSpotifyWidgetToggle}
-                        disabled={loading}
-                        role="switch"
-                        aria-label="Spotify controls"
-                        aria-checked={spotifyWidgetEnabled}
-                      >
-                        <span className="settings-toggle-track">
-                          <span className="settings-toggle-thumb" />
-                        </span>
-                      </button>
-                    </div>
-                  )}
                 </div>
                 <div className="settings-row">
                   <div className="settings-row-info">
@@ -672,6 +654,46 @@ export function SettingsModal({
                       </button>
                     ))}
                   </div>
+                </div>
+              </div>
+            </div>
+          </TabsPanel>
+
+          {/* Things that are switched off by default and might not survive.
+              Kept out of Appearance because none of this is about how the app
+              looks — putting a Spotify remote under "Appearance" was a stretch
+              even with one of them. */}
+          <TabsPanel value="experimental" className="settings-tab-panel">
+            <div className="settings-modal-body">
+              <div className="settings-section">
+                <div className="settings-group">
+                  {isMac() ? (
+                    <div className="settings-row">
+                      <div className="settings-row-info">
+                        <span className="settings-row-label">Spotify controls</span>
+                        <span className="settings-row-description">
+                          Show what's playing in Spotify in the sidebar, with play/pause and skip
+                          controls. macOS will ask permission to control Spotify the first time.
+                        </span>
+                      </div>
+                      <button
+                        className={`settings-toggle ${spotifyWidgetEnabled ? 'on' : 'off'}`}
+                        onClick={handleSpotifyWidgetToggle}
+                        disabled={loading}
+                        role="switch"
+                        aria-label="Spotify controls"
+                        aria-checked={spotifyWidgetEnabled}
+                      >
+                        <span className="settings-toggle-track">
+                          <span className="settings-toggle-thumb" />
+                        </span>
+                      </button>
+                    </div>
+                  ) : (
+                    <p className="settings-empty-note">
+                      Nothing experimental for this platform yet.
+                    </p>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/styles/features/settings.css
+++ b/src/styles/features/settings.css
@@ -73,6 +73,15 @@
   line-height: 1.4;
 }
 
+/* The Experimental tab when the platform has nothing to offer it. Not an error
+   and not a call to action — just an answer, so the tab is never blank. */
+.settings-empty-note {
+  margin: 0;
+  font-size: var(--font-size-body-md);
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
 .settings-icon-options {
   display: flex;
   align-items: flex-start;

--- a/src/styles/features/settings.css
+++ b/src/styles/features/settings.css
@@ -175,6 +175,12 @@
   border-bottom: var(--border-width-default) solid var(--border-subtle);
 }
 
+/* ...but a divider is a separator, and the last group in a panel has nothing
+   to be separated from. There it is just a line above the bottom edge. */
+.settings-section > .settings-group:last-child {
+  border-bottom: none;
+}
+
 .settings-group .settings-row {
   padding: var(--spacing-md) 0;
 }

--- a/src/styles/global/token-inventory.json
+++ b/src/styles/global/token-inventory.json
@@ -3809,7 +3809,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": true,
-      "consumerCount": 588
+      "consumerCount": 589
     },
     {
       "name": "--text-faint",
@@ -4151,7 +4151,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 214
+      "consumerCount": 215
     },
     {
       "name": "--font-size-body-sm",


### PR DESCRIPTION
The Spotify remote was living under **Appearance**, which is a tab about how the app looks. A music player is not that — it went there because Appearance was the least-wrong of the two existing tabs, not because it belonged.

So there is now an **Experimental** tab, for things that are off by default and might not survive. Spotify controls move there unchanged: same toggle, same setting, same analytics event.

Two details worth knowing:

- The Spotify widget is macOS-only, so on other platforms the tab would be empty. The tab is always present (the tab strip is the same shape everywhere) and says "Nothing experimental for this platform yet." rather than showing a blank panel.
- `.settings-group` draws a bottom border so a block of toggles reads as a section. That works when something follows it; when the group is the last thing in a panel — which is every group in the new tab — it is a rule sitting just above the dialog edge, separating the content from nothing. Now scoped to the last group in a section, so the divider that genuinely splits two groups in Appearance is untouched.

Verified in a built app: the tab renders, the toggle works, Appearance keeps its real divider and has no Spotify row.

Gates run locally: `check:all`, `lint:strict`, `pnpm build`, and the frontend suite (2069 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMXU5Xkzu3SpnGKx9hzJfQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Experimental tab to Settings.
  - Moved Spotify controls from Appearance to the Experimental tab.
  - Added an informational message when Experimental settings are unavailable on non-macOS platforms.
  - Improved settings group styling by removing the bottom border from the final group in each section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->