### PR TITLE
Native hosting: replace the Vercel/Cloudflare/Netlify plugins, and start retiring plugins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Ship Studio is a desktop app for web developers that provides:
 - **Plugins, Skills & MCP** - Extend the app with plugins; install agent skills and configure MCP servers
 - **Command Palette** - Cmd+K palette; every user-facing feature registers its actions here (see "New feature → contribute commands")
 - **IDE Integration** - Open projects in VS Code or Cursor with one click
-- **Vercel Deployment** - Publish to staging/production via Vercel integration
+- **Hosting Status** - After a push, see whether *that commit* deployed on Vercel, Cloudflare Pages or Netlify, with the build error when it didn't (see "Hosting Flow")
 - **Auto-Updates** - Automatic update detection and installation
 
 ## Core Principles
@@ -33,8 +33,13 @@ Ship Studio is a desktop app for web developers that provides:
 
 ### Data Storage
 - Project metadata is stored in `.shipstudio/project.json` within each project
-- This file stores: last_opened timestamp, publish records (staging/production with URL, state, publishedAt)
-- Vercel project linking info is in `.vercel/project.json` (managed by Vercel CLI)
+- This file stores: last_opened timestamp, and the project's hosting link (provider, project id, scope)
+- Schema v4 replaced the old `publish` block (staging/production URL + state + timestamp). It carried
+  no commit SHA, provider or deployment id, so it could not say *which* push it described — and it was
+  written from assumption rather than from a provider's answer. Deployment state is not cached in the
+  repo at all now; it is fetched per commit into a short-lived in-memory cache
+- Provider links are read from the CLIs' own files (`.vercel/project.json`, `.netlify/state.json`) or
+  set explicitly by the user; a link is never inferred from a folder merely existing
 - Only trust data that was explicitly saved - don't infer state from file existence alone
 
 ## Architecture
@@ -51,6 +56,7 @@ Ship Studio is a desktop app for web developers that provides:
 Command modules in `src-tauri/src/commands/`. Domains with submodules are directories:
 - `git/` - Git operations (branches, status, stash, sync) with TTL caching
 - `health/` - Project health checks (dependency audit, diagnostics)
+- `hosting/` - Native hosting status: per-provider adapters (Vercel, Cloudflare Pages, Netlify) over one provider-agnostic model, plus credential discovery, commit lookup and build logs
 - `ide/` - VS Code/Cursor launch, preview screenshots
 - `plugins/` - Plugin lifecycle and storage
 - `projects/` - Project CRUD: detection, metadata, dev-server config, pins, sessions, templates, UI state, window registry
@@ -79,7 +85,7 @@ Single-file domains:
 - `monorepo.rs` - Workspace detection for pnpm/yarn/npm monorepos
 - `proxy.rs` - Preview proxy control (the proxy itself lives in `src-tauri/src/proxy/`)
 - `pty_session.rs` - Long-lived backend-owned PTY sessions (e.g. mobile builds)
-- `publishing.rs` - Vercel deployment workflow and publish record tracking
+- `publishing.rs` - Pushing the current branch to origin, and the git-push error taxonomy
 - `pull_requests.rs` - PR listing and creation via `gh` CLI
 - `settings.rs` - App-level settings persistence
 - `snapshots.rs` - Project snapshots / backups (rewind)
@@ -111,6 +117,7 @@ Single-file domains:
 - `preview/` - Live preview, browser tools, device mirror (mobile), locale switcher, screenshots
 - `branches/` - Git/branch UI: branches/PR tabs, conflict resolution, diff, publish controls, GitHub button
 - `code/` - Code mode: viewer, file tree, code tab, health panel
+- `hosting/` - The Push popover's Hosting section: the fixed-geometry row, the address rows, the connect and link-picker flows, and the Deployments panel
 - `plugins/` - Plugin manager/slots/dropdown, MCP and Skills modals
 - `workflows/` - Workflows list, row, editor, template picker, run history
 - `inbox/` - Findings list and the report reader
@@ -147,6 +154,7 @@ Key modules in `src/lib/` (not exhaustive — `ls src/lib` for the full list):
 - `fonts.ts` - Font loading utilities for the terminal
 - `git.ts` - Git operations wrapper (status, commits, branches)
 - `github.ts` - GitHub operations (auth, push, clone) and publishing flow
+- `hosting.ts` / `hostingCopy.ts` - Hosting: the TS mirror of the Rust model, the invoke wrappers, the `deriveSectionState` reducer, and every user-facing string in the section (written to fit a 184px column — see the Hosting Flow)
 - `i18n.ts` - Multilingual support: status/config wrappers, full-ISO language search, locale path helpers for the preview switcher, and agent prompt builders (translate, App Router next-intl setup, removal cleanup)
 - `logger.ts` - Structured frontend logging
 - `mcp.ts` / `skills.ts` / `plugins.ts` / `plugin-loader.ts` - Agent extensions and the plugin system
@@ -346,10 +354,40 @@ These names predate the layered token system. Product code must use the canonica
 ## Common Patterns
 
 ### Publishing Flow
-1. User clicks Publish in PublishBranchDropdown
-2. Backend pushes to GitHub (staging or main branch)
-3. Vercel auto-deploys via GitHub integration
-4. Result (URL, state, timestamp) is saved to `.shipstudio/project.json`
+1. User clicks Push in `PublishBranchDropdown`
+2. `publish_branch` commits any pending changes and pushes the **current** branch to origin
+3. Whatever the project's host does next is the host's business — we push, we don't deploy
+
+That last point is the change: publishing used to push `HEAD:staging` or `HEAD:main` and then
+record `{ url, state, publishedAt }` into `.shipstudio/project.json`. The state was assumed rather
+than observed (a literal `"QUEUED"`), the URL was empty or assembled from the project name, and
+nothing invalidated it. Deployment truth is now *asked for*, per commit, by the Hosting Flow below.
+
+### Hosting Flow
+
+Answers one question: **did the commit I just pushed actually deploy?**
+
+1. `get_hosting_status` resolves the pushed commit (`origin/<branch>`), reads the project's link
+   (`.vercel/project.json`, `.netlify/state.json`, or one the user picked), and asks that provider
+   for a deployment **matching that SHA** — never "the most recent deployment", which answers a
+   different question and is what the old plugin did
+2. Credentials come from the keychain first, then the provider CLI's own login file. A rejected
+   token (401 **or** 403) is `Auth::Rejected` and renders as a broken connection — never as healthy,
+   and never as data
+3. `deriveSectionState` (`src/lib/hosting.ts`) folds auth, link, transport and timing into exactly
+   one state. Order encodes the honesty rules: nothing pushed beats everything; auth problems beat
+   data; a missing deployment is only ever "not found", never "failed"
+4. The row prints the provider's own status word (`status_label`) verbatim — "Ready", "Uploading",
+   "Pending review" — so this and the provider's dashboard never disagree. We own the sentence
+   around those words, not the words
+5. Copy is written to fit: the row's two upper lines get a 184px ellipsised column with no tooltip,
+   so anything longer than ~32 characters belongs on the third line, which wraps. A unit test holds
+   every string to that budget and the UI harness reports anything that still overflows
+6. A failure fetches its own build log and shows the error line, which is the thing people open the
+   dashboard for
+
+Verified against live accounts for all three providers, with what is observed versus assumed
+recorded in [docs/internal/hosting-provider-matrix.md](docs/internal/hosting-provider-matrix.md).
 
 ### Pull Request Flow
 1. User clicks "Submit for Review" on a branch

--- a/docs/design-system.generated.md
+++ b/docs/design-system.generated.md
@@ -40,7 +40,7 @@ one row, while the export list is checked exactly against the source file.
 | --- | --- | ---: | --- |
 | core | `src/styles/global/fonts.css`<br>`src/styles/global/tokens-core.css` | 111 | `--color-white`, `--color-white-o15`, `--color-black`, `--color-black-o15`, `--color-black-o38`, `--color-black-o75` |
 | semantic | `src/styles/global/tokens-semantic.css` | 126 | `--font-size-micro`, `--tracking-micro`, `--surface-app`, `--surface-panel`, `--surface-control`, `--surface-control-hover` |
-| components | `src/styles/global/tokens-components.css` | 239 | `--size-control-standard`, `--size-control-large`, `--size-control-medium`, `--size-control-compact`, `--size-titlebar-project-path`, `--size-element-toolbar-selector` |
+| components | `src/styles/global/tokens-components.css` | 253 | `--size-control-standard`, `--size-control-large`, `--size-control-medium`, `--size-control-compact`, `--size-titlebar-project-path`, `--size-element-toolbar-selector` |
 | compatibility | `src/styles/global/tokens-compatibility.css` | 55 | `--bg-primary`, `--bg-secondary`, `--bg-tertiary`, `--bg-deep`, `--bg-hover`, `--text-bright` |
 
 ## Drift checks

--- a/docs/internal/hosting-provider-matrix.md
+++ b/docs/internal/hosting-provider-matrix.md
@@ -1,0 +1,89 @@
+# Hosting provider API matrix
+
+Empirically verified against live accounts. Anything not marked **verified** is
+from documentation only and must not become load-bearing UI logic until checked.
+
+Last verified: 2026-09-05.
+
+## Credential durability — the finding that shapes the whole design
+
+| Provider   | CLI credential file                                            | Expiry                                                | Usable as our credential?                                                                                                                        |
+| ---------- | -------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Vercel     | `~/Library/Application Support/com.vercel.cli/auth.json`         | **~7 hours** (`expiresAt` seconds, plus `refreshToken`) | **No** — short-lived OAuth access token. Refreshing it means implementing Vercel's OAuth flow against a file the docs say must not be edited manually. |
+| Netlify    | `~/Library/Preferences/netlify/config.json` → `users.<userId>.auth.token` | none present                                          | Opportunistically, yes                                                                                                                             |
+| Cloudflare | `~/.config/.wrangler/config/default.toml`                        | n/a                                                   | Absent unless the user has run wrangler; newer versions use the OS keyring                                                                          |
+
+**Consequence.** Credential resolution is a fallback chain, not a paste-wall:
+
+1. Keychain token via the existing `accounts.rs` mechanism (`VERCEL_TOKEN`,
+   `NETLIFY_AUTH_TOKEN`, `CLOUDFLARE_API_TOKEN`) — durable and supported.
+2. The CLI credential file, if present and unexpired — free instant value with
+   no setup, and the only reason a first-run user sees anything at all.
+3. On rejection, an honest "reconnect" state.
+
+**Why this matters beyond auth.** An expired Vercel token returns
+`403 {"code":"forbidden","invalidToken":true}` — _not_ 401. The current plugin
+treats any non-200 from its git-connection probe as `'unknown'`
+(`plugin-vercel/src/index.tsx:1054`) and then renders
+`gitConnection === 'not-connected' ? 'not-git-connected' : 'connected'`
+(`:863`), so **a 403 renders a fully "connected" card** while the production URL
+silently disappears (`fetchProjectDomains` returns `[]` on non-200). Any adapter
+we write must classify 401 _and_ 403 as rejection, never as healthy.
+
+## Vercel — verified
+
+- **SHA filter is server-side and works.**
+  `GET /v6/deployments?projectId=&teamId=&sha=<sha>` returns the matching
+  deployment; a bogus SHA returns zero. The 2023 community thread claiming no
+  SHA filter is stale.
+- **The list endpoint does not return aliases.** Keys are: `aliasAssigned`,
+  `aliasError`, `buildingAt`, `checks`, `created`, `createdAt`, `creator`,
+  `inspectorUrl`, `isRollbackCandidate`, `meta`, `name`, `projectId`,
+  `projectSettings`, `ready`, `readyState`, `readySubstate`, `source`, `state`,
+  `target`, `type`, `uid`, `url`. Real aliases require
+  `GET /v13/deployments/{uid}` — so resolving a commit to its live URLs is a
+  **two-call flow**. `v13/deployments/{sha}` 404s; it takes a uid or URL only.
+- **Git linkage lives in `meta`, not `gitSource`.** Even with
+  `withGitRepoInfo=true` the response had no `gitSource` key. Use
+  `meta.githubCommitSha`, `meta.githubCommitRef`, `meta.githubCommitMessage`,
+  `meta.githubCommitAuthorName`, `meta.githubCommitOrg`, `meta.githubCommitRepo`.
+- `readySubstate` (e.g. `PROMOTED`) and `target` (`production`) are present and
+  real.
+
+## Netlify — verified
+
+- **`commit_ref` carries the full SHA**; there is no server-side commit filter,
+  so narrow with `?branch=<branch>` and scan client-side.
+- **Every URL is returned by the API — including the branch URL.** A production
+  deploy returned `url`, `ssl_url` (`https://<site>.netlify.app`), `deploy_url`,
+  and `deploy_ssl_url` (`https://<branch>--<site>.netlify.app`), plus
+  `admin_url`. The branch URL never needs constructing, which is exactly what
+  the Netlify plugin does today.
+- **The commit message field is `commit_message`, not `title`.** Both are
+  nullable — the verified deploy had `commit_message: null` and `title: null`,
+  so the UI must fall back to the local `git log` subject.
+- **Netlify does have a skip reason: `skipped_log`** (documentation suggested it
+  had only a boolean). `skipped` is `null` rather than `false` when not skipped,
+  so deserialize as `Option<bool>`.
+- **`pending_review_reason`** supplies the detail for the gated state.
+- **`deploy_source` / `manual_deploy`** distinguish a git-triggered deploy from a
+  CLI/manual one — a manual deploy has no meaningful commit linkage and must not
+  be matched against a pushed SHA.
+- Still unconfirmed: how a canceled or `ignore`-command build appears in the
+  `state` enum. Needs a deliberately canceled build to observe.
+
+## Cloudflare Pages — NOT VERIFIED
+
+No wrangler credentials on the verification machine, so nothing below was
+observed. Treat every field as unconfirmed until a token is available:
+
+- Deployment list is not filterable by commit; scan
+  `deployment_trigger.metadata.commit_hash`.
+- State is two-dimensional (`latest_stage.name` × `latest_stage.status`) and
+  needs its own reducer rather than an enum lookup.
+- `is_skipped` + `skip_reason` are documented as the cleanest skip signal of the
+  three providers.
+- Unconfirmed: whether `aliases[]` appears on the list item or only on the detail
+  call, and whether it includes attached custom domains.
+- Linking needs an `account_id`; Pages projects leave nothing on disk, so the
+  link must be a user pick and the account id persisted.

--- a/docs/internal/hosting-provider-matrix.md
+++ b/docs/internal/hosting-provider-matrix.md
@@ -69,13 +69,33 @@ we write must classify 401 _and_ 403 as rejection, never as healthy.
 - **`deploy_source` / `manual_deploy`** distinguish a git-triggered deploy from a
   CLI/manual one — a manual deploy has no meaningful commit linkage and must not
   be matched against a pushed SHA.
+- **`links` carries both addresses.** `links.alias` is the site's,
+  `links.permalink` is the deploy's own, and `deploy_ssl_url` is the branch's.
+  Verified on a real deploy — none of them needs assembling.
+- **Timestamps are ISO-8601 strings** (`2026-02-22T17:26:51.942Z`), not epoch
+  milliseconds like Vercel.
+- **`manual_deploy`** marks a CLI or drag-and-drop deploy, which carries no
+  commit and must never be matched to a push.
+- **`admin_url` is the site's page, not the deploy's.** There is no per-deploy
+  admin link in the response.
+- **No build-log endpoint is published.** `error_message` on the deploy record
+  is the only failure detail available, so the adapter returns an empty log
+  rather than inventing an endpoint.
+- Endpoints verified against a live account: `GET /user`, `GET /sites`,
+  `GET /sites/{id}`, `GET /sites/{id}/deploys?branch=`.
 - Still unconfirmed: how a canceled or `ignore`-command build appears in the
   `state` enum. Needs a deliberately canceled build to observe.
 
 ## Cloudflare Pages — NOT VERIFIED
 
-No wrangler credentials on the verification machine, so nothing below was
-observed. Treat every field as unconfirmed until a token is available:
+An adapter exists and compiles, but **nothing below has been observed against a
+live account** — there are no Cloudflare credentials on the verification
+machine. The field names and stage values come from Cloudflare's API reference.
+Deserialisation is deliberately permissive so a wrong guess costs one line of
+copy rather than the whole lookup, but this provider should not be considered
+working until someone runs it with a real token.
+
+Specifically unconfirmed:
 
 - Deployment list is not filterable by commit; scan
   `deployment_trigger.metadata.commit_hash`.

--- a/docs/internal/hosting-provider-matrix.md
+++ b/docs/internal/hosting-provider-matrix.md
@@ -86,34 +86,32 @@ we write must classify 401 _and_ 403 as rejection, never as healthy.
 - Still unconfirmed: how a canceled or `ignore`-command build appears in the
   `state` enum. Needs a deliberately canceled build to observe.
 
-## Cloudflare Pages — NOT VERIFIED
+## Cloudflare Pages — verified
 
-An adapter exists and compiles, but **nothing below has been observed against a
-live account** — there are no Cloudflare credentials on the verification
-machine. The field names and stage values come from Cloudflare's API reference.
-Deserialisation is deliberately permissive so a wrong guess costs one line of
-copy rather than the whole lookup, but this provider should not be considered
-working until someone runs it with a real token.
+Verified against a live account and a real deployment. A disposable Pages
+project, `shipstudio-hosting-testbed`, was created and deployed to for this;
+it exists to be re-verified against and can be deleted whenever.
 
-**Verified since:** `wrangler login` was completed on this machine and the
-account and Pages endpoints were exercised for real.
-
-- `GET /accounts` returns the documented `{success, result}` envelope. Verified.
-- `GET /accounts/{id}/pages/projects` returns the same envelope. Verified —
-  though it returned **zero projects**, so the project shape is still unseen.
-- **The credential path in Cloudflare's own docs is wrong for macOS.** An
-  actual `wrangler login` wrote `~/Library/Preferences/.wrangler/config/default.toml`,
-  and the token inside expires about an hour later.
-
-Still unconfirmed, because the account has no Pages project to observe:
-
-- Deployment list is not filterable by commit; scan
-  `deployment_trigger.metadata.commit_hash`.
-- State is two-dimensional (`latest_stage.name` × `latest_stage.status`) and
-  needs its own reducer rather than an enum lookup.
-- `is_skipped` + `skip_reason` are documented as the cleanest skip signal of the
-  three providers.
-- Unconfirmed: whether `aliases[]` appears on the list item or only on the detail
-  call, and whether it includes attached custom domains.
-- Linking needs an `account_id`; Pages projects leave nothing on disk, so the
-  link must be a user pick and the account id persisted.
+- **`latest_stage` is authoritative; `stages` is not.** On a deployment that
+  had already succeeded, the `stages` array still reported
+  `("queued", "active")` alongside `("deploy", "success")`. Walking that array
+  would report a finished deployment as permanently queued. Only `latest_stage`
+  is read.
+- **`aliases` came back `null`, not an empty array**, and did not contain the
+  project's address. The site's address comes from the project's `domains` /
+  `subdomain`, which is a separate call.
+- **A direct upload reports `commit_hash: ""`** — an empty string, not null —
+  with `deployment_trigger.type: "ad_hoc"`. Both are checked, because an
+  empty-string match would pair an upload with any commit.
+- **Timestamps carry microseconds** (`2026-09-06T03:49:12.456043Z`).
+- **The build-log endpoint works and matches the documented shape**:
+  `/deployments/{id}/history/logs` returns `{ data: [{ ts, line }], total,
+  includes_container_logs }`. Cloudflare does not separate stdout from stderr.
+- **`url` already carries its scheme**, unlike Vercel's.
+- Endpoints verified: `GET /accounts`, `/accounts/{id}/pages/projects`,
+  `/accounts/{id}/pages/projects/{name}`, `.../deployments`, and
+  `.../deployments/{id}/history/logs`.
+- Still unobserved: a **failing** build, a **skipped** commit, and a
+  **git-triggered** deployment (the testbed deploys by direct upload). The
+  stage reducer and `skip_reason` handling are therefore still exercised only
+  against documented shapes.

--- a/docs/internal/hosting-provider-matrix.md
+++ b/docs/internal/hosting-provider-matrix.md
@@ -86,6 +86,29 @@ we write must classify 401 _and_ 403 as rejection, never as healthy.
 - Still unconfirmed: how a canceled or `ignore`-command build appears in the
   `state` enum. Needs a deliberately canceled build to observe.
 
+### Known limitation: neither list is paginated
+
+Netlify paginates with `page` / `per_page` and returns the first page when
+`page` is omitted. This adapter requests one page for both list calls and
+follows no `Link` header, which has two consequences worth stating rather than
+leaving to be discovered:
+
+- **`find_for_commit` scans one page of 100 deploys on the branch.** A commit
+  further back than that answers `NotFound`. The degradation is in the honest
+  direction — the UI shows "no deploy reported yet", never a failure and never
+  another commit's status — and the question is always about a commit the user
+  has just pushed, which sits at the top of the list. Vercel needs none of this
+  because it filters by `sha` server-side; Netlify has no such filter, so a
+  bounded scan is the shape of the thing.
+- **`list_projects` shows the first 100 sites.** An account with more than that
+  has sites the link picker cannot offer, and there is no in-app way around it.
+  This is the more user-visible of the two and the better candidate for the
+  first follow-up.
+
+Both are limitations, not defects: neither shows a wrong deployment, a wrong
+site, or a wrong status. Full pagination is a loop plus a stopping rule for each
+call, and is deliberately not in the change that introduced this adapter.
+
 ## Cloudflare Pages — verified
 
 Verified against a live account and a real deployment. A disposable Pages

--- a/docs/internal/hosting-provider-matrix.md
+++ b/docs/internal/hosting-provider-matrix.md
@@ -11,7 +11,7 @@ Last verified: 2026-09-05.
 | ---------- | -------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Vercel     | `~/Library/Application Support/com.vercel.cli/auth.json`         | **~7 hours** (`expiresAt` seconds, plus `refreshToken`) | **No** — short-lived OAuth access token. Refreshing it means implementing Vercel's OAuth flow against a file the docs say must not be edited manually. |
 | Netlify    | `~/Library/Preferences/netlify/config.json` → `users.<userId>.auth.token` | none present                                          | Opportunistically, yes                                                                                                                             |
-| Cloudflare | `~/.config/.wrangler/config/default.toml`                        | n/a                                                   | Absent unless the user has run wrangler; newer versions use the OS keyring                                                                          |
+| Cloudflare | `~/Library/Preferences/.wrangler/config/default.toml` on macOS — **not** the documented `~/.config/.wrangler` | **~1 hour** (`expiration_time`, ISO-8601, plus a `refresh_token`) | Opportunistically, but it lapses within the hour |
 
 **Consequence.** Credential resolution is a fallback chain, not a paste-wall:
 
@@ -95,7 +95,17 @@ Deserialisation is deliberately permissive so a wrong guess costs one line of
 copy rather than the whole lookup, but this provider should not be considered
 working until someone runs it with a real token.
 
-Specifically unconfirmed:
+**Verified since:** `wrangler login` was completed on this machine and the
+account and Pages endpoints were exercised for real.
+
+- `GET /accounts` returns the documented `{success, result}` envelope. Verified.
+- `GET /accounts/{id}/pages/projects` returns the same envelope. Verified —
+  though it returned **zero projects**, so the project shape is still unseen.
+- **The credential path in Cloudflare's own docs is wrong for macOS.** An
+  actual `wrangler login` wrote `~/Library/Preferences/.wrangler/config/default.toml`,
+  and the token inside expires about an hour later.
+
+Still unconfirmed, because the account has no Pages project to observe:
 
 - Deployment list is not filterable by commit; scan
   `deployment_trigger.metadata.commit_hash`.

--- a/scripts/check-patterns.sh
+++ b/scripts/check-patterns.sh
@@ -128,11 +128,16 @@ echo
 
 # 3d. The hosting section's fixed geometry. Its whole purpose is that the Push
 # popover stops resizing while deployment status loads, so nothing in that
-# stylesheet may change box metrics on hover or focus — the previous, plugin-
+# stylesheet may change *layout* on hover or focus — the previous, plugin-
 # rendered version grew ~105px under the user's cursor because the host revealed
-# hidden actions on :hover. Enforced here rather than in a unit test because
-# Vitest stubs CSS imports to an empty string, so a test asserting on stylesheet
-# text passes against nothing.
+# hidden actions on :hover.
+#
+# `opacity` and `visibility` are deliberately NOT banned: neither reflows, so
+# revealing a control in space that was already reserved for it is exactly the
+# right way to do a hover affordance. Only the properties that move things are
+# listed. Enforced here rather than in a unit test because Vitest stubs CSS
+# imports to an empty string, so a test asserting on stylesheet text passes
+# against nothing.
 echo "Checking hosting section geometry…"
 HOSTING_CSS=src/styles/features/publish/hosting.css
 if [ ! -f "$HOSTING_CSS" ]; then
@@ -141,7 +146,7 @@ else
   HOSTING_BODY=$(perl -0pe 's{/\*.*?\*/}{}gs' "$HOSTING_CSS")
   HOSTING_OFFENDERS=$(printf '%s' "$HOSTING_BODY" | awk '
     /:hover|:focus-within/ { inrule = 1 }
-    inrule && /(^|[ \t;{])(display|height|padding|margin|visibility)[ \t]*:/ { print; inrule = 0 }
+    inrule && /(^|[ \t;{])(display|height|width|padding|margin|gap|font-size)[ \t]*:/ { print; inrule = 0 }
     /}/ { inrule = 0 }
   ')
   HOSTING_MISSING=""

--- a/scripts/check-patterns.sh
+++ b/scripts/check-patterns.sh
@@ -126,6 +126,43 @@ else
 fi
 echo
 
+# 3d. The hosting section's fixed geometry. Its whole purpose is that the Push
+# popover stops resizing while deployment status loads, so nothing in that
+# stylesheet may change box metrics on hover or focus — the previous, plugin-
+# rendered version grew ~105px under the user's cursor because the host revealed
+# hidden actions on :hover. Enforced here rather than in a unit test because
+# Vitest stubs CSS imports to an empty string, so a test asserting on stylesheet
+# text passes against nothing.
+echo "Checking hosting section geometry…"
+HOSTING_CSS=src/styles/features/publish/hosting.css
+if [ ! -f "$HOSTING_CSS" ]; then
+  rule "hosting section fixed geometry" 0
+else
+  HOSTING_BODY=$(perl -0pe 's{/\*.*?\*/}{}gs' "$HOSTING_CSS")
+  HOSTING_OFFENDERS=$(printf '%s' "$HOSTING_BODY" | awk '
+    /:hover|:focus-within/ { inrule = 1 }
+    inrule && /(^|[ \t;{])(display|height|padding|margin|visibility)[ \t]*:/ { print; inrule = 0 }
+    /}/ { inrule = 0 }
+  ')
+  HOSTING_MISSING=""
+  printf '%s' "$HOSTING_BODY" | grep -qE 'height:[[:space:]]*var\(--hosting-row-h\)' ||
+    HOSTING_MISSING="$HOSTING_MISSING --hosting-row-h"
+  printf '%s' "$HOSTING_BODY" | grep -qE 'height:[[:space:]]*var\(--hosting-links-h\)' ||
+    HOSTING_MISSING="$HOSTING_MISSING --hosting-links-h"
+
+  if [ -n "$HOSTING_OFFENDERS" ] || [ -n "$HOSTING_MISSING" ]; then
+    [ -n "$HOSTING_OFFENDERS" ] && {
+      echo "  Rules that resize the hosting section on hover/focus:"
+      echo "$HOSTING_OFFENDERS" | sed 's/^/    /'
+    }
+    [ -n "$HOSTING_MISSING" ] && echo "  Row heights no longer token-driven:$HOSTING_MISSING"
+    rule "hosting section fixed geometry" 1
+  else
+    rule "hosting section fixed geometry" 0
+  fi
+fi
+echo
+
 # 4. New onToast?: prop interface introductions (the prop-drilling pattern we killed in Block 5.6)
 echo "Checking for new onToast?: prop interfaces…"
 TOAST_PROPS=$(grep -rn 'onToast?:' src/components/ 2>/dev/null || true)

--- a/scripts/token-layer-baseline.json
+++ b/scripts/token-layer-baseline.json
@@ -1096,6 +1096,12 @@
     },
     {
       "path": "src/styles/features/plugins.css",
+      "token": "--font-weight-medium",
+      "count": 1,
+      "reason": "Transitional primitive consumer; replace with an owner-appropriate semantic or component role."
+    },
+    {
+      "path": "src/styles/features/plugins.css",
       "token": "--transition",
       "count": 3,
       "reason": "Transitional migration-alias consumer; replace with the canonical semantic role."

--- a/scripts/token-layer-baseline.json
+++ b/scripts/token-layer-baseline.json
@@ -1239,6 +1239,24 @@
       "reason": "Transitional primitive consumer; replace with an owner-appropriate semantic or component role."
     },
     {
+      "path": "src/styles/features/publish/hosting.css",
+      "token": "--radius-full",
+      "count": 2,
+      "reason": "Transitional migration-alias consumer; replace with the canonical semantic role."
+    },
+    {
+      "path": "src/styles/features/publish/hosting.css",
+      "token": "--stroke-1",
+      "count": 1,
+      "reason": "Transitional primitive consumer; replace with an owner-appropriate semantic or component role."
+    },
+    {
+      "path": "src/styles/features/publish/hosting.css",
+      "token": "--stroke-2",
+      "count": 1,
+      "reason": "Transitional primitive consumer; replace with an owner-appropriate semantic or component role."
+    },
+    {
       "path": "src/styles/features/publish/rows.css",
       "token": "--stroke-1",
       "count": 1,

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -44,6 +44,8 @@ const KEYCHAIN_PREFIX: &str = "ship-studio-account-";
 const CRED_ENV_VARS: &[(&str, &str)] = &[
     ("anthropic_base_url", "ANTHROPIC_BASE_URL"),
     ("vercel_token", "VERCEL_TOKEN"),
+    ("cloudflare_api_token", "CLOUDFLARE_API_TOKEN"),
+    ("netlify_auth_token", "NETLIFY_AUTH_TOKEN"),
 ];
 
 /// All credential keys storable in the keychain (including git identity,
@@ -51,6 +53,8 @@ const CRED_ENV_VARS: &[(&str, &str)] = &[
 const ALL_CRED_KEYS: &[&str] = &[
     "anthropic_base_url",
     "vercel_token",
+    "cloudflare_api_token",
+    "netlify_auth_token",
     "git_name",
     "git_email",
 ];
@@ -1010,6 +1014,8 @@ pub async fn get_account_credential_status(
         vercel_username,
         has_anthropic_base_url: read_from_keychain(&id, "anthropic_base_url").is_some(),
         has_vercel_token: read_from_keychain(&id, "vercel_token").is_some(),
+        has_cloudflare_api_token: read_from_keychain(&id, "cloudflare_api_token").is_some(),
+        has_netlify_auth_token: read_from_keychain(&id, "netlify_auth_token").is_some(),
         has_git_name: read_from_keychain(&id, "git_name").is_some(),
         has_git_email: read_from_keychain(&id, "git_email").is_some(),
     })

--- a/src-tauri/src/commands/hosting/cloudflare.rs
+++ b/src-tauri/src/commands/hosting/cloudflare.rs
@@ -1,14 +1,15 @@
 //! Cloudflare Pages adapter.
 //!
-//! **Unverified.** Every other adapter in this module was checked against a
-//! live account; this one was written from Cloudflare's API reference with no
-//! credentials to observe a real response. The field names and stage values
-//! below are documented, not seen. `docs/internal/hosting-provider-matrix.md`
-//! lists exactly what remains unconfirmed, and the deserialisation is
-//! deliberately permissive so a wrong guess degrades one line of copy rather
-//! than failing the lookup.
+//! Verified against a live Pages project and deployment (see
+//! `docs/internal/hosting-provider-matrix.md`).
 //!
-//! Three things make Cloudflare different from the other two:
+//! Four things make Cloudflare different from the other two:
+//!
+//! * **`stages` cannot be trusted; `latest_stage` can.** On a finished
+//!   deployment the observed `stages` array still reported
+//!   `("queued", "active")` alongside `("deploy", "success")`, so walking it
+//!   would report a completed deployment as still queued. Only `latest_stage`
+//!   is read.
 //!
 //! * **Status is two-dimensional.** There is no flat state string: a
 //!   deployment has a `latest_stage` with a `name` (which phase) and a
@@ -70,10 +71,30 @@ struct RawDeployment {
     is_skipped: Option<bool>,
     #[serde(default)]
     skip_reason: Option<String>,
+    /// Captured but never read: on a finished deployment this array still
+    /// reported an earlier stage as `active`, so only `latest_stage` is
+    /// trustworthy. Kept so a test can pin that.
+    #[serde(default)]
+    stages: Vec<RawStage>,
     #[serde(default)]
     created_on: Option<String>,
     #[serde(default)]
     modified_on: Option<String>,
+}
+
+impl RawDeployment {
+    #[cfg(test)]
+    fn stages_for_test(&self) -> Vec<(String, String)> {
+        self.stages
+            .iter()
+            .map(|s| {
+                (
+                    s.name.clone().unwrap_or_default(),
+                    s.status.clone().unwrap_or_default(),
+                )
+            })
+            .collect()
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -86,6 +107,10 @@ struct RawStage {
 
 #[derive(Debug, Deserialize)]
 struct RawTrigger {
+    /// `github:push` for a git deployment, `ad_hoc` for a direct upload,
+    /// `deploy_hook` for a webhook.
+    #[serde(rename = "type", default)]
+    kind: Option<String>,
     #[serde(default)]
     metadata: Option<RawTriggerMeta>,
 }
@@ -172,6 +197,29 @@ fn humanize_skip_reason(reason: &str) -> String {
         "pages_to_workers_conversion" => "the project is being converted to Workers".into(),
         other => other.replace('_', " "),
     }
+}
+
+/// True when this deployment came from a commit rather than a direct upload.
+///
+/// An `ad_hoc` deployment reports `commit_hash: ""` — an empty string, not
+/// null — so it must be excluded explicitly rather than relying on a missing
+/// field. Matching one to a push would claim a link that does not exist.
+fn is_git_deployment(raw: &RawDeployment) -> bool {
+    let from_git = raw
+        .deployment_trigger
+        .as_ref()
+        .and_then(|t| t.kind.as_deref())
+        .map(|kind| kind.starts_with("github:") || kind.starts_with("gitlab:"))
+        .unwrap_or(false);
+
+    let has_commit = raw
+        .deployment_trigger
+        .as_ref()
+        .and_then(|t| t.metadata.as_ref())
+        .and_then(|m| m.commit_hash.as_deref())
+        .is_some_and(|hash| !hash.trim().is_empty());
+
+    from_git && has_commit
 }
 
 fn to_deployment(raw: RawDeployment) -> Deployment {
@@ -302,7 +350,11 @@ pub async fn find_for_commit(
         .await?
         .into_result()?;
 
-    let mut deployments: Vec<Deployment> = raw.into_iter().map(to_deployment).collect();
+    let mut deployments: Vec<Deployment> = raw
+        .into_iter()
+        .filter(is_git_deployment)
+        .map(to_deployment)
+        .collect();
     deployments.sort_by(|a, b| b.created_at.cmp(&a.created_at));
 
     let site = fetch_site_url(link, token).await.ok().flatten();
@@ -574,6 +626,83 @@ mod tests {
     #[test]
     fn an_unfamiliar_skip_reason_is_passed_through_rather_than_dropped() {
         assert_eq!(humanize_skip_reason("some_new_reason"), "some new reason");
+    }
+
+    /// Captured verbatim from a live Pages deployment.
+    fn live_fixture() -> &'static str {
+        r#"{
+            "id":"08d86c3f-ce0b-47c5-a9d4-25e7d1c79ee7",
+            "url":"https://08d86c3f.shipstudio-hosting-testbed.pages.dev",
+            "environment":"production",
+            "aliases":null,
+            "is_skipped":false,
+            "skip_reason":null,
+            "latest_stage":{"name":"deploy","started_on":null,
+                "ended_on":"2026-09-06T03:49:13.600985Z","status":"success"},
+            "stages":[
+                {"name":"queued","status":"active"},
+                {"name":"initialize","status":"idle"},
+                {"name":"clone_repo","status":"idle"},
+                {"name":"build","status":"idle"},
+                {"name":"deploy","status":"success"}
+            ],
+            "deployment_trigger":{"type":"ad_hoc","metadata":{
+                "branch":"main","commit_hash":"","commit_message":"","commit_dirty":true}},
+            "created_on":"2026-09-06T03:49:12.456043Z",
+            "modified_on":"2026-09-06T03:49:13.600985Z"
+        }"#
+    }
+
+    #[test]
+    fn a_live_deployment_parses_into_the_shared_shape() {
+        let raw: RawDeployment = serde_json::from_str(live_fixture()).unwrap();
+        let d = to_deployment(raw);
+
+        assert_eq!(d.phase, DeploymentPhase::Ready);
+        assert_eq!(d.status_label, "Success");
+        assert_eq!(d.environment, Environment::Production);
+        assert_eq!(
+            d.urls.deployment.as_deref(),
+            Some("https://08d86c3f.shipstudio-hosting-testbed.pages.dev")
+        );
+        // `aliases` came back null rather than an empty array.
+        assert!(d.urls.aliases.is_empty());
+        // Microsecond precision in the timestamps must not defeat the parser.
+        assert!(d.created_at > 1_700_000_000_000);
+    }
+
+    #[test]
+    fn only_latest_stage_is_read_because_stages_lies() {
+        // The live response reported ("queued", "active") in `stages` on a
+        // deployment that had already succeeded. Walking that array would
+        // report a finished deployment as still queued, forever.
+        let raw: RawDeployment = serde_json::from_str(live_fixture()).unwrap();
+        let stages = raw.stages_for_test();
+        assert!(
+            stages.contains(&("queued".to_string(), "active".to_string())),
+            "the fixture must keep the contradictory stage that motivates this"
+        );
+        assert_eq!(to_deployment(raw).phase, DeploymentPhase::Ready);
+    }
+
+    #[test]
+    fn a_direct_upload_is_never_matched_to_a_push() {
+        // An ad_hoc deployment reports `commit_hash: ""` — empty, not null —
+        // so an empty-string match would pair it with any commit.
+        let raw: RawDeployment = serde_json::from_str(live_fixture()).unwrap();
+        assert!(!is_git_deployment(&raw));
+    }
+
+    #[test]
+    fn a_git_deployment_with_a_real_commit_is_matched() {
+        let body = r#"{
+            "id":"dep_1","url":"https://x.pages.dev",
+            "latest_stage":{"name":"deploy","status":"success"},
+            "deployment_trigger":{"type":"github:push","metadata":{
+                "branch":"main","commit_hash":"222c59fd6d","commit_message":"Fix nav"}}
+        }"#;
+        let raw: RawDeployment = serde_json::from_str(body).unwrap();
+        assert!(is_git_deployment(&raw));
     }
 
     #[test]

--- a/src-tauri/src/commands/hosting/cloudflare.rs
+++ b/src-tauri/src/commands/hosting/cloudflare.rs
@@ -1,0 +1,639 @@
+//! Cloudflare Pages adapter.
+//!
+//! **Unverified.** Every other adapter in this module was checked against a
+//! live account; this one was written from Cloudflare's API reference with no
+//! credentials to observe a real response. The field names and stage values
+//! below are documented, not seen. `docs/internal/hosting-provider-matrix.md`
+//! lists exactly what remains unconfirmed, and the deserialisation is
+//! deliberately permissive so a wrong guess degrades one line of copy rather
+//! than failing the lookup.
+//!
+//! Three things make Cloudflare different from the other two:
+//!
+//! * **Status is two-dimensional.** There is no flat state string: a
+//!   deployment has a `latest_stage` with a `name` (which phase) and a
+//!   `status` (how that phase went), and they have to be read together.
+//! * **Nothing identifies a Pages project on disk.** Vercel writes
+//!   `.vercel/project.json` and Netlify `.netlify/state.json`; Cloudflare
+//!   writes nothing, so a link here can only ever come from the user picking
+//!   one.
+//! * **It has the cleanest skip signal of the three.** `is_skipped` plus a
+//!   `skip_reason` enum says plainly that a commit was deliberately not built —
+//!   which neither Vercel nor Netlify can fully express.
+
+use super::http::{get_json, HostingHttpError};
+use super::model::{
+    iso_to_ms, BuildLog, Deployment, DeploymentDetail, DeploymentPhase, DeploymentUrls,
+    Environment, HostingLink, HostingProjectChoice, Lookup,
+};
+use serde::Deserialize;
+
+const API: &str = "https://api.cloudflare.com/client/v4";
+
+/// Cloudflare wraps every response in a result envelope.
+#[derive(Debug, Deserialize)]
+struct Envelope<T> {
+    #[serde(default = "default_true")]
+    success: bool,
+    result: Option<T>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl<T> Envelope<T> {
+    fn into_result(self) -> Result<T, HostingHttpError> {
+        match (self.success, self.result) {
+            (true, Some(result)) => Ok(result),
+            _ => Err(HostingHttpError::Malformed {
+                message: "Cloudflare reported the request did not succeed".into(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RawDeployment {
+    id: String,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    environment: Option<String>,
+    #[serde(default)]
+    aliases: Option<Vec<String>>,
+    #[serde(default)]
+    latest_stage: Option<RawStage>,
+    #[serde(default)]
+    deployment_trigger: Option<RawTrigger>,
+    #[serde(default)]
+    is_skipped: Option<bool>,
+    #[serde(default)]
+    skip_reason: Option<String>,
+    #[serde(default)]
+    created_on: Option<String>,
+    #[serde(default)]
+    modified_on: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawStage {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawTrigger {
+    #[serde(default)]
+    metadata: Option<RawTriggerMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawTriggerMeta {
+    #[serde(default)]
+    commit_hash: Option<String>,
+    #[serde(default)]
+    commit_message: Option<String>,
+    #[serde(default)]
+    branch: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawProject {
+    name: String,
+    #[serde(default)]
+    subdomain: Option<String>,
+    #[serde(default)]
+    domains: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawAccount {
+    id: String,
+    #[serde(default)]
+    name: Option<String>,
+}
+
+/// Fold Cloudflare's `(stage name, stage status)` pair into one phase.
+///
+/// Order matters: a failure or cancellation in *any* stage decides the
+/// outcome, so status is checked before the stage name. Only once the run is
+/// still going does the stage name say how far it got.
+fn phase_from_stage(name: &str, status: &str) -> DeploymentPhase {
+    match status.to_ascii_lowercase().as_str() {
+        "failure" => return DeploymentPhase::Failed,
+        "canceled" | "cancelled" => return DeploymentPhase::Canceled,
+        _ => {}
+    }
+
+    match name.to_ascii_lowercase().as_str() {
+        "queued" => DeploymentPhase::Queued,
+        "initialize" | "clone_repo" | "build" => DeploymentPhase::Building,
+        "deploy" if status.eq_ignore_ascii_case("success") => DeploymentPhase::Ready,
+        "deploy" => DeploymentPhase::Publishing,
+        other => DeploymentPhase::Unknown {
+            raw: other.to_string(),
+        },
+    }
+}
+
+/// Cloudflare's own words for what is happening, joined as its dashboard reads:
+/// the stage that is current, and how it went.
+fn status_label(name: &str, status: &str) -> String {
+    let stage = match name.to_ascii_lowercase().as_str() {
+        "queued" => "Queued",
+        "initialize" => "Initializing",
+        "clone_repo" => "Cloning repository",
+        "build" => "Building",
+        "deploy" => "Deploying",
+        _ => return "Unknown".to_string(),
+    };
+
+    match status.to_ascii_lowercase().as_str() {
+        "success" if name.eq_ignore_ascii_case("deploy") => "Success".to_string(),
+        "failure" => "Failed".to_string(),
+        "canceled" | "cancelled" => "Canceled".to_string(),
+        _ => stage.to_string(),
+    }
+}
+
+/// Turn `skip_reason` into something a person would say. Cloudflare's values
+/// are snake_case tokens; the ones with an obvious meaning get a sentence and
+/// anything unrecognised is passed through rather than dropped.
+fn humanize_skip_reason(reason: &str) -> String {
+    match reason {
+        "commit_message" => "the commit message asked Cloudflare to skip it".into(),
+        "preview_deployments_disabled" => "preview deployments are turned off".into(),
+        "production_deployments_disabled" => "production deployments are turned off".into(),
+        "path_config" => "no files matched this project's path settings".into(),
+        "branch_config" => "this branch is excluded by the project's branch settings".into(),
+        "pages_to_workers_conversion" => "the project is being converted to Workers".into(),
+        other => other.replace('_', " "),
+    }
+}
+
+fn to_deployment(raw: RawDeployment) -> Deployment {
+    let stage = raw.latest_stage.as_ref();
+    let stage_name = stage.and_then(|s| s.name.as_deref()).unwrap_or("");
+    let stage_status = stage.and_then(|s| s.status.as_deref()).unwrap_or("");
+
+    let skipped = raw.is_skipped.unwrap_or(false);
+    let phase = if skipped {
+        DeploymentPhase::Skipped
+    } else {
+        phase_from_stage(stage_name, stage_status)
+    };
+
+    let detail = if skipped {
+        Some(DeploymentDetail::SkippedBecause {
+            reason: raw.skip_reason.as_deref().map(humanize_skip_reason),
+        })
+    } else {
+        None
+    };
+
+    let environment = match raw.environment.as_deref() {
+        Some("production") => Environment::Production,
+        _ => Environment::Preview,
+    };
+
+    let aliases = raw.aliases.clone().unwrap_or_default();
+    let deployment_url = raw.url.clone();
+    // `site` is filled in by the caller from the project's domains; a
+    // deployment record does not carry the project's address.
+    let primary = match environment {
+        Environment::Preview => deployment_url.clone(),
+        Environment::Production => aliases.first().cloned().or_else(|| deployment_url.clone()),
+    };
+
+    let meta = raw
+        .deployment_trigger
+        .as_ref()
+        .and_then(|t| t.metadata.as_ref());
+
+    Deployment {
+        id: raw.id,
+        status_label: status_label(stage_name, stage_status),
+        phase,
+        detail,
+        environment,
+        branch: meta.and_then(|m| m.branch.clone()),
+        commit_sha: meta.and_then(|m| m.commit_hash.clone()).unwrap_or_default(),
+        commit_message: meta
+            .and_then(|m| m.commit_message.clone())
+            .map(|m| m.trim().to_string())
+            .filter(|m| !m.is_empty()),
+        urls: DeploymentUrls {
+            site: None,
+            deployment: deployment_url,
+            aliases,
+            primary,
+        },
+        // Cloudflare's API returns no link to the dashboard, and assembling one
+        // from account and project ids would be inventing an address.
+        dashboard_url: None,
+        error_message: None,
+        created_at: iso_to_ms(raw.created_on.as_deref()).unwrap_or(0),
+        ready_at: iso_to_ms(raw.modified_on.as_deref()),
+    }
+}
+
+fn account_id(link: &HostingLink) -> Result<&str, HostingHttpError> {
+    link.scope_id
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| HostingHttpError::Malformed {
+            message: "This Cloudflare link is missing its account id — relink the project.".into(),
+        })
+}
+
+/// The project's address. Cloudflare returns a `subdomain` (the
+/// `*.pages.dev` one) and any custom `domains`; a custom one is what the owner
+/// would call the site.
+pub async fn fetch_site_url(
+    link: &HostingLink,
+    token: &str,
+) -> Result<Option<String>, HostingHttpError> {
+    let account = account_id(link)?;
+    let url = format!(
+        "{API}/accounts/{account}/pages/projects/{project}",
+        project = link.project_id,
+    );
+    let project: RawProject = get_json::<Envelope<RawProject>>(&url, token)
+        .await?
+        .into_result()?;
+
+    let custom = project
+        .domains
+        .unwrap_or_default()
+        .into_iter()
+        .find(|d| !d.ends_with(".pages.dev"));
+
+    Ok(custom
+        .or(project.subdomain)
+        .filter(|d| !d.is_empty())
+        .map(|d| {
+            if d.starts_with("http") {
+                d
+            } else {
+                format!("https://{d}")
+            }
+        }))
+}
+
+/// Find the deployment for an exact commit.
+///
+/// Cloudflare has no commit filter and no branch filter, so this lists a page
+/// of deployments and scans `deployment_trigger.metadata.commit_hash`.
+pub async fn find_for_commit(
+    link: &HostingLink,
+    token: &str,
+    sha: &str,
+    branch: &str,
+) -> Result<Lookup, HostingHttpError> {
+    let account = account_id(link)?;
+    let url = format!(
+        "{API}/accounts/{account}/pages/projects/{project}/deployments?per_page=25",
+        project = link.project_id,
+    );
+    let raw: Vec<RawDeployment> = get_json::<Envelope<Vec<RawDeployment>>>(&url, token)
+        .await?
+        .into_result()?;
+
+    let mut deployments: Vec<Deployment> = raw.into_iter().map(to_deployment).collect();
+    deployments.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+    let site = fetch_site_url(link, token).await.ok().flatten();
+
+    if let Some(mut found) = deployments.iter().find(|d| d.commit_sha == sha).cloned() {
+        found.urls.site = site.clone();
+        if found.environment == Environment::Production {
+            found.urls.primary = site.or(found.urls.deployment.clone());
+        }
+        return Ok(Lookup::Found { deployment: found });
+    }
+
+    let mut latest = deployments
+        .into_iter()
+        .find(|d| d.branch.as_deref() == Some(branch));
+    if let Some(deployment) = latest.as_mut() {
+        deployment.urls.site = site;
+    }
+
+    Ok(Lookup::NotFound {
+        latest_on_branch: latest.map(Box::new),
+    })
+}
+
+/// Recent deployments for the project, newest first.
+pub async fn list_recent(
+    link: &HostingLink,
+    token: &str,
+    limit: u32,
+) -> Result<Vec<Deployment>, HostingHttpError> {
+    let account = account_id(link)?;
+    let url = format!(
+        "{API}/accounts/{account}/pages/projects/{project}/deployments?per_page={limit}",
+        project = link.project_id,
+    );
+    let raw: Vec<RawDeployment> = get_json::<Envelope<Vec<RawDeployment>>>(&url, token)
+        .await?
+        .into_result()?;
+
+    let mut deployments: Vec<Deployment> = raw.into_iter().map(to_deployment).collect();
+    deployments.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    Ok(deployments)
+}
+
+/// A deployment's build output.
+///
+/// Cloudflare returns its log as a list of lines with timestamps; the shape of
+/// each entry is documented but unobserved, so a missing field degrades to an
+/// empty log rather than failing.
+#[derive(Debug, Deserialize)]
+struct RawLogs {
+    #[serde(default)]
+    data: Vec<RawLogLine>,
+    #[serde(default)]
+    total: Option<u64>,
+    #[serde(default)]
+    includes_container_logs: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawLogLine {
+    #[serde(default)]
+    ts: Option<String>,
+    #[serde(default)]
+    line: Option<String>,
+}
+
+pub async fn fetch_logs(
+    link: &HostingLink,
+    token: &str,
+    deployment_id: &str,
+) -> Result<BuildLog, HostingHttpError> {
+    use super::model::{LogLine, LogStream};
+
+    let account = account_id(link)?;
+    let url = format!(
+        "{API}/accounts/{account}/pages/projects/{project}/deployments/{deployment_id}/history/logs",
+        project = link.project_id,
+    );
+    let logs: RawLogs = get_json::<Envelope<RawLogs>>(&url, token)
+        .await?
+        .into_result()?;
+
+    let total = logs.total;
+    let lines: Vec<LogLine> = logs
+        .data
+        .into_iter()
+        .filter_map(|entry| {
+            let text = entry.line?;
+            let trimmed = text.trim_end();
+            if trimmed.is_empty() {
+                return None;
+            }
+            Some(LogLine {
+                at: iso_to_ms(entry.ts.as_deref()).unwrap_or(0),
+                // Cloudflare does not separate the streams, so everything is
+                // reported as stdout rather than guessing which lines are
+                // errors.
+                stream: LogStream::Stdout,
+                text: trimmed.to_string(),
+            })
+        })
+        .collect();
+
+    let truncated = total.map(|t| t as usize > lines.len()).unwrap_or(false);
+    let _ = logs.includes_container_logs;
+
+    Ok(BuildLog {
+        deployment_id: deployment_id.to_string(),
+        lines,
+        truncated,
+    })
+}
+
+/// Pages projects this token can see.
+///
+/// Needs an account id, which is why the token requires Account Settings:Read
+/// alongside Pages:Read — with only the latter this returns nothing and the
+/// picker looks broken.
+pub async fn list_projects(
+    token: &str,
+    scope_id: Option<&str>,
+) -> Result<Vec<HostingProjectChoice>, HostingHttpError> {
+    let accounts: Vec<RawAccount> = match scope_id.filter(|s| !s.is_empty()) {
+        Some(id) => vec![RawAccount {
+            id: id.to_string(),
+            name: None,
+        }],
+        None => get_json::<Envelope<Vec<RawAccount>>>(&format!("{API}/accounts"), token)
+            .await?
+            .into_result()?,
+    };
+
+    let mut choices = Vec::new();
+    for account in accounts {
+        let url = format!("{API}/accounts/{}/pages/projects", account.id);
+        let projects: Vec<RawProject> = get_json::<Envelope<Vec<RawProject>>>(&url, token)
+            .await?
+            .into_result()?;
+
+        for project in projects {
+            choices.push(HostingProjectChoice {
+                id: project.name.clone(),
+                name: project.name,
+                scope_id: Some(account.id.clone()),
+                scope_name: account.name.clone(),
+            });
+        }
+    }
+
+    Ok(choices)
+}
+
+/// Confirm a token works. Cloudflare's verify endpoint reports the token's own
+/// status rather than a user, so there is no name to show.
+pub async fn verify_token(token: &str) -> Result<Option<String>, HostingHttpError> {
+    #[derive(Debug, Deserialize)]
+    struct RawVerify {
+        #[serde(default)]
+        status: Option<String>,
+    }
+
+    let verify: RawVerify =
+        get_json::<Envelope<RawVerify>>(&format!("{API}/user/tokens/verify"), token)
+            .await?
+            .into_result()?;
+
+    match verify.status.as_deref() {
+        Some("active") | None => Ok(None),
+        Some(other) => Err(HostingHttpError::Malformed {
+            message: format!("Cloudflare reports this token is {other}"),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_failure_in_any_stage_decides_the_outcome() {
+        // The stage name says how far it got; the status says whether it is
+        // still going. Reading the name first would call a failed build
+        // "Building" forever.
+        assert_eq!(
+            phase_from_stage("build", "failure"),
+            DeploymentPhase::Failed
+        );
+        assert_eq!(
+            phase_from_stage("clone_repo", "failure"),
+            DeploymentPhase::Failed
+        );
+        assert_eq!(
+            phase_from_stage("deploy", "canceled"),
+            DeploymentPhase::Canceled
+        );
+    }
+
+    #[test]
+    fn the_stage_name_says_how_far_a_running_deployment_got() {
+        assert_eq!(
+            phase_from_stage("queued", "active"),
+            DeploymentPhase::Queued
+        );
+        assert_eq!(
+            phase_from_stage("initialize", "active"),
+            DeploymentPhase::Building
+        );
+        assert_eq!(
+            phase_from_stage("clone_repo", "active"),
+            DeploymentPhase::Building
+        );
+        assert_eq!(
+            phase_from_stage("build", "active"),
+            DeploymentPhase::Building
+        );
+        assert_eq!(
+            phase_from_stage("deploy", "active"),
+            DeploymentPhase::Publishing
+        );
+    }
+
+    #[test]
+    fn only_a_successful_deploy_stage_is_ready() {
+        assert_eq!(
+            phase_from_stage("deploy", "success"),
+            DeploymentPhase::Ready
+        );
+        // A successful *build* stage is not a finished deployment.
+        assert_eq!(
+            phase_from_stage("build", "success"),
+            DeploymentPhase::Building
+        );
+    }
+
+    #[test]
+    fn an_unrecognized_stage_is_surfaced_not_guessed() {
+        assert_eq!(
+            phase_from_stage("some_new_stage", "active"),
+            DeploymentPhase::Unknown {
+                raw: "some_new_stage".into()
+            }
+        );
+    }
+
+    #[test]
+    fn a_skipped_commit_says_why_in_plain_words() {
+        // Cloudflare has the clearest skip signal of the three providers, so
+        // it is worth spending words on.
+        let body = r#"{
+            "id":"dep_1","url":"https://abc.my-project.pages.dev",
+            "environment":"production","is_skipped":true,
+            "skip_reason":"branch_config",
+            "latest_stage":{"name":"queued","status":"idle"},
+            "created_on":"2026-02-22T17:26:51.942Z"
+        }"#;
+        let raw: RawDeployment = serde_json::from_str(body).unwrap();
+        let d = to_deployment(raw);
+
+        assert_eq!(d.phase, DeploymentPhase::Skipped);
+        assert_eq!(
+            d.detail,
+            Some(DeploymentDetail::SkippedBecause {
+                reason: Some("this branch is excluded by the project's branch settings".into())
+            })
+        );
+    }
+
+    #[test]
+    fn an_unfamiliar_skip_reason_is_passed_through_rather_than_dropped() {
+        assert_eq!(humanize_skip_reason("some_new_reason"), "some new reason");
+    }
+
+    #[test]
+    fn a_deployment_parses_with_its_commit_and_addresses() {
+        let body = r#"{
+            "id":"dep_1","url":"https://abc123.my-project.pages.dev",
+            "environment":"production",
+            "aliases":["https://my-project.pages.dev"],
+            "latest_stage":{"name":"deploy","status":"success"},
+            "deployment_trigger":{"metadata":{
+                "commit_hash":"222c59fd6dd081cf11dbf40a6779aeb9000be145",
+                "commit_message":"Update the nav",
+                "branch":"main"
+            }},
+            "created_on":"2026-02-22T17:26:51.942Z",
+            "modified_on":"2026-02-22T17:27:51.942Z"
+        }"#;
+        let raw: RawDeployment = serde_json::from_str(body).unwrap();
+        let d = to_deployment(raw);
+
+        assert_eq!(d.phase, DeploymentPhase::Ready);
+        assert_eq!(d.status_label, "Success");
+        assert_eq!(d.commit_sha, "222c59fd6dd081cf11dbf40a6779aeb9000be145");
+        assert_eq!(d.branch.as_deref(), Some("main"));
+        assert_eq!(d.commit_message.as_deref(), Some("Update the nav"));
+        assert_eq!(d.environment, Environment::Production);
+        // Cloudflare gives no dashboard link, and one must not be assembled.
+        assert_eq!(d.dashboard_url, None);
+    }
+
+    #[test]
+    fn a_deployment_with_no_trigger_metadata_still_parses() {
+        // A direct upload has no commit behind it.
+        let body = r#"{"id":"dep_2","latest_stage":{"name":"deploy","status":"success"}}"#;
+        let raw: RawDeployment = serde_json::from_str(body).unwrap();
+        let d = to_deployment(raw);
+
+        assert_eq!(d.commit_sha, "");
+        assert_eq!(d.branch, None);
+    }
+
+    #[test]
+    fn a_link_without_an_account_id_asks_to_be_relinked() {
+        // Cloudflare writes nothing to disk, so an account id can only come
+        // from the picker; without one every call would 404 confusingly.
+        let link = HostingLink {
+            provider: super::super::model::HostingProvider::Cloudflare,
+            project_id: "my-project".into(),
+            scope_id: None,
+            project_name: None,
+            source: super::super::model::LinkSource::UserPicked,
+            linked_at: 0,
+        };
+        assert!(account_id(&link).is_err());
+    }
+
+    #[test]
+    fn an_unsuccessful_envelope_is_not_read_as_data() {
+        let body = r#"{"success":false,"errors":[{"code":10000}],"result":null}"#;
+        let envelope: Envelope<Vec<RawDeployment>> = serde_json::from_str(body).unwrap();
+        assert!(envelope.into_result().is_err());
+    }
+}

--- a/src-tauri/src/commands/hosting/credentials.rs
+++ b/src-tauri/src/commands/hosting/credentials.rs
@@ -59,10 +59,7 @@ fn cli_token(provider: HostingProvider) -> Option<String> {
     match provider {
         HostingProvider::Vercel => vercel_cli_token(),
         HostingProvider::Netlify => netlify_cli_token(),
-        // Wrangler stores nothing until the user logs in, and recent versions
-        // keep it in the OS keyring rather than a readable file. There is no
-        // file to borrow, so Cloudflare always needs a real token.
-        HostingProvider::Cloudflare => None,
+        HostingProvider::Cloudflare => wrangler_cli_token(),
     }
 }
 
@@ -113,6 +110,82 @@ fn vercel_cli_token() -> Option<String> {
         return Some(token);
     }
     None
+}
+
+/// Where wrangler keeps its OAuth credentials.
+///
+/// **Not** `~/.config/.wrangler` on macOS, which is what the documentation's
+/// XDG-style description implies — an actual `wrangler login` on macOS wrote
+/// to `~/Library/Preferences/.wrangler/config/default.toml`. Both are tried,
+/// plus the Windows location.
+fn wrangler_config_paths() -> Vec<PathBuf> {
+    let Some(home) = home() else {
+        return Vec::new();
+    };
+    let mut paths = Vec::new();
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        paths.push(PathBuf::from(xdg).join(".wrangler/config/default.toml"));
+    }
+    paths.push(home.join("Library/Preferences/.wrangler/config/default.toml"));
+    paths.push(home.join(".config/.wrangler/config/default.toml"));
+    paths.push(home.join("AppData/Roaming/xdg.config/.wrangler/config/default.toml"));
+    paths
+}
+
+/// Read wrangler's OAuth token, honouring its expiry.
+///
+/// Short-lived like Vercel's: a token observed straight after `wrangler login`
+/// carried an `expiration_time` one hour out. It is borrowed for convenience
+/// and never depended on — an expired one is skipped so the UI asks for a real
+/// token rather than showing a rejection the user cannot explain.
+fn wrangler_cli_token() -> Option<String> {
+    for path in wrangler_config_paths() {
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Some(token) = toml_string(&raw, "oauth_token") else {
+            continue;
+        };
+        if let Some(expires) = toml_string(&raw, "expiration_time") {
+            if iso_is_past(&expires) {
+                tracing::debug!(
+                    "wrangler token at {} has expired; not using it",
+                    path.display()
+                );
+                continue;
+            }
+        }
+        return Some(token);
+    }
+    None
+}
+
+/// Pull one quoted value out of a flat TOML file.
+///
+/// Deliberately not a TOML parser: this reads exactly two keys from a file the
+/// app does not own, and a dependency for that would be a poor trade.
+fn toml_string(raw: &str, key: &str) -> Option<String> {
+    raw.lines()
+        .map(str::trim)
+        .filter(|line| !line.starts_with('#'))
+        .find_map(|line| {
+            let (name, value) = line.split_once('=')?;
+            if name.trim() != key {
+                return None;
+            }
+            let value = value.trim().trim_matches('"').trim();
+            (!value.is_empty()).then(|| value.to_string())
+        })
+}
+
+/// Whether an ISO-8601 instant is in the past.
+fn iso_is_past(value: &str) -> bool {
+    match super::model::iso_to_ms(Some(value)) {
+        Some(at) => at <= super::model::now_ms(),
+        // An unparseable expiry is treated as still valid: the provider will
+        // reject the token if it is not, and that path already explains itself.
+        None => false,
+    }
 }
 
 /// Documented locations of the Netlify CLI's `config.json`, per platform, plus
@@ -228,8 +301,48 @@ mod tests {
     }
 
     #[test]
-    fn cloudflare_never_borrows_a_cli_token() {
-        assert!(cli_token(HostingProvider::Cloudflare).is_none());
+    fn wrangler_credentials_are_read_from_the_path_it_actually_writes() {
+        // The documentation describes an XDG-style location; a real
+        // `wrangler login` on macOS wrote somewhere else entirely, so both are
+        // tried rather than trusting the docs.
+        let paths = wrangler_config_paths();
+        assert!(
+            paths
+                .iter()
+                .any(|p| p.ends_with("Library/Preferences/.wrangler/config/default.toml")),
+            "the macOS path wrangler actually uses must be tried"
+        );
+        assert!(
+            paths
+                .iter()
+                .any(|p| p.ends_with(".config/.wrangler/config/default.toml")),
+            "the documented path must still be tried"
+        );
+    }
+
+    #[test]
+    fn a_flat_toml_value_is_read_without_a_parser() {
+        let raw = concat!(
+            "oauth_token = \"abc123\"\n",
+            "expiration_time = \"2026-09-06T04:17:18.337Z\"\n",
+            "# oauth_token = \"commented-out\"\n",
+            "scopes = [ \"account:read\" ]\n"
+        );
+        assert_eq!(toml_string(raw, "oauth_token").as_deref(), Some("abc123"));
+        assert_eq!(
+            toml_string(raw, "expiration_time").as_deref(),
+            Some("2026-09-06T04:17:18.337Z")
+        );
+        assert_eq!(toml_string(raw, "missing"), None);
+    }
+
+    #[test]
+    fn an_expired_wrangler_token_is_skipped_not_offered() {
+        assert!(iso_is_past("2020-01-01T00:00:00.000Z"));
+        assert!(!iso_is_past("2099-01-01T00:00:00.000Z"));
+        // An expiry we cannot read is not treated as expired — the provider
+        // will reject it if it is, and that path already explains itself.
+        assert!(!iso_is_past("not a date"));
     }
 
     #[test]

--- a/src-tauri/src/commands/hosting/credentials.rs
+++ b/src-tauri/src/commands/hosting/credentials.rs
@@ -1,0 +1,242 @@
+//! Where a provider token comes from.
+//!
+//! Two sources, in priority order:
+//!
+//! 1. The keychain, via the existing per-workspace credential mechanism in
+//!    `commands::accounts`. Durable, user-controlled, and already injected into
+//!    that workspace's terminals so the provider CLI agrees with the app.
+//! 2. The provider CLI's own credential file, if one is present and still
+//!    valid. This is what makes hosting work with zero setup for someone who
+//!    has simply run `vercel login` — but it is borrowed, not ours.
+//!
+//! The distinction is not academic. The Vercel CLI's token is a short-lived
+//! OAuth access token: a real one observed on a developer machine expired
+//! roughly seven hours after issue, carrying a `refreshToken` we deliberately
+//! do not use (refreshing someone's OAuth session behind their back, against a
+//! file whose own header says it must not be edited, is not a contract we can
+//! keep). So a CLI-sourced token is best-effort: great while it lasts, and when
+//! it stops working the UI says so and offers a durable one, instead of
+//! rendering a healthy card over a dead login the way the plugin does today.
+
+use super::model::{HostingProvider, TokenSource};
+use std::path::{Path, PathBuf};
+
+/// A token plus where it came from, so a rejection can be explained honestly.
+pub struct ResolvedToken {
+    pub token: String,
+    pub source: TokenSource,
+}
+
+/// Resolve a token for this provider in this project's workspace.
+///
+/// Returns `None` when nothing is available, which the caller renders as an
+/// invitation to connect — never as an error.
+pub fn token_for(provider: HostingProvider, project_path: &Path) -> Option<ResolvedToken> {
+    if let Some(token) = keychain_token(provider, project_path) {
+        return Some(ResolvedToken {
+            token,
+            source: TokenSource::Keychain,
+        });
+    }
+    cli_token(provider).map(|token| ResolvedToken {
+        token,
+        source: TokenSource::CliFile,
+    })
+}
+
+/// The workspace-scoped token the user stored, surfaced as an env var by
+/// `accounts`. Reading it through the same path the terminals use means the app
+/// and the user's own CLI can never disagree about which account is active.
+fn keychain_token(provider: HostingProvider, project_path: &Path) -> Option<String> {
+    let vars = crate::commands::accounts::get_env_vars_for_project(project_path);
+    vars.get(provider.env_var())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Best-effort read of the provider CLI's credential file.
+fn cli_token(provider: HostingProvider) -> Option<String> {
+    match provider {
+        HostingProvider::Vercel => vercel_cli_token(),
+        HostingProvider::Netlify => netlify_cli_token(),
+        // Wrangler stores nothing until the user logs in, and recent versions
+        // keep it in the OS keyring rather than a readable file. There is no
+        // file to borrow, so Cloudflare always needs a real token.
+        HostingProvider::Cloudflare => None,
+    }
+}
+
+fn home() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+/// Documented locations of the Vercel CLI's `auth.json`, per platform.
+fn vercel_auth_paths() -> Vec<PathBuf> {
+    let Some(home) = home() else {
+        return Vec::new();
+    };
+    vec![
+        home.join("Library/Application Support/com.vercel.cli/auth.json"),
+        home.join(".local/share/com.vercel.cli/auth.json"),
+        home.join("AppData/Roaming/xdg.data/com.vercel.cli/auth.json"),
+    ]
+}
+
+/// Read the Vercel CLI token, honouring its expiry.
+///
+/// `expiresAt` is in **seconds**, not milliseconds — reading it as ms puts the
+/// expiry in 1970 and makes every token look long dead.
+fn vercel_cli_token() -> Option<String> {
+    for path in vercel_auth_paths() {
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            continue;
+        };
+        let token = json.get("token")?.as_str()?.trim().to_string();
+        if token.is_empty() {
+            continue;
+        }
+        if let Some(expires_at) = json.get("expiresAt").and_then(|v| v.as_u64()) {
+            let now_secs = super::model::now_ms() / 1000;
+            if expires_at <= now_secs {
+                tracing::debug!(
+                    "Vercel CLI token at {} has expired; not using it",
+                    path.display()
+                );
+                continue;
+            }
+        }
+        return Some(token);
+    }
+    None
+}
+
+/// Documented locations of the Netlify CLI's `config.json`, per platform, plus
+/// the legacy path older CLI versions used.
+fn netlify_config_paths() -> Vec<PathBuf> {
+    let Some(home) = home() else {
+        return Vec::new();
+    };
+    let mut paths = Vec::new();
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        paths.push(PathBuf::from(xdg).join("netlify/config.json"));
+    }
+    paths.push(home.join("Library/Preferences/netlify/config.json"));
+    paths.push(home.join(".config/netlify/config.json"));
+    paths.push(home.join("AppData/Roaming/netlify/Config/config.json"));
+    paths.push(home.join(".netlify/config.json"));
+    paths
+}
+
+/// Read the Netlify CLI token.
+///
+/// The file's internal shape is undocumented and has moved across CLI versions,
+/// so this reads defensively: the active user first, then any user entry that
+/// happens to carry a token. No expiry field is present on observed configs.
+fn netlify_cli_token() -> Option<String> {
+    for path in netlify_config_paths() {
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            continue;
+        };
+        if let Some(token) = netlify_token_from_config(&json) {
+            return Some(token);
+        }
+    }
+    None
+}
+
+/// Split out so the shape-tolerance is testable without touching a real home
+/// directory.
+fn netlify_token_from_config(json: &serde_json::Value) -> Option<String> {
+    let users = json.get("users")?.as_object()?;
+
+    let active = json.get("userId").and_then(|v| v.as_str());
+    if let Some(id) = active {
+        if let Some(token) = users
+            .get(id)
+            .and_then(|u| u.pointer("/auth/token"))
+            .and_then(|t| t.as_str())
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+        {
+            return Some(token.to_string());
+        }
+    }
+
+    users
+        .values()
+        .filter_map(|u| u.pointer("/auth/token"))
+        .filter_map(|t| t.as_str())
+        .map(str::trim)
+        .find(|t| !t.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn netlify_token_prefers_the_active_user() {
+        let config = json!({
+            "userId": "active",
+            "users": {
+                "active":  { "auth": { "token": "the-right-one" } },
+                "someone": { "auth": { "token": "the-wrong-one" } },
+            }
+        });
+        assert_eq!(
+            netlify_token_from_config(&config).as_deref(),
+            Some("the-right-one")
+        );
+    }
+
+    #[test]
+    fn netlify_token_falls_back_when_the_active_id_is_stale() {
+        // Observed in the wild after a CLI upgrade rewrote the file.
+        let config = json!({
+            "userId": "no-longer-present",
+            "users": { "someone": { "auth": { "token": "still-usable" } } }
+        });
+        assert_eq!(
+            netlify_token_from_config(&config).as_deref(),
+            Some("still-usable")
+        );
+    }
+
+    #[test]
+    fn netlify_token_absent_rather_than_panicking_on_odd_shapes() {
+        assert_eq!(netlify_token_from_config(&json!({})), None);
+        assert_eq!(netlify_token_from_config(&json!({ "users": {} })), None);
+        assert_eq!(
+            netlify_token_from_config(&json!({ "users": { "a": { "auth": {} } } })),
+            None
+        );
+        assert_eq!(
+            netlify_token_from_config(&json!({ "users": { "a": { "auth": { "token": "  " } } } })),
+            None
+        );
+        assert_eq!(netlify_token_from_config(&json!({ "users": 5 })), None);
+    }
+
+    #[test]
+    fn cloudflare_never_borrows_a_cli_token() {
+        assert!(cli_token(HostingProvider::Cloudflare).is_none());
+    }
+
+    #[test]
+    fn every_provider_offers_at_least_one_credential_path_when_home_is_set() {
+        if home().is_some() {
+            assert!(!vercel_auth_paths().is_empty());
+            assert!(!netlify_config_paths().is_empty());
+        }
+    }
+}

--- a/src-tauri/src/commands/hosting/git_ref.rs
+++ b/src-tauri/src/commands/hosting/git_ref.rs
@@ -1,0 +1,161 @@
+//! Resolving the commit a hosting provider could plausibly have deployed.
+//!
+//! The question the UI answers is "did my push go live?", so the subject is
+//! whatever the *remote* has — `origin/<branch>` — not local `HEAD`. A provider
+//! can only build what it was able to fetch, and showing a status against an
+//! unpushed local commit would be confidently wrong.
+
+use super::model::CommitRef;
+use crate::errors::CommandError;
+use crate::external_command::spawn_with_pressure_retry;
+use crate::utils::git_command_in;
+use std::path::Path;
+
+/// Run a git command in the project and return trimmed stdout, or `None` if it
+/// failed for any reason. Callers treat absence as "unknown", never as an error
+/// — a missing upstream is a normal state, not a fault.
+fn git_output(project: &Path, args: &[&str]) -> Option<String> {
+    let mut cmd = git_command_in(project).ok()?;
+    cmd.args(args);
+    let output =
+        spawn_with_pressure_retry(&format!("git {}", args.join(" ")), || cmd.output()).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+/// The current branch name, or `None` in detached HEAD — where "the branch I
+/// pushed" has no meaning and the UI should say nothing rather than guess.
+fn current_branch(project: &Path) -> Option<String> {
+    git_output(project, &["rev-parse", "--abbrev-ref", "HEAD"]).filter(|b| b != "HEAD")
+}
+
+/// Resolve the commit to ask providers about.
+///
+/// Prefers `origin/<branch>`. When there is no upstream the branch has never
+/// been pushed, so `has_upstream` is false and the UI explains that deployments
+/// appear after the first push rather than showing an empty status.
+pub fn pushed_commit(project: &Path) -> Result<CommitRef, CommandError> {
+    let branch = current_branch(project).ok_or_else(|| {
+        CommandError::expected("This project isn't on a branch, so there's nothing to check.")
+    })?;
+
+    let remote_ref = format!("origin/{branch}");
+    let (sha, has_upstream) = match git_output(project, &["rev-parse", &remote_ref]) {
+        Some(sha) => (sha, true),
+        None => (
+            git_output(project, &["rev-parse", "HEAD"])
+                .ok_or_else(|| CommandError::expected("This project has no commits yet."))?,
+            false,
+        ),
+    };
+
+    let short_sha = sha.chars().take(7).collect::<String>();
+
+    // One call for both fields; `%x00` keeps a subject containing newlines from
+    // being mistaken for the timestamp line.
+    let meta = git_output(project, &["log", "-1", "--format=%s%x00%ct", &sha]);
+    let (subject, committed_at) = match meta {
+        Some(raw) => {
+            let mut parts = raw.split('\0');
+            let subject = parts
+                .next()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+            let committed_at = parts
+                .next()
+                .and_then(|s| s.trim().parse::<u64>().ok())
+                .map(|secs| secs * 1000);
+            (subject, committed_at)
+        }
+        None => (None, None),
+    };
+
+    Ok(CommitRef {
+        sha,
+        short_sha,
+        subject,
+        committed_at,
+        branch,
+        has_upstream,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    /// Build a throwaway repo with one commit. Returns None when git isn't
+    /// usable in the test environment, so the suite degrades rather than fails.
+    fn repo_with_one_commit() -> Option<tempfile::TempDir> {
+        let dir = tempfile::tempdir().ok()?;
+        let path = dir.path();
+        let run = |args: &[&str]| -> bool {
+            Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        };
+        if !run(&["init", "-q"]) {
+            return None;
+        }
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "Test"]);
+        std::fs::write(path.join("file.txt"), b"hello").ok()?;
+        run(&["add", "."]);
+        if !run(&["commit", "-q", "-m", "Add the first thing"]) {
+            return None;
+        }
+        Some(dir)
+    }
+
+    #[test]
+    fn a_never_pushed_branch_reports_no_upstream_and_still_resolves_head() {
+        let Some(dir) = repo_with_one_commit() else {
+            return;
+        };
+        let commit = pushed_commit(dir.path()).expect("resolves against HEAD");
+
+        assert!(
+            !commit.has_upstream,
+            "a fresh repo has no origin, so nothing has been pushed"
+        );
+        assert_eq!(commit.sha.len(), 40);
+        assert_eq!(commit.short_sha.len(), 7);
+        assert!(commit.sha.starts_with(&commit.short_sha));
+        assert_eq!(commit.subject.as_deref(), Some("Add the first thing"));
+        assert!(commit.committed_at.unwrap_or(0) > 1_000_000_000_000);
+    }
+
+    #[test]
+    fn a_repo_with_no_commits_is_an_expected_state_not_a_crash() {
+        let Ok(dir) = tempfile::tempdir() else {
+            return;
+        };
+        let ok = Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(dir.path())
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !ok {
+            return;
+        }
+
+        let err = pushed_commit(dir.path()).unwrap_err();
+        assert!(
+            matches!(err, CommandError::Expected { .. }),
+            "an empty repo is a normal state and must not be reported to telemetry"
+        );
+    }
+}

--- a/src-tauri/src/commands/hosting/http.rs
+++ b/src-tauri/src/commands/hosting/http.rs
@@ -1,0 +1,215 @@
+//! Shared HTTP plumbing for the hosting adapters.
+//!
+//! One client, one error taxonomy. The adapters call providers directly over
+//! HTTPS rather than scraping a CLI's human-formatted table — the current
+//! plugin's entire commit history is a record of that approach breaking.
+
+use crate::errors::CommandError;
+use std::sync::LazyLock;
+use std::time::Duration;
+
+/// Total budget for one provider call. The frontend polls on a few-second
+/// cadence, so a request that outlives that is already useless; failing fast
+/// keeps a wedged provider from stalling the poll chain.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub static CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .connect_timeout(CONNECT_TIMEOUT)
+        .user_agent(concat!("ShipStudio/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+});
+
+/// How a provider call failed, separated by who can do something about it.
+#[derive(Debug, Clone)]
+pub enum HostingHttpError {
+    /// The provider refused our credential. Both 401 and 403 land here: Vercel
+    /// answers an *expired* token with `403 {"invalidToken":true}`, and
+    /// treating that as anything but rejection is exactly the defect that makes
+    /// the current plugin render a healthy card for a dead login.
+    Rejected,
+    /// Asked to slow down, with the provider's own retry hint when it gave one.
+    RateLimited { retry_after_secs: Option<u64> },
+    /// Network, DNS, TLS, timeout, or a provider 5xx. Not the user's fault and
+    /// not ours — shown as "couldn't reach", kept out of telemetry.
+    Transport { message: String },
+    /// The call succeeded but the body wasn't what we expect. This one *is*
+    /// ours: either the provider changed shape or our adapter is wrong, and we
+    /// want to hear about it.
+    Malformed { message: String },
+}
+
+impl HostingHttpError {
+    /// Convert to the app's error type for the rare command that surfaces the
+    /// failure directly rather than folding it into a `ProviderStatus`.
+    pub fn into_command_error(self, provider: &str) -> CommandError {
+        match self {
+            HostingHttpError::Rejected => CommandError::NotAuthenticated {
+                service: provider.to_string(),
+            },
+            HostingHttpError::RateLimited { retry_after_secs } => {
+                let wait = retry_after_secs
+                    .map(|s| format!(" Try again in about {s}s."))
+                    .unwrap_or_default();
+                CommandError::expected(format!("{provider} is rate limiting requests.{wait}"))
+            }
+            HostingHttpError::Transport { message } => {
+                CommandError::expected(format!("Couldn't reach {provider}: {message}"))
+            }
+            HostingHttpError::Malformed { message } => CommandError::Other {
+                message: format!("Unexpected response from {provider}: {message}"),
+            },
+        }
+    }
+}
+
+/// Render a reqwest error with its full source chain — `Display` alone only
+/// prints "error sending request for url (...)" while the actionable cause
+/// (DNS, connection refused, TLS, timeout) lives in `source()`.
+pub fn describe_reqwest_error(e: &reqwest::Error) -> String {
+    let mut msg = e.to_string();
+    let mut source = std::error::Error::source(e);
+    while let Some(s) = source {
+        msg.push_str(&format!(": {s}"));
+        source = s.source();
+    }
+    msg
+}
+
+/// Parse a `Retry-After` header. Only the delta-seconds form is handled; the
+/// HTTP-date form is rare on these APIs and a missing hint just means the
+/// caller falls back to its own backoff.
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+    headers
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse::<u64>()
+        .ok()
+}
+
+/// GET a provider endpoint with a bearer token and decode the JSON body.
+///
+/// Status is classified before the body is touched, so a provider that returns
+/// an error document with a 200-shaped body can't be mistaken for success and
+/// an auth failure can't be mistaken for "no data".
+pub async fn get_json<T: serde::de::DeserializeOwned>(
+    url: &str,
+    token: &str,
+) -> Result<T, HostingHttpError> {
+    let response = CLIENT
+        .get(url)
+        .bearer_auth(token)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .send()
+        .await
+        .map_err(|e| HostingHttpError::Transport {
+            message: describe_reqwest_error(&e),
+        })?;
+
+    let status = response.status();
+
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(HostingHttpError::Rejected);
+    }
+
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        return Err(HostingHttpError::RateLimited {
+            retry_after_secs: parse_retry_after(response.headers()),
+        });
+    }
+
+    if status.is_server_error() {
+        return Err(HostingHttpError::Transport {
+            message: format!(
+                "{provider_status} from the provider",
+                provider_status = status
+            ),
+        });
+    }
+
+    if !status.is_success() {
+        // A 404 on a deployments endpoint means the project id we hold is
+        // wrong or the project was deleted — a real, reportable mismatch
+        // rather than a transient blip.
+        let body = response.text().await.unwrap_or_default();
+        let snippet: String = body.chars().take(200).collect();
+        return Err(HostingHttpError::Malformed {
+            message: format!("HTTP {status}: {snippet}"),
+        });
+    }
+
+    let body = response
+        .text()
+        .await
+        .map_err(|e| HostingHttpError::Transport {
+            message: describe_reqwest_error(&e),
+        })?;
+
+    serde_json::from_str::<T>(&body).map_err(|e| {
+        let snippet: String = body.chars().take(200).collect();
+        HostingHttpError::Malformed {
+            message: format!("{e} (body started: {snippet})"),
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header::{HeaderMap, HeaderValue, RETRY_AFTER};
+
+    #[test]
+    fn retry_after_reads_delta_seconds() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("30"));
+        assert_eq!(parse_retry_after(&headers), Some(30));
+    }
+
+    #[test]
+    fn retry_after_tolerates_a_missing_or_unparseable_header() {
+        assert_eq!(parse_retry_after(&HeaderMap::new()), None);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            RETRY_AFTER,
+            HeaderValue::from_static("Wed, 21 Oct 2026 07:28:00 GMT"),
+        );
+        assert_eq!(parse_retry_after(&headers), None);
+    }
+
+    #[test]
+    fn rejection_maps_to_not_authenticated_not_a_generic_failure() {
+        let err = HostingHttpError::Rejected.into_command_error("Vercel");
+        assert!(matches!(err, CommandError::NotAuthenticated { .. }));
+    }
+
+    #[test]
+    fn transport_and_rate_limit_stay_out_of_telemetry() {
+        // `Expected` is the variant that error_reporting skips.
+        let transport = HostingHttpError::Transport {
+            message: "dns error".into(),
+        }
+        .into_command_error("Netlify");
+        assert!(matches!(transport, CommandError::Expected { .. }));
+
+        let limited = HostingHttpError::RateLimited {
+            retry_after_secs: Some(30),
+        }
+        .into_command_error("Netlify");
+        assert!(matches!(limited, CommandError::Expected { .. }));
+    }
+
+    #[test]
+    fn a_malformed_body_is_reportable_because_it_means_we_are_wrong() {
+        let err = HostingHttpError::Malformed {
+            message: "expected sequence".into(),
+        }
+        .into_command_error("Cloudflare");
+        assert!(matches!(err, CommandError::Other { .. }));
+    }
+}

--- a/src-tauri/src/commands/hosting/link.rs
+++ b/src-tauri/src/commands/hosting/link.rs
@@ -78,10 +78,14 @@ pub fn read_metadata(project: &Path) -> HostingMetadata {
 /// Persist the hosting block, leaving every other field of the metadata file
 /// untouched.
 pub fn write_metadata(project: &Path, hosting: HostingMetadata) -> Result<(), CommandError> {
-    let mut metadata = crate::commands::projects::read_project_metadata_sync(project)
-        .ok()
-        .flatten()
-        .unwrap_or_default();
+    // The read error propagates rather than being swallowed. `.ok().flatten()`
+    // turned "this file is corrupt or unreadable" into "there is no metadata",
+    // and the save below then wrote a *default* file over it — so connecting a
+    // host to a project whose metadata had been damaged would silently discard
+    // its pins, dev-server config and session state. `None` here still means
+    // genuinely absent, which is the only case that may safely default.
+    let mut metadata =
+        crate::commands::projects::read_project_metadata_sync(project)?.unwrap_or_default();
     metadata.hosting = Some(hosting);
     crate::commands::projects::save_project_metadata(project, &metadata)
 }

--- a/src-tauri/src/commands/hosting/link.rs
+++ b/src-tauri/src/commands/hosting/link.rs
@@ -1,0 +1,226 @@
+//! Which provider project a repo deploys to, and where that fact lives.
+//!
+//! Two sources:
+//!
+//! * The provider CLI's own link file, when there is one. Reading `.vercel/`
+//!   and `.netlify/` rather than keeping a private copy means the app and the
+//!   user's CLI can never drift apart — link with the CLI and the app follows.
+//! * Our own `.shipstudio/project.json`, for links the user picked in the app.
+//!   Cloudflare Pages leaves nothing on disk, so that is the only record of a
+//!   Cloudflare link.
+
+use super::model::{DetectedLink, HostingLink, HostingMetadata, HostingProvider, LinkSource};
+use crate::errors::CommandError;
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+struct VercelProjectJson {
+    #[serde(rename = "projectId")]
+    project_id: Option<String>,
+    #[serde(rename = "orgId")]
+    org_id: Option<String>,
+    #[serde(rename = "projectName")]
+    project_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NetlifyStateJson {
+    #[serde(rename = "siteId")]
+    site_id: Option<String>,
+}
+
+/// Links discoverable from files the provider CLIs wrote. Cheap, offline, and
+/// the reason a project someone linked with `vercel link` needs no setup here.
+pub fn detect_local_links(project: &Path) -> Vec<DetectedLink> {
+    let mut found = Vec::new();
+
+    if let Ok(raw) = std::fs::read_to_string(project.join(".vercel/project.json")) {
+        if let Ok(parsed) = serde_json::from_str::<VercelProjectJson>(&raw) {
+            if let Some(project_id) = parsed.project_id.filter(|s| !s.is_empty()) {
+                found.push(DetectedLink {
+                    provider: HostingProvider::Vercel,
+                    project_id,
+                    scope_id: parsed.org_id.filter(|s| !s.is_empty()),
+                    project_name: parsed.project_name.filter(|s| !s.is_empty()),
+                    source: LinkSource::VercelCliFile,
+                });
+            }
+        }
+    }
+
+    if let Ok(raw) = std::fs::read_to_string(project.join(".netlify/state.json")) {
+        if let Ok(parsed) = serde_json::from_str::<NetlifyStateJson>(&raw) {
+            if let Some(site_id) = parsed.site_id.filter(|s| !s.is_empty()) {
+                found.push(DetectedLink {
+                    provider: HostingProvider::Netlify,
+                    project_id: site_id,
+                    scope_id: None,
+                    project_name: None,
+                    source: LinkSource::NetlifyCliFile,
+                });
+            }
+        }
+    }
+
+    found
+}
+
+/// Read the hosting block we persist.
+pub fn read_metadata(project: &Path) -> HostingMetadata {
+    crate::commands::projects::read_project_metadata_sync(project)
+        .ok()
+        .flatten()
+        .and_then(|m| m.hosting)
+        .unwrap_or_default()
+}
+
+/// Persist the hosting block, leaving every other field of the metadata file
+/// untouched.
+pub fn write_metadata(project: &Path, hosting: HostingMetadata) -> Result<(), CommandError> {
+    let mut metadata = crate::commands::projects::read_project_metadata_sync(project)
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    metadata.hosting = Some(hosting);
+    crate::commands::projects::save_project_metadata(project, &metadata)
+}
+
+/// The links to actually query: everything the user has confirmed, plus any
+/// CLI-file link for a provider they haven't explicitly linked.
+///
+/// The CLI file wins on content for a provider it covers, because it is what
+/// the provider itself will act on — a stale saved id would otherwise keep
+/// reporting a project the repo no longer deploys to.
+pub fn effective_links(project: &Path) -> Vec<HostingLink> {
+    let saved = read_metadata(project).links;
+    let detected = detect_local_links(project);
+
+    let mut links: Vec<HostingLink> = Vec::new();
+
+    for link in &saved {
+        match detected.iter().find(|d| d.provider == link.provider) {
+            // The CLI relinked this project elsewhere; follow it.
+            Some(d) if d.project_id != link.project_id => links.push(HostingLink {
+                provider: d.provider,
+                project_id: d.project_id.clone(),
+                scope_id: d.scope_id.clone(),
+                project_name: d.project_name.clone(),
+                source: d.source,
+                linked_at: link.linked_at,
+            }),
+            _ => links.push(link.clone()),
+        }
+    }
+
+    for d in detected {
+        if !links.iter().any(|l| l.provider == d.provider) {
+            links.push(HostingLink {
+                provider: d.provider,
+                project_id: d.project_id,
+                scope_id: d.scope_id,
+                project_name: d.project_name,
+                source: d.source,
+                linked_at: 0,
+            });
+        }
+    }
+
+    links
+}
+
+/// Links found on disk that aren't saved yet, so the UI can offer one-click
+/// setup instead of a picker.
+pub fn unconfirmed_links(project: &Path) -> Vec<DetectedLink> {
+    let saved = read_metadata(project).links;
+    detect_local_links(project)
+        .into_iter()
+        .filter(|d| !saved.iter().any(|l| l.provider == d.provider))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, rel: &str, contents: &str) {
+        let path = dir.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn reads_a_vercel_cli_link() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            ".vercel/project.json",
+            r#"{"projectId":"prj_1","orgId":"team_1","projectName":"acme"}"#,
+        );
+
+        let found = detect_local_links(dir.path());
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].provider, HostingProvider::Vercel);
+        assert_eq!(found[0].project_id, "prj_1");
+        assert_eq!(found[0].scope_id.as_deref(), Some("team_1"));
+        assert_eq!(found[0].source, LinkSource::VercelCliFile);
+    }
+
+    #[test]
+    fn reads_a_netlify_cli_link() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            ".netlify/state.json",
+            r#"{"siteId":"2077e54f-aa34-4517-9fdf-36c2391e08ca"}"#,
+        );
+
+        let found = detect_local_links(dir.path());
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].provider, HostingProvider::Netlify);
+        assert_eq!(found[0].project_id, "2077e54f-aa34-4517-9fdf-36c2391e08ca");
+    }
+
+    #[test]
+    fn a_missing_or_corrupt_link_file_yields_nothing_rather_than_failing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(detect_local_links(dir.path()).is_empty());
+
+        write(dir.path(), ".vercel/project.json", "not json at all");
+        assert!(detect_local_links(dir.path()).is_empty());
+
+        write(dir.path(), ".vercel/project.json", r#"{"orgId":"team_1"}"#);
+        assert!(
+            detect_local_links(dir.path()).is_empty(),
+            "a link with no project id is not a link"
+        );
+
+        write(dir.path(), ".vercel/project.json", r#"{"projectId":""}"#);
+        assert!(detect_local_links(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn detects_both_providers_independently() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            ".vercel/project.json",
+            r#"{"projectId":"prj_1"}"#,
+        );
+        write(dir.path(), ".netlify/state.json", r#"{"siteId":"site_1"}"#);
+
+        let found = detect_local_links(dir.path());
+        assert_eq!(found.len(), 2);
+    }
+
+    #[test]
+    fn cloudflare_is_never_detected_from_disk() {
+        // Pages projects leave no local marker, which is why they must be
+        // picked explicitly. Nothing here should ever invent one.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "wrangler.toml", "name = \"my-pages-project\"\n");
+        assert!(detect_local_links(dir.path())
+            .iter()
+            .all(|l| l.provider != HostingProvider::Cloudflare));
+    }
+}

--- a/src-tauri/src/commands/hosting/mod.rs
+++ b/src-tauri/src/commands/hosting/mod.rs
@@ -1,0 +1,464 @@
+//! # Hosting
+//!
+//! Answers one question for the workspace: **did the commit I just pushed
+//! actually deploy, and can I open it?**
+//!
+//! That framing is the whole design. The previous implementation reported the
+//! *most recent deployment on the project* — any branch, any environment, any
+//! teammate — which is a different question with a frequently different answer.
+//! Everything here is keyed to a specific commit SHA, and when a provider has
+//! nothing for that SHA we say so rather than showing someone else's build.
+//!
+//! Structure:
+//!
+//! * [`model`] — the provider-agnostic vocabulary the frontend renders.
+//! * [`provider`] — the adapter boundary; one exhaustive match per operation.
+//! * `vercel` / (cloudflare, netlify to follow) — per-provider adapters.
+//! * [`http`] — one client, one error taxonomy.
+//! * [`credentials`] — keychain first, CLI credential file as a fallback.
+//! * [`link`] — which provider project this repo deploys to.
+//! * [`git_ref`] — the commit the provider could actually have seen.
+//!
+//! Verified provider behaviour is recorded in
+//! `docs/internal/hosting-provider-matrix.md`; anything unverified is marked
+//! there and must not become load-bearing until it is checked.
+
+pub mod credentials;
+pub mod git_ref;
+pub mod http;
+pub mod link;
+pub mod model;
+pub mod provider;
+pub mod vercel;
+
+use crate::errors::CommandError;
+use crate::utils::validate_project_path;
+use model::{
+    now_ms, Auth, DeploymentSnapshot, DetectedLink, HostingLink, HostingProjectChoice,
+    HostingProvider, HostingStatus, Lookup, ProviderStatus, TokenCheck,
+};
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
+/// How long a status is reused before we ask the provider again.
+///
+/// Short, because the frontend polls on roughly this cadence while a build is
+/// running and two open windows on the same project should share one call
+/// rather than doubling the request rate.
+const ACTIVE_TTL: Duration = Duration::from_secs(3);
+/// A finished deployment does not change. Re-asking is pure waste, so a
+/// terminal phase is held far longer.
+const TERMINAL_TTL: Duration = Duration::from_secs(600);
+
+struct CacheEntry {
+    status: ProviderStatus,
+    expires_at: Instant,
+}
+
+/// Keyed by project, provider, and commit — so a new push is never served a
+/// previous commit's answer.
+static STATUS_CACHE: LazyLock<Mutex<HashMap<(String, HostingProvider, String), CacheEntry>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn cached(key: &(String, HostingProvider, String)) -> Option<ProviderStatus> {
+    let cache = STATUS_CACHE.lock().ok()?;
+    let entry = cache.get(key)?;
+    if Instant::now() >= entry.expires_at {
+        return None;
+    }
+    let mut status = entry.status.clone();
+    status.from_cache = true;
+    Some(status)
+}
+
+fn cache(key: (String, HostingProvider, String), status: &ProviderStatus) {
+    let ttl = match &status.lookup {
+        Some(Lookup::Found { deployment }) if deployment.phase.is_terminal() => TERMINAL_TTL,
+        _ => ACTIVE_TTL,
+    };
+    if let Ok(mut c) = STATUS_CACHE.lock() {
+        c.insert(
+            key,
+            CacheEntry {
+                status: status.clone(),
+                expires_at: Instant::now() + ttl,
+            },
+        );
+    }
+}
+
+/// Drop every cached answer for a project — used when a link or credential
+/// changes and the previous answers can no longer be trusted.
+fn invalidate_project(project_path: &str) {
+    if let Ok(mut c) = STATUS_CACHE.lock() {
+        c.retain(|(path, _, _), _| path != project_path);
+    }
+}
+
+/// Ask one provider about one commit.
+async fn status_for_link(
+    project: &std::path::Path,
+    link: &HostingLink,
+    sha: &str,
+    branch: &str,
+) -> ProviderStatus {
+    let base = ProviderStatus {
+        link: link.clone(),
+        auth: Auth::Ok,
+        token_source: None,
+        lookup: None,
+        transport_error: None,
+        retry_after_secs: None,
+        fetched_at: now_ms(),
+        from_cache: false,
+    };
+
+    let Some(resolved) = credentials::token_for(link.provider, project) else {
+        return ProviderStatus {
+            auth: Auth::NoToken,
+            ..base
+        };
+    };
+
+    match provider::find_for_commit(link, &resolved.token, sha, branch).await {
+        Ok(lookup) => ProviderStatus {
+            token_source: Some(resolved.source),
+            lookup: Some(lookup),
+            ..base
+        },
+        Err(http::HostingHttpError::Rejected) => {
+            // Never rendered as healthy. An expired Vercel CLI login answers
+            // 403, and calling that "connected" is the defect this replaces.
+            tracing::warn!(
+                provider = link.provider.label(),
+                source = ?resolved.source,
+                "Hosting provider rejected the credential"
+            );
+            ProviderStatus {
+                auth: Auth::Rejected,
+                token_source: Some(resolved.source),
+                ..base
+            }
+        }
+        Err(http::HostingHttpError::RateLimited { retry_after_secs }) => ProviderStatus {
+            token_source: Some(resolved.source),
+            transport_error: Some(format!(
+                "{} is rate limiting requests.",
+                link.provider.label()
+            )),
+            retry_after_secs,
+            ..base
+        },
+        Err(http::HostingHttpError::Transport { message }) => ProviderStatus {
+            token_source: Some(resolved.source),
+            transport_error: Some(message),
+            ..base
+        },
+        Err(http::HostingHttpError::Malformed { message }) => {
+            // Ours to fix: either the provider changed shape or the adapter is
+            // wrong. Logged loudly, shown to the user as "couldn't read".
+            tracing::error!(
+                provider = link.provider.label(),
+                error = %message,
+                "Unexpected response shape from hosting provider"
+            );
+            ProviderStatus {
+                token_source: Some(resolved.source),
+                transport_error: Some(format!(
+                    "Couldn't read {}'s response.",
+                    link.provider.label()
+                )),
+                ..base
+            }
+        }
+    }
+}
+
+/// The state of every provider this project deploys to, for the commit that was
+/// actually pushed.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn get_hosting_status(project_path: String) -> Result<HostingStatus, CommandError> {
+    let project = validate_project_path(&project_path)?;
+    let commit = git_ref::pushed_commit(&project)?;
+    let links = link::effective_links(&project);
+
+    let mut providers = Vec::with_capacity(links.len());
+    for link in links {
+        let key = (project_path.clone(), link.provider, commit.sha.clone());
+
+        if let Some(hit) = cached(&key) {
+            providers.push(hit);
+            continue;
+        }
+
+        let status = status_for_link(&project, &link, &commit.sha, &commit.branch).await;
+        cache(key, &status);
+        providers.push(status);
+    }
+
+    // Remember the newest terminal answer so the next open paints instantly and
+    // an offline session can say what it last knew, with its age.
+    if let Some((link, deployment)) = providers.iter().find_map(|p| match &p.lookup {
+        Some(Lookup::Found { deployment }) => Some((&p.link, deployment)),
+        _ => None,
+    }) {
+        let mut meta = link::read_metadata(&project);
+        meta.last = Some(DeploymentSnapshot {
+            provider: link.provider,
+            sha: commit.sha.clone(),
+            phase: deployment.phase.clone(),
+            primary_url: deployment.urls.primary.clone(),
+            fetched_at: now_ms(),
+        });
+        let _ = link::write_metadata(&project, meta);
+    }
+
+    Ok(HostingStatus {
+        commit,
+        providers,
+        detected: link::unconfirmed_links(&project),
+    })
+}
+
+/// Links discoverable from provider CLI files. Local only — no network, so this
+/// is safe to call on project open.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn detect_hosting_links(project_path: String) -> Result<Vec<DetectedLink>, CommandError> {
+    let project = validate_project_path(&project_path)?;
+    Ok(link::detect_local_links(&project))
+}
+
+/// Projects the user could link this repo to.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn list_hosting_projects(
+    project_path: String,
+    provider: HostingProvider,
+    scope_id: Option<String>,
+) -> Result<Vec<HostingProjectChoice>, CommandError> {
+    let project = validate_project_path(&project_path)?;
+    let resolved = credentials::token_for(provider, &project).ok_or_else(|| {
+        CommandError::NotAuthenticated {
+            service: provider.label().to_string(),
+        }
+    })?;
+
+    provider::list_projects(provider, &resolved.token, scope_id.as_deref())
+        .await
+        .map_err(|e| e.into_command_error(provider.label()))
+}
+
+/// Record which provider project this repo deploys to.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn set_hosting_link(project_path: String, link: HostingLink) -> Result<(), CommandError> {
+    let project = validate_project_path(&project_path)?;
+    let mut meta = link::read_metadata(&project);
+    meta.links.retain(|l| l.provider != link.provider);
+    meta.links.push(HostingLink {
+        linked_at: now_ms(),
+        ..link
+    });
+    // The snapshot describes a deployment on the project we just stopped
+    // pointing at.
+    meta.last = None;
+    link::write_metadata(&project, meta)?;
+    invalidate_project(&project_path);
+    Ok(())
+}
+
+/// Forget a provider link.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn clear_hosting_link(
+    project_path: String,
+    provider: HostingProvider,
+) -> Result<(), CommandError> {
+    let project = validate_project_path(&project_path)?;
+    let mut meta = link::read_metadata(&project);
+    meta.links.retain(|l| l.provider != provider);
+    if meta.last.as_ref().is_some_and(|s| s.provider == provider) {
+        meta.last = None;
+    }
+    link::write_metadata(&project, meta)?;
+    invalidate_project(&project_path);
+    Ok(())
+}
+
+/// Check a stored credential without asking about any deployment.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn verify_hosting_token(
+    project_path: String,
+    provider: HostingProvider,
+) -> Result<TokenCheck, CommandError> {
+    let project = validate_project_path(&project_path)?;
+
+    let Some(resolved) = credentials::token_for(provider, &project) else {
+        return Ok(TokenCheck {
+            auth: Auth::NoToken,
+            token_source: None,
+            account_label: None,
+        });
+    };
+
+    match provider::verify_token(provider, &resolved.token).await {
+        Ok(account_label) => Ok(TokenCheck {
+            auth: Auth::Ok,
+            token_source: Some(resolved.source),
+            account_label,
+        }),
+        Err(http::HostingHttpError::Rejected) => Ok(TokenCheck {
+            auth: Auth::Rejected,
+            token_source: Some(resolved.source),
+            account_label: None,
+        }),
+        Err(e) => Err(e.into_command_error(provider.label())),
+    }
+}
+
+/// Drop cached hosting answers for a project. Called when a credential changes,
+/// since a new token can produce a different answer for the same commit.
+pub fn invalidate_hosting_cache(project_path: &str) {
+    invalidate_project(project_path);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use model::{Deployment, DeploymentPhase, DeploymentUrls, Environment, LinkSource};
+
+    fn link_for(provider: HostingProvider) -> HostingLink {
+        HostingLink {
+            provider,
+            project_id: "prj_1".into(),
+            scope_id: None,
+            project_name: None,
+            source: LinkSource::UserPicked,
+            linked_at: 0,
+        }
+    }
+
+    fn status_with(phase: DeploymentPhase) -> ProviderStatus {
+        ProviderStatus {
+            link: link_for(HostingProvider::Vercel),
+            auth: Auth::Ok,
+            token_source: None,
+            lookup: Some(Lookup::Found {
+                deployment: Deployment {
+                    id: "dpl_1".into(),
+                    phase,
+                    detail: None,
+                    environment: Environment::Production,
+                    branch: Some("main".into()),
+                    commit_sha: "abc".into(),
+                    commit_message: None,
+                    urls: DeploymentUrls::default(),
+                    dashboard_url: None,
+                    error_message: None,
+                    created_at: 0,
+                    ready_at: None,
+                },
+            }),
+            transport_error: None,
+            retry_after_secs: None,
+            fetched_at: 0,
+            from_cache: false,
+        }
+    }
+
+    #[test]
+    fn a_cache_hit_is_labelled_so_the_ui_can_be_honest_about_freshness() {
+        let key = (
+            "/p/fresh".to_string(),
+            HostingProvider::Vercel,
+            "abc".to_string(),
+        );
+        cache(key.clone(), &status_with(DeploymentPhase::Ready));
+
+        let hit = cached(&key).expect("still within TTL");
+        assert!(hit.from_cache);
+        invalidate_project("/p/fresh");
+    }
+
+    #[test]
+    fn a_different_commit_never_reads_the_previous_commits_answer() {
+        // The whole point of the rewrite: the status is per-commit.
+        let old = (
+            "/p/commits".to_string(),
+            HostingProvider::Vercel,
+            "old-sha".to_string(),
+        );
+        cache(old, &status_with(DeploymentPhase::Ready));
+
+        let new = (
+            "/p/commits".to_string(),
+            HostingProvider::Vercel,
+            "new-sha".to_string(),
+        );
+        assert!(
+            cached(&new).is_none(),
+            "a new push must not inherit the previous commit's status"
+        );
+        invalidate_project("/p/commits");
+    }
+
+    #[test]
+    fn an_in_flight_build_is_cached_only_briefly() {
+        let key = (
+            "/p/ttl".to_string(),
+            HostingProvider::Vercel,
+            "abc".to_string(),
+        );
+        cache(key.clone(), &status_with(DeploymentPhase::Building));
+
+        let expires = {
+            let c = STATUS_CACHE.lock().unwrap();
+            c.get(&key).unwrap().expires_at
+        };
+        assert!(expires <= Instant::now() + ACTIVE_TTL);
+        invalidate_project("/p/ttl");
+    }
+
+    #[test]
+    fn a_finished_deployment_is_cached_for_much_longer() {
+        let key = (
+            "/p/done".to_string(),
+            HostingProvider::Vercel,
+            "abc".to_string(),
+        );
+        cache(key.clone(), &status_with(DeploymentPhase::Ready));
+
+        let expires = {
+            let c = STATUS_CACHE.lock().unwrap();
+            c.get(&key).unwrap().expires_at
+        };
+        assert!(expires > Instant::now() + ACTIVE_TTL);
+        invalidate_project("/p/done");
+    }
+
+    #[test]
+    fn invalidating_one_project_leaves_others_alone() {
+        let a = (
+            "/p/a".to_string(),
+            HostingProvider::Vercel,
+            "abc".to_string(),
+        );
+        let b = (
+            "/p/b".to_string(),
+            HostingProvider::Vercel,
+            "abc".to_string(),
+        );
+        cache(a.clone(), &status_with(DeploymentPhase::Ready));
+        cache(b.clone(), &status_with(DeploymentPhase::Ready));
+
+        invalidate_project("/p/a");
+
+        assert!(cached(&a).is_none());
+        assert!(cached(&b).is_some());
+        invalidate_project("/p/b");
+    }
+}

--- a/src-tauri/src/commands/hosting/mod.rs
+++ b/src-tauri/src/commands/hosting/mod.rs
@@ -23,11 +23,13 @@
 //! `docs/internal/hosting-provider-matrix.md`; anything unverified is marked
 //! there and must not become load-bearing until it is checked.
 
+pub mod cloudflare;
 pub mod credentials;
 pub mod git_ref;
 pub mod http;
 pub mod link;
 pub mod model;
+pub mod netlify;
 pub mod provider;
 pub mod vercel;
 

--- a/src-tauri/src/commands/hosting/mod.rs
+++ b/src-tauri/src/commands/hosting/mod.rs
@@ -34,8 +34,8 @@ pub mod vercel;
 use crate::errors::CommandError;
 use crate::utils::validate_project_path;
 use model::{
-    now_ms, Auth, DeploymentSnapshot, DetectedLink, HostingLink, HostingProjectChoice,
-    HostingProvider, HostingStatus, Lookup, ProviderStatus, TokenCheck,
+    now_ms, Auth, BuildLog, Deployment, DeploymentSnapshot, DetectedLink, HostingLink,
+    HostingProjectChoice, HostingProvider, HostingStatus, Lookup, ProviderStatus, TokenCheck,
 };
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
@@ -286,6 +286,73 @@ pub async fn clear_hosting_link(
     link::write_metadata(&project, meta)?;
     invalidate_project(&project_path);
     Ok(())
+}
+
+/// The recent deployment history for a project, newest first.
+///
+/// The same data the provider's dashboard leads with, so a user can see the
+/// shape of the last few pushes without leaving the app.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn list_recent_deployments(
+    project_path: String,
+    provider: HostingProvider,
+    limit: Option<u32>,
+) -> Result<Vec<Deployment>, CommandError> {
+    let project = validate_project_path(&project_path)?;
+    let link = link::effective_links(&project)
+        .into_iter()
+        .find(|l| l.provider == provider)
+        .ok_or_else(|| {
+            CommandError::expected(format!(
+                "This project isn't linked to {}.",
+                provider.label()
+            ))
+        })?;
+
+    let resolved = credentials::token_for(provider, &project).ok_or_else(|| {
+        CommandError::NotAuthenticated {
+            service: provider.label().to_string(),
+        }
+    })?;
+
+    provider::list_recent(&link, &resolved.token, limit.unwrap_or(10))
+        .await
+        .map_err(|e| e.into_command_error(provider.label()))
+}
+
+/// A deployment's build output.
+///
+/// This is the call that makes the provider's dashboard unnecessary for the
+/// case people actually go there for: the deployments API reports that a build
+/// failed, and only the log says why.
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn get_deployment_log(
+    project_path: String,
+    provider: HostingProvider,
+    deployment_id: String,
+) -> Result<BuildLog, CommandError> {
+    let project = validate_project_path(&project_path)?;
+    let link = link::effective_links(&project)
+        .into_iter()
+        .find(|l| l.provider == provider)
+        .ok_or_else(|| {
+            CommandError::expected(format!(
+                "This project isn't linked to {}.",
+                provider.label()
+            ))
+        })?;
+
+    let resolved = credentials::token_for(provider, &project).ok_or_else(|| {
+        CommandError::NotAuthenticated {
+            service: provider.label().to_string(),
+        }
+    })?;
+
+    provider::fetch_logs(&link, &resolved.token, &deployment_id)
+        .await
+        .map_err(|e| e.into_command_error(provider.label()))
 }
 
 /// Check a stored credential without asking about any deployment.

--- a/src-tauri/src/commands/hosting/mod.rs
+++ b/src-tauri/src/commands/hosting/mod.rs
@@ -417,6 +417,7 @@ mod tests {
             lookup: Some(Lookup::Found {
                 deployment: Deployment {
                     id: "dpl_1".into(),
+                    status_label: "Ready".into(),
                     phase,
                     detail: None,
                     environment: Environment::Production,

--- a/src-tauri/src/commands/hosting/model.rs
+++ b/src-tauri/src/commands/hosting/model.rs
@@ -1,0 +1,430 @@
+//! Provider-agnostic hosting types.
+//!
+//! Every provider's raw response is reduced to these shapes by its adapter, so
+//! the frontend renders one vocabulary regardless of who is hosting. Pure data
+//! and pure functions only — no I/O, so the reducers stay unit-testable against
+//! recorded fixtures.
+//!
+//! The TS mirror is `src/lib/hosting.ts`; changing a shape here means changing
+//! it there.
+
+use serde::{Deserialize, Serialize};
+
+/// A hosting provider we can talk to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HostingProvider {
+    Vercel,
+    Cloudflare,
+    Netlify,
+}
+
+impl HostingProvider {
+    /// Display name, used verbatim in user-facing copy.
+    pub fn label(self) -> &'static str {
+        match self {
+            HostingProvider::Vercel => "Vercel",
+            HostingProvider::Cloudflare => "Cloudflare",
+            HostingProvider::Netlify => "Netlify",
+        }
+    }
+
+    /// The keychain credential key (see `accounts::CRED_ENV_VARS`).
+    pub fn credential_key(self) -> &'static str {
+        match self {
+            HostingProvider::Vercel => "vercel_token",
+            HostingProvider::Cloudflare => "cloudflare_api_token",
+            HostingProvider::Netlify => "netlify_auth_token",
+        }
+    }
+
+    /// The environment variable the token is injected as.
+    pub fn env_var(self) -> &'static str {
+        match self {
+            HostingProvider::Vercel => "VERCEL_TOKEN",
+            HostingProvider::Cloudflare => "CLOUDFLARE_API_TOKEN",
+            HostingProvider::Netlify => "NETLIFY_AUTH_TOKEN",
+        }
+    }
+}
+
+/// How we learned about a link, which decides whether it can be trusted
+/// without asking the user to confirm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LinkSource {
+    /// Read from `.vercel/project.json`, written by the Vercel CLI.
+    VercelCliFile,
+    /// Read from `.netlify/state.json`, written by the Netlify CLI.
+    NetlifyCliFile,
+    /// The user picked it in the link picker. Cloudflare Pages leaves nothing
+    /// on disk, so this is the only way that provider is ever linked.
+    UserPicked,
+}
+
+/// Which project on which provider this repo deploys to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostingLink {
+    pub provider: HostingProvider,
+    /// Vercel: `projectId` · Cloudflare: Pages project name · Netlify: site id.
+    pub project_id: String,
+    /// Vercel: `teamId` · Cloudflare: `account_id` · Netlify: unused.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope_id: Option<String>,
+    /// Saved at link time for display; never used to build a request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_name: Option<String>,
+    pub source: LinkSource,
+    pub linked_at: u64,
+}
+
+/// A link we found on disk but that the user has not confirmed yet.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DetectedLink {
+    pub provider: HostingProvider,
+    pub project_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_name: Option<String>,
+    pub source: LinkSource,
+}
+
+/// The commit whose deployment we are asking about — always what the remote
+/// has, never local `HEAD`, because a provider can only have deployed what it
+/// could actually fetch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitRef {
+    pub sha: String,
+    pub short_sha: String,
+    /// `git log -1 --format=%s`. Available instantly and offline, so it is the
+    /// primary source for "what was deployed" — the provider's own commit
+    /// message is only a fallback (Netlify's is frequently null).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+    /// Commit timestamp in ms. Used as the floor for the not-found grace
+    /// period so an old, never-deployed commit doesn't sit on a spinner.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub committed_at: Option<u64>,
+    pub branch: String,
+    /// False when the branch has no upstream — nothing has been pushed, so no
+    /// deployment can exist and the UI says so rather than looking broken.
+    pub has_upstream: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Environment {
+    Production,
+    Preview,
+}
+
+/// The unified lifecycle. Every provider's native states reduce into exactly
+/// one of these.
+///
+/// `Unknown` exists because the alternative is worse: mapping an unrecognized
+/// provider status onto `Ready` or `Failed` would state something we do not
+/// know, which the project's "never assume data" rule forbids. Providers add
+/// states without warning; this degrades honestly instead.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "phase", rename_all = "snake_case")]
+pub enum DeploymentPhase {
+    Queued,
+    Building,
+    Publishing,
+    Ready,
+    Failed,
+    Canceled,
+    Skipped,
+    Gated,
+    Unknown { raw: String },
+}
+
+impl DeploymentPhase {
+    /// Terminal phases stop the fast poll. `Gated` is terminal for us even
+    /// though the provider may still move: it is waiting on a human, not on a
+    /// build, so polling it every few seconds buys nothing.
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            DeploymentPhase::Ready
+                | DeploymentPhase::Failed
+                | DeploymentPhase::Canceled
+                | DeploymentPhase::Skipped
+                | DeploymentPhase::Gated
+                | DeploymentPhase::Unknown { .. }
+        )
+    }
+}
+
+/// A qualifier on a phase, already de-jargoned by the adapter so the frontend
+/// never sees a provider enum. Kept as a closed set rather than free text
+/// because copy is chosen from it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "detail", rename_all = "snake_case")]
+pub enum DeploymentDetail {
+    /// Built and available, but not yet serving production traffic
+    /// (Vercel `readySubstate: STAGED`).
+    NotYetPromoted,
+    /// Being handed production traffic (Vercel `readySubstate: ROLLING`).
+    RollingOut,
+    /// The provider deliberately did not build this commit. `reason` is the
+    /// provider's own explanation where it gives one — Cloudflare's
+    /// `skip_reason`, Netlify's `skipped_log`; Vercel supplies nothing.
+    SkippedBecause { reason: Option<String> },
+    /// Netlify's author-trust gate: waiting for a human to approve the build.
+    AwaitingReview { reason: Option<String> },
+    /// Netlify's author-trust gate: a human declined the build.
+    ReviewRejected,
+    /// Superseded by a newer push before it finished.
+    SupersededByNewer,
+}
+
+/// URLs for a deployment. Every value here is copied verbatim from a provider
+/// response — nothing in this struct is ever assembled from parts. Building a
+/// URL from a naming pattern is how the current plugins produce links that
+/// 404, and the adapters have a test asserting each string appears in the raw
+/// response body.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DeploymentUrls {
+    /// This specific deployment's immutable URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deployment: Option<String>,
+    /// Every alias the provider reported for it.
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    /// The one to open when the user clicks through, chosen by the adapter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary: Option<String>,
+}
+
+/// One deployment, reduced to the fields the UI can honestly display.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Deployment {
+    pub id: String,
+    pub phase: DeploymentPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<DeploymentDetail>,
+    pub environment: Environment,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    /// The commit this deployment was built from, as the provider reported it.
+    pub commit_sha: String,
+    /// The provider's own commit message. Frequently absent (Netlify returned
+    /// null on a real production deploy), so the UI prefers `CommitRef.subject`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_message: Option<String>,
+    pub urls: DeploymentUrls,
+    /// Link to the provider's own page for this deployment. `None` for
+    /// Cloudflare, whose API returns nothing usable — and we do not invent one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dashboard_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    pub created_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ready_at: Option<u64>,
+}
+
+/// The result of asking "what happened to this commit?".
+///
+/// `NotFound` is deliberately not an error and never becomes `Failed`. No
+/// provider documents how long it takes for a pushed commit to appear in their
+/// API, so absence can only ever mean "we don't see it", never "it failed to
+/// trigger". The frontend decides when to stop showing hope, using the push
+/// time it alone knows.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Lookup {
+    Found {
+        deployment: Deployment,
+    },
+    NotFound {
+        /// Offered as context ("latest on this branch"), never presented as the
+        /// status of the commit the user asked about.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        latest_on_branch: Option<Box<Deployment>>,
+    },
+}
+
+/// Whether we can talk to the provider at all.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Auth {
+    Ok,
+    /// No credential available from the keychain or a CLI file.
+    NoToken,
+    /// The provider refused the credential we had. Vercel answers an expired
+    /// token with 403, not 401, so both are classified here — treating a 403 as
+    /// anything other than rejection is precisely the bug that makes the
+    /// current plugin show a healthy card for a dead token.
+    Rejected,
+}
+
+/// Where the credential came from, so the UI can explain a rejection that the
+/// user never opted into ("the Vercel CLI's login expired").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TokenSource {
+    /// A durable token the user stored in the keychain.
+    Keychain,
+    /// Borrowed from the provider CLI's own credential file. Free, but the
+    /// provider controls its lifetime — Vercel's lasts hours.
+    CliFile,
+}
+
+/// Everything known about one linked provider for one commit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderStatus {
+    pub link: HostingLink,
+    pub auth: Auth,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_source: Option<TokenSource>,
+    /// `None` whenever `auth` is not `Ok`, or the request never completed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lookup: Option<Lookup>,
+    /// Set when the call failed for reasons that are not the user's fault —
+    /// offline, DNS, 5xx. Carries the cause so the UI can say what went wrong
+    /// rather than silently showing nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport_error: Option<String>,
+    /// Seconds to wait before retrying, from a rate-limit response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_after_secs: Option<u64>,
+    pub fetched_at: u64,
+    pub from_cache: bool,
+}
+
+/// The whole answer to "did my push deploy?", for every provider this project
+/// is linked to.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HostingStatus {
+    pub commit: CommitRef,
+    /// One per persisted link. Empty means the project isn't linked to
+    /// anything, which the UI renders as an invitation rather than an error.
+    pub providers: Vec<ProviderStatus>,
+    /// Links found on disk that aren't persisted yet, so the UI can offer
+    /// one-click setup instead of a picker.
+    #[serde(default)]
+    pub detected: Vec<DetectedLink>,
+}
+
+/// A project the user could link to, for the picker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HostingProjectChoice {
+    pub id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope_name: Option<String>,
+}
+
+/// Enough of the last known state to paint instantly on open and to be honest
+/// about staleness when the network is gone.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeploymentSnapshot {
+    pub provider: HostingProvider,
+    pub sha: String,
+    pub phase: DeploymentPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_url: Option<String>,
+    pub fetched_at: u64,
+}
+
+/// What we persist in `.shipstudio/project.json`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HostingMetadata {
+    #[serde(default)]
+    pub links: Vec<HostingLink>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last: Option<DeploymentSnapshot>,
+}
+
+/// Result of checking a credential without asking about any deployment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenCheck {
+    pub auth: Auth,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_source: Option<TokenSource>,
+    /// The account name the provider says the token belongs to, so the user can
+    /// notice they connected the wrong one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_label: Option<String>,
+}
+
+/// Milliseconds since the Unix epoch.
+pub fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_phases_stop_the_fast_poll() {
+        assert!(DeploymentPhase::Ready.is_terminal());
+        assert!(DeploymentPhase::Failed.is_terminal());
+        assert!(DeploymentPhase::Canceled.is_terminal());
+        assert!(DeploymentPhase::Skipped.is_terminal());
+        assert!(DeploymentPhase::Gated.is_terminal());
+        assert!(DeploymentPhase::Unknown { raw: "WAT".into() }.is_terminal());
+
+        assert!(!DeploymentPhase::Queued.is_terminal());
+        assert!(!DeploymentPhase::Building.is_terminal());
+        assert!(!DeploymentPhase::Publishing.is_terminal());
+    }
+
+    #[test]
+    fn phase_serializes_with_a_tag_the_frontend_can_switch_on() {
+        let json = serde_json::to_string(&DeploymentPhase::Building).unwrap();
+        assert_eq!(json, r#"{"phase":"building"}"#);
+
+        let json = serde_json::to_string(&DeploymentPhase::Unknown {
+            raw: "SOMETHING_NEW".into(),
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"phase":"unknown","raw":"SOMETHING_NEW"}"#);
+    }
+
+    #[test]
+    fn provider_credential_wiring_matches_the_documented_env_vars() {
+        assert_eq!(HostingProvider::Vercel.env_var(), "VERCEL_TOKEN");
+        assert_eq!(
+            HostingProvider::Cloudflare.env_var(),
+            "CLOUDFLARE_API_TOKEN"
+        );
+        assert_eq!(HostingProvider::Netlify.env_var(), "NETLIFY_AUTH_TOKEN");
+
+        assert_eq!(HostingProvider::Vercel.credential_key(), "vercel_token");
+        assert_eq!(
+            HostingProvider::Cloudflare.credential_key(),
+            "cloudflare_api_token"
+        );
+        assert_eq!(
+            HostingProvider::Netlify.credential_key(),
+            "netlify_auth_token"
+        );
+    }
+
+    #[test]
+    fn provider_round_trips_as_a_lowercase_string() {
+        let json = serde_json::to_string(&HostingProvider::Cloudflare).unwrap();
+        assert_eq!(json, r#""cloudflare""#);
+        let back: HostingProvider = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, HostingProvider::Cloudflare);
+    }
+
+    #[test]
+    fn not_found_carries_branch_context_without_claiming_it_is_the_answer() {
+        let lookup = Lookup::NotFound {
+            latest_on_branch: None,
+        };
+        let json = serde_json::to_string(&lookup).unwrap();
+        assert_eq!(json, r#"{"kind":"not_found"}"#);
+    }
+}

--- a/src-tauri/src/commands/hosting/model.rs
+++ b/src-tauri/src/commands/hosting/model.rs
@@ -226,6 +226,61 @@ pub struct Deployment {
     pub ready_at: Option<u64>,
 }
 
+/// Which stream a build-log line came from. `stderr` is not the same as "an
+/// error" — build tools warn on it constantly — but it is where the failure
+/// usually is when there was one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogStream {
+    Stdout,
+    Stderr,
+}
+
+/// One line of a provider's build output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogLine {
+    pub at: u64,
+    pub stream: LogStream,
+    pub text: String,
+}
+
+/// A deployment's build output, as far as the provider will give it to us.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildLog {
+    pub deployment_id: String,
+    pub lines: Vec<LogLine>,
+    /// True when the provider capped what it returned, so the UI can say the
+    /// log is partial rather than implying this is all of it.
+    pub truncated: bool,
+}
+
+impl BuildLog {
+    /// The line most likely to explain a failure, for the one-line summary the
+    /// popover shows before anyone opens the full log.
+    ///
+    /// Heuristic, and deliberately conservative: build tools write to `stderr`
+    /// constantly without failing, so this looks for the last line that reads
+    /// like an error and returns nothing when it can't find one. Showing no
+    /// summary is better than confidently surfacing a deprecation warning as
+    /// the reason a build failed.
+    pub fn likely_error(&self) -> Option<String> {
+        const MARKERS: [&str; 8] = [
+            "error", "failed", "cannot find", "not found", "unexpected", "exited with",
+            "syntaxerror", "typeerror",
+        ];
+
+        self.lines
+            .iter()
+            .rev()
+            .find(|line| {
+                let lower = line.text.to_lowercase();
+                // A bare "warning: ..." on stderr is not the failure.
+                !lower.starts_with("warning") && MARKERS.iter().any(|m| lower.contains(m))
+            })
+            .map(|line| line.text.clone())
+    }
+}
+
 /// The result of asking "what happened to this commit?".
 ///
 /// `NotFound` is deliberately not an error and never becomes `Failed`. No
@@ -364,6 +419,59 @@ pub fn now_ms() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn log(lines: &[(LogStream, &str)]) -> BuildLog {
+        BuildLog {
+            deployment_id: "dpl_1".into(),
+            lines: lines
+                .iter()
+                .map(|(stream, text)| LogLine {
+                    at: 0,
+                    stream: *stream,
+                    text: (*text).to_string(),
+                })
+                .collect(),
+            truncated: false,
+        }
+    }
+
+    #[test]
+    fn the_error_summary_finds_the_actual_failure() {
+        let build = log(&[
+            (LogStream::Stdout, "Installing dependencies..."),
+            (LogStream::Stdout, "Compiling"),
+            (LogStream::Stderr, "Error: Cannot find module './missing'"),
+            (LogStream::Stdout, "Build failed"),
+        ]);
+        assert_eq!(
+            build.likely_error().as_deref(),
+            Some("Build failed"),
+            "the last error-shaped line wins, since it is closest to the failure"
+        );
+    }
+
+    #[test]
+    fn the_error_summary_ignores_a_build_that_merely_warned() {
+        // The failure mode worth preventing: a successful build that wrote
+        // deprecation notices to stderr must not produce a "reason it failed".
+        let build = log(&[
+            (LogStream::Stderr, "warning: 'foo' is deprecated"),
+            (LogStream::Stderr, "Warning: peer dependency unmet"),
+            (LogStream::Stdout, "Build completed in 12s"),
+        ]);
+        assert_eq!(build.likely_error(), None);
+    }
+
+    #[test]
+    fn the_error_summary_says_nothing_rather_than_guessing() {
+        let build = log(&[
+            (LogStream::Stdout, "Running build"),
+            (LogStream::Stdout, "Done"),
+        ]);
+        assert_eq!(build.likely_error(), None);
+
+        assert_eq!(log(&[]).likely_error(), None);
+    }
 
     #[test]
     fn terminal_phases_stop_the_fast_poll() {

--- a/src-tauri/src/commands/hosting/model.rs
+++ b/src-tauri/src/commands/hosting/model.rs
@@ -434,6 +434,34 @@ pub struct TokenCheck {
     pub account_label: Option<String>,
 }
 
+/// ISO-8601 to epoch milliseconds. Netlify sends `2026-02-22T17:26:51.942Z`
+/// where Vercel sends a number, and the shared model uses milliseconds.
+pub fn iso_to_ms(value: Option<&str>) -> Option<u64> {
+    let raw = value?;
+    let date = raw.get(0..10)?;
+    let time = raw.get(11..19)?;
+
+    let year: i64 = date.get(0..4)?.parse().ok()?;
+    let month: i64 = date.get(5..7)?.parse().ok()?;
+    let day: i64 = date.get(8..10)?.parse().ok()?;
+    let hour: i64 = time.get(0..2)?.parse().ok()?;
+    let minute: i64 = time.get(3..5)?.parse().ok()?;
+    let second: i64 = time.get(6..8)?.parse().ok()?;
+
+    // Days from the civil epoch (Howard Hinnant's algorithm), which avoids
+    // pulling in a date crate for one field.
+    let y = if month <= 2 { year - 1 } else { year };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let mp = (month + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days = era * 146_097 + doe - 719_468;
+
+    let secs = days * 86_400 + hour * 3_600 + minute * 60 + second;
+    u64::try_from(secs * 1_000).ok()
+}
+
 /// Milliseconds since the Unix epoch.
 pub fn now_ms() -> u64 {
     std::time::SystemTime::now()

--- a/src-tauri/src/commands/hosting/model.rs
+++ b/src-tauri/src/commands/hosting/model.rs
@@ -560,7 +560,12 @@ mod tests {
         };
 
         let json = serde_json::to_value(&deployment).unwrap();
-        let mut keys: Vec<&str> = json.as_object().unwrap().keys().map(String::as_str).collect();
+        let mut keys: Vec<&str> = json
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
         keys.sort_unstable();
         assert_eq!(
             keys,
@@ -598,7 +603,12 @@ mod tests {
         // shows up as a row rendering the word "null".
         let urls = DeploymentUrls::default();
         let json = serde_json::to_value(&urls).unwrap();
-        let keys: Vec<&str> = json.as_object().unwrap().keys().map(String::as_str).collect();
+        let keys: Vec<&str> = json
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
         assert_eq!(keys, ["aliases"]);
     }
 

--- a/src-tauri/src/commands/hosting/model.rs
+++ b/src-tauri/src/commands/hosting/model.rs
@@ -527,6 +527,81 @@ mod tests {
         assert_eq!(log(&[]).likely_error(), None);
     }
 
+    /// The TS mirror in `src/lib/hosting.ts` is written by hand, so a field
+    /// renamed here drifts silently: Rust still compiles, TypeScript still
+    /// compiles, and the field simply arrives as `undefined` at runtime. That
+    /// is exactly how this section spent a day showing a build permalink where
+    /// the site's address belonged — the value was real, it was just read from
+    /// the wrong key.
+    ///
+    /// Pinning the exact key set turns a rename into a failing test rather than
+    /// a missing row. Update this list and `src/lib/hosting.ts` together.
+    #[test]
+    fn the_wire_shape_the_frontend_reads_is_pinned() {
+        let deployment = Deployment {
+            id: "dpl_1".into(),
+            status_label: "Ready".into(),
+            phase: DeploymentPhase::Ready,
+            detail: None,
+            environment: Environment::Production,
+            branch: Some("main".into()),
+            commit_sha: "abc".into(),
+            commit_message: Some("Fix the nav".into()),
+            urls: DeploymentUrls {
+                site: Some("https://example.com".into()),
+                deployment: Some("https://abc.example.com".into()),
+                aliases: vec![],
+                primary: Some("https://example.com".into()),
+            },
+            dashboard_url: Some("https://vercel.com/x".into()),
+            error_message: None,
+            created_at: 1,
+            ready_at: Some(2),
+        };
+
+        let json = serde_json::to_value(&deployment).unwrap();
+        let mut keys: Vec<&str> = json.as_object().unwrap().keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            [
+                "branch",
+                "commit_message",
+                "commit_sha",
+                "created_at",
+                "dashboard_url",
+                "environment",
+                "id",
+                "phase",
+                "ready_at",
+                "status_label",
+                "urls",
+            ]
+        );
+
+        let mut url_keys: Vec<&str> = json["urls"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        url_keys.sort_unstable();
+        // `site` and `deployment` are different addresses and are not
+        // interchangeable; conflating them is the original defect.
+        assert_eq!(url_keys, ["aliases", "deployment", "primary", "site"]);
+    }
+
+    #[test]
+    fn an_absent_address_is_omitted_rather_than_sent_as_null() {
+        // The TS mirror types these as optional. Emitting an explicit null
+        // where the frontend expects absence is the kind of mismatch that
+        // shows up as a row rendering the word "null".
+        let urls = DeploymentUrls::default();
+        let json = serde_json::to_value(&urls).unwrap();
+        let keys: Vec<&str> = json.as_object().unwrap().keys().map(String::as_str).collect();
+        assert_eq!(keys, ["aliases"]);
+    }
+
     #[test]
     fn terminal_phases_stop_the_fast_poll() {
         assert!(DeploymentPhase::Ready.is_terminal());

--- a/src-tauri/src/commands/hosting/model.rs
+++ b/src-tauri/src/commands/hosting/model.rs
@@ -214,6 +214,15 @@ pub struct DeploymentUrls {
 pub struct Deployment {
     pub id: String,
     pub phase: DeploymentPhase,
+    /// The provider's own word for this status, shown to the user verbatim.
+    ///
+    /// `phase` drives behaviour (what to poll, what colour the dot is);
+    /// this drives copy. Keeping them separate means the UI can say exactly
+    /// what Vercel's dashboard says — "Ready", not a synonym this app made up
+    /// — while the polling logic stays provider-agnostic. It also means each
+    /// provider gets to keep its own vocabulary instead of being flattened
+    /// into a shared one that matches none of them.
+    pub status_label: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub detail: Option<DeploymentDetail>,
     pub environment: Environment,

--- a/src-tauri/src/commands/hosting/model.rs
+++ b/src-tauri/src/commands/hosting/model.rs
@@ -187,13 +187,24 @@ pub enum DeploymentDetail {
 /// response body.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DeploymentUrls {
-    /// This specific deployment's immutable URL.
+    /// The address people actually visit — the project's production domain.
+    ///
+    /// This is a property of the *project*, not of a deployment, and on Vercel
+    /// it lives on a different endpoint entirely. Reading it off the deployment
+    /// record is why this section spent a day showing an unrecognisable
+    /// per-build permalink and calling it the site.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub site: Option<String>,
+    /// This specific build's immutable URL. Always resolves to this exact
+    /// commit, even after newer deploys — which is what makes it useful, and
+    /// also what makes it the wrong thing to show as "your site".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deployment: Option<String>,
     /// Every alias the provider reported for it.
     #[serde(default)]
     pub aliases: Vec<String>,
-    /// The one to open when the user clicks through, chosen by the adapter.
+    /// What a single "open" should go to: the site if we know it, else this
+    /// build. Kept so callers that want one URL don't re-derive the rule.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub primary: Option<String>,
 }
@@ -265,8 +276,14 @@ impl BuildLog {
     /// the reason a build failed.
     pub fn likely_error(&self) -> Option<String> {
         const MARKERS: [&str; 8] = [
-            "error", "failed", "cannot find", "not found", "unexpected", "exited with",
-            "syntaxerror", "typeerror",
+            "error",
+            "failed",
+            "cannot find",
+            "not found",
+            "unexpected",
+            "exited with",
+            "syntaxerror",
+            "typeerror",
         ];
 
         self.lines

--- a/src-tauri/src/commands/hosting/netlify.rs
+++ b/src-tauri/src/commands/hosting/netlify.rs
@@ -1,0 +1,479 @@
+//! Netlify adapter.
+//!
+//! Shapes here were checked against a live site and deploy (see
+//! `docs/internal/hosting-provider-matrix.md`), not taken from documentation:
+//!
+//! * A deploy carries `commit_ref` (the full SHA) but Netlify has **no**
+//!   server-side commit filter, so finding one means narrowing by branch and
+//!   scanning.
+//! * Every address is returned. `links.alias` is the site's, `links.permalink`
+//!   is this deploy's, and `deploy_ssl_url` is the branch's. None of them ever
+//!   needs assembling — which is what the previous Netlify integration did.
+//! * `commit_message` and `title` were both null on a real production deploy,
+//!   so neither can be relied on for what was shipped.
+//! * Timestamps are ISO-8601 strings here, not epoch milliseconds like Vercel.
+
+use super::http::{get_json, HostingHttpError};
+use super::model::{
+    iso_to_ms, BuildLog, Deployment, DeploymentDetail, DeploymentPhase, DeploymentUrls,
+    Environment, HostingLink, HostingProjectChoice, Lookup,
+};
+use serde::Deserialize;
+
+const API: &str = "https://api.netlify.com/api/v1";
+
+#[derive(Debug, Deserialize)]
+struct RawDeploy {
+    id: String,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    context: Option<String>,
+    #[serde(default)]
+    branch: Option<String>,
+    #[serde(default)]
+    commit_ref: Option<String>,
+    #[serde(default)]
+    commit_message: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    admin_url: Option<String>,
+    #[serde(default)]
+    ssl_url: Option<String>,
+    #[serde(default)]
+    deploy_ssl_url: Option<String>,
+    #[serde(default)]
+    links: RawLinks,
+    #[serde(default)]
+    error_message: Option<String>,
+    /// Absent rather than `false` when a deploy was not skipped.
+    #[serde(default)]
+    skipped: Option<bool>,
+    #[serde(default)]
+    skipped_log: Option<String>,
+    #[serde(default)]
+    pending_review_reason: Option<String>,
+    /// True for a CLI or drag-and-drop deploy, which has no commit behind it
+    /// and so must never be matched against a pushed SHA.
+    #[serde(default)]
+    manual_deploy: Option<bool>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    published_at: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawLinks {
+    /// This deploy's immutable address.
+    #[serde(default)]
+    permalink: Option<String>,
+    /// The site's address.
+    #[serde(default)]
+    alias: Option<String>,
+    #[serde(default)]
+    branch: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSite {
+    id: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    ssl_url: Option<String>,
+    #[serde(default)]
+    custom_domain: Option<String>,
+    #[serde(default)]
+    admin_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawUser {
+    #[serde(default)]
+    full_name: Option<String>,
+    #[serde(default)]
+    email: Option<String>,
+}
+
+/// Map Netlify's fifteen-value `state` onto the shared lifecycle.
+///
+/// Netlify genuinely separates building from uploading and CDN propagation, so
+/// unlike Vercel it earns the `Publishing` phase rather than having one
+/// invented for it.
+fn phase_from_state(raw: &str) -> DeploymentPhase {
+    match raw.to_ascii_lowercase().as_str() {
+        "new" | "enqueued" | "accepted" => DeploymentPhase::Queued,
+        "pending_review" | "rejected" => DeploymentPhase::Gated,
+        "building" | "retrying" => DeploymentPhase::Building,
+        "uploading" | "uploaded" | "preparing" | "prepared" | "processing" => {
+            DeploymentPhase::Publishing
+        }
+        "ready" | "processed" => DeploymentPhase::Ready,
+        "error" => DeploymentPhase::Failed,
+        other => DeploymentPhase::Unknown {
+            raw: other.to_string(),
+        },
+    }
+}
+
+/// Netlify's own word, capitalised the way its dashboard capitalises it:
+/// `pending_review` reads as "Pending review".
+fn status_label(raw: &str) -> String {
+    let spaced = raw.replace('_', " ");
+    let mut chars = spaced.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => "Unknown".to_string(),
+    }
+}
+
+fn detail_from(raw: &RawDeploy, phase: &DeploymentPhase) -> Option<DeploymentDetail> {
+    match phase {
+        DeploymentPhase::Skipped => Some(DeploymentDetail::SkippedBecause {
+            reason: raw.skipped_log.clone(),
+        }),
+        DeploymentPhase::Gated if raw.state.as_deref() == Some("rejected") => {
+            Some(DeploymentDetail::ReviewRejected)
+        }
+        DeploymentPhase::Gated => Some(DeploymentDetail::AwaitingReview {
+            reason: raw.pending_review_reason.clone(),
+        }),
+        _ => None,
+    }
+}
+
+fn to_deployment(raw: RawDeploy) -> Deployment {
+    let state = raw.state.clone().unwrap_or_default();
+    // The boolean wins over the state: a skipped deploy still reports some
+    // other word in `state`, and "skipped" is the more useful thing to say.
+    let phase = if raw.skipped.unwrap_or(false) {
+        DeploymentPhase::Skipped
+    } else {
+        phase_from_state(&state)
+    };
+    let detail = detail_from(&raw, &phase);
+
+    let environment = match raw.context.as_deref() {
+        Some("production") => Environment::Production,
+        _ => Environment::Preview,
+    };
+
+    // Every one of these came from the response. Netlify returns the branch
+    // address too — the previous integration assembled `branch--site` by hand
+    // and got it wrong for any name Netlify slugifies differently.
+    let site = raw.links.alias.clone().or_else(|| raw.ssl_url.clone());
+    let deployment_url = raw
+        .links
+        .permalink
+        .clone()
+        .or_else(|| raw.deploy_ssl_url.clone());
+
+    let mut aliases = Vec::new();
+    for candidate in [
+        raw.links.branch.clone(),
+        raw.deploy_ssl_url.clone(),
+        site.clone(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if !aliases.contains(&candidate) {
+            aliases.push(candidate);
+        }
+    }
+
+    let primary = match environment {
+        Environment::Preview => deployment_url.clone(),
+        Environment::Production => site.clone().or_else(|| deployment_url.clone()),
+    };
+
+    Deployment {
+        id: raw.id,
+        status_label: status_label(&state),
+        phase,
+        detail,
+        environment,
+        branch: raw.branch.clone(),
+        commit_sha: raw.commit_ref.clone().unwrap_or_default(),
+        // Both of these were null on a real production deploy, so the local
+        // git subject is the reliable source and this is only a fallback.
+        commit_message: raw
+            .commit_message
+            .clone()
+            .or_else(|| raw.title.clone())
+            .map(|m| m.trim().to_string())
+            .filter(|m| !m.is_empty()),
+        urls: DeploymentUrls {
+            site,
+            deployment: deployment_url,
+            aliases,
+            primary,
+        },
+        // The site's page on Netlify. Netlify returns no per-deploy admin link,
+        // and building one from the id would be assembling a URL.
+        dashboard_url: raw.admin_url.clone(),
+        error_message: raw
+            .error_message
+            .clone()
+            .map(|m| m.trim().to_string())
+            .filter(|m| !m.is_empty()),
+        created_at: iso_to_ms(raw.created_at.as_deref()).unwrap_or(0),
+        ready_at: iso_to_ms(raw.published_at.as_deref()),
+    }
+}
+
+/// Find the deploy for an exact commit.
+///
+/// Netlify has no commit filter, so this narrows by branch — which it does
+/// support — and scans. Manual deploys are excluded: they carry no commit and
+/// matching one to a push would be inventing a link that isn't there.
+pub async fn find_for_commit(
+    link: &HostingLink,
+    token: &str,
+    sha: &str,
+    branch: &str,
+) -> Result<Lookup, HostingHttpError> {
+    let url = format!(
+        "{API}/sites/{site}/deploys?branch={branch}&per_page=30",
+        site = link.project_id,
+    );
+    let raw: Vec<RawDeploy> = get_json(&url, token).await?;
+
+    let mut deploys: Vec<Deployment> = raw
+        .into_iter()
+        .filter(|d| !d.manual_deploy.unwrap_or(false))
+        .map(to_deployment)
+        .collect();
+    deploys.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+    if let Some(found) = deploys.iter().find(|d| d.commit_sha == sha).cloned() {
+        return Ok(Lookup::Found { deployment: found });
+    }
+
+    Ok(Lookup::NotFound {
+        latest_on_branch: deploys.into_iter().next().map(Box::new),
+    })
+}
+
+/// Recent deploys for the site, newest first.
+pub async fn list_recent(
+    link: &HostingLink,
+    token: &str,
+    limit: u32,
+) -> Result<Vec<Deployment>, HostingHttpError> {
+    let url = format!(
+        "{API}/sites/{site}/deploys?per_page={limit}",
+        site = link.project_id,
+    );
+    let raw: Vec<RawDeploy> = get_json(&url, token).await?;
+    let mut deploys: Vec<Deployment> = raw.into_iter().map(to_deployment).collect();
+    deploys.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    Ok(deploys)
+}
+
+/// Netlify publishes no build-log endpoint, so there is nothing to fetch.
+///
+/// A failure still explains itself: `error_message` is on the deploy record
+/// and the panel shows it above where the log would be. Returning an empty log
+/// rather than an error keeps that panel honest — "Netlify returned no build
+/// output" is true, where "couldn't read Netlify's response" would not be.
+pub async fn fetch_logs(
+    _link: &HostingLink,
+    _token: &str,
+    deployment_id: &str,
+) -> Result<BuildLog, HostingHttpError> {
+    Ok(BuildLog {
+        deployment_id: deployment_id.to_string(),
+        lines: Vec::new(),
+        truncated: false,
+    })
+}
+
+/// Sites this token can see, for the link picker.
+pub async fn list_projects(token: &str) -> Result<Vec<HostingProjectChoice>, HostingHttpError> {
+    let raw: Vec<RawSite> = get_json(&format!("{API}/sites?per_page=100"), token).await?;
+    Ok(raw
+        .into_iter()
+        .map(|s| HostingProjectChoice {
+            name: s.name.clone().unwrap_or_else(|| s.id.clone()),
+            id: s.id,
+            scope_id: None,
+            scope_name: None,
+        })
+        .collect())
+}
+
+/// The site's own address, preferring a custom domain when one is attached.
+pub async fn fetch_site_url(
+    link: &HostingLink,
+    token: &str,
+) -> Result<Option<String>, HostingHttpError> {
+    let site: RawSite = get_json(
+        &format!("{API}/sites/{site}", site = link.project_id),
+        token,
+    )
+    .await?;
+    Ok(site
+        .custom_domain
+        .filter(|d| !d.is_empty())
+        .map(|d| format!("https://{d}"))
+        .or(site.ssl_url))
+}
+
+/// Confirm a token works and say whose it is.
+pub async fn verify_token(token: &str) -> Result<Option<String>, HostingHttpError> {
+    let user: RawUser = get_json(&format!("{API}/user"), token).await?;
+    Ok(user.full_name.or(user.email))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Shaped from a real production deploy.
+    fn ready_fixture() -> &'static str {
+        r#"{
+            "id":"699b3c5b8c460f0cec5a8f5b",
+            "state":"ready","context":"production","branch":"main",
+            "commit_ref":"222c59fd6dd081cf11dbf40a6779aeb9000be145",
+            "commit_message":null,"title":null,
+            "admin_url":"https://app.netlify.com/projects/netlify-proj-3",
+            "ssl_url":"https://netlify-proj-3.netlify.app",
+            "deploy_ssl_url":"https://main--netlify-proj-3.netlify.app",
+            "links":{
+              "permalink":"https://699b3c5b--netlify-proj-3.netlify.app",
+              "alias":"https://netlify-proj-3.netlify.app",
+              "branch":null
+            },
+            "created_at":"2026-02-22T17:26:51.942Z",
+            "published_at":"2026-02-22T17:26:57.427Z",
+            "manual_deploy":false
+        }"#
+    }
+
+    #[test]
+    fn a_real_deploy_parses_into_the_shared_shape() {
+        let raw: RawDeploy = serde_json::from_str(ready_fixture()).unwrap();
+        let d = to_deployment(raw);
+
+        assert_eq!(d.phase, DeploymentPhase::Ready);
+        assert_eq!(d.status_label, "Ready");
+        assert_eq!(d.environment, Environment::Production);
+        assert_eq!(d.commit_sha, "222c59fd6dd081cf11dbf40a6779aeb9000be145");
+        assert_eq!(
+            d.urls.site.as_deref(),
+            Some("https://netlify-proj-3.netlify.app")
+        );
+        assert_eq!(
+            d.urls.deployment.as_deref(),
+            Some("https://699b3c5b--netlify-proj-3.netlify.app")
+        );
+    }
+
+    #[test]
+    fn every_address_came_from_the_response() {
+        // The previous integration assembled `branch--site.netlify.app` by
+        // hand. Netlify returns it, so there is no reason to.
+        let body = ready_fixture();
+        let raw: RawDeploy = serde_json::from_str(body).unwrap();
+        let d = to_deployment(raw);
+
+        for url in d
+            .urls
+            .aliases
+            .iter()
+            .chain(d.urls.site.iter())
+            .chain(d.urls.deployment.iter())
+        {
+            assert!(body.contains(url.as_str()), "{url} was assembled");
+        }
+    }
+
+    #[test]
+    fn the_status_word_is_netlifys_own() {
+        assert_eq!(status_label("ready"), "Ready");
+        assert_eq!(status_label("building"), "Building");
+        assert_eq!(status_label("error"), "Error");
+        assert_eq!(status_label("pending_review"), "Pending review");
+        assert_eq!(status_label(""), "Unknown");
+    }
+
+    #[test]
+    fn netlify_earns_the_publishing_phase_vercel_did_not() {
+        // Netlify really does separate building from uploading and CDN
+        // propagation, and names each one.
+        for state in [
+            "uploading",
+            "uploaded",
+            "preparing",
+            "prepared",
+            "processing",
+        ] {
+            assert_eq!(
+                phase_from_state(state),
+                DeploymentPhase::Publishing,
+                "{state}"
+            );
+        }
+        assert_eq!(phase_from_state("building"), DeploymentPhase::Building);
+        assert_eq!(phase_from_state("ready"), DeploymentPhase::Ready);
+        assert_eq!(phase_from_state("error"), DeploymentPhase::Failed);
+    }
+
+    #[test]
+    fn the_author_trust_gate_is_not_a_failure() {
+        assert_eq!(phase_from_state("pending_review"), DeploymentPhase::Gated);
+        assert_eq!(phase_from_state("rejected"), DeploymentPhase::Gated);
+    }
+
+    #[test]
+    fn an_unrecognized_state_is_surfaced_not_guessed() {
+        assert_eq!(
+            phase_from_state("some_new_state"),
+            DeploymentPhase::Unknown {
+                raw: "some_new_state".into()
+            }
+        );
+    }
+
+    #[test]
+    fn a_skipped_deploy_says_why_when_netlify_says_why() {
+        let body = r#"{"id":"d1","state":"ready","skipped":true,
+            "skipped_log":"Skipped due to [skip ci] in commit message",
+            "created_at":"2026-02-22T17:26:51.942Z"}"#;
+        let raw: RawDeploy = serde_json::from_str(body).unwrap();
+        let d = to_deployment(raw);
+
+        assert_eq!(d.phase, DeploymentPhase::Skipped);
+        assert_eq!(
+            d.detail,
+            Some(DeploymentDetail::SkippedBecause {
+                reason: Some("Skipped due to [skip ci] in commit message".into())
+            })
+        );
+    }
+
+    #[test]
+    fn iso_timestamps_become_milliseconds() {
+        // Netlify sends ISO-8601 where Vercel sends a number.
+        let ms = iso_to_ms(Some("2026-02-22T17:26:51.942Z")).unwrap();
+        assert_eq!(ms, 1_771_781_211_000);
+
+        assert_eq!(iso_to_ms(Some("1970-01-01T00:00:00.000Z")), Some(0));
+        assert_eq!(iso_to_ms(None), None);
+        assert_eq!(iso_to_ms(Some("not a date")), None);
+    }
+
+    #[test]
+    fn a_manual_deploy_is_never_matched_to_a_push() {
+        // A CLI or drag-and-drop deploy has no commit behind it, so reporting
+        // one as the result of a push would be inventing a link.
+        let body = r#"{"id":"d1","state":"ready","manual_deploy":true,
+            "created_at":"2026-02-22T17:26:51.942Z"}"#;
+        let raw: RawDeploy = serde_json::from_str(body).unwrap();
+        assert!(raw.manual_deploy.unwrap_or(false));
+        assert_eq!(to_deployment(raw).commit_sha, "");
+    }
+}

--- a/src-tauri/src/commands/hosting/netlify.rs
+++ b/src-tauri/src/commands/hosting/netlify.rs
@@ -85,8 +85,6 @@ struct RawSite {
     ssl_url: Option<String>,
     #[serde(default)]
     custom_domain: Option<String>,
-    #[serde(default)]
-    admin_url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src-tauri/src/commands/hosting/netlify.rs
+++ b/src-tauri/src/commands/hosting/netlify.rs
@@ -238,8 +238,19 @@ pub async fn find_for_commit(
     // the query parameter early — so `fix#123` would silently ask Netlify for
     // the deploys of a branch called `fix`, and get a confident answer about
     // the wrong branch. `sha` needs no such care: it is hex by construction.
+    // One page, deliberately. Netlify has no server-side commit filter, so this
+    // is a bounded scan of the branch's most recent deploys — 100 is its page
+    // maximum and costs the same request as 30 did.
+    //
+    // A commit further back than that answers `NotFound`, which the UI renders
+    // as "no deploy reported yet" and never as a failure or a false success —
+    // the scan degrades to "we don't know", which is the honest direction. It
+    // matters because the question this asks is always about a commit the user
+    // just pushed, which sits at the top of this list. Full pagination is
+    // recorded as a limitation in docs/internal/hosting-provider-matrix.md
+    // rather than left for someone to discover.
     let url = format!(
-        "{API}/sites/{site}/deploys?branch={branch}&per_page=30",
+        "{API}/sites/{site}/deploys?branch={branch}&per_page=100",
         site = link.project_id,
         branch = urlencoding::encode(branch),
     );

--- a/src-tauri/src/commands/hosting/netlify.rs
+++ b/src-tauri/src/commands/hosting/netlify.rs
@@ -233,9 +233,15 @@ pub async fn find_for_commit(
     sha: &str,
     branch: &str,
 ) -> Result<Lookup, HostingHttpError> {
+    // Percent-encoded, because a branch name is the one value in this URL the
+    // user chooses. Git allows `&` and `#` in a refname, and either one ends
+    // the query parameter early — so `fix#123` would silently ask Netlify for
+    // the deploys of a branch called `fix`, and get a confident answer about
+    // the wrong branch. `sha` needs no such care: it is hex by construction.
     let url = format!(
         "{API}/sites/{site}/deploys?branch={branch}&per_page=30",
         site = link.project_id,
+        branch = urlencoding::encode(branch),
     );
     let raw: Vec<RawDeploy> = get_json(&url, token).await?;
 

--- a/src-tauri/src/commands/hosting/provider.rs
+++ b/src-tauri/src/commands/hosting/provider.rs
@@ -6,7 +6,9 @@
 //! surprise in the one path nobody remembered.
 
 use super::http::HostingHttpError;
-use super::model::{BuildLog, Deployment, HostingLink, HostingProjectChoice, HostingProvider, Lookup};
+use super::model::{
+    BuildLog, Deployment, HostingLink, HostingProjectChoice, HostingProvider, Lookup,
+};
 use super::vercel;
 
 /// Placeholder for a provider whose adapter has not landed yet. Returns a

--- a/src-tauri/src/commands/hosting/provider.rs
+++ b/src-tauri/src/commands/hosting/provider.rs
@@ -6,7 +6,7 @@
 //! surprise in the one path nobody remembered.
 
 use super::http::HostingHttpError;
-use super::model::{HostingLink, HostingProjectChoice, HostingProvider, Lookup};
+use super::model::{BuildLog, Deployment, HostingLink, HostingProjectChoice, HostingProvider, Lookup};
 use super::vercel;
 
 /// Placeholder for a provider whose adapter has not landed yet. Returns a
@@ -27,6 +27,35 @@ pub async fn find_for_commit(
 ) -> Result<Lookup, HostingHttpError> {
     match link.provider {
         HostingProvider::Vercel => vercel::find_for_commit(link, token, sha, branch).await,
+        HostingProvider::Cloudflare | HostingProvider::Netlify => {
+            Err(not_yet_implemented(link.provider))
+        }
+    }
+}
+
+/// A deployment's build output — the reason a failure happened, which the
+/// deployments endpoints do not carry.
+pub async fn fetch_logs(
+    link: &HostingLink,
+    token: &str,
+    deployment_id: &str,
+) -> Result<BuildLog, HostingHttpError> {
+    match link.provider {
+        HostingProvider::Vercel => vercel::fetch_logs(link, token, deployment_id).await,
+        HostingProvider::Cloudflare | HostingProvider::Netlify => {
+            Err(not_yet_implemented(link.provider))
+        }
+    }
+}
+
+/// Recent deployments on this project, newest first.
+pub async fn list_recent(
+    link: &HostingLink,
+    token: &str,
+    limit: u32,
+) -> Result<Vec<Deployment>, HostingHttpError> {
+    match link.provider {
+        HostingProvider::Vercel => vercel::list_recent(link, token, limit).await,
         HostingProvider::Cloudflare | HostingProvider::Netlify => {
             Err(not_yet_implemented(link.provider))
         }

--- a/src-tauri/src/commands/hosting/provider.rs
+++ b/src-tauri/src/commands/hosting/provider.rs
@@ -1,0 +1,61 @@
+//! The adapter boundary.
+//!
+//! Every provider-specific call goes through one of these functions, and each
+//! is an exhaustive `match` on [`HostingProvider`]. Adding a provider is then a
+//! compile error in exactly the places that need work, rather than a runtime
+//! surprise in the one path nobody remembered.
+
+use super::http::HostingHttpError;
+use super::model::{HostingLink, HostingProjectChoice, HostingProvider, Lookup};
+use super::vercel;
+
+/// Placeholder for a provider whose adapter has not landed yet. Returns a
+/// transport-shaped failure so the UI shows "couldn't reach" rather than
+/// pretending the project is unlinked or, worse, healthy.
+fn not_yet_implemented(provider: HostingProvider) -> HostingHttpError {
+    HostingHttpError::Transport {
+        message: format!("{} support is still being built.", provider.label()),
+    }
+}
+
+/// Find the deployment for an exact commit.
+pub async fn find_for_commit(
+    link: &HostingLink,
+    token: &str,
+    sha: &str,
+    branch: &str,
+) -> Result<Lookup, HostingHttpError> {
+    match link.provider {
+        HostingProvider::Vercel => vercel::find_for_commit(link, token, sha, branch).await,
+        HostingProvider::Cloudflare | HostingProvider::Netlify => {
+            Err(not_yet_implemented(link.provider))
+        }
+    }
+}
+
+/// Projects this token can see, for the link picker.
+pub async fn list_projects(
+    provider: HostingProvider,
+    token: &str,
+    scope_id: Option<&str>,
+) -> Result<Vec<HostingProjectChoice>, HostingHttpError> {
+    match provider {
+        HostingProvider::Vercel => vercel::list_projects(token, scope_id).await,
+        HostingProvider::Cloudflare | HostingProvider::Netlify => {
+            Err(not_yet_implemented(provider))
+        }
+    }
+}
+
+/// Confirm a credential works, and say whose it is.
+pub async fn verify_token(
+    provider: HostingProvider,
+    token: &str,
+) -> Result<Option<String>, HostingHttpError> {
+    match provider {
+        HostingProvider::Vercel => vercel::verify_token(token).await,
+        HostingProvider::Cloudflare | HostingProvider::Netlify => {
+            Err(not_yet_implemented(provider))
+        }
+    }
+}

--- a/src-tauri/src/commands/hosting/provider.rs
+++ b/src-tauri/src/commands/hosting/provider.rs
@@ -9,16 +9,7 @@ use super::http::HostingHttpError;
 use super::model::{
     BuildLog, Deployment, HostingLink, HostingProjectChoice, HostingProvider, Lookup,
 };
-use super::vercel;
-
-/// Placeholder for a provider whose adapter has not landed yet. Returns a
-/// transport-shaped failure so the UI shows "couldn't reach" rather than
-/// pretending the project is unlinked or, worse, healthy.
-fn not_yet_implemented(provider: HostingProvider) -> HostingHttpError {
-    HostingHttpError::Transport {
-        message: format!("{} support is still being built.", provider.label()),
-    }
-}
+use super::{cloudflare, netlify, vercel};
 
 /// Find the deployment for an exact commit.
 pub async fn find_for_commit(
@@ -29,9 +20,8 @@ pub async fn find_for_commit(
 ) -> Result<Lookup, HostingHttpError> {
     match link.provider {
         HostingProvider::Vercel => vercel::find_for_commit(link, token, sha, branch).await,
-        HostingProvider::Cloudflare | HostingProvider::Netlify => {
-            Err(not_yet_implemented(link.provider))
-        }
+        HostingProvider::Cloudflare => cloudflare::find_for_commit(link, token, sha, branch).await,
+        HostingProvider::Netlify => netlify::find_for_commit(link, token, sha, branch).await,
     }
 }
 
@@ -44,9 +34,8 @@ pub async fn fetch_logs(
 ) -> Result<BuildLog, HostingHttpError> {
     match link.provider {
         HostingProvider::Vercel => vercel::fetch_logs(link, token, deployment_id).await,
-        HostingProvider::Cloudflare | HostingProvider::Netlify => {
-            Err(not_yet_implemented(link.provider))
-        }
+        HostingProvider::Cloudflare => cloudflare::fetch_logs(link, token, deployment_id).await,
+        HostingProvider::Netlify => netlify::fetch_logs(link, token, deployment_id).await,
     }
 }
 
@@ -58,9 +47,8 @@ pub async fn list_recent(
 ) -> Result<Vec<Deployment>, HostingHttpError> {
     match link.provider {
         HostingProvider::Vercel => vercel::list_recent(link, token, limit).await,
-        HostingProvider::Cloudflare | HostingProvider::Netlify => {
-            Err(not_yet_implemented(link.provider))
-        }
+        HostingProvider::Cloudflare => cloudflare::list_recent(link, token, limit).await,
+        HostingProvider::Netlify => netlify::list_recent(link, token, limit).await,
     }
 }
 
@@ -72,9 +60,8 @@ pub async fn list_projects(
 ) -> Result<Vec<HostingProjectChoice>, HostingHttpError> {
     match provider {
         HostingProvider::Vercel => vercel::list_projects(token, scope_id).await,
-        HostingProvider::Cloudflare | HostingProvider::Netlify => {
-            Err(not_yet_implemented(provider))
-        }
+        HostingProvider::Cloudflare => cloudflare::list_projects(token, scope_id).await,
+        HostingProvider::Netlify => netlify::list_projects(token).await,
     }
 }
 
@@ -85,8 +72,7 @@ pub async fn verify_token(
 ) -> Result<Option<String>, HostingHttpError> {
     match provider {
         HostingProvider::Vercel => vercel::verify_token(token).await,
-        HostingProvider::Cloudflare | HostingProvider::Netlify => {
-            Err(not_yet_implemented(provider))
-        }
+        HostingProvider::Cloudflare => cloudflare::verify_token(token).await,
+        HostingProvider::Netlify => netlify::verify_token(token).await,
     }
 }

--- a/src-tauri/src/commands/hosting/vercel.rs
+++ b/src-tauri/src/commands/hosting/vercel.rs
@@ -65,10 +65,33 @@ struct RawDeployment {
     alias: Vec<String>,
     /// The list endpoint's answer to "are the aliases attached yet", which is
     /// the only way to tell "built" from "serving" without the detail call.
+    ///
+    /// Its type is not stable: a live response returned the epoch-millisecond
+    /// timestamp of the assignment (`1787594676951`) where the docs imply a
+    /// boolean. Both are accepted, and anything else is treated as "unknown"
+    /// rather than failing the whole lookup over one field.
     #[serde(default)]
-    alias_assigned: Option<bool>,
+    alias_assigned: Option<AliasAssigned>,
     #[serde(default)]
     meta: RawMeta,
+}
+
+/// `aliasAssigned` arrives as either a flag or the timestamp at which the
+/// aliases were attached. A timestamp means they are attached.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum AliasAssigned {
+    Flag(bool),
+    At(u64),
+}
+
+impl AliasAssigned {
+    fn is_assigned(&self) -> bool {
+        match self {
+            AliasAssigned::Flag(v) => *v,
+            AliasAssigned::At(ts) => *ts > 0,
+        }
+    }
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -163,7 +186,11 @@ fn with_scheme(host: &str) -> String {
 fn to_deployment(raw: RawDeployment) -> Deployment {
     // `aliasAssigned` is authoritative where the endpoint sends it (the list);
     // on the detail response the presence of aliases says the same thing.
-    let alias_assigned = raw.alias_assigned.unwrap_or(!raw.alias.is_empty());
+    let alias_assigned = raw
+        .alias_assigned
+        .as_ref()
+        .map(AliasAssigned::is_assigned)
+        .unwrap_or(!raw.alias.is_empty());
     let ready_state = raw
         .ready_state
         .as_deref()

--- a/src-tauri/src/commands/hosting/vercel.rs
+++ b/src-tauri/src/commands/hosting/vercel.rs
@@ -117,6 +117,27 @@ struct RawProject {
     name: String,
 }
 
+/// A domain attached to the project. `git_branch` marks a branch-specific
+/// alias; `redirect` marks one that only forwards elsewhere. Neither is the
+/// site's address.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawDomain {
+    name: String,
+    #[serde(default)]
+    verified: Option<bool>,
+    #[serde(default)]
+    git_branch: Option<String>,
+    #[serde(default)]
+    redirect: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawDomainList {
+    #[serde(default)]
+    domains: Vec<RawDomain>,
+}
+
 #[derive(Debug, Deserialize)]
 struct RawUser {
     #[serde(default)]
@@ -206,16 +227,10 @@ fn to_deployment(raw: RawDeployment) -> Deployment {
 
     let aliases: Vec<String> = raw.alias.iter().map(|a| with_scheme(a)).collect();
     let deployment_url = raw.url.as_deref().map(with_scheme);
-    // Vercel returns several aliases in no useful order: a project's stable
-    // domain sits alongside per-deployment hosts carrying a generated hash and
-    // the account name. The shortest is reliably the one a human would
-    // recognise and the only one that fits the row. Still chosen from what the
-    // API returned — never assembled.
-    let primary = aliases
-        .iter()
-        .min_by_key(|a| a.len())
-        .cloned()
-        .or_else(|| deployment_url.clone());
+    // `site` is filled in by the caller from the project's domains — it is not
+    // on this record. Until then the build permalink is the only thing we can
+    // honestly offer.
+    let primary = deployment_url.clone();
 
     let environment = match raw.target.as_deref() {
         Some("production") => Environment::Production,
@@ -236,6 +251,7 @@ fn to_deployment(raw: RawDeployment) -> Deployment {
             .map(|m| m.trim().to_string())
             .filter(|m| !m.is_empty()),
         urls: DeploymentUrls {
+            site: None,
             deployment: deployment_url,
             aliases,
             primary,
@@ -287,6 +303,10 @@ pub async fn find_for_commit(
         b_prod.cmp(&a_prod).then(b.created_at.cmp(&a.created_at))
     });
 
+    // The site's address is a project property on a separate endpoint, so it
+    // is fetched once here and attached to whatever deployment we return.
+    let site = fetch_site_url(link, token).await.ok().flatten();
+
     if let Some(mut found) = candidates.into_iter().next() {
         // Only worth a second call once it is live: that is the only moment
         // aliases exist and the only moment the user wants a link to click.
@@ -310,12 +330,14 @@ pub async fn find_for_commit(
         return Ok(Lookup::Found { deployment: found });
     }
 
+    let mut latest = latest_for_branch(link, token, branch).await.ok().flatten();
+    if let Some(deployment) = latest.as_mut() {
+        deployment.urls.site = site.clone();
+        deployment.urls.primary = site.or(deployment.urls.deployment.clone());
+    }
+
     Ok(Lookup::NotFound {
-        latest_on_branch: latest_for_branch(link, token, branch)
-            .await
-            .ok()
-            .flatten()
-            .map(Box::new),
+        latest_on_branch: latest.map(Box::new),
     })
 }
 
@@ -382,6 +404,41 @@ pub async fn list_projects(
         .collect())
 }
 
+/// The address people visit.
+///
+/// A custom domain wins over the generated `*.vercel.app` when there is one —
+/// it is what the owner would say the site's address is. Unverified domains
+/// are skipped: Vercel will list a domain the moment it is added, long before
+/// DNS resolves, and offering a link that does not load is worse than offering
+/// the one that does.
+fn pick_site_domain(domains: Vec<RawDomain>) -> Option<String> {
+    let usable: Vec<RawDomain> = domains
+        .into_iter()
+        .filter(|d| d.verified.unwrap_or(false) && d.git_branch.is_none() && d.redirect.is_none())
+        .collect();
+
+    let custom = usable
+        .iter()
+        .find(|d| !d.name.ends_with(".vercel.app"))
+        .map(|d| d.name.clone());
+
+    custom.or_else(|| usable.first().map(|d| d.name.clone()))
+}
+
+/// The project's production domain, which is not on the deployment record.
+pub async fn fetch_site_url(
+    link: &HostingLink,
+    token: &str,
+) -> Result<Option<String>, HostingHttpError> {
+    let scope = scope_query(link);
+    let url = format!(
+        "{API}/v9/projects/{project}/domains?limit=50{scope}",
+        project = link.project_id,
+    );
+    let list: RawDomainList = get_json(&url, token).await?;
+    Ok(pick_site_domain(list.domains).map(|d| with_scheme(&d)))
+}
+
 /// One line of build output as Vercel sends it.
 #[derive(Debug, Deserialize)]
 struct RawEvent {
@@ -411,8 +468,7 @@ pub async fn fetch_logs(
         .strip_prefix('&')
         .map(|s| format!("&{s}"))
         .unwrap_or_default();
-    let url =
-        format!("{API}/v3/deployments/{deployment_id}/events?limit={LOG_LIMIT}{scope}");
+    let url = format!("{API}/v3/deployments/{deployment_id}/events?limit={LOG_LIMIT}{scope}");
 
     let raw: Vec<RawEvent> = get_json(&url, token).await?;
     let truncated = raw.len() >= LOG_LIMIT;
@@ -605,35 +661,86 @@ mod tests {
 
         assert_eq!(d.phase, DeploymentPhase::Ready);
         assert_eq!(d.urls.aliases.len(), 2);
+        // A deployment record alone can only offer its own permalink; the
+        // site's address is attached by the caller from the project's domains.
         assert_eq!(
             d.urls.primary.as_deref(),
-            Some("https://acme-saas-tau.vercel.app")
+            Some("https://acme-saas-fi9rttan8-native-073e1cec.vercel.app")
+        );
+        assert_eq!(d.urls.site, None);
+    }
+
+    #[test]
+    fn the_site_address_is_the_project_domain_not_a_build_permalink() {
+        // The bug this pins: every deployment's `url` is a per-build permalink
+        // carrying a generated hash and the account name. It is not the site,
+        // it is unrecognisable, and it does not fit anywhere. The address
+        // people visit lives on the project's domains endpoint.
+        let domains = vec![
+            RawDomain {
+                name: "pepper-cayenne-accessories.vercel.app".into(),
+                verified: Some(true),
+                git_branch: None,
+                redirect: None,
+            },
+            RawDomain {
+                name: "preview.example.com".into(),
+                verified: Some(true),
+                git_branch: Some("dev".into()),
+                redirect: None,
+            },
+        ];
+        assert_eq!(
+            pick_site_domain(domains).as_deref(),
+            Some("pepper-cayenne-accessories.vercel.app"),
+            "a branch-specific alias is not the site's address"
         );
     }
 
     #[test]
-    fn the_primary_url_is_the_one_a_human_would_recognise() {
-        // Vercel lists a project's stable domain alongside per-deployment hosts
-        // carrying a generated hash and the account name. Taking whichever came
-        // first surfaced the unreadable one.
-        let body = r#"{
-            "uid":"dpl_1","url":"short.vercel.app","readyState":"READY","target":"production",
-            "createdAt":1,
-            "alias":[
-              "pepper-cayenne-accessories-myos1awic-juliangalluzzo.vercel.app",
-              "pepper-cayenne.vercel.app"
-            ],
-            "meta":{"githubCommitSha":"abc","githubCommitRef":"main"}
-        }"#;
-        let raw: RawDeployment = serde_json::from_str(body).unwrap();
-        let d = to_deployment(raw);
-
+    fn a_custom_domain_beats_the_generated_one() {
+        let domains = vec![
+            RawDomain {
+                name: "acme-saas.vercel.app".into(),
+                verified: Some(true),
+                git_branch: None,
+                redirect: None,
+            },
+            RawDomain {
+                name: "peppercayenne.com".into(),
+                verified: Some(true),
+                git_branch: None,
+                redirect: None,
+            },
+        ];
         assert_eq!(
-            d.urls.primary.as_deref(),
-            Some("https://pepper-cayenne.vercel.app")
+            pick_site_domain(domains).as_deref(),
+            Some("peppercayenne.com"),
+            "the owner would call the custom domain the site's address"
         );
-        // The long one is still available; it just isn't what we lead with.
-        assert_eq!(d.urls.aliases.len(), 2);
+    }
+
+    #[test]
+    fn an_unverified_or_redirecting_domain_is_never_offered() {
+        // Vercel lists a domain the moment it is added, long before DNS
+        // resolves. Linking to one that does not load is worse than linking to
+        // the generated address that does.
+        let domains = vec![
+            RawDomain {
+                name: "not-live-yet.com".into(),
+                verified: Some(false),
+                git_branch: None,
+                redirect: None,
+            },
+            RawDomain {
+                name: "old-domain.com".into(),
+                verified: Some(true),
+                git_branch: None,
+                redirect: Some("https://new.com".into()),
+            },
+        ];
+        assert_eq!(pick_site_domain(domains), None);
+        assert_eq!(pick_site_domain(Vec::new()), None);
     }
 
     #[test]

--- a/src-tauri/src/commands/hosting/vercel.rs
+++ b/src-tauri/src/commands/hosting/vercel.rs
@@ -206,7 +206,16 @@ fn to_deployment(raw: RawDeployment) -> Deployment {
 
     let aliases: Vec<String> = raw.alias.iter().map(|a| with_scheme(a)).collect();
     let deployment_url = raw.url.as_deref().map(with_scheme);
-    let primary = aliases.first().cloned().or_else(|| deployment_url.clone());
+    // Vercel returns several aliases in no useful order: a project's stable
+    // domain sits alongside per-deployment hosts carrying a generated hash and
+    // the account name. The shortest is reliably the one a human would
+    // recognise and the only one that fits the row. Still chosen from what the
+    // API returned — never assembled.
+    let primary = aliases
+        .iter()
+        .min_by_key(|a| a.len())
+        .cloned()
+        .or_else(|| deployment_url.clone());
 
     let environment = match raw.target.as_deref() {
         Some("production") => Environment::Production,
@@ -513,6 +522,45 @@ mod tests {
             d.urls.primary.as_deref(),
             Some("https://acme-saas-tau.vercel.app")
         );
+    }
+
+    #[test]
+    fn the_primary_url_is_the_one_a_human_would_recognise() {
+        // Vercel lists a project's stable domain alongside per-deployment hosts
+        // carrying a generated hash and the account name. Taking whichever came
+        // first surfaced the unreadable one.
+        let body = r#"{
+            "uid":"dpl_1","url":"short.vercel.app","readyState":"READY","target":"production",
+            "createdAt":1,
+            "alias":[
+              "pepper-cayenne-accessories-myos1awic-juliangalluzzo.vercel.app",
+              "pepper-cayenne.vercel.app"
+            ],
+            "meta":{"githubCommitSha":"abc","githubCommitRef":"main"}
+        }"#;
+        let raw: RawDeployment = serde_json::from_str(body).unwrap();
+        let d = to_deployment(raw);
+
+        assert_eq!(
+            d.urls.primary.as_deref(),
+            Some("https://pepper-cayenne.vercel.app")
+        );
+        // The long one is still available; it just isn't what we lead with.
+        assert_eq!(d.urls.aliases.len(), 2);
+    }
+
+    #[test]
+    fn alias_assigned_accepts_the_timestamp_form_vercel_actually_sends() {
+        // A live response returned the epoch-millisecond assignment time where
+        // the docs imply a boolean, which failed the whole lookup.
+        let body = r#"{"deployments":[{
+            "uid":"dpl_3","url":"x.vercel.app","readyState":"READY",
+            "aliasAssigned":1787594676951,"target":"production","createdAt":3,
+            "meta":{"githubCommitSha":"abc","githubCommitRef":"main"}
+        }]}"#;
+        let list: RawList = serde_json::from_str(body).unwrap();
+        let d = to_deployment(list.deployments.into_iter().next().unwrap());
+        assert_eq!(d.phase, DeploymentPhase::Ready);
     }
 
     #[test]

--- a/src-tauri/src/commands/hosting/vercel.rs
+++ b/src-tauri/src/commands/hosting/vercel.rs
@@ -1,0 +1,546 @@
+//! Vercel adapter.
+//!
+//! Everything here talks to `api.vercel.com` directly. The previous
+//! implementation scraped `vercel ls`, and its entire commit history is a log
+//! of that table changing shape underneath it.
+//!
+//! Two verified facts shape this file (see
+//! `docs/internal/hosting-provider-matrix.md`):
+//!
+//! * `?sha=` really is a server-side filter — a real SHA returns its
+//!   deployment, a bogus one returns nothing.
+//! * The list endpoint carries **no** aliases. Resolving a commit to the URLs a
+//!   human can open needs a second call to `/v13/deployments/{uid}`, so this
+//!   adapter only pays for it once a deployment is actually live.
+//!
+//! Git metadata lives on `meta.github*`. `gitSource` was absent from a real
+//! response even with `withGitRepoInfo=true`, so nothing here depends on it.
+
+use super::http::{get_json, HostingHttpError};
+use super::model::{
+    Deployment, DeploymentDetail, DeploymentPhase, DeploymentUrls, Environment, HostingLink,
+    HostingProjectChoice, Lookup,
+};
+use serde::Deserialize;
+
+const API: &str = "https://api.vercel.com";
+
+// --------------------------------------------------------------------------
+// Raw response shapes. Deliberately permissive: every field the UI doesn't
+// strictly need is optional, so a missing one degrades a single line of copy
+// instead of failing the whole lookup.
+// --------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct RawList {
+    #[serde(default)]
+    deployments: Vec<RawDeployment>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawDeployment {
+    uid: String,
+    #[serde(default)]
+    url: Option<String>,
+    /// Present on both the list and detail endpoints; `state` is the older
+    /// alias and is accepted as a fallback.
+    #[serde(default)]
+    ready_state: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    ready_substate: Option<String>,
+    #[serde(default)]
+    target: Option<String>,
+    #[serde(default)]
+    created_at: Option<u64>,
+    #[serde(default)]
+    ready: Option<u64>,
+    #[serde(default)]
+    inspector_url: Option<String>,
+    /// Only ever populated on the detail endpoint — the list endpoint returns
+    /// no aliases at all.
+    #[serde(default)]
+    alias: Vec<String>,
+    /// The list endpoint's answer to "are the aliases attached yet", which is
+    /// the only way to tell "built" from "serving" without the detail call.
+    #[serde(default)]
+    alias_assigned: Option<bool>,
+    #[serde(default)]
+    meta: RawMeta,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawMeta {
+    #[serde(default)]
+    github_commit_sha: Option<String>,
+    #[serde(default)]
+    github_commit_ref: Option<String>,
+    #[serde(default)]
+    github_commit_message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawProjectList {
+    #[serde(default)]
+    projects: Vec<RawProject>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawProject {
+    id: String,
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawUser {
+    #[serde(default)]
+    user: Option<RawUserInner>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawUserInner {
+    #[serde(default)]
+    username: Option<String>,
+    #[serde(default)]
+    email: Option<String>,
+}
+
+// --------------------------------------------------------------------------
+// Reducers
+// --------------------------------------------------------------------------
+
+/// Map Vercel's `readyState` onto the shared lifecycle.
+///
+/// `alias_assigned` distinguishes "built" from "actually serving": a READY
+/// deployment whose aliases haven't been attached yet is still finishing, and
+/// calling it live would be premature.
+fn phase_from_ready_state(raw: &str, alias_assigned: bool) -> DeploymentPhase {
+    match raw.to_ascii_uppercase().as_str() {
+        "QUEUED" => DeploymentPhase::Queued,
+        "INITIALIZING" => DeploymentPhase::Queued,
+        "BUILDING" => DeploymentPhase::Building,
+        "READY" if !alias_assigned => DeploymentPhase::Publishing,
+        "READY" => DeploymentPhase::Ready,
+        "ERROR" => DeploymentPhase::Failed,
+        "CANCELED" | "CANCELLED" => DeploymentPhase::Canceled,
+        // Documented on the list endpoint but not the detail one, and not a
+        // state a user's own push produces. Surfaced honestly rather than
+        // guessed at.
+        other => DeploymentPhase::Unknown {
+            raw: other.to_string(),
+        },
+    }
+}
+
+/// Vercel's production-traffic cutover, translated out of its own vocabulary.
+/// `PROMOTED` is the normal end state and needs no qualifier.
+fn detail_from_substate(substate: Option<&str>) -> Option<DeploymentDetail> {
+    match substate?.to_ascii_uppercase().as_str() {
+        "STAGED" => Some(DeploymentDetail::NotYetPromoted),
+        "ROLLING" => Some(DeploymentDetail::RollingOut),
+        _ => None,
+    }
+}
+
+/// Prefix a bare host with a scheme. Vercel returns `url` without one; this is
+/// formatting a value the API gave us, not inventing an address.
+fn with_scheme(host: &str) -> String {
+    if host.starts_with("http://") || host.starts_with("https://") {
+        host.to_string()
+    } else {
+        format!("https://{host}")
+    }
+}
+
+/// Convert a raw deployment into the shared shape.
+///
+/// Every URL here originates in the response. Nothing is assembled from a
+/// naming pattern — the plugin's constructed preview URLs 404 whenever a name
+/// pushes the alias past Vercel's 63-character limit.
+fn to_deployment(raw: RawDeployment) -> Deployment {
+    // `aliasAssigned` is authoritative where the endpoint sends it (the list);
+    // on the detail response the presence of aliases says the same thing.
+    let alias_assigned = raw.alias_assigned.unwrap_or(!raw.alias.is_empty());
+    let ready_state = raw
+        .ready_state
+        .as_deref()
+        .or(raw.state.as_deref())
+        .unwrap_or("");
+
+    let phase = phase_from_ready_state(ready_state, alias_assigned);
+    let detail = if matches!(phase, DeploymentPhase::Ready) {
+        detail_from_substate(raw.ready_substate.as_deref())
+    } else {
+        None
+    };
+
+    let aliases: Vec<String> = raw.alias.iter().map(|a| with_scheme(a)).collect();
+    let deployment_url = raw.url.as_deref().map(with_scheme);
+    let primary = aliases.first().cloned().or_else(|| deployment_url.clone());
+
+    let environment = match raw.target.as_deref() {
+        Some("production") => Environment::Production,
+        _ => Environment::Preview,
+    };
+
+    Deployment {
+        id: raw.uid,
+        phase,
+        detail,
+        environment,
+        branch: raw.meta.github_commit_ref.clone(),
+        commit_sha: raw.meta.github_commit_sha.clone().unwrap_or_default(),
+        commit_message: raw
+            .meta
+            .github_commit_message
+            .clone()
+            .map(|m| m.trim().to_string())
+            .filter(|m| !m.is_empty()),
+        urls: DeploymentUrls {
+            deployment: deployment_url,
+            aliases,
+            primary,
+        },
+        dashboard_url: raw.inspector_url.clone(),
+        error_message: None,
+        created_at: raw.created_at.unwrap_or(0),
+        ready_at: raw.ready,
+    }
+}
+
+// --------------------------------------------------------------------------
+// Queries
+// --------------------------------------------------------------------------
+
+fn scope_query(link: &HostingLink) -> String {
+    link.scope_id
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .map(|team| format!("&teamId={team}"))
+        .unwrap_or_default()
+}
+
+/// Find the deployment for an exact commit.
+///
+/// The `sha=` filter is server-side, so the common case is one cheap call. When
+/// it finds nothing we make a second, wider request to offer "latest on this
+/// branch" as context — never as the answer to the question that was asked.
+pub async fn find_for_commit(
+    link: &HostingLink,
+    token: &str,
+    sha: &str,
+    branch: &str,
+) -> Result<Lookup, HostingHttpError> {
+    let scope = scope_query(link);
+    let url = format!(
+        "{API}/v6/deployments?projectId={project}{scope}&sha={sha}&limit=5",
+        project = link.project_id,
+    );
+
+    let list: RawList = get_json(&url, token).await?;
+
+    // Newest first, preferring production when a commit produced both a
+    // preview and a production deployment.
+    let mut candidates: Vec<Deployment> = list.deployments.into_iter().map(to_deployment).collect();
+    candidates.sort_by(|a, b| {
+        let a_prod = a.environment == Environment::Production;
+        let b_prod = b.environment == Environment::Production;
+        b_prod.cmp(&a_prod).then(b.created_at.cmp(&a.created_at))
+    });
+
+    if let Some(mut found) = candidates.into_iter().next() {
+        // Only worth a second call once it is live: that is the only moment
+        // aliases exist and the only moment the user wants a link to click.
+        if matches!(
+            found.phase,
+            DeploymentPhase::Ready | DeploymentPhase::Publishing
+        ) {
+            if let Ok(detailed) = fetch_detail(link, token, &found.id).await {
+                found = detailed;
+            }
+        }
+        return Ok(Lookup::Found { deployment: found });
+    }
+
+    Ok(Lookup::NotFound {
+        latest_on_branch: latest_for_branch(link, token, branch)
+            .await
+            .ok()
+            .flatten()
+            .map(Box::new),
+    })
+}
+
+/// Fetch one deployment's full record — the only source of aliases.
+async fn fetch_detail(
+    link: &HostingLink,
+    token: &str,
+    uid: &str,
+) -> Result<Deployment, HostingHttpError> {
+    let scope = scope_query(link);
+    let scope = scope
+        .strip_prefix('&')
+        .map(|s| format!("?{s}"))
+        .unwrap_or_default();
+    let url = format!("{API}/v13/deployments/{uid}{scope}");
+    let raw: RawDeployment = get_json(&url, token).await?;
+    Ok(to_deployment(raw))
+}
+
+/// The most recent deployment on a branch, used only as context for a commit we
+/// could not find.
+pub async fn latest_for_branch(
+    link: &HostingLink,
+    token: &str,
+    branch: &str,
+) -> Result<Option<Deployment>, HostingHttpError> {
+    let scope = scope_query(link);
+    let url = format!(
+        "{API}/v6/deployments?projectId={project}{scope}&limit=20",
+        project = link.project_id,
+    );
+    let list: RawList = get_json(&url, token).await?;
+
+    let mut on_branch: Vec<Deployment> = list
+        .deployments
+        .into_iter()
+        .map(to_deployment)
+        .filter(|d| d.branch.as_deref() == Some(branch))
+        .collect();
+    on_branch.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    Ok(on_branch.into_iter().next())
+}
+
+/// Projects the token can see, for the link picker.
+pub async fn list_projects(
+    token: &str,
+    scope_id: Option<&str>,
+) -> Result<Vec<HostingProjectChoice>, HostingHttpError> {
+    let scope = scope_id
+        .filter(|s| !s.is_empty())
+        .map(|t| format!("&teamId={t}"))
+        .unwrap_or_default();
+    let url = format!("{API}/v9/projects?limit=100{scope}");
+    let list: RawProjectList = get_json(&url, token).await?;
+    Ok(list
+        .projects
+        .into_iter()
+        .map(|p| HostingProjectChoice {
+            id: p.id,
+            name: p.name,
+            scope_id: scope_id.map(str::to_string),
+            scope_name: None,
+        })
+        .collect())
+}
+
+/// Confirm a token works and say who it belongs to.
+pub async fn verify_token(token: &str) -> Result<Option<String>, HostingHttpError> {
+    let raw: RawUser = get_json(&format!("{API}/v2/user"), token).await?;
+    Ok(raw.user.and_then(|u| u.username.or(u.email)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ready_state_maps_onto_the_shared_lifecycle() {
+        assert_eq!(
+            phase_from_ready_state("QUEUED", true),
+            DeploymentPhase::Queued
+        );
+        assert_eq!(
+            phase_from_ready_state("INITIALIZING", true),
+            DeploymentPhase::Queued
+        );
+        assert_eq!(
+            phase_from_ready_state("BUILDING", true),
+            DeploymentPhase::Building
+        );
+        assert_eq!(
+            phase_from_ready_state("READY", true),
+            DeploymentPhase::Ready
+        );
+        assert_eq!(
+            phase_from_ready_state("ERROR", true),
+            DeploymentPhase::Failed
+        );
+        assert_eq!(
+            phase_from_ready_state("CANCELED", true),
+            DeploymentPhase::Canceled
+        );
+    }
+
+    #[test]
+    fn a_ready_deployment_without_aliases_is_still_finishing() {
+        assert_eq!(
+            phase_from_ready_state("READY", false),
+            DeploymentPhase::Publishing
+        );
+    }
+
+    #[test]
+    fn an_unrecognized_state_is_surfaced_not_guessed() {
+        // The failure mode this prevents: a new provider state silently
+        // rendering as success or failure.
+        let phase = phase_from_ready_state("SOME_NEW_STATE", true);
+        assert_eq!(
+            phase,
+            DeploymentPhase::Unknown {
+                raw: "SOME_NEW_STATE".into()
+            }
+        );
+    }
+
+    #[test]
+    fn substate_is_translated_out_of_vercel_vocabulary() {
+        assert_eq!(
+            detail_from_substate(Some("STAGED")),
+            Some(DeploymentDetail::NotYetPromoted)
+        );
+        assert_eq!(
+            detail_from_substate(Some("ROLLING")),
+            Some(DeploymentDetail::RollingOut)
+        );
+        // The normal end state needs no qualifier.
+        assert_eq!(detail_from_substate(Some("PROMOTED")), None);
+        assert_eq!(detail_from_substate(None), None);
+    }
+
+    /// Shaped from a real `/v6/deployments` response.
+    fn list_fixture() -> &'static str {
+        r#"{"deployments":[{
+            "uid":"dpl_74f2kUYmdRRBKxirrb3bAdQdVHnx",
+            "url":"acme-saas-fi9rttan8-native-073e1cec.vercel.app",
+            "state":"READY","readyState":"READY","readySubstate":"PROMOTED",
+            "target":"production","createdAt":1757100000000,"ready":1757100060000,
+            "aliasAssigned":true,
+            "inspectorUrl":"https://vercel.com/native/acme-saas/74f2kUYm",
+            "meta":{
+                "githubCommitSha":"a0728a0c6f1976dee739b994e8d2108993ecf6b1",
+                "githubCommitRef":"main",
+                "githubCommitMessage":"Update from Ship Studio"
+            }
+        }]}"#
+    }
+
+    #[test]
+    fn list_response_parses_into_the_shared_shape() {
+        let list: RawList = serde_json::from_str(list_fixture()).unwrap();
+        let d = to_deployment(list.deployments.into_iter().next().unwrap());
+
+        assert_eq!(d.commit_sha, "a0728a0c6f1976dee739b994e8d2108993ecf6b1");
+        assert_eq!(d.branch.as_deref(), Some("main"));
+        assert_eq!(d.commit_message.as_deref(), Some("Update from Ship Studio"));
+        assert_eq!(d.environment, Environment::Production);
+        assert_eq!(
+            d.dashboard_url.as_deref(),
+            Some("https://vercel.com/native/acme-saas/74f2kUYm")
+        );
+    }
+
+    #[test]
+    fn the_list_endpoint_is_live_but_has_no_urls_to_offer_yet() {
+        // It reports `aliasAssigned` but sends no aliases, so the phase is
+        // trustworthy while the links still require the detail call.
+        let list: RawList = serde_json::from_str(list_fixture()).unwrap();
+        let d = to_deployment(list.deployments.into_iter().next().unwrap());
+        assert_eq!(d.phase, DeploymentPhase::Ready);
+        assert!(d.urls.aliases.is_empty());
+    }
+
+    #[test]
+    fn a_built_deployment_whose_aliases_are_not_attached_is_still_finishing() {
+        // `aliasAssigned: false` is the difference between "built" and
+        // "serving"; calling it live here would be premature.
+        let body = r#"{"deployments":[{
+            "uid":"dpl_2","url":"two.vercel.app","readyState":"READY",
+            "aliasAssigned":false,"target":"production","createdAt":2,
+            "meta":{"githubCommitSha":"def","githubCommitRef":"main"}
+        }]}"#;
+        let list: RawList = serde_json::from_str(body).unwrap();
+        let d = to_deployment(list.deployments.into_iter().next().unwrap());
+        assert_eq!(d.phase, DeploymentPhase::Publishing);
+    }
+
+    #[test]
+    fn detail_response_supplies_the_urls_and_marks_it_live() {
+        let detail = r#"{
+            "uid":"dpl_74f2kUYmdRRBKxirrb3bAdQdVHnx",
+            "url":"acme-saas-fi9rttan8-native-073e1cec.vercel.app",
+            "readyState":"READY","readySubstate":"PROMOTED","target":"production",
+            "createdAt":1757100000000,
+            "alias":["acme-saas-tau.vercel.app","acme-saas-native-073e1cec.vercel.app"],
+            "meta":{"githubCommitSha":"a0728a0c","githubCommitRef":"main"}
+        }"#;
+        let raw: RawDeployment = serde_json::from_str(detail).unwrap();
+        let d = to_deployment(raw);
+
+        assert_eq!(d.phase, DeploymentPhase::Ready);
+        assert_eq!(d.urls.aliases.len(), 2);
+        assert_eq!(
+            d.urls.primary.as_deref(),
+            Some("https://acme-saas-tau.vercel.app")
+        );
+    }
+
+    #[test]
+    fn every_url_we_emit_came_from_the_response() {
+        // The guard against reintroducing constructed URLs.
+        let body = r#"{
+            "uid":"dpl_1","url":"one.vercel.app","readyState":"READY","target":"production",
+            "createdAt":1,"alias":["two.vercel.app"],
+            "meta":{"githubCommitSha":"abc","githubCommitRef":"feature/long-branch-name"}
+        }"#;
+        let raw: RawDeployment = serde_json::from_str(body).unwrap();
+        let d = to_deployment(raw);
+
+        for url in d
+            .urls
+            .aliases
+            .iter()
+            .chain(d.urls.deployment.iter())
+            .chain(d.urls.primary.iter())
+        {
+            let host = url.trim_start_matches("https://");
+            assert!(
+                body.contains(host),
+                "{url} was assembled rather than read from the response"
+            );
+        }
+    }
+
+    #[test]
+    fn a_deployment_with_no_git_metadata_still_parses() {
+        // Manual `vercel --prod` deploys carry no commit info.
+        let body = r#"{"uid":"dpl_x","readyState":"READY","createdAt":1,"meta":{}}"#;
+        let raw: RawDeployment = serde_json::from_str(body).unwrap();
+        let d = to_deployment(raw);
+        assert_eq!(d.commit_sha, "");
+        assert_eq!(d.branch, None);
+        assert_eq!(d.environment, Environment::Preview);
+    }
+
+    #[test]
+    fn scope_query_is_omitted_entirely_for_a_personal_account() {
+        let link = HostingLink {
+            provider: super::super::model::HostingProvider::Vercel,
+            project_id: "prj_1".into(),
+            scope_id: None,
+            project_name: None,
+            source: super::super::model::LinkSource::VercelCliFile,
+            linked_at: 0,
+        };
+        assert_eq!(scope_query(&link), "");
+
+        let team = HostingLink {
+            scope_id: Some("team_1".into()),
+            ..link
+        };
+        assert_eq!(scope_query(&team), "&teamId=team_1");
+    }
+}

--- a/src-tauri/src/commands/hosting/vercel.rs
+++ b/src-tauri/src/commands/hosting/vercel.rs
@@ -327,6 +327,12 @@ pub async fn find_for_commit(
                 found.error_message = log.likely_error();
             }
         }
+
+        found.urls.site = site.clone();
+        // A single "open" goes to the address people visit, falling back to
+        // this build's permalink only when the site's isn't known.
+        found.urls.primary = site.or(found.urls.deployment.clone());
+
         return Ok(Lookup::Found { deployment: found });
     }
 
@@ -694,6 +700,28 @@ mod tests {
             pick_site_domain(domains).as_deref(),
             Some("pepper-cayenne-accessories.vercel.app"),
             "a branch-specific alias is not the site's address"
+        );
+    }
+
+    /// The success path must attach the site address, not just the not-found
+    /// path. It silently did not for one build: the domain was fetched and
+    /// then dropped, so a live deployment showed only its build permalink.
+    #[test]
+    fn the_found_path_attaches_the_site_address() {
+        let source = include_str!("vercel.rs");
+        let found_branch = source
+            .split("if let Some(mut found) = candidates.into_iter().next() {")
+            .nth(1)
+            .expect("find_for_commit still has a found branch");
+        let body = found_branch
+            .split("return Ok(Lookup::Found")
+            .next()
+            .expect("the found branch still returns");
+
+        assert!(
+            body.contains("found.urls.site = site"),
+            "a found deployment must carry the site address, or the section \
+             shows only an unrecognisable per-build permalink"
         );
     }
 

--- a/src-tauri/src/commands/hosting/vercel.rs
+++ b/src-tauri/src/commands/hosting/vercel.rs
@@ -18,8 +18,8 @@
 
 use super::http::{get_json, HostingHttpError};
 use super::model::{
-    Deployment, DeploymentDetail, DeploymentPhase, DeploymentUrls, Environment, HostingLink,
-    HostingProjectChoice, Lookup,
+    BuildLog, Deployment, DeploymentDetail, DeploymentPhase, DeploymentUrls, Environment,
+    HostingLink, HostingProjectChoice, LogLine, LogStream, Lookup,
 };
 use serde::Deserialize;
 
@@ -298,6 +298,15 @@ pub async fn find_for_commit(
                 found = detailed;
             }
         }
+
+        // A failed build is the one case where the deployments API alone sends
+        // the user to the provider's dashboard: it reports the failure without
+        // the reason. One extra call, only on failure, buys the reason.
+        if matches!(found.phase, DeploymentPhase::Failed) && found.error_message.is_none() {
+            if let Ok(log) = fetch_logs(link, token, &found.id).await {
+                found.error_message = log.likely_error();
+            }
+        }
         return Ok(Lookup::Found { deployment: found });
     }
 
@@ -371,6 +380,84 @@ pub async fn list_projects(
             scope_name: None,
         })
         .collect())
+}
+
+/// One line of build output as Vercel sends it.
+#[derive(Debug, Deserialize)]
+struct RawEvent {
+    #[serde(default)]
+    created: Option<u64>,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(rename = "type", default)]
+    kind: Option<String>,
+}
+
+/// Vercel caps a single events response; beyond this we tell the user the log
+/// is partial rather than pretending it is complete.
+const LOG_LIMIT: usize = 1000;
+
+/// Fetch a deployment's build output.
+///
+/// This is the endpoint that makes the provider dashboard unnecessary: the
+/// deployments API says a build failed, but only the event stream says why.
+pub async fn fetch_logs(
+    link: &HostingLink,
+    token: &str,
+    deployment_id: &str,
+) -> Result<BuildLog, HostingHttpError> {
+    let scope = scope_query(link);
+    let scope = scope
+        .strip_prefix('&')
+        .map(|s| format!("&{s}"))
+        .unwrap_or_default();
+    let url =
+        format!("{API}/v3/deployments/{deployment_id}/events?limit={LOG_LIMIT}{scope}");
+
+    let raw: Vec<RawEvent> = get_json(&url, token).await?;
+    let truncated = raw.len() >= LOG_LIMIT;
+
+    let lines = raw
+        .into_iter()
+        .filter_map(|e| {
+            let text = e.text?;
+            let trimmed = text.trim_end();
+            if trimmed.is_empty() {
+                return None;
+            }
+            Some(LogLine {
+                at: e.created.unwrap_or(0),
+                stream: match e.kind.as_deref() {
+                    Some("stderr") => LogStream::Stderr,
+                    _ => LogStream::Stdout,
+                },
+                text: trimmed.to_string(),
+            })
+        })
+        .collect();
+
+    Ok(BuildLog {
+        deployment_id: deployment_id.to_string(),
+        lines,
+        truncated,
+    })
+}
+
+/// The most recent deployments on this project, newest first.
+pub async fn list_recent(
+    link: &HostingLink,
+    token: &str,
+    limit: u32,
+) -> Result<Vec<Deployment>, HostingHttpError> {
+    let scope = scope_query(link);
+    let url = format!(
+        "{API}/v6/deployments?projectId={project}{scope}&limit={limit}",
+        project = link.project_id,
+    );
+    let list: RawList = get_json(&url, token).await?;
+    let mut out: Vec<Deployment> = list.deployments.into_iter().map(to_deployment).collect();
+    out.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    Ok(out)
 }
 
 /// Confirm a token works and say who it belongs to.

--- a/src-tauri/src/commands/hosting/vercel.rs
+++ b/src-tauri/src/commands/hosting/vercel.rs
@@ -156,26 +156,32 @@ struct RawUserInner {
 // Reducers
 // --------------------------------------------------------------------------
 
-/// Map Vercel's `readyState` onto the shared lifecycle.
+/// Map Vercel's `readyState` onto the shared lifecycle used for behaviour.
 ///
-/// `alias_assigned` distinguishes "built" from "actually serving": a READY
-/// deployment whose aliases haven't been attached yet is still finishing, and
-/// calling it live would be premature.
-fn phase_from_ready_state(raw: &str, alias_assigned: bool) -> DeploymentPhase {
+/// Only for deciding what to poll and which colour the dot is — the words the
+/// user reads come from `status_label`, which is Vercel's own.
+fn phase_from_ready_state(raw: &str) -> DeploymentPhase {
     match raw.to_ascii_uppercase().as_str() {
-        "QUEUED" => DeploymentPhase::Queued,
-        "INITIALIZING" => DeploymentPhase::Queued,
+        "QUEUED" | "INITIALIZING" => DeploymentPhase::Queued,
         "BUILDING" => DeploymentPhase::Building,
-        "READY" if !alias_assigned => DeploymentPhase::Publishing,
         "READY" => DeploymentPhase::Ready,
         "ERROR" => DeploymentPhase::Failed,
         "CANCELED" | "CANCELLED" => DeploymentPhase::Canceled,
-        // Documented on the list endpoint but not the detail one, and not a
-        // state a user's own push produces. Surfaced honestly rather than
-        // guessed at.
         other => DeploymentPhase::Unknown {
             raw: other.to_string(),
         },
+    }
+}
+
+/// Vercel's status word, as Vercel writes it: `READY` becomes "Ready".
+///
+/// Not translated into a synonym. The dashboard says "Ready" and so does this,
+/// so there is no vocabulary to reconcile when someone looks at both.
+fn status_label(raw: &str) -> String {
+    let mut chars = raw.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + &chars.as_str().to_lowercase(),
+        None => "Unknown".to_string(),
     }
 }
 
@@ -205,20 +211,13 @@ fn with_scheme(host: &str) -> String {
 /// naming pattern — the plugin's constructed preview URLs 404 whenever a name
 /// pushes the alias past Vercel's 63-character limit.
 fn to_deployment(raw: RawDeployment) -> Deployment {
-    // `aliasAssigned` is authoritative where the endpoint sends it (the list);
-    // on the detail response the presence of aliases says the same thing.
-    let alias_assigned = raw
-        .alias_assigned
-        .as_ref()
-        .map(AliasAssigned::is_assigned)
-        .unwrap_or(!raw.alias.is_empty());
     let ready_state = raw
         .ready_state
         .as_deref()
         .or(raw.state.as_deref())
         .unwrap_or("");
 
-    let phase = phase_from_ready_state(ready_state, alias_assigned);
+    let phase = phase_from_ready_state(ready_state);
     let detail = if matches!(phase, DeploymentPhase::Ready) {
         detail_from_substate(raw.ready_substate.as_deref())
     } else {
@@ -239,6 +238,7 @@ fn to_deployment(raw: RawDeployment) -> Deployment {
 
     Deployment {
         id: raw.uid,
+        status_label: status_label(ready_state),
         phase,
         detail,
         environment,
@@ -329,9 +329,7 @@ pub async fn find_for_commit(
         }
 
         found.urls.site = site.clone();
-        // A single "open" goes to the address people visit, falling back to
-        // this build's permalink only when the site's isn't known.
-        found.urls.primary = site.or(found.urls.deployment.clone());
+        found.urls.primary = primary_for(&found, site.clone());
 
         return Ok(Lookup::Found { deployment: found });
     }
@@ -339,7 +337,7 @@ pub async fn find_for_commit(
     let mut latest = latest_for_branch(link, token, branch).await.ok().flatten();
     if let Some(deployment) = latest.as_mut() {
         deployment.urls.site = site.clone();
-        deployment.urls.primary = site.or(deployment.urls.deployment.clone());
+        deployment.urls.primary = primary_for(deployment, site.clone());
     }
 
     Ok(Lookup::NotFound {
@@ -408,6 +406,18 @@ pub async fn list_projects(
             scope_name: None,
         })
         .collect())
+}
+
+/// The one address a single "open" should go to.
+///
+/// A preview deployment never reached production, so sending someone to the
+/// production domain from a feature branch would open a page that does not
+/// contain the change they just pushed.
+fn primary_for(deployment: &Deployment, site: Option<String>) -> Option<String> {
+    match deployment.environment {
+        Environment::Preview => deployment.urls.deployment.clone(),
+        Environment::Production => site.or_else(|| deployment.urls.deployment.clone()),
+    }
 }
 
 /// The address people visit.
@@ -534,45 +544,41 @@ mod tests {
 
     #[test]
     fn ready_state_maps_onto_the_shared_lifecycle() {
+        assert_eq!(phase_from_ready_state("QUEUED"), DeploymentPhase::Queued);
         assert_eq!(
-            phase_from_ready_state("QUEUED", true),
+            phase_from_ready_state("INITIALIZING"),
             DeploymentPhase::Queued
         );
         assert_eq!(
-            phase_from_ready_state("INITIALIZING", true),
-            DeploymentPhase::Queued
-        );
-        assert_eq!(
-            phase_from_ready_state("BUILDING", true),
+            phase_from_ready_state("BUILDING"),
             DeploymentPhase::Building
         );
+        assert_eq!(phase_from_ready_state("READY"), DeploymentPhase::Ready);
+        assert_eq!(phase_from_ready_state("ERROR"), DeploymentPhase::Failed);
         assert_eq!(
-            phase_from_ready_state("READY", true),
-            DeploymentPhase::Ready
-        );
-        assert_eq!(
-            phase_from_ready_state("ERROR", true),
-            DeploymentPhase::Failed
-        );
-        assert_eq!(
-            phase_from_ready_state("CANCELED", true),
+            phase_from_ready_state("CANCELED"),
             DeploymentPhase::Canceled
         );
     }
 
     #[test]
-    fn a_ready_deployment_without_aliases_is_still_finishing() {
-        assert_eq!(
-            phase_from_ready_state("READY", false),
-            DeploymentPhase::Publishing
-        );
+    fn the_status_word_is_vercels_own() {
+        // "Ready" is what the dashboard says, so it is what this says. The
+        // previous mapping invented "Live" and a "Publishing" state Vercel
+        // does not have, leaving two vocabularies to reconcile.
+        assert_eq!(status_label("READY"), "Ready");
+        assert_eq!(status_label("BUILDING"), "Building");
+        assert_eq!(status_label("ERROR"), "Error");
+        assert_eq!(status_label("CANCELED"), "Canceled");
+        assert_eq!(status_label("QUEUED"), "Queued");
+        assert_eq!(status_label(""), "Unknown");
     }
 
     #[test]
     fn an_unrecognized_state_is_surfaced_not_guessed() {
         // The failure mode this prevents: a new provider state silently
         // rendering as success or failure.
-        let phase = phase_from_ready_state("SOME_NEW_STATE", true);
+        let phase = phase_from_ready_state("SOME_NEW_STATE");
         assert_eq!(
             phase,
             DeploymentPhase::Unknown {
@@ -629,27 +635,13 @@ mod tests {
     }
 
     #[test]
-    fn the_list_endpoint_is_live_but_has_no_urls_to_offer_yet() {
-        // It reports `aliasAssigned` but sends no aliases, so the phase is
-        // trustworthy while the links still require the detail call.
+    fn the_list_endpoint_is_ready_but_has_no_urls_to_offer_yet() {
+        // The status is trustworthy from the list; the addresses still need
+        // the detail call, because the list carries no aliases at all.
         let list: RawList = serde_json::from_str(list_fixture()).unwrap();
         let d = to_deployment(list.deployments.into_iter().next().unwrap());
         assert_eq!(d.phase, DeploymentPhase::Ready);
         assert!(d.urls.aliases.is_empty());
-    }
-
-    #[test]
-    fn a_built_deployment_whose_aliases_are_not_attached_is_still_finishing() {
-        // `aliasAssigned: false` is the difference between "built" and
-        // "serving"; calling it live here would be premature.
-        let body = r#"{"deployments":[{
-            "uid":"dpl_2","url":"two.vercel.app","readyState":"READY",
-            "aliasAssigned":false,"target":"production","createdAt":2,
-            "meta":{"githubCommitSha":"def","githubCommitRef":"main"}
-        }]}"#;
-        let list: RawList = serde_json::from_str(body).unwrap();
-        let d = to_deployment(list.deployments.into_iter().next().unwrap());
-        assert_eq!(d.phase, DeploymentPhase::Publishing);
     }
 
     #[test]
@@ -666,6 +658,7 @@ mod tests {
         let d = to_deployment(raw);
 
         assert_eq!(d.phase, DeploymentPhase::Ready);
+        assert_eq!(d.status_label, "Ready");
         assert_eq!(d.urls.aliases.len(), 2);
         // A deployment record alone can only offer its own permalink; the
         // site's address is attached by the caller from the project's domains.

--- a/src-tauri/src/commands/hosting/vercel.rs
+++ b/src-tauri/src/commands/hosting/vercel.rs
@@ -63,35 +63,8 @@ struct RawDeployment {
     /// no aliases at all.
     #[serde(default)]
     alias: Vec<String>,
-    /// The list endpoint's answer to "are the aliases attached yet", which is
-    /// the only way to tell "built" from "serving" without the detail call.
-    ///
-    /// Its type is not stable: a live response returned the epoch-millisecond
-    /// timestamp of the assignment (`1787594676951`) where the docs imply a
-    /// boolean. Both are accepted, and anything else is treated as "unknown"
-    /// rather than failing the whole lookup over one field.
-    #[serde(default)]
-    alias_assigned: Option<AliasAssigned>,
     #[serde(default)]
     meta: RawMeta,
-}
-
-/// `aliasAssigned` arrives as either a flag or the timestamp at which the
-/// aliases were attached. A timestamp means they are attached.
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum AliasAssigned {
-    Flag(bool),
-    At(u64),
-}
-
-impl AliasAssigned {
-    fn is_assigned(&self) -> bool {
-        match self {
-            AliasAssigned::Flag(v) => *v,
-            AliasAssigned::At(ts) => *ts > 0,
-        }
-    }
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -765,12 +738,14 @@ mod tests {
     }
 
     #[test]
-    fn alias_assigned_accepts_the_timestamp_form_vercel_actually_sends() {
-        // A live response returned the epoch-millisecond assignment time where
-        // the docs imply a boolean, which failed the whole lookup.
+    fn unknown_fields_never_fail_the_lookup() {
+        // `aliasAssigned` is no longer read, and a live response sends it as a
+        // timestamp where the docs imply a boolean. Either way an unread field
+        // must not take the whole deployment down with it.
         let body = r#"{"deployments":[{
             "uid":"dpl_3","url":"x.vercel.app","readyState":"READY",
-            "aliasAssigned":1787594676951,"target":"production","createdAt":3,
+            "aliasAssigned":1787594676951,"somethingNew":{"nested":true},
+            "target":"production","createdAt":3,
             "meta":{"githubCommitSha":"abc","githubCommitRef":"main"}
         }]}"#;
         let list: RawList = serde_json::from_str(body).unwrap();

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -22,6 +22,7 @@ pub mod folders;
 pub mod git;
 pub mod github;
 pub mod health;
+pub mod hosting;
 pub mod i18n;
 pub mod ide;
 pub mod mcp;

--- a/src-tauri/src/commands/projects/metadata.rs
+++ b/src-tauri/src/commands/projects/metadata.rs
@@ -38,13 +38,14 @@ pub(crate) fn save_project_metadata(
         .map_err(|e| crate::utils::classify_fs_error("write project metadata", &metadata_path, &e))
 }
 
-/// Reads project metadata from .shipstudio/project.json with automatic schema migration
-#[tauri::command]
-#[tracing::instrument(fields(project = %project_path))]
-pub async fn read_project_metadata(
-    project_path: String,
+/// Read `.shipstudio/project.json`, migrating it in place if the schema moved.
+///
+/// The synchronous half of [`read_project_metadata`], so non-command callers
+/// (hosting link resolution, for one) share the same parse-and-migrate path
+/// rather than re-implementing it and drifting.
+pub(crate) fn read_project_metadata_sync(
+    project: &std::path::Path,
 ) -> Result<Option<ProjectMetadata>, CommandError> {
-    let project = validate_project_path(&project_path)?;
     let metadata_path = project.join(".shipstudio").join("project.json");
 
     if !metadata_path.exists() {
@@ -60,10 +61,20 @@ pub async fn read_project_metadata(
 
     // Apply migrations if needed and save the updated metadata
     if metadata.migrate() {
-        save_project_metadata(&project, &metadata)?;
+        save_project_metadata(project, &metadata)?;
     }
 
     Ok(Some(metadata))
+}
+
+/// Reads project metadata from .shipstudio/project.json with automatic schema migration
+#[tauri::command]
+#[tracing::instrument(fields(project = %project_path))]
+pub async fn read_project_metadata(
+    project_path: String,
+) -> Result<Option<ProjectMetadata>, CommandError> {
+    let project = validate_project_path(&project_path)?;
+    read_project_metadata_sync(&project)
 }
 
 /// Writes project metadata to .shipstudio/project.json

--- a/src-tauri/src/commands/publishing.rs
+++ b/src-tauri/src/commands/publishing.rs
@@ -1,6 +1,13 @@
 //! # Publishing Commands
 //!
-//! Commands for publishing to GitHub, staging, and production.
+//! Pushing the current branch to origin, and the git-push error taxonomy that
+//! turns GitHub's stderr into something a user can act on.
+//!
+//! There used to be `publish_to_staging` and `publish_to_production` here too,
+//! pushing `HEAD:staging` and `HEAD:main` and each returning a `PublishResult`
+//! of `{ url: "", state: "QUEUED" }` — a deploy state nobody had observed,
+//! about a URL nobody knew. Nothing called them. Deployment status now comes
+//! from asking the provider about the commit (`commands::hosting`).
 
 use crate::commands::ai::resolve_commit_message;
 use crate::commands::git::git_stage_and_commit;
@@ -12,7 +19,7 @@ use crate::commands::github::ensure_git_identity;
 use crate::errors::CommandError;
 use crate::types::PublishResult;
 use crate::utils::validate_project_path;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{error, info, instrument, warn};
 
 /// GitHub's push-time auth/permission rejections. The phrasing varies by
 /// transport and failure mode: SSH's "Permission denied", the credential
@@ -145,248 +152,6 @@ pub(crate) fn push_unresolvable_branch_error(stderr: &str, branch: &str) -> Opti
              `git branch -a` in a terminal, rename or delete the similarly-named branch, then \
              try again."
         ))
-    })
-}
-
-#[tauri::command]
-#[instrument(name = "publish_to_github", skip(project_path, commit_message), fields(project = %project_path))]
-pub async fn publish_to_github(
-    project_path: String,
-    commit_message: Option<String>,
-) -> Result<(), CommandError> {
-    let validated_path = validate_project_path(&project_path).map_err(CommandError::from)?;
-    let message = resolve_commit_message(&validated_path, commit_message).await;
-    info!(message = %message, "Publishing to GitHub");
-
-    // Get current branch name
-    let branch_output = crate::utils::git_command_in(&validated_path)?
-        .args(["branch", "--show-current"])
-        .output()
-        .map_err(CommandError::from)?;
-
-    let branch = String::from_utf8_lossy(&branch_output.stdout)
-        .trim()
-        .to_string();
-    let branch = if branch.is_empty() {
-        "main".to_string()
-    } else {
-        branch
-    };
-
-    // Pull latest changes first (rebase to keep history clean)
-    let pull_output = run_git_net(
-        &["pull", "--rebase", "origin", &branch],
-        &validated_path,
-        "pull --rebase",
-    )
-    .await;
-
-    // Handle pull errors - log unexpected ones but don't fail
-    match pull_output {
-        Ok(output) if !output.status.success() => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            // These errors are expected for new repos/branches
-            let is_expected_error = stderr.contains("no tracking")
-                || stderr.contains("Couldn't find remote ref")
-                || stderr.contains("There is no tracking information")
-                || stderr.contains("fatal: couldn't find remote ref");
-
-            if !is_expected_error {
-                warn!(error = %stderr, "Unexpected pull error (continuing anyway)");
-            } else {
-                debug!(error = %stderr, "Expected pull error for new repo/branch");
-            }
-        }
-        Err(e) => {
-            warn!(error = %e, "Failed to execute git pull");
-        }
-        _ => {}
-    }
-
-    // Ensure git identity matches GitHub account before committing
-    let _ = ensure_git_identity(&validated_path);
-
-    // Stage and commit through the shared helper: it retries sparse-checkout
-    // refusals (issue #275) and treats an empty commit as a no-op instead of a
-    // hard failure (issue #274), unlike the hand-rolled sequence it replaces.
-    git_stage_and_commit(&validated_path, &message).map_err(CommandError::from)?;
-
-    // Push to origin
-    let output = run_git_net(&["push", "-u", "origin", &branch], &validated_path, "push").await?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        // Large-file / ref-too-long pre-receive declines carry a specific fix
-        // of their own (issues #626/#636) — and without this arm they'd fall
-        // through to the auto-reported generic Process error below.
-        if let Some(err) = push_pre_receive_error(&stderr) {
-            warn!(error = %stderr, branch = %branch, "Push declined by GitHub pre-receive check");
-            return Err(err);
-        }
-        // GitHub-side 5xx during the push — retryable, not a malfunction
-        // (issue #678).
-        if let Some(err) = push_transient_server_error(&stderr) {
-            warn!(error = %stderr, branch = %branch, "Push failed on a GitHub server error");
-            return Err(err);
-        }
-        if let Some(err) = push_auth_error(&stderr) {
-            error!(error = %stderr, branch = %branch, "Authentication error");
-            return Err(err);
-        }
-        if let Some(err) = push_missing_remote_error(&stderr) {
-            return Err(err);
-        }
-        if !stderr.contains("Everything up-to-date") {
-            error!(error = %stderr, branch = %branch, "Push to GitHub failed");
-            return Err(CommandError::Process {
-                cmd: "git push".to_string(),
-                exit_code: output.status.code().unwrap_or(-1),
-                stderr: stderr.to_string(),
-            });
-        }
-    }
-
-    info!(branch = %branch, "Published to GitHub successfully");
-    Ok(())
-}
-
-#[tauri::command]
-#[instrument(name = "publish_to_staging", skip(project_path, commit_message), fields(project = %project_path))]
-pub async fn publish_to_staging(
-    project_path: String,
-    commit_message: Option<String>,
-) -> Result<PublishResult, CommandError> {
-    let validated_path = validate_project_path(&project_path).map_err(CommandError::from)?;
-    let message = resolve_commit_message(&validated_path, commit_message).await;
-    info!(message = %message, "Publishing to staging");
-
-    // Ensure git identity matches GitHub account before committing
-    let _ = ensure_git_identity(&validated_path);
-
-    // Stage and commit any changes. A real staging/commit failure must not be
-    // swallowed — the push below would silently deploy stale code (benign cases
-    // like "nothing to commit" and sparse-checkout are handled in the helper).
-    git_stage_and_commit(&validated_path, &message).map_err(CommandError::from)?;
-
-    // Push to staging branch - Vercel auto-deploys via GitHub integration
-    // Note: Using regular push instead of force push to avoid overwriting others' work
-    let push_output = run_git_net(
-        &["push", "-u", "origin", "HEAD:staging"],
-        &validated_path,
-        "push staging",
-    )
-    .await?;
-
-    if !push_output.status.success() {
-        let stderr = String::from_utf8_lossy(&push_output.stderr);
-        // Pre-receive declines (GH001 large file, GH005 ref too long) contain
-        // the word "rejected" but are NOT the diverged-branch race — check
-        // them first or the user gets "pull changes first" advice that can't
-        // fix anything (issues #626/#636).
-        if let Some(err) = push_pre_receive_error(&stderr) {
-            warn!(error = %stderr, "Push declined by GitHub pre-receive check");
-            return Err(err);
-        }
-        // GitHub-side 5xx: contains "rejected" but isn't the diverged-branch
-        // race — must run before that arm (issue #678).
-        if let Some(err) = push_transient_server_error(&stderr) {
-            warn!(error = %stderr, "Push failed on a GitHub server error");
-            return Err(err);
-        }
-        if stderr.contains("rejected") || stderr.contains("non-fast-forward") {
-            warn!(error = %stderr, "Push rejected - staging branch has diverged");
-            // Retain the legacy PUSH_REJECTED sentinel so the frontend can
-            // still discriminate this case via substring match. A concurrent
-            // push landing first is a benign race with dedicated UI, not a
-            // malfunction — Expected keeps it out of telemetry (issue #617,
-            // same class as #312/#521/#609).
-            return Err(CommandError::expected(format!(
-                "PUSH_REJECTED: Staging branch has diverged. Pull changes first or resolve conflicts.\n{stderr}"
-            )));
-        }
-        if let Some(err) = push_auth_error(&stderr) {
-            error!(error = %stderr, "Authentication error");
-            return Err(err);
-        }
-        if let Some(err) = push_missing_remote_error(&stderr) {
-            return Err(err);
-        }
-        if !stderr.contains("Everything up-to-date") {
-            error!(error = %stderr, "Failed to push to staging");
-            return Err(CommandError::Process {
-                cmd: "git push staging".to_string(),
-                exit_code: push_output.status.code().unwrap_or(-1),
-                stderr: stderr.to_string(),
-            });
-        }
-    }
-
-    info!("Published to staging successfully");
-    Ok(PublishResult {
-        url: String::new(),
-        state: "QUEUED".to_string(),
-    })
-}
-
-#[tauri::command]
-#[instrument(name = "publish_to_production", skip(project_path, commit_message), fields(project = %project_path))]
-pub async fn publish_to_production(
-    project_path: String,
-    commit_message: Option<String>,
-) -> Result<PublishResult, CommandError> {
-    let validated_path = validate_project_path(&project_path).map_err(CommandError::from)?;
-    let message = resolve_commit_message(&validated_path, commit_message).await;
-    info!(message = %message, "Publishing to production");
-
-    // Ensure git identity matches GitHub account before committing
-    let _ = ensure_git_identity(&validated_path);
-
-    // Stage and commit any changes (real failures propagate — see staging).
-    git_stage_and_commit(&validated_path, &message).map_err(CommandError::from)?;
-
-    // Push to main branch - Vercel auto-deploys to production via GitHub integration
-    let push_output = run_git_net(
-        &["push", "-u", "origin", "HEAD:main"],
-        &validated_path,
-        "push main",
-    )
-    .await?;
-
-    if !push_output.status.success() {
-        let stderr = String::from_utf8_lossy(&push_output.stderr);
-        // Pre-receive declines have their own fix and would otherwise be
-        // auto-reported as a generic Process error (issues #626/#636).
-        if let Some(err) = push_pre_receive_error(&stderr) {
-            warn!(error = %stderr, "Push declined by GitHub pre-receive check");
-            return Err(err);
-        }
-        // GitHub-side 5xx during the push — retryable, not a malfunction
-        // (issue #678).
-        if let Some(err) = push_transient_server_error(&stderr) {
-            warn!(error = %stderr, "Push failed on a GitHub server error");
-            return Err(err);
-        }
-        if let Some(err) = push_auth_error(&stderr) {
-            error!(error = %stderr, "Authentication error");
-            return Err(err);
-        }
-        if let Some(err) = push_missing_remote_error(&stderr) {
-            return Err(err);
-        }
-        if !stderr.contains("Everything up-to-date") {
-            error!(error = %stderr, "Failed to push to production");
-            return Err(CommandError::Process {
-                cmd: "git push main".to_string(),
-                exit_code: push_output.status.code().unwrap_or(-1),
-                stderr: stderr.to_string(),
-            });
-        }
-    }
-
-    info!("Published to production successfully");
-    Ok(PublishResult {
-        url: String::new(),
-        state: "QUEUED".to_string(),
     })
 }
 

--- a/src-tauri/src/commands/skills/bundled.rs
+++ b/src-tauri/src/commands/skills/bundled.rs
@@ -1,0 +1,359 @@
+//! Skills Ship Studio ships with, written into each installed agent's skills
+//! directory on launch.
+//!
+//! ## Why this exists
+//!
+//! Ship Studio used to extend itself with plugins: separate repos, cloned
+//! per-project, rendering their own UI through a parallel component library.
+//! For anything whose real job is *constructing a prompt* that was the wrong
+//! container — it meant a second design system, a per-project install, and a
+//! version pinned at whatever commit the clone happened to catch. A skill is
+//! the right container for that work: the agent is already open, the user is
+//! already talking to it, and there is nothing to install or keep up to date.
+//!
+//! So: features with genuine UI and persistent state became native modules;
+//! features that were a prompt with a form in front of it live here.
+//!
+//! ## Adding one
+//!
+//! Add a [`BundledSkill`] to [`BUNDLED_SKILLS`] and bump its `version`.
+//! Installation is idempotent and only writes when the body differs, so this
+//! is cheap on every launch and never churns file mtimes.
+//!
+//! Nothing is created from nothing: if `~/.claude` doesn't exist the agent
+//! isn't installed, and scattering directories into someone's home for tools
+//! they don't use is not ours to do.
+
+use crate::agent::{CLAUDE_CODE, CODEX};
+use serde::Serialize;
+use std::path::PathBuf;
+use tracing::{debug, warn};
+
+/// One skill this app ships.
+pub struct BundledSkill {
+    /// Directory name under the agent's `skills/`.
+    pub dir_name: &'static str,
+    /// Bump when `body` changes so installed copies refresh.
+    pub version: &'static str,
+    /// Produces the full SKILL.md, front matter included.
+    pub body: fn() -> String,
+}
+
+/// Every skill Ship Studio installs.
+pub const BUNDLED_SKILLS: &[BundledSkill] = &[
+    BundledSkill {
+        dir_name: "shipstudio-workflows",
+        version: "1",
+        body: super::super::workflows::skill::skill_markdown,
+    },
+    BundledSkill {
+        dir_name: "shipstudio-brand-guidelines",
+        version: "1",
+        body: brand_guidelines_skill,
+    },
+    BundledSkill {
+        dir_name: "shipstudio-site-to-code",
+        version: "1",
+        body: site_to_code_skill,
+    },
+];
+
+/// Extracting a design system from a site someone already built.
+///
+/// Replaces the `brand-guidelines` plugin, which paired a real extraction step
+/// with a bespoke modal and its own file-sync engine — then handed the result
+/// to `claude -p` anyway. The extraction is something an agent can do directly,
+/// and the agent already knows where this project keeps its conventions.
+fn brand_guidelines_skill() -> String {
+    r#"---
+name: shipstudio-brand-guidelines
+description: >-
+  Capture a project's visual language — colours, type, spacing, radii, shadows —
+  and write it down where this project's agents will actually read it. Use when
+  the user says a new page should "match the rest of the site", asks to write
+  down or extract brand guidelines or a design system, mentions their brand
+  colours or fonts, points at a site and says "make it look like this", or asks
+  why the styling keeps drifting between pages.
+---
+
+# Capture a project's visual language
+
+The goal is that the next thing built in this project looks like it belongs,
+without anyone having to say so.
+
+## Where it goes
+
+Write the result into the project's own agent instructions — `CLAUDE.md`, or
+`AGENTS.md` where that is what the project uses. A design system in a file
+nobody loads changes nothing. Append a `## Visual language` section rather than
+rewriting the file, and preserve everything already there.
+
+If the project already has such a section, update it in place and say what
+changed rather than duplicating it.
+
+## What to capture
+
+Read the actual source, not a screenshot. Look at the stylesheets, the token
+files, the component library, and a couple of representative pages.
+
+- **Colours.** The ones actually used, with the names the codebase uses for
+  them. If they are CSS custom properties, record the property names — those
+  are what future code should reference, not the hex values.
+- **Type.** Families, the sizes that recur, and their weights. Note which is
+  for UI and which for code, if they differ.
+- **Spacing.** The rhythm the layout is on, and whether it comes from tokens.
+- **Radii, borders, shadows.** Usually a small closed set. Record the set.
+- **What is conspicuously absent.** "No gradients anywhere", "shadows only on
+  overlays" — the rules a newcomer would break are as useful as the palette.
+
+## The one rule
+
+Record what you found, not what you would have chosen. If a project uses four
+near-identical greys, say so; that is a fact about the codebase and possibly a
+cleanup worth suggesting separately. Do not quietly tidy it into three on the
+way past, and do not invent a value to fill a gap in the set.
+
+If a category genuinely has no pattern, write that. An honest "spacing is
+ad-hoc; no scale in use" tells the next agent far more than an invented scale
+it will then apply wrongly.
+"#
+    .to_string()
+}
+
+/// Turning an existing site or an export into a migration plan.
+///
+/// Replaces the `url-to-code`, `webflow-to-code`, `weweb-to-code` and
+/// `wordpress-to-code` plugins. Each was a local extraction pipeline that
+/// terminated in a prompt on the clipboard; the differences between them were
+/// the parser, not the workflow.
+fn site_to_code_skill() -> String {
+    r#"---
+name: shipstudio-site-to-code
+description: >-
+  Turn an existing site — a live URL, or an export from Webflow, WeWeb, Framer
+  or WordPress — into a migration plan and then into code in this project. Use
+  when the user wants to rebuild, port, recreate or migrate a site, says "make
+  this in Next.js/Astro", points at a URL and asks to copy its structure, or
+  has a .zip export from a site builder.
+---
+
+# Rebuild an existing site in this project
+
+Two phases, and the first one is not optional. Migrations fail by starting to
+write components before anyone has established what the site actually contains.
+
+## Phase 1 — survey, then agree a plan
+
+Do not write application code in this phase.
+
+**From a live URL**, fetch the pages themselves. Establish: how many distinct
+page templates there really are (usually far fewer than there are pages), the
+navigation structure, which sections repeat across templates, the breakpoints,
+and where content is dynamic rather than authored once.
+
+**From an export**, read the archive. Webflow and Framer exports carry their
+pages as HTML with a stylesheet; WeWeb exports carry a JSON project; WordPress
+backups carry SQL, sometimes with PHP-serialized fields inside it. In every
+case what you want is the same: templates, components, content model.
+
+Then write a plan to `MIGRATION.md` in the project root:
+
+- A page inventory, grouped by template rather than listed one by one.
+- The components each template needs, named as they will be named in code.
+- The content model: what is authored, and where it will live.
+- Anything that cannot come across — a builder interaction with no equivalent,
+  a font that isn't licensed for self-hosting, a third-party embed.
+- What you are unsure about.
+
+Show the plan and get agreement before building. A migration is mostly
+judgement calls about what to keep, and those are the user's to make.
+
+## Phase 2 — build against the plan
+
+Work template by template, not page by page. Build the shared components first,
+then compose pages from them. Check each template in the preview before moving
+on: the point of a migration is fidelity, and fidelity is a visual property.
+
+Keep `MIGRATION.md` updated as you go — it is the record of what is done and
+what is left, and it survives the conversation ending.
+
+## What not to do
+
+- **Do not copy the markup.** A builder's export is machine-generated: wrapper
+  divs many levels deep, generated class names, absolute positioning where a
+  layout should be. Rebuild it in this project's idiom.
+- **Do not recreate the CSS wholesale.** Read it to learn the visual language,
+  then express that in whatever this project already uses. If the project has a
+  design system, use it — see the `shipstudio-brand-guidelines` skill for
+  capturing one first.
+- **Do not invent content.** Placeholder text is fine and should be visibly
+  placeholder. Do not write plausible-looking copy that reads as real.
+- **Do not silently drop a page.** If something cannot be migrated, it belongs
+  in the plan's "cannot come across" list where the user can see it.
+"#
+    .to_string()
+}
+
+/// Where each agent keeps user-scope skills. `None` for agents without skills.
+fn skill_dirs(dir_name: &str) -> Vec<(&'static str, PathBuf)> {
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    [CLAUDE_CODE, CODEX]
+        .into_iter()
+        .filter_map(|agent| {
+            let skills_dir = agent.skills_dir_name?;
+            Some((
+                agent.id,
+                home.join(agent.auth_config_dir)
+                    .join(skills_dir)
+                    .join(dir_name),
+            ))
+        })
+        .collect()
+}
+
+/// Whether a bundled skill is installed for one agent.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BundledSkillStatus {
+    pub skill: String,
+    pub agent_id: String,
+    pub installed: bool,
+    pub path: String,
+}
+
+/// Write every bundled skill for every agent that supports one.
+pub fn install_bundled_skills() -> Vec<BundledSkillStatus> {
+    let mut statuses = Vec::new();
+
+    for skill in BUNDLED_SKILLS {
+        let body = (skill.body)();
+        for (agent_id, dir) in skill_dirs(skill.dir_name) {
+            let installed = write_skill_if_agent_present(&dir, &body).unwrap_or_else(|err| {
+                warn!(
+                    agent = agent_id,
+                    skill = skill.dir_name,
+                    error = %err,
+                    "could not install a bundled skill"
+                );
+                false
+            });
+            statuses.push(BundledSkillStatus {
+                skill: skill.dir_name.to_string(),
+                agent_id: agent_id.to_string(),
+                installed,
+                path: dir.join("SKILL.md").to_string_lossy().to_string(),
+            });
+        }
+    }
+
+    statuses
+}
+
+fn write_skill_if_agent_present(dir: &std::path::Path, body: &str) -> std::io::Result<bool> {
+    // dir is <home>/<config>/skills/<name> — the agent's own config dir is two
+    // levels up and must already exist.
+    match dir.parent().and_then(|p| p.parent()) {
+        Some(root) if root.exists() => {}
+        _ => {
+            debug!(?dir, "agent config dir absent — skipping skill install");
+            return Ok(false);
+        }
+    }
+
+    let file = dir.join("SKILL.md");
+    if std::fs::read_to_string(&file).is_ok_and(|existing| existing == body) {
+        return Ok(true);
+    }
+    std::fs::create_dir_all(dir)?;
+    std::fs::write(&file, body)?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_bundled_skill_has_the_front_matter_an_agent_needs() {
+        // Without a name and a description the agent has no basis to decide
+        // when to load it, and a skill that never loads is not a feature.
+        for skill in BUNDLED_SKILLS {
+            let body = (skill.body)();
+            assert!(
+                body.starts_with("---\n"),
+                "{} has no front matter",
+                skill.dir_name
+            );
+            assert!(
+                body.contains("\nname:"),
+                "{} declares no name",
+                skill.dir_name
+            );
+            assert!(
+                body.contains("\ndescription:"),
+                "{} declares no description",
+                skill.dir_name
+            );
+        }
+    }
+
+    #[test]
+    fn descriptions_name_what_a_user_would_actually_say() {
+        // A description written in the feature's own vocabulary never fires:
+        // someone who has not found the feature will not use its name. These
+        // have to match the sentences people say instead.
+        for skill in BUNDLED_SKILLS {
+            let body = (skill.body)();
+            // Whitespace is collapsed first: front matter wraps these across
+            // lines, so a phrase can be split mid-way and a naive contains()
+            // reports a description that plainly does say when to load.
+            let description = body
+                .split("description:")
+                .nth(1)
+                .and_then(|d| d.split("\n---").next())
+                .unwrap_or_default()
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ")
+                .to_lowercase();
+
+            assert!(
+                description.contains("use when") || description.contains("use this"),
+                "{} never says when to load",
+                skill.dir_name
+            );
+            assert!(
+                description.len() > 120,
+                "{}'s description is too thin to route on",
+                skill.dir_name
+            );
+        }
+    }
+
+    #[test]
+    fn skill_directory_names_are_namespaced() {
+        // These land in a shared directory alongside skills the user installed
+        // themselves; a generic name would collide with one of theirs.
+        for skill in BUNDLED_SKILLS {
+            assert!(
+                skill.dir_name.starts_with("shipstudio-"),
+                "{} would collide in a shared skills directory",
+                skill.dir_name
+            );
+        }
+    }
+
+    #[test]
+    fn no_two_bundled_skills_share_a_directory() {
+        let mut seen = std::collections::HashSet::new();
+        for skill in BUNDLED_SKILLS {
+            assert!(
+                seen.insert(skill.dir_name),
+                "{} is declared twice and would overwrite itself",
+                skill.dir_name
+            );
+        }
+    }
+}

--- a/src-tauri/src/commands/skills/mod.rs
+++ b/src-tauri/src/commands/skills/mod.rs
@@ -12,9 +12,11 @@
  *
  * Legacy plugin-based skills are also supported from ~/.claude/plugins/installed_plugins.json
  */
+mod bundled;
 mod install;
 mod search;
 
+pub use bundled::*;
 pub use install::*;
 pub use search::*;
 

--- a/src-tauri/src/commands/workflows/mod.rs
+++ b/src-tauri/src/commands/workflows/mod.rs
@@ -31,7 +31,7 @@
 mod files;
 mod progress;
 mod runs;
-mod skill;
+pub mod skill;
 mod state;
 
 pub use files::*;

--- a/src-tauri/src/commands/workflows/skill.rs
+++ b/src-tauri/src/commands/workflows/skill.rs
@@ -36,7 +36,7 @@ const SKILL_DIR_NAME: &str = "shipstudio-workflows";
 ///    is the one word a user who hasn't discovered the feature will never say.
 /// 2. **Author.** Once loaded, the format spec is complete enough that the
 ///    agent can write a valid file without asking Ship Studio anything.
-fn skill_markdown() -> String {
+pub(crate) fn skill_markdown() -> String {
     format!(
         r#"---
 name: shipstudio-workflows

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -661,6 +661,8 @@ pub fn run() {
             commands::hosting::set_hosting_link,
             commands::hosting::clear_hosting_link,
             commands::hosting::verify_hosting_token,
+            commands::hosting::list_recent_deployments,
+            commands::hosting::get_deployment_log,
             // Pull requests
             commands::pull_requests::list_pull_requests,
             commands::pull_requests::create_pull_request,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -132,7 +132,7 @@ pub fn run() {
             {
                 let handle = _app.handle().clone();
                 tauri::async_runtime::spawn(async move {
-                    commands::workflows::install_workflows_skill();
+                    commands::skills::install_bundled_skills();
                     workflow_scheduler::spawn(handle);
                 });
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -653,6 +653,14 @@ pub fn run() {
             commands::publishing::publish_to_staging,
             commands::publishing::publish_to_production,
             commands::publishing::publish_branch,
+            // Hosting — which provider a project deploys to, and whether the
+            // pushed commit actually went live.
+            commands::hosting::get_hosting_status,
+            commands::hosting::detect_hosting_links,
+            commands::hosting::list_hosting_projects,
+            commands::hosting::set_hosting_link,
+            commands::hosting::clear_hosting_link,
+            commands::hosting::verify_hosting_token,
             // Pull requests
             commands::pull_requests::list_pull_requests,
             commands::pull_requests::create_pull_request,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -649,9 +649,6 @@ pub fn run() {
             commands::github::list_collaborator_repos,
             commands::github::detect_package_manager,
             // Publishing
-            commands::publishing::publish_to_github,
-            commands::publishing::publish_to_staging,
-            commands::publishing::publish_to_production,
             commands::publishing::publish_branch,
             // Hosting — which provider a project deploys to, and whether the
             // pushed commit actually went live.

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -89,23 +89,16 @@ pub struct PageInfo {
     pub file_path: String,
 }
 
-// ============ Project Metadata (Publish State Persistence) ============
-
-/// Record of a single publish event (staging or production)
-#[derive(Serialize, Deserialize, Clone)]
-pub struct PublishRecord {
-    pub url: String,
-    pub state: String,
-    #[serde(rename = "publishedAt")]
-    pub published_at: u64,
-}
-
-/// Publish metadata for staging and production
-#[derive(Serialize, Deserialize, Clone, Default)]
-pub struct PublishMetadata {
-    pub staging: Option<PublishRecord>,
-    pub production: Option<PublishRecord>,
-}
+// ============ Project Metadata ============
+//
+// A `publish: { staging, production }` block used to live here, holding a URL
+// and a free-text state per environment. Nothing ever wrote it and nothing ever
+// read it, and its shape could not answer the question the hosting UI actually
+// asks — it carried no commit SHA, no provider, and no deployment id, so it
+// could not tell you whether *your* push went live. It was removed in schema
+// v4 in favour of `hosting` (see `commands::hosting::model`). Old files keep
+// the stale key on disk until their next write, which is harmless: unknown
+// fields are ignored on read.
 
 /// Information about stashed changes from a branch switch
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -142,7 +135,7 @@ pub struct RestoreResult {
 
 /// Current schema version for project metadata.
 /// Increment this when making breaking changes to the schema.
-pub const PROJECT_METADATA_SCHEMA_VERSION: u32 = 3;
+pub const PROJECT_METADATA_SCHEMA_VERSION: u32 = 4;
 
 /// A single saved terminal tab.
 #[derive(Serialize, Deserialize, Clone)]
@@ -175,7 +168,10 @@ pub struct ProjectMetadata {
     /// Schema version for migration support. Defaults to 1 if not present (legacy files).
     #[serde(default = "default_schema_version")]
     pub schema_version: u32,
-    pub publish: PublishMetadata,
+    /// Which provider(s) this project deploys to, and the last deployment we
+    /// saw, so the hosting section can paint before the network answers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hosting: Option<crate::commands::hosting::model::HostingMetadata>,
     /// Unix timestamp (ms) when project was last opened
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_opened: Option<u64>,
@@ -266,7 +262,7 @@ impl Default for ProjectMetadata {
         ProjectMetadata {
             description: "Ship Studio project metadata. Auto-generated - safe to delete if needed, will be recreated.".to_string(),
             schema_version: PROJECT_METADATA_SCHEMA_VERSION,
-            publish: PublishMetadata::default(),
+            hosting: None,
             last_opened: None,
             branch_prefix_username: None,
             stash_info: None,
@@ -297,10 +293,14 @@ impl ProjectMetadata {
             return false;
         }
 
+        // v3 -> v4 dropped the `publish` block. No data work is needed: the
+        // field is gone from the struct, so it is ignored on read and simply
+        // absent from the next write. Nothing consumed it, so nothing is lost.
+
         // Future migrations go here:
-        // if self.schema_version < 2 {
-        //     // Migrate from v1 to v2
-        //     self.schema_version = 2;
+        // if self.schema_version < 5 {
+        //     // Migrate from v4 to v5
+        //     self.schema_version = 5;
         // }
 
         // Update to current version
@@ -926,6 +926,8 @@ pub struct AccountCredentialStatus {
     pub vercel_username: Option<String>,
     pub has_anthropic_base_url: bool,
     pub has_vercel_token: bool,
+    pub has_cloudflare_api_token: bool,
+    pub has_netlify_auth_token: bool,
     pub has_git_name: bool,
     pub has_git_email: bool,
 }

--- a/src/commands/useWorkspaceCommands.tsx
+++ b/src/commands/useWorkspaceCommands.tsx
@@ -1,10 +1,12 @@
 import { useCommands } from './useCommands';
+import { useOpenModal } from '../contexts/ModalContext';
 import {
   BranchIcon,
   PlusIcon,
   PullIcon,
   PullRequestIcon,
   PushIcon,
+  GlobeIcon,
   WarningIcon,
 } from '@/components/icons';
 
@@ -59,8 +61,20 @@ export function useWorkspaceCommands({
   openWorktreeCreate,
   hasWorktreeData,
 }: UseWorkspaceCommandsParams) {
+  const openModal = useOpenModal();
+
   useCommands(
     () => [
+      {
+        id: 'hosting.deployments',
+        title: 'View deployments',
+        subtitle: 'Recent deploys and their build output',
+        icon: <GlobeIcon size={14} />,
+        category: 'branch',
+        when: 'project',
+        keywords: ['deploy', 'vercel', 'netlify', 'cloudflare', 'hosting', 'build', 'logs'],
+        run: () => openModal('deployments'),
+      },
       {
         id: 'git.push',
         title: 'Push to GitHub',

--- a/src/components/branches/PublishBranchDropdown.test.tsx
+++ b/src/components/branches/PublishBranchDropdown.test.tsx
@@ -6,7 +6,6 @@
  * "Go Live". That label churn was a real UX complaint; these tests pin it.
  */
 
-import { useState } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { PublishBranchDropdown } from './PublishBranchDropdown';
@@ -14,7 +13,15 @@ import type { ProjectGitHubStatus } from '../../lib/github';
 
 vi.mock('../../lib/branches', () => ({
   publishBranch: vi.fn().mockResolvedValue({ state: 'PUSHED', url: null }),
+  formatRelativeTime: () => 'just now',
 }));
+
+// The hosting section owns its own data now. These tests are about the
+// popover's structure, so hold it in a single settled state.
+vi.mock('../../lib/hosting', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/hosting')>('../../lib/hosting');
+  return { ...actual, getHostingStatus: vi.fn().mockRejectedValue(new Error('not linked')) };
+});
 
 const connectedStatus = {
   status: 'connected',
@@ -35,49 +42,6 @@ function makeProps(overrides?: Partial<Parameters<typeof PublishBranchDropdown>[
 }
 
 const BANNED_LABELS = ['Sync', 'Synced', 'Syncing...', 'Publish', 'Publishing...', 'Go Live'];
-
-function FakeCloudflareControls() {
-  const [open, setOpen] = useState(false);
-  return (
-    <div className="cf-dropdown-wrapper" onMouseEnter={() => setOpen(true)}>
-      <button type="button">Cloudflare</button>
-      {open && (
-        <div className="cf-dropdown">
-          <div className="cf-dropdown-inner">
-            <button type="button">Prod site</button>
-            <button type="button">Dashboard</button>
-            <button type="button" className="cf-dropdown-action">
-              Deploy now
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function FakeVercelControls() {
-  const [open, setOpen] = useState(false);
-  return (
-    <div className="vercel-button-container" onMouseEnter={() => setOpen(true)}>
-      <button type="button" className="toolbar-icon-btn vercel-button">
-        Vercel
-      </button>
-      {open && (
-        <div className="vercel-site-dropdown">
-          <div className="vercel-site-dropdown-inner">
-            <button type="button">Production</button>
-            <button type="button">Dashboard</button>
-            <div className="vercel-dropdown-separator" />
-            <button type="button" className="vercel-dropdown-action">
-              Deploy now
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
 
 function expectNoBannedLabels() {
   for (const label of BANNED_LABELS) {
@@ -192,27 +156,16 @@ describe('PublishBranchDropdown open panel', () => {
     expect(actionRow).toContainElement(pushButtons[pushButtons.length - 1]);
   });
 
-  it('renders hosting plugin controls inside the Push menu', () => {
-    render(
-      <PublishBranchDropdown
-        {...makeProps()}
-        hostingControls={<button type="button">Cloudflare deploy controls</button>}
-      />
-    );
+  it('renders the hosting section inside the Push menu', () => {
+    render(<PublishBranchDropdown {...makeProps()} />);
 
     fireEvent.click(screen.getByText('Push'));
 
     expect(screen.getByText('Hosting')).toBeInTheDocument();
-    expect(screen.getByText('Cloudflare deploy controls')).toBeInTheDocument();
   });
 
   it('keeps the panel actions below the hosting section', () => {
-    const { container } = render(
-      <PublishBranchDropdown
-        {...makeProps()}
-        hostingControls={<button type="button">Cloudflare deploy controls</button>}
-      />
-    );
+    const { container } = render(<PublishBranchDropdown {...makeProps()} />);
 
     fireEvent.click(screen.getByText('Push'));
 
@@ -227,10 +180,7 @@ describe('PublishBranchDropdown open panel', () => {
 
   it('keeps Done below the hosting section when GitHub is up to date', () => {
     const { container } = render(
-      <PublishBranchDropdown
-        {...makeProps({ hasChangesToSync: false })}
-        hostingControls={<button type="button">Cloudflare deploy controls</button>}
-      />
+      <PublishBranchDropdown {...makeProps({ hasChangesToSync: false })} />
     );
 
     fireEvent.click(screen.getByText('Push'));
@@ -242,24 +192,33 @@ describe('PublishBranchDropdown open panel', () => {
     expect(menu?.lastElementChild).toBe(actions);
   });
 
-  it('reveals Cloudflare production links by default', async () => {
-    render(<PublishBranchDropdown {...makeProps()} hostingControls={<FakeCloudflareControls />} />);
+  it('never reaches into plugin DOM to force a menu open', () => {
+    // The popover used to hold the Vercel/Cloudflare plugins' hover menus open
+    // with a synthetic `mouseover` dispatched from a MutationObserver, so every
+    // mouse-out collapsed and restored the whole panel.
+    const observe = vi.fn();
+    const original = globalThis.MutationObserver;
+    globalThis.MutationObserver = class {
+      observe = observe;
+      disconnect = vi.fn();
+      takeRecords = vi.fn(() => []);
+    } as unknown as typeof MutationObserver;
 
-    fireEvent.click(screen.getByText('Push'));
-
-    expect(await screen.findByText('Prod site')).toBeInTheDocument();
-    expect(screen.getByText('Dashboard')).toBeInTheDocument();
-    expect(screen.getByText('Deploy now')).toHaveClass('cf-dropdown-action');
+    try {
+      render(<PublishBranchDropdown {...makeProps()} />);
+      fireEvent.click(screen.getByText('Push'));
+      expect(observe).not.toHaveBeenCalled();
+    } finally {
+      globalThis.MutationObserver = original;
+    }
   });
 
-  it('reveals Vercel production links by default', async () => {
-    render(<PublishBranchDropdown {...makeProps()} hostingControls={<FakeVercelControls />} />);
+  it('can hide the hosting section where there is no room for it', () => {
+    const { container } = render(<PublishBranchDropdown {...makeProps({ hideHosting: true })} />);
 
     fireEvent.click(screen.getByText('Push'));
 
-    expect(await screen.findByText('Production')).toBeInTheDocument();
-    expect(screen.getByText('Dashboard')).toBeInTheDocument();
-    expect(screen.getByText('Deploy now')).toHaveClass('vercel-dropdown-action');
+    expect(container.querySelector('.publish-hosting-section')).not.toBeInTheDocument();
   });
 
   it('describes the GitHub push without inferring deployment state', () => {

--- a/src/components/branches/PublishBranchDropdown.test.tsx
+++ b/src/components/branches/PublishBranchDropdown.test.tsx
@@ -18,26 +18,6 @@ vi.mock('../../lib/branches', () => ({
 
 // The hosting section owns its own data now. These tests are about the
 // popover's structure, so hold it in a single settled state.
-// The hosting section fetches its own status. These tests are about the
-// popover's structure, so hold it in the unlinked state rather than letting it
-// reach a real `invoke`.
-vi.mock('../../lib/hosting', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../lib/hosting')>();
-  return {
-    ...actual,
-    getHostingStatus: vi.fn().mockResolvedValue({
-      commit: {
-        sha: 'abc',
-        short_sha: 'abc1234',
-        branch: 'main',
-        has_upstream: true,
-      },
-      providers: [],
-      detected: [],
-    }),
-  };
-});
-
 const connectedStatus = {
   status: 'connected',
   github_repo: 'user/repo',
@@ -171,12 +151,15 @@ describe('PublishBranchDropdown open panel', () => {
     expect(actionRow).toContainElement(pushButtons[pushButtons.length - 1]);
   });
 
-  it('renders the hosting section inside the Push menu', () => {
+  it('renders the hosting section inside the Push menu', async () => {
     render(<PublishBranchDropdown {...makeProps()} />);
 
     fireEvent.click(screen.getByText('Push'));
 
     expect(screen.getByText('Hosting')).toBeInTheDocument();
+    // And it reaches a real state rather than sitting on the spinner — the
+    // default IPC mock reports a project that deploys nowhere.
+    expect(await screen.findByText('See whether each push went live')).toBeInTheDocument();
   });
 
   it('keeps the panel actions below the hosting section', () => {

--- a/src/components/branches/PublishBranchDropdown.test.tsx
+++ b/src/components/branches/PublishBranchDropdown.test.tsx
@@ -170,7 +170,7 @@ describe('PublishBranchDropdown open panel', () => {
     expect(screen.getByText('Hosting')).toBeInTheDocument();
     // And it reaches a real state rather than sitting on the spinner — the
     // default IPC mock reports a project that deploys nowhere.
-    expect(await screen.findByText('See whether each push went live')).toBeInTheDocument();
+    expect(await screen.findByText('See if each push went live')).toBeInTheDocument();
   });
 
   it('keeps the panel actions below the hosting section', () => {

--- a/src/components/branches/PublishBranchDropdown.test.tsx
+++ b/src/components/branches/PublishBranchDropdown.test.tsx
@@ -18,9 +18,24 @@ vi.mock('../../lib/branches', () => ({
 
 // The hosting section owns its own data now. These tests are about the
 // popover's structure, so hold it in a single settled state.
-vi.mock('../../lib/hosting', async () => {
-  const actual = await vi.importActual<typeof import('../../lib/hosting')>('../../lib/hosting');
-  return { ...actual, getHostingStatus: vi.fn().mockRejectedValue(new Error('not linked')) };
+// The hosting section fetches its own status. These tests are about the
+// popover's structure, so hold it in the unlinked state rather than letting it
+// reach a real `invoke`.
+vi.mock('../../lib/hosting', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/hosting')>();
+  return {
+    ...actual,
+    getHostingStatus: vi.fn().mockResolvedValue({
+      commit: {
+        sha: 'abc',
+        short_sha: 'abc1234',
+        branch: 'main',
+        has_upstream: true,
+      },
+      providers: [],
+      detected: [],
+    }),
+  };
 });
 
 const connectedStatus = {

--- a/src/components/branches/PublishBranchDropdown.test.tsx
+++ b/src/components/branches/PublishBranchDropdown.test.tsx
@@ -7,7 +7,9 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render as rtlRender, screen, fireEvent } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { ModalProvider } from '../../contexts/ModalContext';
 import { PublishBranchDropdown } from './PublishBranchDropdown';
 import type { ProjectGitHubStatus } from '../../lib/github';
 
@@ -37,6 +39,15 @@ function makeProps(overrides?: Partial<Parameters<typeof PublishBranchDropdown>[
 }
 
 const BANNED_LABELS = ['Sync', 'Synced', 'Syncing...', 'Publish', 'Publishing...', 'Go Live'];
+
+/**
+ * The hosting section opens the deployments panel through ModalContext, which
+ * the app always provides around this component. Rendering bare would test a
+ * tree that never exists.
+ */
+function render(ui: ReactElement) {
+  return rtlRender(<ModalProvider>{ui}</ModalProvider>);
+}
 
 function expectNoBannedLabels() {
   for (const label of BANNED_LABELS) {

--- a/src/components/branches/PublishBranchDropdown.tsx
+++ b/src/components/branches/PublishBranchDropdown.tsx
@@ -9,7 +9,7 @@
  * @module components/PublishBranchDropdown
  */
 
-import { useState, useRef, useCallback, useEffect, type ReactNode } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { ProjectGitHubStatus } from '../../lib/github';
 import { publishBranch } from '../../lib/branches';
 import { ChevronIcon, BranchIcon, SuccessIcon, ErrorIcon, PushIcon } from '@/components/icons';
@@ -24,6 +24,7 @@ import { MenuButton } from '../primitives/MenuButton';
 import { TextButton } from '../primitives/TextButton';
 import type { ChangedFile } from '../../lib/git';
 import { ChangedFilesActions, ChangedFilesSection } from './ChangedFilesSection';
+import { HostingSection } from '../hosting/HostingSection';
 
 // Module-scoped so the metric spans dropdown re-mounts. Per-project would be
 // better but cross-project publish cadence is also useful and far simpler.
@@ -65,8 +66,8 @@ interface PublishBranchDropdownProps {
   /** Changed-file review is part of this single source-control menu. */
   changedFiles?: ChangedFile[];
   onDiscardChanges?: () => void;
-  /** Hosting integration controls rendered inside the Push workflow. */
-  hostingControls?: ReactNode;
+  /** Hide the native hosting section (compact mode has no room for it). */
+  hideHosting?: boolean;
   /**
    * CSS selector for elements that should NOT trigger click-outside closing.
    * Used by compact mode to exclude its publish button from closing the dropdown.
@@ -102,7 +103,7 @@ export function PublishBranchDropdown({
   grouped = false,
   changedFiles = [],
   onDiscardChanges,
-  hostingControls,
+  hideHosting = false,
   excludeClickOutsideSelector,
 }: PublishBranchDropdownProps) {
   const { showToast } = useOptionalToast();
@@ -112,7 +113,9 @@ export function PublishBranchDropdown({
   const [publishState, setPublishState] = useState<PublishState>({ status: 'idle' });
   const dropdownRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const hostingRef = useRef<HTMLDivElement>(null);
+  // When the push landed, so the hosting section can tell "the provider hasn't
+  // picked this up yet" apart from "it never will".
+  const [pushedAt, setPushedAt] = useState<number | undefined>(undefined);
 
   const hasGitHubRepo =
     projectGithubStatus?.status === 'connected' && projectGithubStatus?.github_repo;
@@ -188,33 +191,6 @@ export function PublishBranchDropdown({
     }
   }, [isOpen, publishState.status]);
 
-  useEffect(() => {
-    if (!isOpen || !hostingControls) return;
-    const host = hostingRef.current;
-    if (!host) return;
-
-    const revealHostingLinks = () => {
-      const wrappers = host.querySelectorAll<HTMLElement>(
-        '.cf-dropdown-wrapper, .vercel-button-container'
-      );
-
-      wrappers.forEach((wrapper) => {
-        const menu = wrapper.querySelector('.cf-dropdown, .vercel-site-dropdown');
-        if (!menu) {
-          wrapper.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
-        }
-      });
-    };
-
-    const frame = requestAnimationFrame(revealHostingLinks);
-    const observer = new MutationObserver(revealHostingLinks);
-    observer.observe(host, { childList: true, subtree: true });
-    return () => {
-      cancelAnimationFrame(frame);
-      observer.disconnect();
-    };
-  }, [hostingControls, isOpen]);
-
   const handlePublish = async () => {
     logger.info('Starting publish', { branch: currentBranch, isMainBranch, projectPath });
     setIsPublishing(true);
@@ -245,6 +221,7 @@ export function PublishBranchDropdown({
       lastPublishAt = now;
       onToast?.('Pushed to GitHub!', 'success');
       onStatusChange();
+      setPushedAt(Date.now());
       setPublishState({ status: 'success' });
     } catch (e) {
       const message = formatCommandError(asCommandError(e));
@@ -468,15 +445,8 @@ export function PublishBranchDropdown({
             </>
           )}
 
-          {hostingControls && (
-            <section className="publish-hosting-section" aria-labelledby="publish-hosting-heading">
-              <div className="publish-hosting-heading" id="publish-hosting-heading">
-                Hosting
-              </div>
-              <div className="publish-hosting-plugins" ref={hostingRef}>
-                {hostingControls}
-              </div>
-            </section>
+          {!hideHosting && (
+            <HostingSection projectPath={projectPath} open={isOpen} pushedAt={pushedAt} />
           )}
 
           {publishState.status === 'success' && (

--- a/src/components/hosting/DeploymentsModal.test.tsx
+++ b/src/components/hosting/DeploymentsModal.test.tsx
@@ -22,6 +22,10 @@ import { ModalProvider, useModal } from '../../contexts/ModalContext';
 import { DeploymentsModal } from './DeploymentsModal';
 import type { ReactNode } from 'react';
 import { useEffect } from 'react';
+// `?raw` rather than node:fs — `src` carries no node type declarations, and
+// Vite resolves this at build time, so the assertion cannot drift from the file
+// it claims to be reading.
+import workspaceModalsSource from '../workspace/WorkspaceModals.tsx?raw';
 
 /** Opens the modal on mount, the way the palette command does. */
 function OpenIt({ children }: { children: ReactNode }) {
@@ -137,5 +141,76 @@ describe('DeploymentsModal', () => {
     });
     expect(screen.getByText(/Deployments — Vercel/)).toBeInTheDocument();
     expect(screen.queryByText(/doesn’t deploy anywhere yet/i)).not.toBeInTheDocument();
+  });
+
+  it("drops the previous project's deployments when the path changes", async () => {
+    // Everything in this component is scoped to one project, so the reset is a
+    // remount rather than a pile of clears the component must remember to
+    // keep in step. `WorkspaceModals` supplies the key; this renders the same
+    // composition, because testing the component without it would assert a
+    // guarantee the product does not actually have.
+    mockIPC((cmd, args) => {
+      const path = (args as { projectPath?: string })?.projectPath;
+      if (cmd === 'get_hosting_status') {
+        if (path === '/project/b') return UNLINKED;
+        return {
+          ...UNLINKED,
+          providers: [
+            {
+              link: { provider: 'vercel', project_id: 'prj_a', source: 'vercel_cli_file' },
+              auth: { kind: 'ok' },
+              fetched_at: Date.now(),
+              from_cache: false,
+            },
+          ],
+        };
+      }
+      if (cmd === 'list_recent_deployments') {
+        return [
+          {
+            id: 'dpl_a',
+            status_label: 'Ready',
+            phase: { phase: 'ready' },
+            environment: 'production',
+            commit_sha: 'aaa1111',
+            commit_message: 'Project A deploy',
+            urls: { aliases: [] },
+            created_at: Date.now() - 60_000,
+          },
+        ];
+      }
+      if (cmd === 'get_deployment_log') {
+        return { deployment_id: 'dpl_a', lines: [], truncated: false };
+      }
+      throw new Error(`unexpected command: ${cmd}`);
+    });
+
+    const tree = (path: string) => (
+      <ModalProvider>
+        <OpenIt>
+          <DeploymentsModal key={path} projectPath={path} />
+        </OpenIt>
+      </ModalProvider>
+    );
+
+    const { rerender } = render(tree('/project/a'));
+    await waitFor(() => {
+      expect(screen.getByText('Project A deploy')).toBeInTheDocument();
+    });
+
+    rerender(tree('/project/b'));
+    await waitFor(() => {
+      expect(screen.getByText(/doesn\u2019t deploy anywhere yet/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Project A deploy')).not.toBeInTheDocument();
+  });
+
+  it('is keyed by project path where it is actually rendered', () => {
+    // The test above proves the remount clears everything; it cannot prove the
+    // product asks for one. Removing the key would leave that test green and
+    // put the previous project's deploys back on screen under the new
+    // project's name, so the call site is asserted directly.
+    const source = workspaceModalsSource;
+    expect(source).toMatch(/<DeploymentsModal\s+key=\{projectPath\}/);
   });
 });

--- a/src/components/hosting/DeploymentsModal.test.tsx
+++ b/src/components/hosting/DeploymentsModal.test.tsx
@@ -87,15 +87,16 @@ describe('DeploymentsModal', () => {
       throw new Error(`unexpected command in this scenario: ${cmd}`);
     });
 
-    const { container } = renderModal();
+    renderModal();
 
     await waitFor(() => {
       expect(screen.getByText(/doesn’t deploy anywhere yet/i)).toBeInTheDocument();
     });
 
-    // "Deployments — your host" was the shipped heading. A title is a name, and
-    // naming a thing "your host" tells the reader nothing they didn't know.
-    expect(container.textContent).not.toMatch(/your host/i);
+    // `document.body`, not the render container: ModalFrame renders through a
+    // portal, so `container.textContent` is the empty string and a negative
+    // assertion against it passes whatever the modal actually says.
+    expect(document.body.textContent).not.toMatch(/your host/i);
     expect(screen.getByText('Deployments')).toBeInTheDocument();
   });
 
@@ -203,6 +204,53 @@ describe('DeploymentsModal', () => {
       expect(screen.getByText(/doesn\u2019t deploy anywhere yet/i)).toBeInTheDocument();
     });
     expect(screen.queryByText('Project A deploy')).not.toBeInTheDocument();
+  });
+
+  it("prints the provider's own status word, not a synonym for it", async () => {
+    // The Push row shows Vercel's "Ready"; this list used to call the same
+    // deployment "Live", and "Error" read as "Failed". One deployment, two
+    // vocabularies, inside the feature rewritten to stop doing exactly that.
+    mockIPC((cmd) => {
+      if (cmd === 'get_hosting_status') {
+        return {
+          ...UNLINKED,
+          providers: [
+            {
+              link: { provider: 'vercel', project_id: 'prj_1', source: 'vercel_cli_file' },
+              auth: { kind: 'ok' },
+              fetched_at: Date.now(),
+              from_cache: false,
+            },
+          ],
+        };
+      }
+      if (cmd === 'list_recent_deployments') {
+        return [
+          {
+            id: 'dpl_1',
+            status_label: 'Ready',
+            phase: { phase: 'ready' },
+            environment: 'production',
+            commit_sha: 'abc1234',
+            commit_message: 'Fix the nav',
+            urls: { aliases: [] },
+            created_at: Date.now() - 60_000,
+          },
+        ];
+      }
+      if (cmd === 'get_deployment_log') {
+        return { deployment_id: 'dpl_1', lines: [], truncated: false };
+      }
+      throw new Error(`unexpected command: ${cmd}`);
+    });
+
+    renderModal();
+    await waitFor(() => {
+      expect(screen.getByText('Fix the nav')).toBeInTheDocument();
+    });
+
+    expect(document.body.textContent).toContain('Ready');
+    expect(document.body.textContent).not.toContain('Live');
   });
 
   it('is keyed by project path where it is actually rendered', () => {

--- a/src/components/hosting/DeploymentsModal.test.tsx
+++ b/src/components/hosting/DeploymentsModal.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * The Deployments panel, and specifically the state it spent this whole branch
+ * getting wrong: a project that deploys nowhere.
+ *
+ * `provider` was a two-state value — `null` meaning both "we haven't asked
+ * yet" and "asked, nothing there". The effect that lists deployments bails on
+ * a falsy provider, so on a project with no hosting link it never ran,
+ * `deployments` stayed `null`, and `null` renders "Loading…". The panel
+ * claimed to be loading a request it was never going to make, under a heading
+ * reading "Deployments — your host".
+ *
+ * Nothing caught it. There was no test for this component, the harness covered
+ * it only through a palette-command capture that asserts a command doesn't
+ * crash rather than what it shows, and a permanent spinner looks exactly like
+ * a slow one. It was found by opening the screenshot.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { mockIPC } from '@tauri-apps/api/mocks';
+import { ModalProvider, useModal } from '../../contexts/ModalContext';
+import { DeploymentsModal } from './DeploymentsModal';
+import type { ReactNode } from 'react';
+import { useEffect } from 'react';
+
+/** Opens the modal on mount, the way the palette command does. */
+function OpenIt({ children }: { children: ReactNode }) {
+  const { open } = useModal('deployments');
+  useEffect(() => {
+    open();
+  }, [open]);
+  return <>{children}</>;
+}
+
+function renderModal() {
+  return render(
+    <ModalProvider>
+      <OpenIt>
+        <DeploymentsModal projectPath="/test/path" />
+      </OpenIt>
+    </ModalProvider>
+  );
+}
+
+/** A `HostingStatus` with no providers — a project that deploys nowhere. */
+const UNLINKED = {
+  commit: {
+    sha: 'abc1234567',
+    short_sha: 'abc1234',
+    subject: 'Fix the nav',
+    branch: 'main',
+    has_upstream: true,
+  },
+  providers: [],
+  detected: [],
+};
+
+describe('DeploymentsModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('says a project deploys nowhere instead of loading forever', async () => {
+    mockIPC((cmd) => {
+      if (cmd === 'get_hosting_status') return UNLINKED;
+      throw new Error(`unexpected command in this scenario: ${cmd}`);
+    });
+
+    renderModal();
+
+    await waitFor(() => {
+      expect(screen.getByText(/doesn’t deploy anywhere yet/i)).toBeInTheDocument();
+    });
+
+    // The precise regression: a request that will never be made must not be
+    // described as in flight.
+    expect(screen.queryByText('Loading…')).not.toBeInTheDocument();
+  });
+
+  it('never puts a placeholder host name in its heading', async () => {
+    mockIPC((cmd) => {
+      if (cmd === 'get_hosting_status') return UNLINKED;
+      throw new Error(`unexpected command in this scenario: ${cmd}`);
+    });
+
+    const { container } = renderModal();
+
+    await waitFor(() => {
+      expect(screen.getByText(/doesn’t deploy anywhere yet/i)).toBeInTheDocument();
+    });
+
+    // "Deployments — your host" was the shipped heading. A title is a name, and
+    // naming a thing "your host" tells the reader nothing they didn't know.
+    expect(container.textContent).not.toMatch(/your host/i);
+    expect(screen.getByText('Deployments')).toBeInTheDocument();
+  });
+
+  it('lists what the provider returned once there is a provider', async () => {
+    mockIPC((cmd) => {
+      if (cmd === 'get_hosting_status') {
+        return {
+          ...UNLINKED,
+          providers: [
+            {
+              link: { provider: 'vercel', project_id: 'prj_1', source: 'vercel_cli_file' },
+              auth: { kind: 'ok' },
+              fetched_at: Date.now(),
+              from_cache: false,
+            },
+          ],
+        };
+      }
+      if (cmd === 'list_recent_deployments') {
+        return [
+          {
+            id: 'dpl_1',
+            status_label: 'Ready',
+            phase: { phase: 'ready' },
+            environment: 'production',
+            commit_sha: 'abc1234',
+            commit_message: 'Fix the nav',
+            urls: { aliases: [] },
+            created_at: Date.now() - 60_000,
+          },
+        ];
+      }
+      if (cmd === 'get_deployment_log') {
+        return { deployment_id: 'dpl_1', lines: [], truncated: false };
+      }
+      throw new Error(`unexpected command: ${cmd}`);
+    });
+
+    renderModal();
+
+    await waitFor(() => {
+      expect(screen.getByText('Fix the nav')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Deployments — Vercel/)).toBeInTheDocument();
+    expect(screen.queryByText(/doesn’t deploy anywhere yet/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/hosting/DeploymentsModal.tsx
+++ b/src/components/hosting/DeploymentsModal.tsx
@@ -1,0 +1,331 @@
+/**
+ * Recent deployments for a project, with each one's build output.
+ *
+ * The reason this exists: the deployments API says a build failed, and only
+ * the build log says why — so without this, "Build failed" sends you to the
+ * provider's dashboard, which is the trip this feature is meant to remove.
+ *
+ * Deliberately shaped like `RunHistoryModal`: a list you pick from on the
+ * left, the raw output on the right. That similarity is the point. Reading
+ * exactly what the provider returned, rather than taking a status word on
+ * trust, is the same job in both places.
+ *
+ * @module components/hosting/DeploymentsModal
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { openUrl } from '@tauri-apps/plugin-opener';
+import { AlertIcon } from '@/components/icons';
+import { ModalFrame } from '../primitives/ModalFrame';
+import { Button } from '../primitives/Button';
+import { Spinner } from '../primitives/Spinner';
+import { useOptionalToast } from '../../contexts/ToastContext';
+import { asCommandError, formatCommandError } from '../../lib/errors';
+import { formatRelativeTime } from '../../lib/branches';
+import { logger } from '../../lib/logger';
+import { useModal } from '../../contexts/ModalContext';
+import {
+  getDeploymentLog,
+  getHostingStatus,
+  listRecentDeployments,
+  PROVIDER_LABELS,
+  type BuildLog,
+  type Deployment,
+  type HostingProvider,
+} from '../../lib/hosting';
+
+/** The row's status word. Plain language, never the provider's enum. */
+const PHASE_LABEL: Record<string, string> = {
+  queued: 'Waiting',
+  building: 'Building',
+  publishing: 'Publishing',
+  ready: 'Live',
+  failed: 'Failed',
+  canceled: 'Canceled',
+  skipped: 'Skipped',
+  gated: 'Needs approval',
+  unknown: 'Unrecognized',
+};
+
+/** Maps a phase onto the dot colours the rest of the app already uses. */
+const DOT_STATE: Record<string, string> = {
+  queued: 'pending',
+  building: 'running',
+  publishing: 'running',
+  ready: 'ok',
+  failed: 'failed',
+  canceled: 'pending',
+  skipped: 'pending',
+  gated: 'findings',
+  unknown: 'pending',
+};
+
+/** How long a build took, when the provider told us both ends of it. */
+function buildDuration(deployment: Deployment): string | null {
+  if (!deployment.ready_at || !deployment.created_at) return null;
+  const seconds = Math.round((deployment.ready_at - deployment.created_at) / 1000);
+  if (seconds < 0) return null;
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+function titleFor(deployment: Deployment): string {
+  return deployment.commit_message?.trim() || deployment.commit_sha.slice(0, 7) || 'Deployment';
+}
+
+interface Props {
+  projectPath: string;
+}
+
+/**
+ * Reads its own open state so it can be opened from the command palette as
+ * well as from the hosting row, and resolves which provider this project
+ * deploys to rather than being handed one — a payload-free modal is what the
+ * rest of this app's modal context supports.
+ */
+export function DeploymentsModal({ projectPath }: Props) {
+  const { isOpen, close } = useModal('deployments');
+  const [provider, setProvider] = useState<HostingProvider | null>(null);
+  const { showToast } = useOptionalToast();
+  const [deployments, setDeployments] = useState<Deployment[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  // Keyed by the deployment it describes, so switching selection derives
+  // "loading" rather than clearing state in an effect — which would flash the
+  // previous deployment's log under the new one's heading for a render.
+  const [logEntry, setLogEntry] = useState<{
+    id: string;
+    log?: BuildLog;
+    error?: string;
+  } | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  const name = provider ? PROVIDER_LABELS[provider] : 'your host';
+  const selected =
+    deployments?.find((d) => d.id === selectedId) ?? deployments?.[0] ?? null;
+
+  const forSelected = selected && logEntry?.id === selected.id ? logEntry : null;
+  const log = forSelected?.log ?? null;
+  const logError = forSelected?.error ?? null;
+  const loadingLog = selected != null && forSelected === null;
+
+  // Which provider this project deploys to. Cheap: the status call is cached
+  // backend-side for a few seconds and the popover has usually just made it.
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    void getHostingStatus(projectPath)
+      .then((status) => {
+        if (!cancelled) setProvider(status.providers[0]?.link.provider ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setProvider(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, projectPath]);
+
+  useEffect(() => {
+    if (!isOpen || !provider) return;
+    let cancelled = false;
+    listRecentDeployments(projectPath, provider, 15)
+      .then((list) => {
+        if (cancelled) return;
+        setDeployments(list);
+        setSelectedId((current) => current ?? list[0]?.id ?? null);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setLoadError(formatCommandError(asCommandError(err)));
+        setDeployments([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, projectPath, provider]);
+
+  // The log is fetched per selection rather than up front: it's a separate
+  // request per deployment, and most of them are never opened.
+  useEffect(() => {
+    if (!selected || !provider) return;
+    const id = selected.id;
+    let cancelled = false;
+    getDeploymentLog(projectPath, provider, id)
+      .then((next) => {
+        if (!cancelled) setLogEntry({ id, log: next });
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setLogEntry({ id, error: formatCommandError(asCommandError(err)) });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectPath, provider, selected]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!deployments || (event.key !== 'ArrowDown' && event.key !== 'ArrowUp')) return;
+      event.preventDefault();
+      const index = deployments.findIndex((d) => d.id === selected?.id);
+      const next =
+        deployments[
+          Math.min(
+            deployments.length - 1,
+            Math.max(0, index + (event.key === 'ArrowDown' ? 1 : -1))
+          )
+        ];
+      if (!next) return;
+      setSelectedId(next.id);
+      listRef.current
+        ?.querySelector<HTMLElement>(`[data-deployment-id="${CSS.escape(next.id)}"]`)
+        ?.focus();
+    },
+    [deployments, selected]
+  );
+
+  const open = useCallback(
+    (url?: string | null) => {
+      if (!url) return;
+      void openUrl(url).catch((err) => {
+        logger.warn('deployments: failed to open url', { error: String(err) });
+        showToast("Couldn't open that link", 'error');
+      });
+    },
+    [showToast]
+  );
+
+  if (!isOpen) return null;
+
+  return (
+    <ModalFrame
+      isOpen
+      onClose={close}
+      title={`Deployments — ${name}`}
+      className="deployments-modal"
+    >
+      <div className="deployments">
+        <div
+          className="deployments-list"
+          role="listbox"
+          aria-label={`Recent ${name} deployments`}
+          aria-activedescendant={selected ? `deployment-${selected.id}` : undefined}
+          ref={listRef}
+          onKeyDown={handleKeyDown}
+        >
+          {deployments === null && (
+            <p className="deployments-empty text-style-hint">Loading…</p>
+          )}
+          {deployments?.length === 0 && (
+            <p className="deployments-empty text-style-hint">
+              {loadError ?? `${name} has no deployments for this project yet.`}
+            </p>
+          )}
+          {deployments?.map((deployment) => (
+            <button
+              key={deployment.id}
+              id={`deployment-${deployment.id}`}
+              data-deployment-id={deployment.id}
+              type="button"
+              role="option"
+              aria-selected={deployment.id === selected?.id}
+              tabIndex={deployment.id === selected?.id ? 0 : -1}
+              className={`deployments-item${
+                deployment.id === selected?.id ? ' is-selected' : ''
+              }`}
+              onClick={() => setSelectedId(deployment.id)}
+            >
+              <span
+                className="deployments-item-dot"
+                data-state={DOT_STATE[deployment.phase.phase] ?? 'pending'}
+                aria-hidden
+              />
+              <span className="deployments-item-body">
+                <span className="deployments-item-title text-style-control-semibold">
+                  {titleFor(deployment)}
+                </span>
+                <span className="deployments-item-meta text-style-hint">
+                  {PHASE_LABEL[deployment.phase.phase] ?? 'Unrecognized'}
+                  {` · ${formatRelativeTime(deployment.created_at)}`}
+                  {deployment.environment === 'preview' && ' · Preview'}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <div className="deployments-detail">
+          {selected ? (
+            <>
+              <div className="deployments-detail-header">
+                <div className="deployments-detail-meta">
+                  {selected.branch && (
+                    <span className="deployments-chip">{selected.branch}</span>
+                  )}
+                  <span className="deployments-chip">{selected.commit_sha.slice(0, 7)}</span>
+                  {buildDuration(selected) && (
+                    <span className="text-style-hint">Built in {buildDuration(selected)}</span>
+                  )}
+                </div>
+                <div className="deployments-detail-actions">
+                  {selected.urls.primary && (
+                    <Button size="compact" onClick={() => open(selected.urls.primary)}>
+                      Open site
+                    </Button>
+                  )}
+                  {selected.dashboard_url && (
+                    <Button
+                      size="compact"
+                      variant="secondary"
+                      onClick={() => open(selected.dashboard_url)}
+                    >
+                      Open in {name}
+                    </Button>
+                  )}
+                </div>
+              </div>
+
+              {/* Said plainly and first: if this build failed, the reason is
+                  what you opened the panel for. */}
+              {selected.error_message && (
+                <p className="deployments-error">
+                  <AlertIcon size={12} />
+                  <span>{selected.error_message}</span>
+                </p>
+              )}
+
+              <div className="deployments-log">
+                {loadingLog ? (
+                  <div className="deployments-log-loading">
+                    <Spinner size="sm" />
+                    <span className="text-style-hint">Loading build output…</span>
+                  </div>
+                ) : logError ? (
+                  <p className="deployments-log-note text-style-hint">{logError}</p>
+                ) : log && log.lines.length > 0 ? (
+                  <pre className="deployments-log-body">
+                    {log.lines.map((line) => line.text).join('\n')}
+                  </pre>
+                ) : (
+                  <p className="deployments-log-note text-style-hint">
+                    {name} returned no build output for this deployment.
+                  </p>
+                )}
+              </div>
+
+              {log?.truncated && (
+                <p className="deployments-note text-style-hint">
+                  Showing the most recent output — {name} caps how much it returns.
+                </p>
+              )}
+            </>
+          ) : (
+            <p className="text-style-hint">Nothing to show.</p>
+          )}
+        </div>
+      </div>
+    </ModalFrame>
+  );
+}

--- a/src/components/hosting/DeploymentsModal.tsx
+++ b/src/components/hosting/DeploymentsModal.tsx
@@ -34,18 +34,32 @@ import {
   type HostingProvider,
 } from '../../lib/hosting';
 
-/** The row's status word. Plain language, never the provider's enum. */
+/**
+ * Fallback status words, for a deployment whose provider sent none.
+ *
+ * The provider's own `status_label` wins — this panel and the Push popover
+ * describe the same deployments, and until now they disagreed about them: the
+ * row printed Vercel's "Ready" while this list called the same deploy "Live",
+ * and "Error" here read as "Failed". Two vocabularies for one deployment is
+ * the thing the rest of this feature was rewritten to stop doing, and a user
+ * comparing either against the Vercel dashboard had three.
+ */
 const PHASE_LABEL: Record<string, string> = {
-  queued: 'Waiting',
+  queued: 'Queued',
   building: 'Building',
   publishing: 'Publishing',
-  ready: 'Live',
-  failed: 'Failed',
+  ready: 'Ready',
+  failed: 'Error',
   canceled: 'Canceled',
   skipped: 'Skipped',
   gated: 'Needs approval',
   unknown: 'Unrecognized',
 };
+
+/** The provider's own word, exactly as the hosting row resolves it. */
+function statusWord(deployment: Deployment): string {
+  return deployment.status_label?.trim() || PHASE_LABEL[deployment.phase.phase] || 'Unrecognized';
+}
 
 /** Maps a phase onto the dot colours the rest of the app already uses. */
 const DOT_STATE: Record<string, string> = {
@@ -269,7 +283,7 @@ export function DeploymentsModal({ projectPath }: Props) {
                   {titleFor(deployment)}
                 </span>
                 <span className="deployments-item-meta text-style-hint">
-                  {PHASE_LABEL[deployment.phase.phase] ?? 'Unrecognized'}
+                  {statusWord(deployment)}
                   {` · ${formatRelativeTime(deployment.created_at)}`}
                   {deployment.environment === 'preview' && ' · Preview'}
                 </span>

--- a/src/components/hosting/DeploymentsModal.tsx
+++ b/src/components/hosting/DeploymentsModal.tsx
@@ -85,7 +85,17 @@ interface Props {
  */
 export function DeploymentsModal({ projectPath }: Props) {
   const { isOpen, close } = useModal('deployments');
-  const [provider, setProvider] = useState<HostingProvider | null>(null);
+  /**
+   * Three states, not two. `undefined` is "we haven't asked yet", `null` is
+   * "asked, and this project deploys nowhere".
+   *
+   * Collapsing those into one `null` is what made this panel claim to be
+   * loading forever: the fetch below bails on a falsy provider, so
+   * `deployments` stayed null, and null renders "Loading…". Every project
+   * without a hosting link — which is every project before you connect one —
+   * opened this to a spinner for a request that was never going to be made.
+   */
+  const [provider, setProvider] = useState<HostingProvider | null | undefined>(undefined);
   const { showToast } = useOptionalToast();
   const [deployments, setDeployments] = useState<Deployment[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -100,7 +110,11 @@ export function DeploymentsModal({ projectPath }: Props) {
   } | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
 
-  const name = provider ? PROVIDER_LABELS[provider] : 'your host';
+  // No "your host" placeholder in a heading: until we know the provider the
+  // honest title is just "Deployments", and once we know there isn't one the
+  // panel says so in its body rather than in its name.
+  const name = provider ? PROVIDER_LABELS[provider] : null;
+  const title = name ? `Deployments — ${name}` : 'Deployments';
   const selected = deployments?.find((d) => d.id === selectedId) ?? deployments?.[0] ?? null;
 
   const forSelected = selected && logEntry?.id === selected.id ? logEntry : null;
@@ -199,25 +213,32 @@ export function DeploymentsModal({ projectPath }: Props) {
   if (!isOpen) return null;
 
   return (
-    <ModalFrame
-      isOpen
-      onClose={close}
-      title={`Deployments — ${name}`}
-      className="deployments-modal"
-    >
+    <ModalFrame isOpen onClose={close} title={title} className="deployments-modal">
       <div className="deployments">
         <div
           className="deployments-list"
           role="listbox"
-          aria-label={`Recent ${name} deployments`}
+          aria-label={name ? `Recent ${name} deployments` : 'Recent deployments'}
           aria-activedescendant={selected ? `deployment-${selected.id}` : undefined}
           ref={listRef}
           onKeyDown={handleKeyDown}
         >
-          {deployments === null && <p className="deployments-empty text-style-hint">Loading…</p>}
+          {/* "Loading" is claimed only while a request is actually outstanding.
+              A project that deploys nowhere gets told so, because the request
+              that would fill this list is never going to be made. */}
+          {provider === undefined && <p className="deployments-empty text-style-hint">Loading…</p>}
+          {provider === null && (
+            <p className="deployments-empty text-style-hint">
+              This project doesn’t deploy anywhere yet. Connect a host in the Push menu and
+              deployments will show up here.
+            </p>
+          )}
+          {provider && deployments === null && (
+            <p className="deployments-empty text-style-hint">Loading…</p>
+          )}
           {deployments?.length === 0 && (
             <p className="deployments-empty text-style-hint">
-              {loadError ?? `${name} has no deployments for this project yet.`}
+              {loadError ?? `${name ?? 'This host'} has no deployments for this project yet.`}
             </p>
           )}
           {deployments?.map((deployment) => (

--- a/src/components/hosting/DeploymentsModal.tsx
+++ b/src/components/hosting/DeploymentsModal.tsx
@@ -127,6 +127,12 @@ export function DeploymentsModal({ projectPath }: Props) {
   useEffect(() => {
     if (!isOpen) return;
     let cancelled = false;
+    // No state is cleared here on purpose. Everything in this component is
+    // scoped to one project, and `WorkspaceModals` keys it by `projectPath`
+    // so a switch remounts it — which discards all of it at once, rather than
+    // relying on this effect to remember every field. Clearing by hand also
+    // trips `react-hooks/set-state-in-effect`, and the rule is right: the fix
+    // for "this state belongs to a different prop" is a key, not a reset.
     void getHostingStatus(projectPath)
       .then((status) => {
         if (!cancelled) setProvider(status.providers[0]?.link.provider ?? null);

--- a/src/components/hosting/DeploymentsModal.tsx
+++ b/src/components/hosting/DeploymentsModal.tsx
@@ -101,8 +101,7 @@ export function DeploymentsModal({ projectPath }: Props) {
   const listRef = useRef<HTMLDivElement | null>(null);
 
   const name = provider ? PROVIDER_LABELS[provider] : 'your host';
-  const selected =
-    deployments?.find((d) => d.id === selectedId) ?? deployments?.[0] ?? null;
+  const selected = deployments?.find((d) => d.id === selectedId) ?? deployments?.[0] ?? null;
 
   const forSelected = selected && logEntry?.id === selected.id ? logEntry : null;
   const log = forSelected?.log ?? null;
@@ -215,9 +214,7 @@ export function DeploymentsModal({ projectPath }: Props) {
           ref={listRef}
           onKeyDown={handleKeyDown}
         >
-          {deployments === null && (
-            <p className="deployments-empty text-style-hint">Loading…</p>
-          )}
+          {deployments === null && <p className="deployments-empty text-style-hint">Loading…</p>}
           {deployments?.length === 0 && (
             <p className="deployments-empty text-style-hint">
               {loadError ?? `${name} has no deployments for this project yet.`}
@@ -232,9 +229,7 @@ export function DeploymentsModal({ projectPath }: Props) {
               role="option"
               aria-selected={deployment.id === selected?.id}
               tabIndex={deployment.id === selected?.id ? 0 : -1}
-              className={`deployments-item${
-                deployment.id === selected?.id ? ' is-selected' : ''
-              }`}
+              className={`deployments-item${deployment.id === selected?.id ? ' is-selected' : ''}`}
               onClick={() => setSelectedId(deployment.id)}
             >
               <span
@@ -261,9 +256,7 @@ export function DeploymentsModal({ projectPath }: Props) {
             <>
               <div className="deployments-detail-header">
                 <div className="deployments-detail-meta">
-                  {selected.branch && (
-                    <span className="deployments-chip">{selected.branch}</span>
-                  )}
+                  {selected.branch && <span className="deployments-chip">{selected.branch}</span>}
                   <span className="deployments-chip">{selected.commit_sha.slice(0, 7)}</span>
                   {buildDuration(selected) && (
                     <span className="text-style-hint">Built in {buildDuration(selected)}</span>

--- a/src/components/hosting/HostingLinkPicker.tsx
+++ b/src/components/hosting/HostingLinkPicker.tsx
@@ -10,7 +10,7 @@
  *    the only path for Cloudflare Pages, which leaves nothing on disk.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { Spinner } from '../primitives/Spinner';
@@ -56,6 +56,15 @@ export function HostingLinkPicker({
   const [projects, setProjects] = useState<HostingProjectChoice[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
+  /**
+   * Which provider request is current. Pick Vercel, go back, pick Netlify, and
+   * Vercel's slower response could still land last — storing Vercel's projects
+   * while the header says Netlify. Choosing a row then wrote a Vercel project
+   * id as the project's *Netlify* link, and a stale `NotAuthenticated` opened
+   * the token flow for the wrong provider. Both persist wrong data from a
+   * request the user had already abandoned.
+   */
+  const requestRef = useRef(0);
 
   const confirmDetected = useCallback(
     async (link: DetectedLink) => {
@@ -81,12 +90,17 @@ export function HostingLinkPicker({
 
   const choose = useCallback(
     async (next: HostingProvider) => {
+      const generation = ++requestRef.current;
+      const isCurrent = () => requestRef.current === generation;
+
       setProvider(next);
       setProjects(null);
       setLoading(true);
       try {
-        setProjects(await listHostingProjects(projectPath, next));
+        const list = await listHostingProjects(projectPath, next);
+        if (isCurrent()) setProjects(list);
       } catch (err) {
+        if (!isCurrent()) return;
         const error = asCommandError(err);
         // A missing credential is the expected first-run state, not a failure
         // worth a red toast — hand the user straight to the connect flow.
@@ -97,7 +111,7 @@ export function HostingLinkPicker({
         showToast(formatCommandError(error), 'error');
         setProvider(null);
       } finally {
-        setLoading(false);
+        if (isCurrent()) setLoading(false);
       }
     },
     [projectPath, onNeedsToken, showToast]
@@ -198,7 +212,21 @@ export function HostingLinkPicker({
         ) : null}
 
         <div className="connect-modal-actions">
-          <Button variant="secondary" onClick={provider ? () => setProvider(null) : onClose}>
+          {/* Going back invalidates the in-flight request too, so an abandoned
+              provider's response can never land behind the user. */}
+          <Button
+            variant="secondary"
+            onClick={
+              provider
+                ? () => {
+                    requestRef.current += 1;
+                    setProvider(null);
+                    setProjects(null);
+                    setLoading(false);
+                  }
+                : onClose
+            }
+          >
             {provider ? 'Back' : 'Cancel'}
           </Button>
         </div>

--- a/src/components/hosting/HostingLinkPicker.tsx
+++ b/src/components/hosting/HostingLinkPicker.tsx
@@ -1,0 +1,207 @@
+/**
+ * Choose which provider project this repo deploys to.
+ *
+ * Two paths, in the order that respects what the user already did:
+ *
+ * 1. **A link found on disk.** If `.vercel/project.json` or
+ *    `.netlify/state.json` is there, the user already linked this repo with the
+ *    provider's own CLI and the answer is one click, no network.
+ * 2. **Pick from the account.** Otherwise, list what the token can see. This is
+ *    the only path for Cloudflare Pages, which leaves nothing on disk.
+ */
+
+import { useCallback, useState } from 'react';
+import { ModalFrame } from '../primitives/ModalFrame';
+import { Button } from '../primitives/Button';
+import { Spinner } from '../primitives/Spinner';
+import { EmptyState } from '../primitives/EmptyState';
+import { VercelIcon, CloudflareIcon } from '../icons';
+import { useOptionalToast } from '../../contexts/ToastContext';
+import { asCommandError, formatCommandError } from '../../lib/errors';
+import {
+  listHostingProjects,
+  setHostingLink,
+  PROVIDER_LABELS,
+  type DetectedLink,
+  type HostingProjectChoice,
+  type HostingProvider,
+} from '../../lib/hosting';
+
+const PROVIDERS: HostingProvider[] = ['vercel', 'cloudflare', 'netlify'];
+
+function ProviderMark({ provider }: { provider: HostingProvider }) {
+  if (provider === 'vercel') return <VercelIcon size={14} />;
+  if (provider === 'cloudflare') return <CloudflareIcon size={14} />;
+  return <span className="hosting-row-globe" aria-hidden="true" />;
+}
+
+interface Props {
+  projectPath: string;
+  detected: DetectedLink[];
+  onLinked: () => void;
+  /** The chosen provider has no usable credential yet. */
+  onNeedsToken: (provider: HostingProvider) => void;
+  onClose: () => void;
+}
+
+export function HostingLinkPicker({
+  projectPath,
+  detected,
+  onLinked,
+  onNeedsToken,
+  onClose,
+}: Props) {
+  const { showToast } = useOptionalToast();
+  const [provider, setProvider] = useState<HostingProvider | null>(null);
+  const [projects, setProjects] = useState<HostingProjectChoice[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const confirmDetected = useCallback(
+    async (link: DetectedLink) => {
+      setSaving(true);
+      try {
+        await setHostingLink(projectPath, {
+          provider: link.provider,
+          project_id: link.project_id,
+          scope_id: link.scope_id,
+          project_name: link.project_name,
+          source: link.source,
+          linked_at: 0,
+        });
+        onLinked();
+      } catch (err) {
+        showToast(formatCommandError(asCommandError(err)), 'error');
+      } finally {
+        setSaving(false);
+      }
+    },
+    [projectPath, onLinked, showToast],
+  );
+
+  const choose = useCallback(
+    async (next: HostingProvider) => {
+      setProvider(next);
+      setProjects(null);
+      setLoading(true);
+      try {
+        setProjects(await listHostingProjects(projectPath, next));
+      } catch (err) {
+        const error = asCommandError(err);
+        // A missing credential is the expected first-run state, not a failure
+        // worth a red toast — hand the user straight to the connect flow.
+        if (error.type === 'NotAuthenticated') {
+          onNeedsToken(next);
+          return;
+        }
+        showToast(formatCommandError(error), 'error');
+        setProvider(null);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [projectPath, onNeedsToken, showToast],
+  );
+
+  const link = useCallback(
+    async (choice: HostingProjectChoice) => {
+      if (!provider) return;
+      setSaving(true);
+      try {
+        await setHostingLink(projectPath, {
+          provider,
+          project_id: choice.id,
+          scope_id: choice.scope_id,
+          project_name: choice.name,
+          source: 'user_picked',
+          linked_at: 0,
+        });
+        onLinked();
+      } catch (err) {
+        showToast(formatCommandError(asCommandError(err)), 'error');
+      } finally {
+        setSaving(false);
+      }
+    },
+    [projectPath, provider, onLinked, showToast],
+  );
+
+  return (
+    <ModalFrame isOpen onClose={onClose} title="Connect hosting" className="connect-modal">
+      <div className="connect-modal-body">
+        {detected.length > 0 && !provider ? (
+          <>
+            <p>
+              This project is already linked with the provider's own command-line tool. Use it?
+            </p>
+            {detected.map((link) => (
+              <Button
+                key={link.provider}
+                variant="secondary"
+                width="fill"
+                disabled={saving}
+                onClick={() => void confirmDetected(link)}
+              >
+                <ProviderMark provider={link.provider} />
+                {link.project_name
+                  ? `${PROVIDER_LABELS[link.provider]} — ${link.project_name}`
+                  : PROVIDER_LABELS[link.provider]}
+              </Button>
+            ))}
+            <p className="connect-modal-muted">Or choose a different project:</p>
+          </>
+        ) : null}
+
+        {!provider ? (
+          <>
+            {detected.length === 0 ? (
+              <p>Pick where this project deploys, so Ship Studio can show you whether each push went live.</p>
+            ) : null}
+            {PROVIDERS.map((p) => (
+              <Button key={p} variant="secondary" width="fill" onClick={() => void choose(p)}>
+                <ProviderMark provider={p} />
+                {PROVIDER_LABELS[p]}
+              </Button>
+            ))}
+          </>
+        ) : null}
+
+        {provider && loading ? (
+          <div className="connect-modal-loading">
+            <Spinner />
+            <span>Loading your {PROVIDER_LABELS[provider]} projects…</span>
+          </div>
+        ) : null}
+
+        {provider && !loading && projects ? (
+          projects.length === 0 ? (
+            <EmptyState
+              title={`No ${PROVIDER_LABELS[provider]} projects`}
+              description="Nothing was returned for this account. Create a project on the provider first, or try a different token."
+            />
+          ) : (
+            <div className="connect-modal-list">
+              {projects.map((choice) => (
+                <Button
+                  key={choice.id}
+                  variant="secondary"
+                  width="fill"
+                  disabled={saving}
+                  onClick={() => void link(choice)}
+                >
+                  {choice.name}
+                </Button>
+              ))}
+            </div>
+          )
+        ) : null}
+
+        <div className="connect-modal-actions">
+          <Button variant="secondary" onClick={provider ? () => setProvider(null) : onClose}>
+            {provider ? 'Back' : 'Cancel'}
+          </Button>
+        </div>
+      </div>
+    </ModalFrame>
+  );
+}

--- a/src/components/hosting/HostingLinkPicker.tsx
+++ b/src/components/hosting/HostingLinkPicker.tsx
@@ -76,7 +76,7 @@ export function HostingLinkPicker({
         setSaving(false);
       }
     },
-    [projectPath, onLinked, showToast],
+    [projectPath, onLinked, showToast]
   );
 
   const choose = useCallback(
@@ -100,7 +100,7 @@ export function HostingLinkPicker({
         setLoading(false);
       }
     },
-    [projectPath, onNeedsToken, showToast],
+    [projectPath, onNeedsToken, showToast]
   );
 
   const link = useCallback(
@@ -123,7 +123,7 @@ export function HostingLinkPicker({
         setSaving(false);
       }
     },
-    [projectPath, provider, onLinked, showToast],
+    [projectPath, provider, onLinked, showToast]
   );
 
   return (
@@ -131,9 +131,7 @@ export function HostingLinkPicker({
       <div className="connect-modal-body">
         {detected.length > 0 && !provider ? (
           <>
-            <p>
-              This project is already linked with the provider's own command-line tool. Use it?
-            </p>
+            <p>This project is already linked with the provider's own command-line tool. Use it?</p>
             {detected.map((link) => (
               <Button
                 key={link.provider}
@@ -155,7 +153,10 @@ export function HostingLinkPicker({
         {!provider ? (
           <>
             {detected.length === 0 ? (
-              <p>Pick where this project deploys, so Ship Studio can show you whether each push went live.</p>
+              <p>
+                Pick where this project deploys, so Ship Studio can show you whether each push went
+                live.
+              </p>
             ) : null}
             {PROVIDERS.map((p) => (
               <Button key={p} variant="secondary" width="fill" onClick={() => void choose(p)}>

--- a/src/components/hosting/HostingRow.tsx
+++ b/src/components/hosting/HostingRow.tsx
@@ -112,7 +112,6 @@ export function HostingRow({ state, commitSubject, shortSha, onAction }: Props) 
         <div className="hosting-row-title">{copy.title}</div>
         <div className="hosting-row-status">
           {copy.status}
-          {state.isStale ? <span className="hosting-row-stale"> · not just checked</span> : null}
         </div>
       </div>
 

--- a/src/components/hosting/HostingRow.tsx
+++ b/src/components/hosting/HostingRow.tsx
@@ -127,13 +127,23 @@ export function HostingRow({ state, commitSubject, shortSha, onAction }: Props) 
   );
 }
 
-/** The third line: hints and links, also a fixed height. */
+/**
+ * The third line, when a state has something extra to say.
+ *
+ * It used to be always present at a fixed height, reserving space so the
+ * section stayed one size across every state. That stopped being worth its
+ * cost: the section's height now legitimately varies with how many addresses a
+ * deployment has, and the reserved line left a visible empty band under the
+ * common live state, which has no hint. Collapsing when empty costs a 28px
+ * change between states that genuinely differ — a real event, not data
+ * arriving mid-read, which was the shift worth preventing.
+ */
 export function HostingLinks({ state, hint }: { state: SectionState; hint?: string }) {
+  if (!hint) return null;
+
   return (
     <div className="hosting-links" data-state={state.kind}>
-      {hint ? (
-        <span className="hosting-links-hint">{hint}</span>
-      ) : null}
+      <span className="hosting-links-hint">{hint}</span>
     </div>
   );
 }

--- a/src/components/hosting/HostingRow.tsx
+++ b/src/components/hosting/HostingRow.tsx
@@ -110,9 +110,7 @@ export function HostingRow({ state, commitSubject, shortSha, onAction }: Props) 
           written to fit instead. */}
       <div className="hosting-row-text" data-slot="text">
         <div className="hosting-row-title">{copy.title}</div>
-        <div className="hosting-row-status">
-          {copy.status}
-        </div>
+        <div className="hosting-row-status">{copy.status}</div>
       </div>
 
       {/* Always rendered so the column keeps its width in every state. */}

--- a/src/components/hosting/HostingRow.tsx
+++ b/src/components/hosting/HostingRow.tsx
@@ -1,0 +1,132 @@
+/**
+ * One provider's status, in a row whose height never changes.
+ *
+ * That invariant is the whole point. The section this replaces swapped entire
+ * DOM subtrees between states and grew ~85px when deployment data arrived a few
+ * seconds after first paint, then another ~105px when the pointer touched it.
+ * Here every state renders the same three slots — icon, two lines of text,
+ * action — and an absent action reserves its width rather than collapsing.
+ *
+ * Nothing in this component or its stylesheet may change size on hover.
+ */
+
+import { Spinner } from '../primitives/Spinner';
+import { Button } from '../primitives/Button';
+import { VercelIcon, CloudflareIcon } from '../icons';
+import type { HostingProvider, SectionState } from '../../lib/hosting';
+import { copyFor } from '../../lib/hostingCopy';
+
+/** Status dot appearance per state. Purely presentational. */
+type DotTone = 'success' | 'progress' | 'error' | 'muted' | 'hollow' | 'none';
+
+const DOT_TONES: Record<SectionState['kind'], DotTone> = {
+  checking: 'muted',
+  not_pushed: 'hollow',
+  queued: 'muted',
+  building: 'progress',
+  publishing: 'progress',
+  ready: 'success',
+  failed: 'error',
+  canceled: 'muted',
+  skipped: 'muted',
+  gated: 'progress',
+  unknown: 'muted',
+  not_found_yet: 'muted',
+  not_found: 'hollow',
+  no_token: 'none',
+  token_rejected: 'error',
+  no_link: 'none',
+  offline: 'muted',
+  rate_limited: 'muted',
+};
+
+/** States whose dot pulses because something is genuinely in motion. */
+const PULSING = new Set<SectionState['kind']>([
+  'checking',
+  'queued',
+  'building',
+  'publishing',
+  'not_found_yet',
+]);
+
+function ProviderMark({ provider }: { provider?: HostingProvider }) {
+  switch (provider) {
+    case 'vercel':
+      return <VercelIcon size={14} />;
+    case 'cloudflare':
+      return <CloudflareIcon size={14} />;
+    // Netlify has no brand mark in the icon set yet, and inventing one from a
+    // raw SVG would break the icon rules. The neutral globe is honest until it
+    // is imported properly.
+    default:
+      return <GlobeMark />;
+  }
+}
+
+/** Neutral placeholder used before a provider is known. */
+function GlobeMark() {
+  return <span className="hosting-row-globe" aria-hidden="true" />;
+}
+
+interface Props {
+  state: SectionState;
+  commitSubject?: string | null;
+  shortSha?: string;
+  onAction?: () => void;
+}
+
+export function HostingRow({ state, commitSubject, shortSha, onAction }: Props) {
+  const copy = copyFor(state, commitSubject, shortSha);
+  const tone = DOT_TONES[state.kind];
+  const pulsing = PULSING.has(state.kind);
+
+  return (
+    <div className="hosting-row" data-state={state.kind}>
+      <div className="hosting-row-icon" data-slot="icon">
+        <ProviderMark provider={state.provider} />
+        {state.kind === 'checking' ? (
+          <Spinner size="sm" className="hosting-row-spinner" />
+        ) : tone === 'none' ? null : (
+          <span
+            className={`hosting-row-dot hosting-row-dot--${tone}${
+              pulsing ? ' hosting-row-dot--pulsing' : ''
+            }`}
+            aria-hidden="true"
+          />
+        )}
+      </div>
+
+      <div className="hosting-row-text" data-slot="text">
+        <div className="hosting-row-title" title={copy.title}>
+          {copy.title}
+        </div>
+        <div className="hosting-row-status" title={copy.status}>
+          {copy.status}
+          {state.isStale ? <span className="hosting-row-stale"> · not just checked</span> : null}
+        </div>
+      </div>
+
+      {/* Always rendered so the column keeps its width in every state. */}
+      <div className="hosting-row-action" data-slot="action" data-empty={!copy.action}>
+        {copy.action ? (
+          <Button size="compact" variant="secondary" onClick={onAction}>
+            {copy.action}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/** The third line: hints and links, also a fixed height. */
+export function HostingLinks({ state, hint }: { state: SectionState; hint?: string }) {
+  return (
+    <div className="hosting-links" data-state={state.kind}>
+      {hint ? (
+        <span className="hosting-links-hint" title={hint}>
+          {hint}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/hosting/HostingRow.tsx
+++ b/src/components/hosting/HostingRow.tsx
@@ -83,24 +83,34 @@ export function HostingRow({ state, commitSubject, shortSha, onAction }: Props) 
   return (
     <div className="hosting-row" data-state={state.kind}>
       <div className="hosting-row-icon" data-slot="icon">
-        <ProviderMark provider={state.provider} />
+        {/* While checking, the slot holds the spinner alone. Drawing the
+            provider mark underneath it meant a bare outlined circle with a
+            spinner on top — two concentric rings, which read as a broken
+            double spinner rather than as loading. */}
         {state.kind === 'checking' ? (
-          <Spinner size="sm" className="hosting-row-spinner" />
-        ) : tone === 'none' ? null : (
-          <span
-            className={`hosting-row-dot hosting-row-dot--${tone}${
-              pulsing ? ' hosting-row-dot--pulsing' : ''
-            }`}
-            aria-hidden="true"
-          />
+          <Spinner size="sm" />
+        ) : (
+          <>
+            <ProviderMark provider={state.provider} />
+            {tone === 'none' ? null : (
+              <span
+                className={`hosting-row-dot hosting-row-dot--${tone}${
+                  pulsing ? ' hosting-row-dot--pulsing' : ''
+                }`}
+                aria-hidden="true"
+              />
+            )}
+          </>
         )}
       </div>
 
+      {/* No `title` attributes: a native tooltip paints an opaque box over the
+          row below it, and it lags a state change — so the loading placeholder
+          was still hovering over a row that had already resolved. Copy is
+          written to fit instead. */}
       <div className="hosting-row-text" data-slot="text">
-        <div className="hosting-row-title" title={copy.title}>
-          {copy.title}
-        </div>
-        <div className="hosting-row-status" title={copy.status}>
+        <div className="hosting-row-title">{copy.title}</div>
+        <div className="hosting-row-status">
           {copy.status}
           {state.isStale ? <span className="hosting-row-stale"> · not just checked</span> : null}
         </div>
@@ -123,9 +133,7 @@ export function HostingLinks({ state, hint }: { state: SectionState; hint?: stri
   return (
     <div className="hosting-links" data-state={state.kind}>
       {hint ? (
-        <span className="hosting-links-hint" title={hint}>
-          {hint}
-        </span>
+        <span className="hosting-links-hint">{hint}</span>
       ) : null}
     </div>
   );

--- a/src/components/hosting/HostingSection.test.tsx
+++ b/src/components/hosting/HostingSection.test.tsx
@@ -128,6 +128,70 @@ describe('HostingRow geometry', () => {
 });
 
 describe('hosting copy', () => {
+  /**
+   * The row's text column is 184px: a 320px popover, less 24px of section
+   * padding, less the 24px icon slot, less the 72px action column that stays
+   * reserved in every state, less two 8px gaps. At 11px that is roughly 32
+   * characters, and both upper lines are `text-overflow: ellipsis` with no
+   * tooltip to recover what gets cut.
+   *
+   * The budget is approximate on purpose — it is a character count standing in
+   * for a pixel measurement, so it is set where a real overflow trips it and a
+   * merely long line does not. The UI harness measures the real thing and
+   * reports every ellipsised element per scenario; this catches it at the point
+   * someone edits the string.
+   */
+  const COLUMN_BUDGET = 34;
+
+  /**
+   * States whose line 1 is the user's own commit subject, which is theirs to
+   * make as long as they like. Clipping that is legitimate; clipping a sentence
+   * we wrote is not.
+   */
+  const OUR_OWN_TITLE = new Set<SectionStateKind>(['no_token', 'token_rejected', 'no_link']);
+
+  it('writes both upper lines to fit the column they render in', () => {
+    for (const kind of ALL_KINDS) {
+      const copy = copyFor(stateFor(kind), 'Fix the nav', 'abc123a');
+      expect(copy.status.length, `${kind} status: "${copy.status}"`).toBeLessThanOrEqual(
+        COLUMN_BUDGET
+      );
+      if (OUR_OWN_TITLE.has(kind)) {
+        expect(copy.title.length, `${kind} title: "${copy.title}"`).toBeLessThanOrEqual(
+          COLUMN_BUDGET
+        );
+      }
+    }
+  });
+
+  it('gives the informative half of a state its own full-width line', () => {
+    // Everything below used to be appended to the status line after an em
+    // dash, where it was the part the ellipsis ate.
+    const skipped = copyFor(
+      {
+        kind: 'skipped',
+        provider: 'vercel',
+        deployment: deployment(),
+        detail: { detail: 'skipped_because', reason: '[skip ci] in commit message' },
+      },
+      'Fix the nav'
+    );
+    expect(skipped.hint).toContain('[skip ci] in commit message');
+    expect(skipped.status).not.toContain('[skip ci]');
+
+    const canceled = copyFor(
+      {
+        kind: 'canceled',
+        provider: 'vercel',
+        deployment: deployment(),
+        detail: { detail: 'superseded_by_newer' },
+      },
+      'Fix the nav'
+    );
+    expect(canceled.hint).toMatch(/newer push replaced it/);
+    expect(canceled.status).not.toMatch(/newer push/);
+  });
+
   it('never leaks provider jargon in any state', () => {
     for (const kind of ALL_KINDS) {
       const copy = copyFor(stateFor(kind), 'Fix the nav', 'abc123a');
@@ -177,9 +241,13 @@ describe('hosting copy', () => {
   });
 
   it('describes a missing deployment without claiming it failed', () => {
-    const copy = copyFor({ kind: 'not_found', provider: 'vercel' }, 'Fix the nav');
+    const copy = copyFor({ kind: 'not_found', provider: 'vercel' }, 'Fix the nav', '9f3c1ab');
     expect(copy.status).not.toMatch(/fail/i);
-    expect(copy.status).toMatch(/hasn't reported/);
+    expect(copy.hint).not.toMatch(/fail/i);
+    expect(copy.status).toBe('No deploy reported yet');
+    // And it names the commit it found nothing for, so "nothing reported" can
+    // never be read as a verdict on some other push.
+    expect(copy.hint).toMatch(/Vercel has nothing for commit 9f3c1ab/);
   });
 
   it('explains an expired CLI login in terms of the CLI', () => {
@@ -187,11 +255,13 @@ describe('hosting copy', () => {
       { kind: 'token_rejected', provider: 'vercel', tokenSource: 'cli_file' },
       'Fix the nav'
     );
-    expect(copy.status).toMatch(/command-line login has expired/);
+    expect(copy.status).toMatch(/CLI login has expired/);
+    // The title is the way out, not a restatement of the problem.
+    expect(copy.title).toBe('Reconnect Vercel');
   });
 
   it('reassures that deploys still run when we simply cannot see them', () => {
     const copy = copyFor({ kind: 'no_token', provider: 'vercel' });
-    expect(copy.hint).toMatch(/Deploys still run/);
+    expect(copy.hint).toMatch(/deploys run either way/i);
   });
 });

--- a/src/components/hosting/HostingSection.test.tsx
+++ b/src/components/hosting/HostingSection.test.tsx
@@ -148,7 +148,7 @@ describe('hosting copy', () => {
       { kind: 'token_rejected', provider: 'vercel', tokenSource: 'cli_file' },
       'Fix the nav'
     );
-    expect(copy.status).toMatch(/CLI's login has expired/);
+    expect(copy.status).toMatch(/command-line login has expired/);
   });
 
   it('reassures that deploys still run when we simply cannot see them', () => {

--- a/src/components/hosting/HostingSection.test.tsx
+++ b/src/components/hosting/HostingSection.test.tsx
@@ -94,6 +94,28 @@ describe('HostingRow geometry', () => {
     }
   });
 
+  it('shows exactly one indicator while checking', () => {
+    // The loading state used to draw the provider mark *and* a spinner in the
+    // same slot. With no provider known yet the mark is a bare outlined
+    // circle, so it rendered as two concentric rings — read as a broken double
+    // spinner rather than as loading.
+    const { container } = render(<HostingRow state={{ kind: 'checking' }} />);
+    const icon = container.querySelector('[data-slot="icon"]');
+
+    expect(icon?.querySelectorAll('.hosting-row-globe')).toHaveLength(0);
+    expect(icon?.querySelectorAll('.hosting-row-dot')).toHaveLength(0);
+    expect(icon?.children).toHaveLength(1);
+  });
+
+  it('never uses native title tooltips, which paint over the row below', () => {
+    for (const kind of ALL_KINDS) {
+      const { container } = render(
+        <HostingRow state={stateFor(kind)} commitSubject="Fix the nav" />
+      );
+      expect(container.querySelectorAll('[title]')).toHaveLength(0);
+    }
+  });
+
   it('hides an unavailable action rather than dropping the column', () => {
     const { container } = render(
       <HostingRow state={{ kind: 'not_found_yet', provider: 'vercel' }} />

--- a/src/components/hosting/HostingSection.test.tsx
+++ b/src/components/hosting/HostingSection.test.tsx
@@ -45,6 +45,7 @@ const ALL_KINDS: SectionStateKind[] = [
 function deployment(): Deployment {
   return {
     id: 'dpl_1',
+    status_label: 'Ready',
     phase: { phase: 'ready' },
     environment: 'production',
     branch: 'main',
@@ -144,10 +145,26 @@ describe('hosting copy', () => {
     }
   });
 
-  it('leads with what the user shipped, not the integration state', () => {
+  it('leads with what the user shipped, then what the provider says', () => {
     const copy = copyFor(stateFor('ready'), 'Fix the nav');
     expect(copy.title).toBe('Fix the nav');
-    expect(copy.status).toMatch(/Live on Vercel/);
+    // Vercel's own word, not a synonym — so this and the Vercel dashboard
+    // never disagree about what a deployment is called.
+    expect(copy.status).toMatch(/^Ready · Production/);
+  });
+
+  it("uses the provider's status word rather than one of its own", () => {
+    const building = {
+      ...stateFor('building'),
+      deployment: { ...deployment(), status_label: 'Building' },
+    };
+    expect(copyFor(building, 'Fix the nav').status).toMatch(/^Building/);
+
+    const errored = {
+      ...stateFor('failed'),
+      deployment: { ...deployment(), status_label: 'Error' },
+    };
+    expect(copyFor(errored, 'Fix the nav').status).toMatch(/^Error/);
   });
 
   it('prefers the local commit subject over the provider message', () => {

--- a/src/components/hosting/HostingSection.test.tsx
+++ b/src/components/hosting/HostingSection.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * The layout-shift invariant, plus the copy rules.
+ *
+ * jsdom has no layout engine, so "the row is always 56px" cannot be asserted
+ * directly. It is pinned two ways instead:
+ *
+ * 1. **Structurally, here** — every state renders the same three slots, the
+ *    action column is present in the DOM even when there is nothing to click,
+ *    and a scripted transition preserves node identity rather than remounting.
+ * 2. **In the stylesheet, by `pnpm check:patterns`** — the heights are
+ *    token-driven and no rule inside the section may change box metrics on
+ *    hover, which is what made the previous implementation grow ~105px under
+ *    the cursor. That half lives with the other CSS policy checks because
+ *    Vitest stubs CSS imports to an empty string, so asserting on stylesheet
+ *    text from a unit test silently passes against nothing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { HostingRow } from './HostingRow';
+import { copyFor, BANNED_JARGON, titleFor } from '../../lib/hostingCopy';
+import type { Deployment, SectionState, SectionStateKind } from '../../lib/hosting';
+
+const ALL_KINDS: SectionStateKind[] = [
+  'checking',
+  'not_pushed',
+  'queued',
+  'building',
+  'publishing',
+  'ready',
+  'failed',
+  'canceled',
+  'skipped',
+  'gated',
+  'unknown',
+  'not_found_yet',
+  'not_found',
+  'no_token',
+  'token_rejected',
+  'no_link',
+  'offline',
+  'rate_limited',
+];
+
+function deployment(): Deployment {
+  return {
+    id: 'dpl_1',
+    phase: { phase: 'ready' },
+    environment: 'production',
+    branch: 'main',
+    commit_sha: 'abc123',
+    urls: { aliases: [], primary: 'https://example.vercel.app' },
+    dashboard_url: 'https://vercel.com/x/y',
+    created_at: Date.now() - 60_000,
+  };
+}
+
+function stateFor(kind: SectionStateKind): SectionState {
+  return { kind, provider: 'vercel', deployment: deployment() };
+}
+
+describe('HostingRow geometry', () => {
+  it.each(ALL_KINDS)('renders the same three slots in the %s state', (kind) => {
+    const { container } = render(<HostingRow state={stateFor(kind)} commitSubject="Fix the nav" />);
+
+    const row = container.querySelector('.hosting-row');
+    expect(row).toBeInTheDocument();
+    expect(row?.querySelector('[data-slot="icon"]')).toBeInTheDocument();
+    expect(row?.querySelector('[data-slot="text"]')).toBeInTheDocument();
+    // Present in every state — hidden, never removed, so the column keeps
+    // its width and the text column never reflows.
+    expect(row?.querySelector('[data-slot="action"]')).toBeInTheDocument();
+  });
+
+  it.each(ALL_KINDS)('always renders exactly two lines of text in %s', (kind) => {
+    const { container } = render(<HostingRow state={stateFor(kind)} commitSubject="Fix the nav" />);
+
+    expect(container.querySelectorAll('.hosting-row-title')).toHaveLength(1);
+    expect(container.querySelectorAll('.hosting-row-status')).toHaveLength(1);
+  });
+
+  it('keeps the same DOM nodes across a full deployment lifecycle', () => {
+    // A remount is a repaint, and a repaint is where a height jump hides.
+    const { container, rerender } = render(
+      <HostingRow state={stateFor('checking')} commitSubject="Fix the nav" />
+    );
+    const firstRow = container.querySelector('.hosting-row');
+    const firstText = container.querySelector('.hosting-row-text');
+
+    for (const kind of ['not_found_yet', 'queued', 'building', 'publishing', 'ready'] as const) {
+      rerender(<HostingRow state={stateFor(kind)} commitSubject="Fix the nav" />);
+      expect(container.querySelector('.hosting-row')).toBe(firstRow);
+      expect(container.querySelector('.hosting-row-text')).toBe(firstText);
+    }
+  });
+
+  it('hides an unavailable action rather than dropping the column', () => {
+    const { container } = render(
+      <HostingRow state={{ kind: 'not_found_yet', provider: 'vercel' }} />
+    );
+    const action = container.querySelector('[data-slot="action"]');
+    expect(action).toBeInTheDocument();
+    expect(action).toHaveAttribute('data-empty', 'true');
+  });
+});
+
+describe('hosting copy', () => {
+  it('never leaks provider jargon in any state', () => {
+    for (const kind of ALL_KINDS) {
+      const copy = copyFor(stateFor(kind), 'Fix the nav', 'abc123a');
+      for (const line of [copy.title, copy.status, copy.hint, copy.action]) {
+        if (!line) continue;
+        expect(line, `${kind}: "${line}"`).not.toMatch(BANNED_JARGON);
+      }
+    }
+  });
+
+  it('never mentions plugins', () => {
+    for (const kind of ALL_KINDS) {
+      const copy = copyFor(stateFor(kind), 'Fix the nav');
+      expect(`${copy.title} ${copy.status} ${copy.hint ?? ''}`).not.toMatch(/plugin/i);
+    }
+  });
+
+  it('leads with what the user shipped, not the integration state', () => {
+    const copy = copyFor(stateFor('ready'), 'Fix the nav');
+    expect(copy.title).toBe('Fix the nav');
+    expect(copy.status).toMatch(/Live on Vercel/);
+  });
+
+  it('prefers the local commit subject over the provider message', () => {
+    // Netlify returned null for both `commit_message` and `title` on a real
+    // production deploy, so git is the reliable source.
+    const withProviderMessage = { ...deployment(), commit_message: 'from the API' };
+    expect(titleFor('from git', withProviderMessage)).toBe('from git');
+    expect(titleFor(null, withProviderMessage)).toBe('from the API');
+    expect(titleFor(null, undefined)).toBe('Your latest push');
+  });
+
+  it('describes a missing deployment without claiming it failed', () => {
+    const copy = copyFor({ kind: 'not_found', provider: 'vercel' }, 'Fix the nav');
+    expect(copy.status).not.toMatch(/fail/i);
+    expect(copy.status).toMatch(/hasn't reported/);
+  });
+
+  it('explains an expired CLI login in terms of the CLI', () => {
+    const copy = copyFor(
+      { kind: 'token_rejected', provider: 'vercel', tokenSource: 'cli_file' },
+      'Fix the nav'
+    );
+    expect(copy.status).toMatch(/CLI's login has expired/);
+  });
+
+  it('reassures that deploys still run when we simply cannot see them', () => {
+    const copy = copyFor({ kind: 'no_token', provider: 'vercel' });
+    expect(copy.hint).toMatch(/Deploys still run/);
+  });
+});

--- a/src/components/hosting/HostingSection.tsx
+++ b/src/components/hosting/HostingSection.tsx
@@ -17,7 +17,6 @@ import { HostingRow, HostingLinks } from './HostingRow';
 import { HostingUrls } from './HostingUrls';
 import { HostingTokenModal } from './HostingTokenModal';
 import { HostingLinkPicker } from './HostingLinkPicker';
-import { useOpenModal } from '../../contexts/ModalContext';
 import { copyFor } from '../../lib/hostingCopy';
 import { logger } from '../../lib/logger';
 import {
@@ -38,7 +37,6 @@ interface Props {
 export function HostingSection({ projectPath, open, pushedAt }: Props) {
   const { status, state, refresh } = useHostingStatus({ projectPath, open, pushedAt });
   const { showToast } = useOptionalToast();
-  const openDeployments = useOpenModal();
 
   const [connecting, setConnecting] = useState<HostingProvider | null>(null);
   const [picking, setPicking] = useState(false);
@@ -76,9 +74,10 @@ export function HostingSection({ projectPath, open, pushedAt }: Props) {
   const handleAction = useCallback(() => {
 
     switch (state.kind) {
+      // Every state that has a deployment opens it on the provider. The
+      // addresses are already clickable directly above, so the button spends
+      // its space on the one thing the row cannot show.
       case 'ready':
-        openExternal(state.deployment?.urls.primary);
-        return;
       case 'queued':
       case 'building':
       case 'publishing':
@@ -87,9 +86,7 @@ export function HostingSection({ projectPath, open, pushedAt }: Props) {
       case 'skipped':
       case 'gated':
       case 'unknown':
-        // Not the provider's dashboard: the panel has the build output, the
-        // recent history, and the links, which is what the trip was for.
-        openDeployments('deployments');
+        openExternal(state.deployment?.dashboard_url);
         return;
       case 'no_token':
       case 'token_rejected':
@@ -104,7 +101,7 @@ export function HostingSection({ projectPath, open, pushedAt }: Props) {
       default:
         return;
     }
-  }, [state, refresh, openExternal, openDeployments]);
+  }, [state, refresh, openExternal]);
 
   return (
     <>

--- a/src/components/hosting/HostingSection.tsx
+++ b/src/components/hosting/HostingSection.tsx
@@ -9,13 +9,21 @@
  * @see lib/hosting for the state reducer, lib/hostingCopy for every string.
  */
 
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { useHostingStatus } from '../../hooks/useHostingStatus';
 import { useOptionalToast } from '../../contexts/ToastContext';
 import { HostingRow, HostingLinks } from './HostingRow';
+import { HostingTokenModal } from './HostingTokenModal';
+import { HostingLinkPicker } from './HostingLinkPicker';
 import { copyFor } from '../../lib/hostingCopy';
 import { logger } from '../../lib/logger';
+import {
+  getProjectAccountId,
+  notifyAccountCredentialsChanged,
+  DEFAULT_ACCOUNT_ID,
+} from '../../lib/accounts';
+import type { HostingProvider } from '../../lib/hosting';
 
 interface Props {
   projectPath: string;
@@ -23,13 +31,31 @@ interface Props {
   open: boolean;
   /** When the push completed, if it happened in this session. */
   pushedAt?: number;
-  /** Opens the connect-a-token flow. */
-  onConnect?: () => void;
 }
 
-export function HostingSection({ projectPath, open, pushedAt, onConnect }: Props) {
+export function HostingSection({ projectPath, open, pushedAt }: Props) {
   const { status, state, refresh } = useHostingStatus({ projectPath, open, pushedAt });
   const { showToast } = useOptionalToast();
+
+  const [connecting, setConnecting] = useState<HostingProvider | null>(null);
+  const [picking, setPicking] = useState(false);
+  // Which workspace's keychain the token belongs to — the project's, matching
+  // how git push authenticates, not whichever workspace happens to be active.
+  const [accountId, setAccountId] = useState(DEFAULT_ACCOUNT_ID);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getProjectAccountId(projectPath)
+      .then((id) => {
+        if (!cancelled) setAccountId(id);
+      })
+      .catch(() => {
+        // Falls back to Default, which is where an untagged project lives.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectPath]);
 
   const copy = copyFor(state, status?.commit.subject, status?.commit.short_sha);
 
@@ -58,8 +84,10 @@ export function HostingSection({ projectPath, open, pushedAt, onConnect }: Props
         return;
       case 'no_token':
       case 'token_rejected':
+        setConnecting(state.provider ?? 'vercel');
+        return;
       case 'no_link':
-        onConnect?.();
+        setPicking(true);
         return;
       case 'offline':
         refresh();
@@ -67,20 +95,54 @@ export function HostingSection({ projectPath, open, pushedAt, onConnect }: Props
       default:
         return;
     }
-  }, [state, onConnect, refresh, showToast]);
+  }, [state, refresh, showToast]);
 
   return (
-    <section className="publish-hosting-section" aria-labelledby="publish-hosting-heading">
-      <div className="publish-hosting-heading" id="publish-hosting-heading">
-        Hosting
-      </div>
-      <HostingRow
-        state={state}
-        commitSubject={status?.commit.subject}
-        shortSha={status?.commit.short_sha}
-        onAction={handleAction}
-      />
-      <HostingLinks state={state} hint={copy.hint} />
-    </section>
+    <>
+      <section className="publish-hosting-section" aria-labelledby="publish-hosting-heading">
+        <div className="publish-hosting-heading" id="publish-hosting-heading">
+          Hosting
+        </div>
+        <HostingRow
+          state={state}
+          commitSubject={status?.commit.subject}
+          shortSha={status?.commit.short_sha}
+          onAction={handleAction}
+        />
+        <HostingLinks state={state} hint={copy.hint} />
+      </section>
+
+      {connecting ? (
+        <HostingTokenModal
+          provider={connecting}
+          accountId={accountId}
+          workspaceName="this workspace"
+          wasRejected={state.kind === 'token_rejected'}
+          onSaved={() => {
+            setConnecting(null);
+            // Terminals in this workspace get the new token too, so tell them.
+            notifyAccountCredentialsChanged(accountId);
+            refresh();
+          }}
+          onClose={() => setConnecting(null)}
+        />
+      ) : null}
+
+      {picking ? (
+        <HostingLinkPicker
+          projectPath={projectPath}
+          detected={status?.detected ?? []}
+          onLinked={() => {
+            setPicking(false);
+            refresh();
+          }}
+          onNeedsToken={(provider) => {
+            setPicking(false);
+            setConnecting(provider);
+          }}
+          onClose={() => setPicking(false)}
+        />
+      ) : null}
+    </>
   );
 }

--- a/src/components/hosting/HostingSection.tsx
+++ b/src/components/hosting/HostingSection.tsx
@@ -40,18 +40,41 @@ export function HostingSection({ projectPath, open, pushedAt }: Props) {
 
   const [connecting, setConnecting] = useState<HostingProvider | null>(null);
   const [picking, setPicking] = useState(false);
-  // Which workspace's keychain the token belongs to — the project's, matching
-  // how git push authenticates, not whichever workspace happens to be active.
-  const [accountId, setAccountId] = useState(DEFAULT_ACCOUNT_ID);
+  /**
+   * Which workspace's keychain the token belongs to — the project's, matching
+   * how git push authenticates, not whichever workspace happens to be active.
+   *
+   * `null` means "not resolved yet", and it is deliberately not the same value
+   * as `DEFAULT_ACCOUNT_ID`. Starting at Default meant that between mounting
+   * and the lookup returning — and, worse, across a `projectPath` change, when
+   * the *previous* project's id was still in state — a `no_token` row could
+   * open the connect modal against an account this project does not belong to,
+   * saving the credential into the wrong workspace's keychain and notifying
+   * the wrong workspace's terminals. Default is the answer for a project that
+   * has no tag, not the answer for a project we have not asked about.
+   */
+  const [account, setAccount] = useState<{ path: string; id: string } | null>(null);
+
+  /**
+   * Derived, not reset. Storing the path the answer belongs to means a stale
+   * id cannot outlive its project: the moment `projectPath` changes this is
+   * `null` again, with no effect needing to remember to clear it. Same shape
+   * as the log cache in `DeploymentsModal`, and it keeps the effect free of a
+   * synchronous `setState` that `react-hooks/set-state-in-effect` would
+   * rightly reject.
+   */
+  const accountId = account?.path === projectPath ? account.id : null;
 
   useEffect(() => {
     let cancelled = false;
     void getProjectAccountId(projectPath)
       .then((id) => {
-        if (!cancelled) setAccountId(id);
+        if (!cancelled) setAccount({ path: projectPath, id });
       })
       .catch(() => {
-        // Falls back to Default, which is where an untagged project lives.
+        // An untagged project genuinely lives in Default. A failed lookup is
+        // the one case where that is an answer rather than a guess.
+        if (!cancelled) setAccount({ path: projectPath, id: DEFAULT_ACCOUNT_ID });
       });
     return () => {
       cancelled = true;
@@ -118,7 +141,9 @@ export function HostingSection({ projectPath, open, pushedAt }: Props) {
         <HostingLinks state={state} hint={copy.hint} />
       </section>
 
-      {connecting ? (
+      {/* Gated on a resolved account: a token saved against the wrong
+          workspace is worse than a connect button that waits a moment. */}
+      {connecting && accountId ? (
         <HostingTokenModal
           provider={connecting}
           accountId={accountId}

--- a/src/components/hosting/HostingSection.tsx
+++ b/src/components/hosting/HostingSection.tsx
@@ -1,0 +1,86 @@
+/**
+ * The "Hosting" block inside the Push popover.
+ *
+ * Replaces a slot that rendered an external plugin's hover menu, which the host
+ * then reshaped with CSS written against that plugin's own class names and held
+ * open with a synthetic `mouseover` dispatched from a MutationObserver. All of
+ * that is gone: this owns its markup, so it can own its geometry.
+ *
+ * @see lib/hosting for the state reducer, lib/hostingCopy for every string.
+ */
+
+import { useCallback } from 'react';
+import { openUrl } from '@tauri-apps/plugin-opener';
+import { useHostingStatus } from '../../hooks/useHostingStatus';
+import { useOptionalToast } from '../../contexts/ToastContext';
+import { HostingRow, HostingLinks } from './HostingRow';
+import { copyFor } from '../../lib/hostingCopy';
+import { logger } from '../../lib/logger';
+
+interface Props {
+  projectPath: string;
+  /** True only while the popover is on screen, so nothing polls in the dark. */
+  open: boolean;
+  /** When the push completed, if it happened in this session. */
+  pushedAt?: number;
+  /** Opens the connect-a-token flow. */
+  onConnect?: () => void;
+}
+
+export function HostingSection({ projectPath, open, pushedAt, onConnect }: Props) {
+  const { status, state, refresh } = useHostingStatus({ projectPath, open, pushedAt });
+  const { showToast } = useOptionalToast();
+
+  const copy = copyFor(state, status?.commit.subject, status?.commit.short_sha);
+
+  const handleAction = useCallback(() => {
+    const openExternal = (url?: string | null) => {
+      if (!url) return;
+      void openUrl(url).catch((err) => {
+        logger.warn('hosting: failed to open url', { error: String(err) });
+        showToast("Couldn't open that link", 'error');
+      });
+    };
+
+    switch (state.kind) {
+      case 'ready':
+        openExternal(state.deployment?.urls.primary);
+        return;
+      case 'queued':
+      case 'building':
+      case 'publishing':
+      case 'failed':
+      case 'canceled':
+      case 'skipped':
+      case 'gated':
+      case 'unknown':
+        openExternal(state.deployment?.dashboard_url);
+        return;
+      case 'no_token':
+      case 'token_rejected':
+      case 'no_link':
+        onConnect?.();
+        return;
+      case 'offline':
+        refresh();
+        return;
+      default:
+        return;
+    }
+  }, [state, onConnect, refresh, showToast]);
+
+  return (
+    <section className="publish-hosting-section" aria-labelledby="publish-hosting-heading">
+      <div className="publish-hosting-heading" id="publish-hosting-heading">
+        Hosting
+      </div>
+      <HostingRow
+        state={state}
+        commitSubject={status?.commit.subject}
+        shortSha={status?.commit.short_sha}
+        onAction={handleAction}
+      />
+      <HostingLinks state={state} hint={copy.hint} />
+    </section>
+  );
+}

--- a/src/components/hosting/HostingSection.tsx
+++ b/src/components/hosting/HostingSection.tsx
@@ -72,7 +72,6 @@ export function HostingSection({ projectPath, open, pushedAt }: Props) {
   );
 
   const handleAction = useCallback(() => {
-
     switch (state.kind) {
       // Every state that has a deployment opens it on the provider. The
       // addresses are already clickable directly above, so the button spends

--- a/src/components/hosting/HostingSection.tsx
+++ b/src/components/hosting/HostingSection.tsx
@@ -16,6 +16,7 @@ import { useOptionalToast } from '../../contexts/ToastContext';
 import { HostingRow, HostingLinks } from './HostingRow';
 import { HostingTokenModal } from './HostingTokenModal';
 import { HostingLinkPicker } from './HostingLinkPicker';
+import { useOpenModal } from '../../contexts/ModalContext';
 import { copyFor } from '../../lib/hostingCopy';
 import { logger } from '../../lib/logger';
 import {
@@ -36,6 +37,7 @@ interface Props {
 export function HostingSection({ projectPath, open, pushedAt }: Props) {
   const { status, state, refresh } = useHostingStatus({ projectPath, open, pushedAt });
   const { showToast } = useOptionalToast();
+  const openDeployments = useOpenModal();
 
   const [connecting, setConnecting] = useState<HostingProvider | null>(null);
   const [picking, setPicking] = useState(false);
@@ -80,7 +82,9 @@ export function HostingSection({ projectPath, open, pushedAt }: Props) {
       case 'skipped':
       case 'gated':
       case 'unknown':
-        openExternal(state.deployment?.dashboard_url);
+        // Not the provider's dashboard: the panel has the build output, the
+        // recent history, and the links, which is what the trip was for.
+        openDeployments('deployments');
         return;
       case 'no_token':
       case 'token_rejected':
@@ -95,7 +99,7 @@ export function HostingSection({ projectPath, open, pushedAt }: Props) {
       default:
         return;
     }
-  }, [state, refresh, showToast]);
+  }, [state, refresh, showToast, openDeployments]);
 
   return (
     <>

--- a/src/components/hosting/HostingSection.tsx
+++ b/src/components/hosting/HostingSection.tsx
@@ -14,6 +14,7 @@ import { openUrl } from '@tauri-apps/plugin-opener';
 import { useHostingStatus } from '../../hooks/useHostingStatus';
 import { useOptionalToast } from '../../contexts/ToastContext';
 import { HostingRow, HostingLinks } from './HostingRow';
+import { HostingUrls } from './HostingUrls';
 import { HostingTokenModal } from './HostingTokenModal';
 import { HostingLinkPicker } from './HostingLinkPicker';
 import { useOpenModal } from '../../contexts/ModalContext';
@@ -61,14 +62,18 @@ export function HostingSection({ projectPath, open, pushedAt }: Props) {
 
   const copy = copyFor(state, status?.commit.subject, status?.commit.short_sha);
 
-  const handleAction = useCallback(() => {
-    const openExternal = (url?: string | null) => {
+  const openExternal = useCallback(
+    (url?: string | null) => {
       if (!url) return;
       void openUrl(url).catch((err) => {
         logger.warn('hosting: failed to open url', { error: String(err) });
         showToast("Couldn't open that link", 'error');
       });
-    };
+    },
+    [showToast]
+  );
+
+  const handleAction = useCallback(() => {
 
     switch (state.kind) {
       case 'ready':
@@ -99,7 +104,7 @@ export function HostingSection({ projectPath, open, pushedAt }: Props) {
       default:
         return;
     }
-  }, [state, refresh, showToast, openDeployments]);
+  }, [state, refresh, openExternal, openDeployments]);
 
   return (
     <>
@@ -113,6 +118,7 @@ export function HostingSection({ projectPath, open, pushedAt }: Props) {
           shortSha={status?.commit.short_sha}
           onAction={handleAction}
         />
+        <HostingUrls deployment={state.deployment} onOpen={openExternal} />
         <HostingLinks state={state} hint={copy.hint} />
       </section>
 

--- a/src/components/hosting/HostingTokenModal.tsx
+++ b/src/components/hosting/HostingTokenModal.tsx
@@ -1,0 +1,138 @@
+/**
+ * Connect a hosting provider by storing a token in the OS keychain.
+ *
+ * Generalises the old Vercel-only modal over all three providers. The token is
+ * kept by `setAccountCredential` and injected into this workspace's terminals
+ * as the provider's documented environment variable — it never crosses back
+ * into the webview.
+ *
+ * Why a token rather than the CLI's own login: the Vercel CLI's credential is a
+ * short-lived OAuth access token (about seven hours on a real machine). Ship
+ * Studio will happily borrow it when it's there — that's what makes hosting
+ * work with no setup at all — but it stops working mid-afternoon, and the only
+ * durable fix is a token the user owns. See
+ * `docs/internal/hosting-provider-matrix.md`.
+ */
+
+import { useState } from 'react';
+import { openUrl } from '@tauri-apps/plugin-opener';
+import { ModalFrame } from '../primitives/ModalFrame';
+import { Button } from '../primitives/Button';
+import { setAccountCredential, type CredentialKey } from '../../lib/accounts';
+import { asCommandError, formatCommandError } from '../../lib/errors';
+import { useOptionalToast } from '../../contexts/ToastContext';
+import { PROVIDER_LABELS, type HostingProvider } from '../../lib/hosting';
+
+interface ProviderCopy {
+  credentialKey: CredentialKey;
+  tokensUrl: string;
+  tokensLabel: string;
+  placeholder: string;
+  /** Anything the user must get right when creating the token. */
+  requirement?: string;
+}
+
+const PROVIDERS: Record<HostingProvider, ProviderCopy> = {
+  vercel: {
+    credentialKey: 'vercel_token',
+    tokensUrl: 'https://vercel.com/account/tokens',
+    tokensLabel: 'vercel.com/account/tokens',
+    placeholder: 'vercel_xxxxxxxxxxxxxxxx',
+  },
+  cloudflare: {
+    credentialKey: 'cloudflare_api_token',
+    tokensUrl: 'https://dash.cloudflare.com/profile/api-tokens',
+    tokensLabel: 'dash.cloudflare.com/profile/api-tokens',
+    placeholder: 'xxxxxxxxxxxxxxxxxxxxxxxx',
+    requirement:
+      'Give it the Cloudflare Pages:Read and Account Settings:Read permissions — without both, deployments come back empty.',
+  },
+  netlify: {
+    credentialKey: 'netlify_auth_token',
+    tokensUrl: 'https://app.netlify.com/user/applications',
+    tokensLabel: 'app.netlify.com/user/applications',
+    placeholder: 'nfp_xxxxxxxxxxxxxxxx',
+  },
+};
+
+interface Props {
+  provider: HostingProvider;
+  accountId: string;
+  workspaceName: string;
+  /** True when we had a credential and the provider refused it. */
+  wasRejected?: boolean;
+  onSaved: () => void;
+  onClose: () => void;
+}
+
+export function HostingTokenModal({
+  provider,
+  accountId,
+  workspaceName,
+  wasRejected = false,
+  onSaved,
+  onClose,
+}: Props) {
+  const [token, setToken] = useState('');
+  const [saving, setSaving] = useState(false);
+  const { showToast } = useOptionalToast();
+
+  const name = PROVIDER_LABELS[provider];
+  const copy = PROVIDERS[provider];
+
+  const save = async () => {
+    const trimmed = token.trim();
+    if (!trimmed || saving) return;
+    setSaving(true);
+    try {
+      await setAccountCredential(accountId, copy.credentialKey, trimmed);
+      onSaved();
+    } catch (err) {
+      showToast(
+        `Couldn't save the ${name} token: ${formatCommandError(asCommandError(err))}`,
+        'error',
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <ModalFrame isOpen onClose={onClose} title={`Connect ${name}`} className="connect-modal">
+      <div className="connect-modal-body">
+        <p>
+          {wasRejected
+            ? `${name} refused the sign-in Ship Studio was using. Create a token for the account you deploy with and paste it below.`
+            : `Create a token for the ${name} account ${workspaceName} deploys with, then paste it below. It's stored in your Keychain and used only by this workspace.`}
+        </p>
+        {copy.requirement ? <p className="connect-modal-muted">{copy.requirement}</p> : null}
+        <Button variant="secondary" onClick={() => void openUrl(copy.tokensUrl)}>
+          Open {copy.tokensLabel} →
+        </Button>
+        <label className="connect-modal-field">
+          <span>
+            {name} token <span className="connect-modal-muted">(stays in your Keychain)</span>
+          </span>
+          <input
+            type="password"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            placeholder={copy.placeholder}
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void save();
+            }}
+          />
+        </label>
+        <div className="connect-modal-actions">
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={() => void save()} disabled={!token.trim() || saving}>
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
+      </div>
+    </ModalFrame>
+  );
+}

--- a/src/components/hosting/HostingTokenModal.tsx
+++ b/src/components/hosting/HostingTokenModal.tsx
@@ -90,7 +90,7 @@ export function HostingTokenModal({
     } catch (err) {
       showToast(
         `Couldn't save the ${name} token: ${formatCommandError(asCommandError(err))}`,
-        'error',
+        'error'
       );
     } finally {
       setSaving(false);

--- a/src/components/hosting/HostingUrls.test.tsx
+++ b/src/components/hosting/HostingUrls.test.tsx
@@ -13,11 +13,15 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { HostingUrls } from './HostingUrls';
 import type { Deployment } from '../../lib/hosting';
 
-function deployment(urls: Partial<Deployment['urls']>): Deployment {
+function deployment(
+  urls: Partial<Deployment['urls']>,
+  environment: Deployment['environment'] = 'production'
+): Deployment {
   return {
     id: 'dpl_1',
+    status_label: 'Ready',
     phase: { phase: 'ready' },
-    environment: 'production',
+    environment,
     branch: 'main',
     commit_sha: 'abc1234',
     urls: { aliases: [], ...urls },
@@ -29,11 +33,28 @@ const SITE = 'https://pepper-cayenne-accessories.vercel.app';
 const BUILD = 'https://pepper-cayenne-accessories-myos1awic-juliangalluzzo.vercel.app';
 
 describe('HostingUrls', () => {
-  it('labels the site and the build so they cannot be confused', () => {
+  it("names the addresses the way Vercel names them", () => {
+    // "Site" and "Build" were this app's own words. Vercel calls one the
+    // production domain and the other the deployment URL.
     render(<HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={vi.fn()} />);
 
-    expect(screen.getByText('Site')).toBeInTheDocument();
-    expect(screen.getByText('Build')).toBeInTheDocument();
+    expect(screen.getByText('Domain')).toBeInTheDocument();
+    expect(screen.getByText('Deployment')).toBeInTheDocument();
+  });
+
+  it('never offers the production domain from a preview', () => {
+    // The change isn't there. Showing production beside a preview is an
+    // invitation to click the wrong one and conclude the deploy did nothing.
+    render(
+      <HostingUrls
+        deployment={deployment({ site: SITE, deployment: BUILD }, 'preview')}
+        onOpen={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText('Domain')).not.toBeInTheDocument();
+    expect(screen.getByText('Deployment')).toBeInTheDocument();
+    expect(screen.getAllByRole('button')).toHaveLength(1);
   });
 
   it('surfaces the site address, not just the build permalink', () => {
@@ -45,7 +66,7 @@ describe('HostingUrls', () => {
 
     expect(
       screen.getByRole('button', {
-        name: 'Open the live site — pepper-cayenne-accessories.vercel.app',
+        name: 'Open the production domain — pepper-cayenne-accessories.vercel.app',
       })
     ).toBeInTheDocument();
   });
@@ -54,8 +75,8 @@ describe('HostingUrls', () => {
     render(<HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={vi.fn()} />);
 
     // A bare "Open" can't say which of two addresses it means.
-    expect(screen.getByLabelText(/Open the live site/)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Open this exact build/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Open the production domain/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Open this deployment/)).toBeInTheDocument();
   });
 
   it('opens when the address text itself is clicked, not only the icon', () => {
@@ -64,7 +85,7 @@ describe('HostingUrls', () => {
     const onOpen = vi.fn();
     render(<HostingUrls deployment={deployment({ site: SITE })} onOpen={onOpen} />);
 
-    fireEvent.click(screen.getByText('Site'));
+    fireEvent.click(screen.getByText('Domain'));
     expect(onOpen).toHaveBeenCalledWith(SITE);
   });
 
@@ -79,10 +100,10 @@ describe('HostingUrls', () => {
     const onOpen = vi.fn();
     render(<HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={onOpen} />);
 
-    fireEvent.click(screen.getByLabelText(/Open the live site/));
+    fireEvent.click(screen.getByLabelText(/Open the production domain/));
     expect(onOpen).toHaveBeenCalledWith(SITE);
 
-    fireEvent.click(screen.getByLabelText(/Open this exact build/));
+    fireEvent.click(screen.getByLabelText(/Open this deployment/));
     expect(onOpen).toHaveBeenCalledWith(BUILD);
   });
 
@@ -91,8 +112,8 @@ describe('HostingUrls', () => {
     // row, not the same string twice.
     render(<HostingUrls deployment={deployment({ site: SITE, deployment: SITE })} onOpen={vi.fn()} />);
 
-    expect(screen.getByText('Site')).toBeInTheDocument();
-    expect(screen.queryByText('Build')).not.toBeInTheDocument();
+    expect(screen.getByText('Domain')).toBeInTheDocument();
+    expect(screen.queryByText('Deployment')).not.toBeInTheDocument();
   });
 
   it('shows the build alone when the site address is unknown', () => {
@@ -101,8 +122,8 @@ describe('HostingUrls', () => {
     // "Build", never presented as the site.
     render(<HostingUrls deployment={deployment({ deployment: BUILD })} onOpen={vi.fn()} />);
 
-    expect(screen.queryByText('Site')).not.toBeInTheDocument();
-    expect(screen.getByText('Build')).toBeInTheDocument();
+    expect(screen.queryByText('Domain')).not.toBeInTheDocument();
+    expect(screen.getByText('Deployment')).toBeInTheDocument();
   });
 
   it('renders nothing rather than an empty frame when there are no addresses', () => {
@@ -119,7 +140,7 @@ describe('HostingUrls', () => {
 
     // The label names the host without a scheme; the click still carries one.
     const button = screen.getByRole('button', {
-      name: 'Open the live site — pepper-cayenne-accessories.vercel.app',
+      name: 'Open the production domain — pepper-cayenne-accessories.vercel.app',
     });
     fireEvent.click(button);
     expect(onOpen).toHaveBeenCalledWith(SITE);

--- a/src/components/hosting/HostingUrls.test.tsx
+++ b/src/components/hosting/HostingUrls.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * The addresses, and which is which.
+ *
+ * The bug these pin: the section showed one unlabelled URL, taken from the
+ * deployment record. That record's `url` is a per-build permalink carrying a
+ * generated hash and the account name — so the section displayed something
+ * unrecognisable, never showed the address people actually visit, and gave no
+ * way to tell which kind of URL it was.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { HostingUrls } from './HostingUrls';
+import type { Deployment } from '../../lib/hosting';
+
+function deployment(urls: Partial<Deployment['urls']>): Deployment {
+  return {
+    id: 'dpl_1',
+    phase: { phase: 'ready' },
+    environment: 'production',
+    branch: 'main',
+    commit_sha: 'abc1234',
+    urls: { aliases: [], ...urls },
+    created_at: Date.now(),
+  };
+}
+
+const SITE = 'https://pepper-cayenne-accessories.vercel.app';
+const BUILD = 'https://pepper-cayenne-accessories-myos1awic-juliangalluzzo.vercel.app';
+
+describe('HostingUrls', () => {
+  it('labels the site and the build so they cannot be confused', () => {
+    render(<HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={vi.fn()} />);
+
+    expect(screen.getByText('Site')).toBeInTheDocument();
+    expect(screen.getByText('Build')).toBeInTheDocument();
+  });
+
+  it('surfaces the site address, not just the build permalink', () => {
+    // Asserted through the accessible name: the visible text goes through
+    // MiddleTruncate, which measures with canvas and so collapses to an
+    // ellipsis under jsdom's zero-width layout. The address itself is what
+    // matters here, and it reaches the user either way.
+    render(<HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={vi.fn()} />);
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Open the live site — pepper-cayenne-accessories.vercel.app',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('gives each address its own open control, each saying what it opens', () => {
+    render(<HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={vi.fn()} />);
+
+    // A bare "Open" can't say which of two addresses it means.
+    expect(screen.getByLabelText(/Open the live site/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Open this exact build/)).toBeInTheDocument();
+  });
+
+  it('opens the address its own control belongs to', () => {
+    const onOpen = vi.fn();
+    render(<HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={onOpen} />);
+
+    fireEvent.click(screen.getByLabelText(/Open the live site/));
+    expect(onOpen).toHaveBeenCalledWith(SITE);
+
+    fireEvent.click(screen.getByLabelText(/Open this exact build/));
+    expect(onOpen).toHaveBeenCalledWith(BUILD);
+  });
+
+  it('does not repeat one address under two labels', () => {
+    // A project whose site domain is also the deployment URL should show one
+    // row, not the same string twice.
+    render(<HostingUrls deployment={deployment({ site: SITE, deployment: SITE })} onOpen={vi.fn()} />);
+
+    expect(screen.getByText('Site')).toBeInTheDocument();
+    expect(screen.queryByText('Build')).not.toBeInTheDocument();
+  });
+
+  it('shows the build alone when the site address is unknown', () => {
+    // Honest degradation: if the project's domains couldn't be read, the
+    // permalink is still real and still worth offering — but it is labelled
+    // "Build", never presented as the site.
+    render(<HostingUrls deployment={deployment({ deployment: BUILD })} onOpen={vi.fn()} />);
+
+    expect(screen.queryByText('Site')).not.toBeInTheDocument();
+    expect(screen.getByText('Build')).toBeInTheDocument();
+  });
+
+  it('renders nothing rather than an empty frame when there are no addresses', () => {
+    const { container } = render(<HostingUrls deployment={deployment({})} onOpen={vi.fn()} />);
+    expect(container.querySelector('.hosting-urls')).not.toBeInTheDocument();
+
+    const { container: noDeployment } = render(<HostingUrls onOpen={vi.fn()} />);
+    expect(noDeployment.querySelector('.hosting-urls')).not.toBeInTheDocument();
+  });
+
+  it('strips the scheme for display but opens the full URL', () => {
+    const onOpen = vi.fn();
+    render(<HostingUrls deployment={deployment({ site: SITE })} onOpen={onOpen} />);
+
+    // The label names the host without a scheme; the click still carries one.
+    const button = screen.getByRole('button', {
+      name: 'Open the live site — pepper-cayenne-accessories.vercel.app',
+    });
+    fireEvent.click(button);
+    expect(onOpen).toHaveBeenCalledWith(SITE);
+  });
+});

--- a/src/components/hosting/HostingUrls.test.tsx
+++ b/src/components/hosting/HostingUrls.test.tsx
@@ -33,10 +33,12 @@ const SITE = 'https://pepper-cayenne-accessories.vercel.app';
 const BUILD = 'https://pepper-cayenne-accessories-myos1awic-juliangalluzzo.vercel.app';
 
 describe('HostingUrls', () => {
-  it("names the addresses the way Vercel names them", () => {
+  it('names the addresses the way Vercel names them', () => {
     // "Site" and "Build" were this app's own words. Vercel calls one the
     // production domain and the other the deployment URL.
-    render(<HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={vi.fn()} />);
+    render(
+      <HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={vi.fn()} />
+    );
 
     expect(screen.getByText('Domain')).toBeInTheDocument();
     expect(screen.getByText('Deployment')).toBeInTheDocument();
@@ -62,7 +64,9 @@ describe('HostingUrls', () => {
     // MiddleTruncate, which measures with canvas and so collapses to an
     // ellipsis under jsdom's zero-width layout. The address itself is what
     // matters here, and it reaches the user either way.
-    render(<HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={vi.fn()} />);
+    render(
+      <HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={vi.fn()} />
+    );
 
     expect(
       screen.getByRole('button', {
@@ -72,7 +76,9 @@ describe('HostingUrls', () => {
   });
 
   it('gives each address its own open control, each saying what it opens', () => {
-    render(<HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={vi.fn()} />);
+    render(
+      <HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={vi.fn()} />
+    );
 
     // A bare "Open" can't say which of two addresses it means.
     expect(screen.getByLabelText(/Open the production domain/)).toBeInTheDocument();
@@ -92,13 +98,17 @@ describe('HostingUrls', () => {
   it('exposes one control per address, not two', () => {
     // The icon lives inside the row's button; announcing it separately would
     // give screen readers and keyboard users the same action twice.
-    render(<HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={vi.fn()} />);
+    render(
+      <HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={vi.fn()} />
+    );
     expect(screen.getAllByRole('button')).toHaveLength(2);
   });
 
   it('opens the address its own control belongs to', () => {
     const onOpen = vi.fn();
-    render(<HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={onOpen} />);
+    render(
+      <HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={onOpen} />
+    );
 
     fireEvent.click(screen.getByLabelText(/Open the production domain/));
     expect(onOpen).toHaveBeenCalledWith(SITE);
@@ -110,7 +120,9 @@ describe('HostingUrls', () => {
   it('does not repeat one address under two labels', () => {
     // A project whose site domain is also the deployment URL should show one
     // row, not the same string twice.
-    render(<HostingUrls deployment={deployment({ site: SITE, deployment: SITE })} onOpen={vi.fn()} />);
+    render(
+      <HostingUrls deployment={deployment({ site: SITE, deployment: SITE })} onOpen={vi.fn()} />
+    );
 
     expect(screen.getByText('Domain')).toBeInTheDocument();
     expect(screen.queryByText('Deployment')).not.toBeInTheDocument();

--- a/src/components/hosting/HostingUrls.test.tsx
+++ b/src/components/hosting/HostingUrls.test.tsx
@@ -58,6 +58,23 @@ describe('HostingUrls', () => {
     expect(screen.getByLabelText(/Open this exact build/)).toBeInTheDocument();
   });
 
+  it('opens when the address text itself is clicked, not only the icon', () => {
+    // The icon is a hover affordance. A row that reads like a link has to
+    // behave like one when you click the part you were reading.
+    const onOpen = vi.fn();
+    render(<HostingUrls deployment={deployment({ site: SITE })} onOpen={onOpen} />);
+
+    fireEvent.click(screen.getByText('Site'));
+    expect(onOpen).toHaveBeenCalledWith(SITE);
+  });
+
+  it('exposes one control per address, not two', () => {
+    // The icon lives inside the row's button; announcing it separately would
+    // give screen readers and keyboard users the same action twice.
+    render(<HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={vi.fn()} />);
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+  });
+
   it('opens the address its own control belongs to', () => {
     const onOpen = vi.fn();
     render(<HostingUrls deployment={deployment({ site: SITE, deployment: BUILD })} onOpen={onOpen} />);

--- a/src/components/hosting/HostingUrls.tsx
+++ b/src/components/hosting/HostingUrls.tsx
@@ -1,0 +1,90 @@
+/**
+ * The addresses a deployment produced, each said plainly.
+ *
+ * Two URLs matter and they are not interchangeable:
+ *
+ * - **Site** — the project's production domain. What people visit, and what
+ *   the owner would call "the site". It is a property of the *project* and on
+ *   Vercel lives on a different endpoint from the deployment entirely.
+ * - **Build** — this deployment's immutable permalink. Always resolves to this
+ *   exact commit even after newer deploys, which is what makes it useful for
+ *   checking what you just shipped, and what makes it wrong to present as the
+ *   site's address.
+ *
+ * Showing one unlabelled URL meant showing a per-build permalink and calling
+ * it the site. Each row is labelled so it is never ambiguous which is which,
+ * and each gets its own open control so "open" always has one meaning.
+ */
+
+import { MiddleTruncate } from '../primitives/MiddleTruncate';
+import { ExternalLinkIcon } from '@/components/icons';
+import type { Deployment } from '../../lib/hosting';
+
+interface Row {
+  label: string;
+  url: string;
+  /** Read out to screen readers, where the visual label isn't enough. */
+  description: string;
+}
+
+function rowsFor(deployment?: Deployment): Row[] {
+  if (!deployment) return [];
+  const rows: Row[] = [];
+
+  if (deployment.urls.site) {
+    rows.push({
+      label: 'Site',
+      url: deployment.urls.site,
+      description: 'Open the live site',
+    });
+  }
+
+  // Only worth its own row when it is actually a different address. On a
+  // project with no custom domain these can coincide.
+  if (deployment.urls.deployment && deployment.urls.deployment !== deployment.urls.site) {
+    rows.push({
+      label: 'Build',
+      url: deployment.urls.deployment,
+      description: 'Open this exact build',
+    });
+  }
+
+  return rows;
+}
+
+/** Strip the scheme for display. The value opened is still the full URL. */
+function displayHost(url: string): string {
+  return url.replace(/^https?:\/\//, '').replace(/\/$/, '');
+}
+
+interface Props {
+  deployment?: Deployment;
+  onOpen: (url: string) => void;
+}
+
+export function HostingUrls({ deployment, onOpen }: Props) {
+  const rows = rowsFor(deployment);
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="hosting-urls">
+      {rows.map((row) => (
+        <div className="hosting-url" key={row.label}>
+          <span className="hosting-url-label">{row.label}</span>
+          {/* Middle-truncated, not end-truncated: a build permalink's tail
+              carries the domain, so cutting the end leaves an address you
+              can't identify at all. */}
+          <MiddleTruncate className="hosting-url-value" text={displayHost(row.url)} />
+          <button
+            type="button"
+            className="hosting-url-open"
+            onClick={() => onOpen(row.url)}
+            aria-label={`${row.description} — ${displayHost(row.url)}`}
+          >
+            <ExternalLinkIcon size={12} />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/hosting/HostingUrls.tsx
+++ b/src/components/hosting/HostingUrls.tsx
@@ -1,19 +1,25 @@
 /**
- * The addresses a deployment produced, each said plainly.
+ * The addresses a deployment produced, named the way the provider names them.
  *
- * Two URLs matter and they are not interchangeable:
+ * Vercel's own vocabulary: a project has a **production domain**, and each
+ * deployment gets its own **deployment URL** ("Each time you deploy, Vercel
+ * generates a unique URL"). "Site" and "Build" were words this app invented,
+ * and neither told you which one had your change on it.
  *
- * - **Site** — the project's production domain. What people visit, and what
- *   the owner would call "the site". It is a property of the *project* and on
- *   Vercel lives on a different endpoint from the deployment entirely.
- * - **Build** — this deployment's immutable permalink. Always resolves to this
- *   exact commit even after newer deploys, which is what makes it useful for
- *   checking what you just shipped, and what makes it wrong to present as the
- *   site's address.
+ * What is shown depends on where the deployment went, because that is what
+ * decides which address is worth clicking:
  *
- * Showing one unlabelled URL meant showing a per-build permalink and calling
- * it the site. Each row is labelled so it is never ambiguous which is which,
- * and each gets its own open control so "open" always has one meaning.
+ * - A **production** deploy shows the production domain first — your change is
+ *   live there — with the commit permalink under it for pinning this exact
+ *   version.
+ * - A **preview** deploy shows only its own URL. The production domain does
+ *   *not* contain this change, so offering it invites clicking the wrong one.
+ *
+ * There is deliberately no branch URL. Vercel documents the shape of one
+ * (`<project>-git-<branch>-<scope>.vercel.app`) but does not return it on the
+ * deployment, and the same docs note it is truncated past 63 characters and
+ * mangled by anti-phishing rules — which is exactly why the previous
+ * implementation's assembled preview links 404'd.
  */
 
 import { MiddleTruncate } from '../primitives/MiddleTruncate';
@@ -27,25 +33,40 @@ interface Row {
   description: string;
 }
 
-function rowsFor(deployment?: Deployment): Row[] {
+export function rowsFor(deployment?: Deployment): Row[] {
   if (!deployment) return [];
+
+  // A preview never reached production, so the production domain would be a
+  // link to somebody else's change sitting directly under yours.
+  if (deployment.environment === 'preview') {
+    return deployment.urls.deployment
+      ? [
+          {
+            label: 'Deployment',
+            url: deployment.urls.deployment,
+            description: 'Open this preview deployment',
+          },
+        ]
+      : [];
+  }
+
   const rows: Row[] = [];
 
   if (deployment.urls.site) {
     rows.push({
-      label: 'Site',
+      label: 'Domain',
       url: deployment.urls.site,
-      description: 'Open the live site',
+      description: 'Open the production domain',
     });
   }
 
-  // Only worth its own row when it is actually a different address. On a
-  // project with no custom domain these can coincide.
+  // Only worth its own row when it is a different address — a project with no
+  // custom domain can have these coincide.
   if (deployment.urls.deployment && deployment.urls.deployment !== deployment.urls.site) {
     rows.push({
-      label: 'Build',
+      label: 'Deployment',
       url: deployment.urls.deployment,
-      description: 'Open this exact build',
+      description: 'Open this deployment',
     });
   }
 

--- a/src/components/hosting/HostingUrls.tsx
+++ b/src/components/hosting/HostingUrls.tsx
@@ -69,21 +69,27 @@ export function HostingUrls({ deployment, onOpen }: Props) {
   return (
     <div className="hosting-urls">
       {rows.map((row) => (
-        <div className="hosting-url" key={row.label}>
+        /* The whole row is the control. An address that looks like a link
+           should open when you click it, rather than sending you hunting for
+           a small icon at the end of the line. */
+        <button
+          type="button"
+          className="hosting-url"
+          key={row.label}
+          onClick={() => onOpen(row.url)}
+          aria-label={`${row.description} — ${displayHost(row.url)}`}
+        >
           <span className="hosting-url-label">{row.label}</span>
           {/* Middle-truncated, not end-truncated: a build permalink's tail
               carries the domain, so cutting the end leaves an address you
               can't identify at all. */}
           <MiddleTruncate className="hosting-url-value" text={displayHost(row.url)} />
-          <button
-            type="button"
-            className="hosting-url-open"
-            onClick={() => onOpen(row.url)}
-            aria-label={`${row.description} — ${displayHost(row.url)}`}
-          >
+          {/* Decorative: the row itself is the button, so this must not be a
+              second tab stop announcing the same action twice. */}
+          <span className="hosting-url-open" aria-hidden="true">
             <ExternalLinkIcon size={12} />
-          </button>
-        </div>
+          </span>
+        </button>
       ))}
     </div>
   );

--- a/src/components/plugins/PluginStatusGrid.test.tsx
+++ b/src/components/plugins/PluginStatusGrid.test.tsx
@@ -4,31 +4,36 @@ import type { LoadedPlugin } from '../../hooks/usePlugins';
 import type { PluginInfo } from '../../lib/plugins';
 import { PluginStatusGrid } from './PluginStatusGrid';
 
-const plugin: PluginInfo = {
-  manifest: {
-    id: 'vercel',
-    name: 'Vercel',
-    version: '1.0.0',
-    description: 'Deploy with Vercel',
-    slots: ['toolbar'],
-    author: 'Ship Studio',
-    repository: 'https://github.com/ship-studio/plugin-vercel',
-    setup: [],
-    min_app_version: '',
-    icon: '',
-    required_commands: [],
-  },
-  enabled: true,
-  installed_at: 0,
-  source_url: 'https://github.com/ship-studio/plugin-vercel',
-  is_dev: false,
-  local_path: '',
-};
+function makePlugin(overrides: Partial<PluginInfo['manifest']> = {}): PluginInfo {
+  return {
+    manifest: {
+      id: 'ccusage',
+      name: 'Claude Usage',
+      version: '1.0.0',
+      description: 'Shows Claude Code spend',
+      slots: ['toolbar'],
+      author: 'Ship Studio',
+      repository: 'https://github.com/ship-studio/plugin-ccusage',
+      setup: [],
+      min_app_version: '',
+      icon: '',
+      required_commands: [],
+      ...overrides,
+    },
+    enabled: true,
+    installed_at: 0,
+    source_url: 'https://github.com/ship-studio/plugin-ccusage',
+    is_dev: false,
+    local_path: '',
+  };
+}
 
-function renderGrid(loadedPlugins: LoadedPlugin[]) {
+const plugin = makePlugin();
+
+function renderGrid(loadedPlugins: LoadedPlugin[], plugins: PluginInfo[] = [plugin]) {
   render(
     <PluginStatusGrid
-      plugins={[plugin]}
+      plugins={plugins}
       loadedPlugins={loadedPlugins}
       togglingId={null}
       removingId={null}
@@ -61,7 +66,34 @@ describe('PluginStatusGrid', () => {
       },
     ]);
 
-    expect(screen.getByText('Vercel')).toBeInTheDocument();
+    expect(screen.getByText('Claude Usage')).toBeInTheDocument();
     expect(toolbarRender).not.toHaveBeenCalled();
+  });
+});
+
+describe('a plugin the app now does itself', () => {
+  const superseded = makePlugin({ id: 'vercel', name: 'Vercel' });
+
+  it('says why it stopped doing anything', () => {
+    // It is skipped at load, so it renders nothing anywhere else in the app.
+    // This row is the only place someone finds out why.
+    renderGrid([], [superseded]);
+
+    expect(screen.getByText('Built in now')).toBeInTheDocument();
+    expect(screen.getByText(/Hosting is built in now/)).toBeInTheDocument();
+  });
+
+  it('offers no on/off toggle', () => {
+    // Turning it on would change nothing, and offering the switch implies it
+    // would.
+    renderGrid([], [superseded]);
+
+    expect(screen.queryByTitle('Disable')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Enable')).not.toBeInTheDocument();
+  });
+
+  it("leaves an ordinary plugin's toggle alone", () => {
+    renderGrid([]);
+    expect(screen.getByTitle('Disable')).toBeInTheDocument();
   });
 });

--- a/src/components/plugins/PluginStatusGrid.tsx
+++ b/src/components/plugins/PluginStatusGrid.tsx
@@ -6,7 +6,7 @@
  * @module components/PluginStatusGrid
  */
 
-import type { PluginInfo } from '../../lib/plugins';
+import { supersededReason, type PluginInfo } from '../../lib/plugins';
 import type { LoadedPlugin } from '../../hooks/usePlugins';
 import { PuzzleIcon } from '@/components/icons';
 import { TextButton } from '../primitives/TextButton';
@@ -45,8 +45,15 @@ export function PluginStatusGrid({
   return (
     <div className="plugins-list">
       {plugins.map((plugin) => {
+        // Superseded plugins are skipped at load, so this row is the only place
+        // a user finds out why one stopped doing anything.
+        const superseded = supersededReason(plugin.manifest.id);
+
         return (
-          <ExtensionListRow key={plugin.manifest.id} className="plugin-row">
+          <ExtensionListRow
+            key={plugin.manifest.id}
+            className={`plugin-row${superseded ? ' is-superseded' : ''}`}
+          >
             <div className="plugin-icon-container">
               <PuzzleIcon size={14} />
             </div>
@@ -56,29 +63,34 @@ export function PluginStatusGrid({
                   <span className="plugin-name">
                     {plugin.manifest.name}
                     {plugin.is_dev && <span className="plugin-dev-badge">DEV</span>}
+                    {superseded && <span className="plugin-superseded-badge">Built in now</span>}
                   </span>
                   <span className="plugin-meta">
                     v{plugin.manifest.version}
                     {plugin.manifest.author && <> · {plugin.manifest.author}</>}
                   </span>
                 </div>
-                <button
-                  className={`plugin-toggle-btn ${plugin.enabled ? 'enabled' : ''}`}
-                  onClick={() => {
-                    onToggle(plugin.manifest.id, !plugin.enabled);
-                  }}
-                  disabled={togglingId === plugin.manifest.id}
-                  title={plugin.enabled ? 'Disable' : 'Enable'}
-                >
-                  {plugin.enabled ? 'On' : 'Off'}
-                </button>
+                {/* No toggle for a superseded plugin: it is skipped at load,
+                    so switching it on would change nothing and imply it had. */}
+                {!superseded && (
+                  <button
+                    className={`plugin-toggle-btn ${plugin.enabled ? 'enabled' : ''}`}
+                    onClick={() => {
+                      onToggle(plugin.manifest.id, !plugin.enabled);
+                    }}
+                    disabled={togglingId === plugin.manifest.id}
+                    title={plugin.enabled ? 'Disable' : 'Enable'}
+                  >
+                    {plugin.enabled ? 'On' : 'Off'}
+                  </button>
+                )}
               </div>
               {plugin.is_dev && plugin.local_path && (
                 <div className="plugin-local-path" title={plugin.local_path}>
                   {plugin.local_path}
                 </div>
               )}
-              <div className="plugin-desc">{plugin.manifest.description}</div>
+              <div className="plugin-desc">{superseded ?? plugin.manifest.description}</div>
               <div className="plugin-actions">
                 {plugin.is_dev ? (
                   <>

--- a/src/components/workspace/WorkspaceHeader.tsx
+++ b/src/components/workspace/WorkspaceHeader.tsx
@@ -52,10 +52,10 @@ import type { ChangedFile } from '../../lib/git';
 
 /** Re-exported from lib/plugins so non-UI code can share the list (issue #386). */
 export { HOSTING_PLUGIN_IDS } from '../../lib/plugins';
-import { HOSTING_PLUGIN_IDS } from '../../lib/plugins';
+import { HOSTING_PLUGIN_IDS, NATIVE_HOSTING_IDS } from '../../lib/plugins';
 
 /** The subset of hosting plugins whose controls render inside the Push workflow. */
-export const PUSH_HOSTING_PLUGIN_IDS = ['vercel', 'cloudflare'];
+export { NATIVE_HOSTING_IDS } from '../../lib/plugins';
 
 export interface WorkspaceHeaderProps {
   // Project
@@ -367,18 +367,11 @@ export function WorkspaceHeader({
       hosting: all.filter((p) => HOSTING_PLUGIN_IDS.includes(p.info.manifest.id)),
     };
   }, [getSlotPlugins]);
-  const pushHostingPlugins = useMemo(
-    () =>
-      toolbarPlugins.hosting.filter((plugin) =>
-        PUSH_HOSTING_PLUGIN_IDS.includes(plugin.info.manifest.id)
-      ),
-    [toolbarPlugins.hosting]
-  );
+  // Hosting is native now (components/hosting), so a hosting plugin no longer
+  // renders anywhere. `usePlugins` skips loading them outright — filtering only
+  // here would still run their activation and background timers.
   const headerHostingPlugins = useMemo(
-    () =>
-      toolbarPlugins.hosting.filter(
-        (plugin) => !PUSH_HOSTING_PLUGIN_IDS.includes(plugin.info.manifest.id)
-      ),
+    () => toolbarPlugins.hosting.filter((p) => !NATIVE_HOSTING_IDS.includes(p.info.manifest.id)),
     [toolbarPlugins.hosting]
   );
 
@@ -460,17 +453,6 @@ export function WorkspaceHeader({
           changedFiles={changedFiles}
           onDiscardChanges={onDiscardChanges}
           excludeClickOutsideSelector=".source-control-push"
-          hostingControls={
-            pushHostingPlugins.length > 0 ? (
-              <PluginSlot
-                name="toolbar"
-                plugins={pushHostingPlugins}
-                project={pluginProject}
-                actions={pluginActions}
-                theme={pluginTheme}
-              />
-            ) : undefined
-          }
         />
       </div>
     </div>

--- a/src/components/workspace/WorkspaceModals.tsx
+++ b/src/components/workspace/WorkspaceModals.tsx
@@ -244,7 +244,13 @@ export function WorkspaceModals({
         onCreatePR={onBackupCreatePR}
       />
 
-      <DeploymentsModal projectPath={projectPath} />
+      {/* Keyed by path so switching projects remounts it. Every piece of state
+          in there — provider, deployments, selection, build log — belongs to
+          one project, and a remount discards all of it without the component
+          having to remember to. Clearing them by hand left the previous
+          project's deploys on screen under the new project's name whenever a
+          field was missed. */}
+      <DeploymentsModal key={projectPath} projectPath={projectPath} />
 
       <AssetsPanel projectPath={projectPath} />
 

--- a/src/components/workspace/WorkspaceModals.tsx
+++ b/src/components/workspace/WorkspaceModals.tsx
@@ -13,6 +13,7 @@
 import { EnvEditor } from './EnvEditor';
 import { LanguagesModal } from './LanguagesModal';
 import { BackupsModal } from './BackupsModal';
+import { DeploymentsModal } from '../hosting/DeploymentsModal';
 import { AssetsPanel } from './AssetsPanel';
 import { EducationOverlay } from '../EducationOverlay';
 import { ScreenshotToast, ScreenshotPreviewModal } from '../preview/ScreenshotPreview';
@@ -242,6 +243,8 @@ export function WorkspaceModals({
         onRestore={onBackupRestore}
         onCreatePR={onBackupCreatePR}
       />
+
+      <DeploymentsModal projectPath={projectPath} />
 
       <AssetsPanel projectPath={projectPath} />
 

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -39,6 +39,7 @@ export type ModalId =
   | 'quitConfirm'
   | 'commandPalette'
   | 'shopifyStore'
+  | 'deployments'
   | 'worktreeCreate';
 
 interface ModalContextValue {

--- a/src/harness/scenarios/hosting.test.ts
+++ b/src/harness/scenarios/hosting.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Check the hosting fixtures against the adapters they claim to come from.
+ *
+ * There are two ways a fixture goes wrong, and they need different defences.
+ * One is *expiry*: a fixture that was true when written and drifted when the
+ * code moved. Re-reading catches that, and so does the runner's `requires`
+ * check, because an expired fixture usually stops rendering its subject.
+ *
+ * The other is *invention*: a fixture that was never true, not even on the day
+ * it was written. Nothing catches that by looking at the fixture, because it is
+ * internally consistent — it type-checks, it renders, it screenshots, and the
+ * picture looks entirely plausible. The only way to catch it is to check the
+ * fixture against the thing it is pretending to be.
+ *
+ * This file is that check for one specific pairing: which `DeploymentPhase`
+ * each provider can actually emit. Two fixtures here got it wrong. The first
+ * was a Vercel deployment in the `publishing` phase — Vercel has no state
+ * between building and ready, and an earlier version of this feature invented
+ * one for it; the fixture outlived the code that mistake came from. The second
+ * was a Vercel deployment in the `skipped` phase, found by writing this test.
+ *
+ * ## Keeping this honest
+ *
+ * The table below is a hand-copy of Rust, which is exactly the kind of mirror
+ * that drifts. It is written to drift *safely*: it lists what each provider can
+ * emit, and the test asserts fixtures stay inside it. If an adapter gains a
+ * phase and this table doesn't, a legitimate new fixture fails loudly and
+ * someone updates both. The failure direction is a false alarm, never a false
+ * pass — which is the only kind of staleness worth accepting in a mirror.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { hostingScenarios } from './hosting';
+import type { DeploymentPhase, HostingProvider } from '../../lib/hosting';
+
+/**
+ * What each adapter's phase mapping can actually return.
+ *
+ * Sources, one per provider — update this table and that function together:
+ * - `vercel.rs` → `phase_from_ready_state`: five readyStates, plus `Unknown`
+ *   for anything else. Notably absent: `publishing`, `skipped` and `gated`,
+ *   none of which Vercel's API expresses.
+ * - `netlify.rs` → `phase_from_state` (fifteen states) and the `skipped`
+ *   boolean in `to_deployment`, which wins over the state.
+ * - `cloudflare.rs` → `phase_from_stage` (stage name × status) and the
+ *   `is_skipped` flag in `to_deployment`.
+ */
+const PHASES_BY_PROVIDER: Record<HostingProvider, ReadonlySet<DeploymentPhase['phase']>> = {
+  vercel: new Set(['queued', 'building', 'ready', 'failed', 'canceled', 'unknown']),
+  netlify: new Set([
+    'queued',
+    'gated',
+    'building',
+    'publishing',
+    'ready',
+    'failed',
+    'skipped',
+    'unknown',
+  ]),
+  cloudflare: new Set([
+    'queued',
+    'building',
+    'publishing',
+    'ready',
+    'failed',
+    'canceled',
+    'skipped',
+    'unknown',
+  ]),
+};
+
+/** Every deployment a scenario puts in front of a reviewer, with its provider. */
+function deploymentsUnderReview() {
+  const found: Array<{ id: string; provider: HostingProvider; phase: string; where: string }> = [];
+
+  for (const scenario of hostingScenarios) {
+    const status = scenario.commands?.get_hosting_status as
+      | { providers?: Array<Record<string, unknown>> }
+      | undefined;
+
+    for (const p of status?.providers ?? []) {
+      const provider = (p.link as { provider: HostingProvider } | undefined)?.provider;
+      const lookup = p.lookup as
+        | { kind: string; deployment?: unknown; latest_on_branch?: unknown }
+        | null
+        | undefined;
+      if (!provider || !lookup) continue;
+
+      // Both shapes a deployment reaches the UI through. `latest_on_branch` is
+      // shown as context on a not-found, and it is a real deployment from the
+      // same provider — an impossible phase there is just as wrong.
+      const candidates: Array<[unknown, string]> = [
+        [lookup.deployment, 'deployment'],
+        [lookup.latest_on_branch, 'latest_on_branch'],
+      ];
+
+      for (const [candidate, where] of candidates) {
+        const phase = (candidate as { phase?: { phase?: string } } | undefined)?.phase?.phase;
+        if (phase) found.push({ id: scenario.id, provider, phase, where });
+      }
+    }
+  }
+
+  return found;
+}
+
+describe('hosting scenarios', () => {
+  it('only shows phases the named provider can actually emit', () => {
+    const offenders = deploymentsUnderReview().filter(
+      (d) => !PHASES_BY_PROVIDER[d.provider].has(d.phase as DeploymentPhase['phase'])
+    );
+
+    expect(
+      offenders,
+      offenders
+        .map(
+          (d) =>
+            `${d.id}: ${d.provider} cannot emit phase "${d.phase}" (${d.where}). ` +
+            `A screenshot of it reviews a screen no user can reach.`
+        )
+        .join('\n')
+    ).toEqual([]);
+  });
+
+  it('finds deployments to check, so the check above cannot pass vacuously', () => {
+    // Without this, renaming a fixture field would make the assertion above
+    // green by finding nothing — a check agreeing with itself about the wrong
+    // thing, which is the failure this whole file exists to prevent.
+    const found = deploymentsUnderReview();
+    expect(found.length).toBeGreaterThanOrEqual(6);
+    expect(new Set(found.map((d) => d.provider)).size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('names a status_label on every deployment, since the row prints it verbatim', () => {
+    for (const scenario of hostingScenarios) {
+      const status = scenario.commands?.get_hosting_status as
+        | { providers?: Array<{ lookup?: { deployment?: { status_label?: string } } | null }> }
+        | undefined;
+
+      for (const p of status?.providers ?? []) {
+        const deployment = p.lookup?.deployment;
+        if (!deployment) continue;
+        expect(deployment.status_label, `${scenario.id} has no status_label`).toBeTruthy();
+      }
+    }
+  });
+});

--- a/src/harness/scenarios/hosting.ts
+++ b/src/harness/scenarios/hosting.ts
@@ -33,6 +33,15 @@ const vercelLink = {
   linked_at: 1_757_000_000_000,
 };
 
+const netlifyLink = {
+  provider: 'netlify' as const,
+  project_id: '8f2b1c40-harness-site',
+  scope_id: null,
+  project_name: 'acme-marketing',
+  source: 'netlify_cli_file' as const,
+  linked_at: 1_757_000_000_000,
+};
+
 /** One provider row, with the lookup the scenario is about. */
 const status = (lookup: unknown, over: Record<string, unknown> = {}) => ({
   commit,
@@ -50,14 +59,25 @@ const status = (lookup: unknown, over: Record<string, unknown> = {}) => ({
   detected: [],
 });
 
-const deployment = (phase: unknown, over: Record<string, unknown> = {}) => ({
+/**
+ * `status_label` is the provider's own status word and the row prints it
+ * verbatim, so a fixture that omits it exercises our fallback rather than the
+ * thing that actually ships. Every scenario below names it.
+ *
+ * `dashboard_url` is here for the same reason: Vercel returns an inspector link
+ * on every deployment, and it is what the row's only button opens. A fixture
+ * without one quietly hides that button from review.
+ */
+const deployment = (phase: unknown, statusLabel: string, over: Record<string, unknown> = {}) => ({
   id: 'dpl_harness000000000000000000',
+  status_label: statusLabel,
   phase,
   environment: 'production',
   branch: 'main',
   commit_sha: commit.sha,
   commit_message: commit.subject,
   urls: {},
+  dashboard_url: 'https://vercel.com/harness/acme-marketing/dpl_harness',
   created_at: Date.now() - 45_000,
   ...over,
 });
@@ -88,7 +108,7 @@ export const hostingScenarios: Scenario[] = [
     clipSelector: '.publish-dropdown-menu',
     commands: {
       ...workspaceCommands,
-      get_hosting_status: status(found(deployment({ phase: 'building' }))),
+      get_hosting_status: status(found(deployment({ phase: 'building' }, 'Building'))),
     },
   },
   {
@@ -102,21 +122,31 @@ export const hostingScenarios: Scenario[] = [
     commands: {
       ...workspaceCommands,
       get_hosting_status: status(
-        found(deployment({ phase: 'ready' }, { urls: liveUrls, ready_at: Date.now() - 5_000 }))
+        found(
+          deployment({ phase: 'ready' }, 'Ready', { urls: liveUrls, ready_at: Date.now() - 5_000 })
+        )
       ),
     },
   },
   {
     id: 'hosting-publishing',
-    title: 'Push popover — built but not yet serving',
+    title: 'Push popover — built but not yet serving (Netlify)',
     looksRightWhen:
-      'Distinct from "ready": the build finished but aliases are not attached, so no live URL is promised yet.',
+      'Distinct from "ready": the build finished but is not serving visitors yet, so no live URL is promised. Says "Uploading", which is Netlify\'s own word — and note the provider mark, which is a neutral circle because Netlify has no icon in the set yet.',
     project: WORKSPACE_PROJECT,
     openSelector: '.source-control-push-button',
     clipSelector: '.publish-dropdown-menu',
     commands: {
       ...workspaceCommands,
-      get_hosting_status: status(found(deployment({ phase: 'publishing' }))),
+      // Netlify on purpose. Vercel has no state between building and ready —
+      // an earlier version invented one for it — so a Vercel row here would be
+      // reviewing a screen no user can reach. Netlify genuinely separates
+      // building from uploading, and this is also the only scenario that puts
+      // a non-Vercel provider in front of a reviewer.
+      get_hosting_status: status(found(deployment({ phase: 'publishing' }, 'Uploading')), {
+        link: netlifyLink,
+        token_source: 'keychain',
+      }),
     },
   },
   {
@@ -131,13 +161,9 @@ export const hostingScenarios: Scenario[] = [
       ...workspaceCommands,
       get_hosting_status: status(
         found(
-          deployment(
-            { phase: 'failed' },
-            {
-              error_message: 'Build exited with code 1',
-              dashboard_url: 'https://vercel.com/harness/acme-marketing/dpl_harness',
-            }
-          )
+          deployment({ phase: 'failed' }, 'Error', {
+            error_message: "Module not found: Can't resolve '@/lib/analytics' in ./app/layout.tsx",
+          })
         )
       ),
     },
@@ -153,7 +179,11 @@ export const hostingScenarios: Scenario[] = [
     commands: {
       ...workspaceCommands,
       get_hosting_status: status(
-        found(deployment({ phase: 'canceled' }, { detail: { detail: 'superseded_by_newer' } }))
+        found(
+          deployment({ phase: 'canceled' }, 'Canceled', {
+            detail: { detail: 'superseded_by_newer' },
+          })
+        )
       ),
     },
   },
@@ -169,10 +199,9 @@ export const hostingScenarios: Scenario[] = [
       ...workspaceCommands,
       get_hosting_status: status(
         found(
-          deployment(
-            { phase: 'skipped' },
-            { detail: { detail: 'skipped_because', reason: '[skip ci] in commit message' } }
-          )
+          deployment({ phase: 'skipped' }, 'Skipped', {
+            detail: { detail: 'skipped_because', reason: '[skip ci] in commit message' },
+          })
         )
       ),
     },
@@ -192,14 +221,11 @@ export const hostingScenarios: Scenario[] = [
         // A *different* commit on purpose. Reusing this push's subject made the
         // context line read as if it described the push, which is the exact
         // confusion the state exists to avoid.
-        latest_on_branch: deployment(
-          { phase: 'ready' },
-          {
-            commit_sha: 'aaaa111',
-            commit_message: 'Bump the pricing table copy',
-            urls: liveUrls,
-          }
-        ),
+        latest_on_branch: deployment({ phase: 'ready' }, 'Ready', {
+          commit_sha: 'aaaa111',
+          commit_message: 'Bump the pricing table copy',
+          urls: liveUrls,
+        }),
       }),
     },
   },

--- a/src/harness/scenarios/hosting.ts
+++ b/src/harness/scenarios/hosting.ts
@@ -42,6 +42,15 @@ const netlifyLink = {
   linked_at: 1_757_000_000_000,
 };
 
+const cloudflareLink = {
+  provider: 'cloudflare' as const,
+  project_id: 'shipstudio-harness-testbed',
+  scope_id: 'acct_harness0000000000000000000',
+  project_name: 'shipstudio-harness-testbed',
+  source: 'user_picked' as const,
+  linked_at: 1_757_000_000_000,
+};
+
 /** One provider row, with the lookup the scenario is about. */
 const status = (lookup: unknown, over: Record<string, unknown> = {}) => ({
   commit,
@@ -189,20 +198,31 @@ export const hostingScenarios: Scenario[] = [
   },
   {
     id: 'hosting-skipped',
-    title: 'Push popover — commit deliberately not built',
+    title: 'Push popover — commit deliberately not built (Cloudflare)',
     looksRightWhen:
-      'Explains that the provider chose not to build, and shows the provider’s own reason rather than guessing one.',
+      'Explains that the provider chose not to build, in the provider’s own reason rather than a guessed one. Also the only scenario with no “Open in …” button, because Cloudflare’s API returns no link to the deployment — the column stays reserved rather than collapsing.',
     project: WORKSPACE_PROJECT,
     openSelector: '.source-control-push-button',
     clipSelector: '.publish-dropdown-menu',
     commands: {
       ...workspaceCommands,
+      // Cloudflare, because Vercel cannot produce this phase: its
+      // `phase_from_ready_state` maps five readyStates and none of them is a
+      // skip. Skipped comes from Netlify's `skipped` flag or Cloudflare's
+      // `is_skipped`, and only Cloudflare carries a machine-readable
+      // `skip_reason` for the sentence below (`humanize_skip_reason`).
       get_hosting_status: status(
         found(
           deployment({ phase: 'skipped' }, 'Skipped', {
-            detail: { detail: 'skipped_because', reason: '[skip ci] in commit message' },
+            detail: {
+              detail: 'skipped_because',
+              reason: 'the commit message asked Cloudflare to skip it',
+            },
+            // Cloudflare's deployments endpoint returns no dashboard link.
+            dashboard_url: null,
           })
-        )
+        ),
+        { link: cloudflareLink, token_source: 'cli_file' }
       ),
     },
   },

--- a/src/harness/scenarios/hosting.ts
+++ b/src/harness/scenarios/hosting.ts
@@ -10,12 +10,12 @@
  * that mapping is the adapter's job and is verified against provider fixtures
  * in the Rust unit tests, not here.
  *
- * STATUS ON `main`: the native hosting module is not merged yet, so the Push
- * popover currently renders without a HOSTING section and these scenarios
- * capture the popover as it is today. That is deliberate — they are the
- * before-picture, and the same ids start showing the hosting rows the moment
- * the feature lands, with no change needed here. `get_hosting_status` is
- * simply an unread fixture until then.
+ * These were written against `main` before the native section existed, as a
+ * before-picture whose fixtures would start being read the moment it landed.
+ * It has landed: every scenario below now renders a real HOSTING row. If one
+ * of them captures a popover with no HOSTING section at all, that is not an
+ * empty state — it means the capture hit a server serving a different
+ * checkout, which the runner's identity check exists to refuse.
  */
 
 import type { Scenario } from '../types';
@@ -64,10 +64,17 @@ const deployment = (phase: unknown, over: Record<string, unknown> = {}) => ({
 
 const found = (d: unknown) => ({ kind: 'found', deployment: d });
 
+/**
+ * Both addresses, because they are the pair the section has to keep straight:
+ * `site` is where visitors go and stays put, `deployment` is this build's
+ * immutable permalink. Showing only one was the original defect — the row
+ * offered a preview permalink under the word "Domain".
+ */
 const liveUrls = {
+  site: 'https://acme-marketing.com',
   deployment: 'https://acme-marketing-9f3c1ab.vercel.app',
   aliases: ['https://acme-marketing.vercel.app'],
-  primary: 'https://acme-marketing.vercel.app',
+  primary: 'https://acme-marketing.com',
 };
 
 export const hostingScenarios: Scenario[] = [
@@ -182,7 +189,17 @@ export const hostingScenarios: Scenario[] = [
       ...workspaceCommands,
       get_hosting_status: status({
         kind: 'not_found',
-        latest_on_branch: deployment({ phase: 'ready' }, { commit_sha: 'aaaa111', urls: liveUrls }),
+        // A *different* commit on purpose. Reusing this push's subject made the
+        // context line read as if it described the push, which is the exact
+        // confusion the state exists to avoid.
+        latest_on_branch: deployment(
+          { phase: 'ready' },
+          {
+            commit_sha: 'aaaa111',
+            commit_message: 'Bump the pricing table copy',
+            urls: liveUrls,
+          }
+        ),
       }),
     },
   },

--- a/src/hooks/useHostingStatus.ts
+++ b/src/hooks/useHostingStatus.ts
@@ -1,0 +1,119 @@
+/**
+ * Keeps the hosting section's answer current, without burning requests.
+ *
+ * Three rules shape the cadence:
+ *
+ * 1. **Only poll what someone is looking at.** The section it replaces ran a
+ *    `vercel ls` every 15s and two `git` spawns every 3s for every open
+ *    project, forever, whether or not the popover was open or the window even
+ *    focused. This polls only while the popover is open and the window is
+ *    visible and focused.
+ * 2. **Match the cadence to the state.** A build in flight is worth a few
+ *    seconds; a finished deployment does not change.
+ * 3. **Back off on failure rather than hammering.** Transport errors are thrown
+ *    so `usePolling`'s exponential backoff engages; auth and no-link states are
+ *    returned as data and simply stop the poll, because nothing will change
+ *    until the user acts.
+ *
+ * @module hooks/useHostingStatus
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { usePolling } from './usePolling';
+import { getHostingStatus, deriveSectionState, isActive, shouldPoll } from '../lib/hosting';
+import type { HostingStatus, SectionState } from '../lib/hosting';
+import { logger } from '../lib/logger';
+
+/** While something is moving. */
+const ACTIVE_INTERVAL_MS = 4000;
+/** Once it has settled, but the popover is still open. */
+const SETTLED_INTERVAL_MS = 30000;
+
+interface Options {
+  projectPath: string;
+  /** Only true while the popover is actually on screen. */
+  open: boolean;
+  /** When the user's push completed, so "not found" can be given a grace period. */
+  pushedAt?: number;
+}
+
+interface Result {
+  status: HostingStatus | null;
+  state: SectionState;
+  /** Force an immediate refetch — the Retry action. */
+  refresh: () => void;
+}
+
+/** True when the window is both visible and focused. */
+function useWindowActive(): boolean {
+  const [active, setActive] = useState(() => typeof document === 'undefined' || !document.hidden);
+
+  useEffect(() => {
+    const update = () => setActive(!document.hidden && document.hasFocus());
+    document.addEventListener('visibilitychange', update);
+    window.addEventListener('focus', update);
+    window.addEventListener('blur', update);
+    update();
+    return () => {
+      document.removeEventListener('visibilitychange', update);
+      window.removeEventListener('focus', update);
+      window.removeEventListener('blur', update);
+    };
+  }, []);
+
+  return active;
+}
+
+export function useHostingStatus({ projectPath, open, pushedAt }: Options): Result {
+  // The answer is stored with the project it describes. Clearing it in an
+  // effect on `projectPath` would leave one render showing the previous
+  // project's deployment under the new project's name.
+  const [entry, setEntry] = useState<{ path: string; status: HostingStatus } | null>(null);
+  const status = entry?.path === projectPath ? entry.status : null;
+
+  const windowActive = useWindowActive();
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const fetchOnce = useCallback(async () => {
+    const next = await getHostingStatus(projectPath);
+    if (!mounted.current) return next;
+    setEntry({ path: projectPath, status: next });
+
+    // A transport failure is reported inside the payload rather than thrown,
+    // so re-throw it here to engage the poller's backoff instead of retrying
+    // an unreachable provider at full rate.
+    const failing = next.providers.find((p) => p.transport_error);
+    if (failing) {
+      throw new Error(failing.transport_error ?? 'hosting provider unreachable');
+    }
+    return next;
+  }, [projectPath]);
+
+  const state = deriveSectionState(status, {
+    pushedAt,
+    stalenessMs: ACTIVE_INTERVAL_MS * 2,
+  });
+
+  const enabled = open && windowActive && Boolean(projectPath) && shouldPoll(state.kind);
+  const intervalMs = isActive(state.kind) ? ACTIVE_INTERVAL_MS : SETTLED_INTERVAL_MS;
+
+  // No separate "fetch on open" effect: the poller fires its first tick
+  // immediately on start, and `enabled` flipping true starts it. Opening the
+  // popover therefore fetches at once rather than after a full interval.
+  usePolling(fetchOnce, { intervalMs, enabled, name: 'hosting-status' });
+
+  const refresh = useCallback(() => {
+    void fetchOnce().catch((err) => {
+      logger.debug('hosting: manual refresh failed', { error: String(err) });
+    });
+  }, [fetchOnce]);
+
+  return { status, state, refresh };
+}

--- a/src/hooks/useHostingStatus.ts
+++ b/src/hooks/useHostingStatus.ts
@@ -105,9 +105,12 @@ export function useHostingStatus({ projectPath, open, pushedAt }: Options): Resu
     return next;
   }, [projectPath]);
 
+  // Measured against the settled cadence, not the active one: a finished
+  // deployment is polled every 30s by design, so judging it against the 4s
+  // build interval marked it stale between every ordinary tick.
   const state = deriveSectionState(status, {
     pushedAt,
-    stalenessMs: ACTIVE_INTERVAL_MS * 2,
+    stalenessMs: SETTLED_INTERVAL_MS * 2,
   });
 
   const enabled = open && windowActive && Boolean(projectPath) && shouldPoll(state.kind);

--- a/src/hooks/useHostingStatus.ts
+++ b/src/hooks/useHostingStatus.ts
@@ -83,6 +83,15 @@ export function useHostingStatus({ projectPath, open, pushedAt }: Options): Resu
 
   const fetchOnce = useCallback(async () => {
     const next = await getHostingStatus(projectPath);
+
+    // Defensive: a malformed or absent payload must back the poller off, not
+    // throw a TypeError out of a render-adjacent callback. The command always
+    // returns a status or rejects, so reaching here means something upstream
+    // is wrong and retrying at full rate would not help.
+    if (!next || !Array.isArray(next.providers)) {
+      throw new Error('hosting status came back in an unexpected shape');
+    }
+
     if (!mounted.current) return next;
     setEntry({ path: projectPath, status: next });
 

--- a/src/hooks/usePluginState.ts
+++ b/src/hooks/usePluginState.ts
@@ -2,13 +2,12 @@
  * Hook for plugin terminal and suggestion popup state.
  *
  * Manages the plugin terminal modal (for CLI commands triggered by plugins)
- * and the plugin suggestion popup (e.g., suggesting Vercel plugin).
+ * and the plugin suggestion popup (currently dormant — hosting moved native).
  */
 
 import { useState, useCallback } from 'react';
-import { installPlugin, listPlugins, VERCEL_PLUGIN_REPO } from '../lib/plugins';
+import { installPlugin } from '../lib/plugins';
 import { asCommandError, formatCommandError } from '../lib/errors';
-import { invoke } from '@tauri-apps/api/core';
 
 interface PluginTerminalState {
   command: string;
@@ -69,27 +68,15 @@ export function usePluginState() {
     [pluginTerminal]
   );
 
-  // Check if Vercel plugin should be suggested for this project
-  const checkPluginSuggestion = useCallback(async (projectPath: string) => {
-    try {
-      const sessionKey = `plugin-suggested-vercel-${projectPath}`;
-      if (sessionStorage.getItem(sessionKey)) return;
-
-      const hasVercelConfig = await invoke<boolean>('has_vercel_config', { projectPath });
-      if (!hasVercelConfig) return;
-
-      const installed = await listPlugins(projectPath);
-      if (installed.some((p) => p.manifest.id === 'vercel')) return;
-
-      sessionStorage.setItem(sessionKey, '1');
-      setPluginSuggestion({
-        pluginName: 'Vercel',
-        projectPath,
-        repoUrl: VERCEL_PLUGIN_REPO,
-      });
-    } catch {
-      // Non-critical — silently ignore detection errors
-    }
+  // Hosting is becoming a native feature, so detecting `.vercel/project.json`
+  // no longer offers to install the Vercel plugin — a project linked to a
+  // provider is picked up by the native hosting module instead. The suggestion
+  // machinery below stays wired (nothing else suggests a plugin today) so this
+  // is a one-line revert if the native rollout is paused; it is removed
+  // wholesale once the native module ships for all three providers.
+  // Still returns a promise so callers keep awaiting it unchanged.
+  const checkPluginSuggestion = useCallback((_projectPath: string): Promise<void> => {
+    return Promise.resolve();
   }, []);
 
   // Install suggested plugin

--- a/src/hooks/usePlugins.test.tsx
+++ b/src/hooks/usePlugins.test.tsx
@@ -17,6 +17,10 @@ import type { PluginModule } from '../lib/plugin-loader';
 vi.mock('../lib/plugins', () => ({
   listPlugins: vi.fn(),
   updatePlugin: vi.fn(),
+  // The hook reads this to skip plugins superseded by native hosting; the
+  // fixtures here are unrelated plugins, so an empty list keeps them loading.
+  NATIVE_HOSTING_IDS: [] as string[],
+  isExpectedPluginFailure: () => false,
 }));
 
 vi.mock('../lib/plugin-loader', () => ({

--- a/src/hooks/usePlugins.test.tsx
+++ b/src/hooks/usePlugins.test.tsx
@@ -17,9 +17,9 @@ import type { PluginModule } from '../lib/plugin-loader';
 vi.mock('../lib/plugins', () => ({
   listPlugins: vi.fn(),
   updatePlugin: vi.fn(),
-  // The hook reads this to skip plugins superseded by native hosting; the
-  // fixtures here are unrelated plugins, so an empty list keeps them loading.
-  NATIVE_HOSTING_IDS: [] as string[],
+  // The hook asks this whether a plugin has been replaced by a native feature
+  // or a skill. These fixtures are unrelated plugins, so nothing is superseded.
+  supersededReason: () => null,
   isExpectedPluginFailure: () => false,
 }));
 

--- a/src/hooks/usePlugins.ts
+++ b/src/hooks/usePlugins.ts
@@ -17,7 +17,7 @@ import {
   listPlugins,
   updatePlugin,
   isExpectedPluginFailure,
-  NATIVE_HOSTING_IDS,
+  supersededReason,
   PluginInfo,
 } from '../lib/plugins';
 import { loadPluginModule, unloadPluginModule, PluginModule } from '../lib/plugin-loader';
@@ -151,13 +151,11 @@ export function usePlugins(
       setIsLoading(true);
       try {
         const installed = await listPlugins(path);
-        // Hosting is a native feature now. Superseded plugins are skipped at
-        // load time rather than at render, because merely not rendering one
-        // still runs its activation and its background git/CLI timers — which
-        // was most of what made the old hosting integration expensive.
-        const enabled = installed.filter(
-          (p) => p.enabled && !NATIVE_HOSTING_IDS.includes(p.manifest.id)
-        );
+        // A plugin the app now does itself is skipped at load, not at render:
+        // merely not rendering one still runs its activation hook and its
+        // background timers, which was most of what made the old hosting
+        // integration expensive. The Plugin Manager explains the skip.
+        const enabled = installed.filter((p) => p.enabled && !supersededReason(p.manifest.id));
         const failed: PluginFailure[] = [];
 
         // Skip plugins with unsupported API versions

--- a/src/hooks/usePlugins.ts
+++ b/src/hooks/usePlugins.ts
@@ -13,7 +13,13 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { listPlugins, updatePlugin, isExpectedPluginFailure, PluginInfo } from '../lib/plugins';
+import {
+  listPlugins,
+  updatePlugin,
+  isExpectedPluginFailure,
+  NATIVE_HOSTING_IDS,
+  PluginInfo,
+} from '../lib/plugins';
 import { loadPluginModule, unloadPluginModule, PluginModule } from '../lib/plugin-loader';
 import { asCommandError, formatCommandError } from '../lib/errors';
 import { logger } from '../lib/logger';
@@ -145,7 +151,13 @@ export function usePlugins(
       setIsLoading(true);
       try {
         const installed = await listPlugins(path);
-        const enabled = installed.filter((p) => p.enabled);
+        // Hosting is a native feature now. Superseded plugins are skipped at
+        // load time rather than at render, because merely not rendering one
+        // still runs its activation and its background git/CLI timers — which
+        // was most of what made the old hosting integration expensive.
+        const enabled = installed.filter(
+          (p) => p.enabled && !NATIVE_HOSTING_IDS.includes(p.manifest.id)
+        );
         const failed: PluginFailure[] = [];
 
         // Skip plugins with unsupported API versions

--- a/src/hooks/useProjectCreation.ts
+++ b/src/hooks/useProjectCreation.ts
@@ -8,8 +8,8 @@
  * progress UI via `getStepStatus`): clone (`git clone` through a `spawn_pty`
  * PTY; zips go through `extract_template_zip`; blank uses
  * `create_blank_project`) → init (`remove_git_history` so the project
- * detaches from the template repo, gitignore `.shipstudio/`, fire-and-forget
- * Vercel plugin install) → install (`npm install` via PTY, gated on an npm
+ * detaches from the template repo, gitignore `.shipstudio/`) → install
+ * (`npm install` via PTY, gated on an npm
  * cache-permission pre-check) → done → `onComplete(projectPath)`, which the
  * caller turns into a project open. `retryInstall` re-runs just the install
  * step against `createdProjectPath`.
@@ -20,7 +20,7 @@
  * mapped to friendly errors: 243 npm cache, 128 fatal git failure, 69 Xcode
  * license),
  * `list_projects` (duplicate-name check), `ensure_shipstudio_dir`,
- * lib/setup (`checkNpmCachePermissions`), lib/plugins.
+ * lib/setup (`checkNpmCachePermissions`).
  *
  * Gotchas: `waitForPtyExit` treats a `null` exit code (process killed) as
  * SUCCESS, so a killed install proceeds to the next step; the clone step is
@@ -40,7 +40,6 @@ import { trackError } from '../lib/analytics';
 import { friendlyProcessError } from '../lib/errors';
 import { getWindowLabel } from '../lib/window';
 import { checkNpmCachePermissions } from '../lib/setup';
-import { installPlugin, VERCEL_PLUGIN_REPO } from '../lib/plugins';
 import { basename } from '../lib/paths';
 
 // ---------------------------------------------------------------------------
@@ -462,9 +461,6 @@ export function useProjectCreation({ onComplete, onCancel }: UseProjectCreationP
 
         // Ensure .shipstudio/ is gitignored to prevent phantom changes
         await invoke('ensure_gitignore_has_shipstudio', { projectPath: projectPath });
-
-        // Pre-install Vercel plugin (fire-and-forget, don't block creation)
-        installPlugin(projectPath, VERCEL_PLUGIN_REPO).catch(() => {});
 
         // Install dependencies (skip for templates with no package.json)
         setCreatedProjectPath(projectPath);

--- a/src/lib/accounts.ts
+++ b/src/lib/accounts.ts
@@ -39,17 +39,27 @@ export interface AccountCredentialStatus {
   vercelUsername: string | null;
   hasAnthropicBaseUrl: boolean;
   hasVercelToken: boolean;
+  hasCloudflareApiToken: boolean;
+  hasNetlifyAuthToken: boolean;
   hasGitName: boolean;
   hasGitEmail: boolean;
 }
 
 /** Credential key identifiers accepted by set/clear commands. */
-export type CredentialKey = 'anthropic_base_url' | 'vercel_token' | 'git_name' | 'git_email';
+export type CredentialKey =
+  | 'anthropic_base_url'
+  | 'vercel_token'
+  | 'cloudflare_api_token'
+  | 'netlify_auth_token'
+  | 'git_name'
+  | 'git_email';
 
 /** Human-readable labels for each credential key. */
 export const CREDENTIAL_LABELS: Record<CredentialKey, string> = {
   anthropic_base_url: 'Anthropic Base URL',
   vercel_token: 'Vercel Token',
+  cloudflare_api_token: 'Cloudflare API Token',
+  netlify_auth_token: 'Netlify Token',
   git_name: 'Git Name',
   git_email: 'Git Email',
 };
@@ -63,13 +73,22 @@ export const CREDENTIAL_DESCRIPTIONS: Record<CredentialKey, string> = {
   anthropic_base_url:
     'Point Claude Code at a custom Anthropic endpoint (a proxy or gateway) instead of the default. Leave unset unless your org requires it.',
   vercel_token:
-    'Lets this workspace publish to Vercel without an interactive login — use a token from a specific Vercel account or team.',
+    'Lets this workspace publish to Vercel without an interactive login — use a token from a specific Vercel account or team, and lets Ship Studio show whether your pushes deployed.',
+  cloudflare_api_token:
+    'Lets Ship Studio read your Cloudflare Pages deployments. Needs the Pages:Read and Account Settings:Read permissions.',
+  netlify_auth_token:
+    'Lets Ship Studio read your Netlify deploys without depending on the CLI login, which can expire.',
   git_name: "Sets the author name on commits made in this workspace's projects.",
   git_email: "Sets the author email on commits made in this workspace's projects.",
 };
 
 /** Credential keys that are sensitive (masked input). */
-export const SENSITIVE_KEYS = new Set<CredentialKey>(['anthropic_base_url', 'vercel_token']);
+export const SENSITIVE_KEYS = new Set<CredentialKey>([
+  'anthropic_base_url',
+  'vercel_token',
+  'cloudflare_api_token',
+  'netlify_auth_token',
+]);
 
 /** Maps AccountCredentialStatus boolean field → CredentialKey. */
 export const STATUS_FIELD_TO_KEY: Record<
@@ -85,6 +104,8 @@ export const STATUS_FIELD_TO_KEY: Record<
 > = {
   hasAnthropicBaseUrl: 'anthropic_base_url',
   hasVercelToken: 'vercel_token',
+  hasCloudflareApiToken: 'cloudflare_api_token',
+  hasNetlifyAuthToken: 'netlify_auth_token',
   hasGitName: 'git_name',
   hasGitEmail: 'git_email',
 };

--- a/src/lib/hosting.test.ts
+++ b/src/lib/hosting.test.ts
@@ -25,6 +25,7 @@ const NOW = 1_700_000_000_000;
 function deployment(phase: DeploymentPhase, overrides: Partial<Deployment> = {}): Deployment {
   return {
     id: 'dpl_1',
+    status_label: 'Ready',
     phase,
     environment: 'production',
     branch: 'main',

--- a/src/lib/hosting.test.ts
+++ b/src/lib/hosting.test.ts
@@ -1,0 +1,254 @@
+/**
+ * The reducer decides what the user is told, so it is tested exhaustively.
+ *
+ * Two invariants matter more than the rest and have their own tests below:
+ * a missing deployment never becomes a failure, and a rejected credential is
+ * never rendered as healthy — that second one is the exact defect that made
+ * the old hosting card show a connected state over an expired login.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  deriveSectionState,
+  isActive,
+  shouldPoll,
+  NOT_FOUND_GRACE_MS,
+  type Deployment,
+  type DeploymentPhase,
+  type HostingStatus,
+  type Lookup,
+  type ProviderStatus,
+} from './hosting';
+
+const NOW = 1_700_000_000_000;
+
+function deployment(phase: DeploymentPhase, overrides: Partial<Deployment> = {}): Deployment {
+  return {
+    id: 'dpl_1',
+    phase,
+    environment: 'production',
+    branch: 'main',
+    commit_sha: 'abc123',
+    urls: { aliases: [], primary: 'https://example.vercel.app' },
+    created_at: NOW - 60_000,
+    ...overrides,
+  };
+}
+
+function provider(overrides: Partial<ProviderStatus> = {}): ProviderStatus {
+  return {
+    link: {
+      provider: 'vercel',
+      project_id: 'prj_1',
+      source: 'vercel_cli_file',
+      linked_at: 0,
+    },
+    auth: { kind: 'ok' },
+    fetched_at: NOW,
+    from_cache: false,
+    ...overrides,
+  };
+}
+
+function status(
+  providers: ProviderStatus[],
+  commit: Partial<HostingStatus['commit']> = {}
+): HostingStatus {
+  return {
+    commit: {
+      sha: 'abc123',
+      short_sha: 'abc123a',
+      subject: 'Update from Ship Studio',
+      committed_at: NOW - 30_000,
+      branch: 'main',
+      has_upstream: true,
+      ...commit,
+    },
+    providers,
+    detected: [],
+  };
+}
+
+const found = (phase: DeploymentPhase): Lookup => ({
+  kind: 'found',
+  deployment: deployment(phase),
+});
+
+describe('deriveSectionState', () => {
+  it('is checking before anything has loaded', () => {
+    expect(deriveSectionState(null, { now: NOW }).kind).toBe('checking');
+  });
+
+  it('invites setup when the project deploys nowhere', () => {
+    expect(deriveSectionState(status([]), { now: NOW }).kind).toBe('no_link');
+  });
+
+  it('says nothing has been pushed before there is an upstream', () => {
+    // A provider cannot have deployed a commit it never received.
+    const s = status([provider({ lookup: found({ phase: 'ready' }) })], { has_upstream: false });
+    expect(deriveSectionState(s, { now: NOW }).kind).toBe('not_pushed');
+  });
+
+  it.each([
+    ['queued', 'queued'],
+    ['building', 'building'],
+    ['publishing', 'publishing'],
+    ['ready', 'ready'],
+    ['failed', 'failed'],
+    ['canceled', 'canceled'],
+    ['skipped', 'skipped'],
+    ['gated', 'gated'],
+  ] as const)('maps the %s phase straight through', (phase, expected) => {
+    const s = status([provider({ lookup: found({ phase }) })]);
+    expect(deriveSectionState(s, { now: NOW }).kind).toBe(expected);
+  });
+
+  it('surfaces an unrecognized provider status instead of guessing', () => {
+    const s = status([provider({ lookup: found({ phase: 'unknown', raw: 'SOMETHING_NEW' }) })]);
+    expect(deriveSectionState(s, { now: NOW }).kind).toBe('unknown');
+  });
+
+  describe('a missing deployment', () => {
+    const notFound: Lookup = { kind: 'not_found' };
+
+    it('still hopes inside the grace period', () => {
+      const s = status([provider({ lookup: notFound })]);
+      const state = deriveSectionState(s, { now: NOW, pushedAt: NOW - 5_000 });
+      expect(state.kind).toBe('not_found_yet');
+    });
+
+    it('goes neutral once the grace period lapses', () => {
+      const s = status([provider({ lookup: notFound })]);
+      const state = deriveSectionState(s, {
+        now: NOW,
+        pushedAt: NOW - NOT_FOUND_GRACE_MS - 1,
+      });
+      expect(state.kind).toBe('not_found');
+    });
+
+    it('never becomes a failure, however long it has been', () => {
+      // No provider API can distinguish "ignored this push" from "hasn't got
+      // to it yet", so claiming a failure would be inventing information.
+      const s = status([provider({ lookup: notFound })]);
+      const state = deriveSectionState(s, { now: NOW, pushedAt: NOW - 86_400_000 });
+      expect(state.kind).toBe('not_found');
+      expect(state.kind).not.toBe('failed');
+    });
+
+    it('falls back to the commit time when the push was in an earlier session', () => {
+      const s = status([provider({ lookup: notFound })], { committed_at: NOW - 3_600_000 });
+      expect(deriveSectionState(s, { now: NOW }).kind).toBe('not_found');
+    });
+
+    it('offers the latest deploy on the branch as context, not as the answer', () => {
+      const latest = deployment({ phase: 'ready' });
+      const s = status([provider({ lookup: { kind: 'not_found', latest_on_branch: latest } })]);
+      const state = deriveSectionState(s, { now: NOW, pushedAt: NOW - 200_000 });
+
+      expect(state.kind).toBe('not_found');
+      expect(state.latestOnBranch).toBe(latest);
+      // Crucially, the branch's deployment is NOT reported as this commit's.
+      expect(state.deployment).toBeUndefined();
+    });
+  });
+
+  describe('credentials', () => {
+    it('asks for a connection when there is no token', () => {
+      const s = status([provider({ auth: { kind: 'no_token' } })]);
+      expect(deriveSectionState(s, { now: NOW }).kind).toBe('no_token');
+    });
+
+    it('never renders a rejected credential as healthy', () => {
+      // The defect this replaces: a 403 from an expired token was mapped to
+      // "unknown" and then coerced to "connected", so a dead login showed a
+      // connected card with a spinner and no URL.
+      const s = status([
+        provider({
+          auth: { kind: 'rejected' },
+          token_source: 'cli_file',
+          lookup: found({ phase: 'ready' }),
+        }),
+      ]);
+      const state = deriveSectionState(s, { now: NOW });
+
+      expect(state.kind).toBe('token_rejected');
+      expect(state.kind).not.toBe('ready');
+    });
+
+    it('remembers a rejection came from the CLI so the copy can explain it', () => {
+      const s = status([provider({ auth: { kind: 'rejected' }, token_source: 'cli_file' })]);
+      expect(deriveSectionState(s, { now: NOW }).tokenSource).toBe('cli_file');
+    });
+  });
+
+  describe('when the provider cannot be reached', () => {
+    it('says so rather than showing nothing', () => {
+      const s = status([provider({ transport_error: 'dns error' })]);
+      const state = deriveSectionState(s, { now: NOW });
+      expect(state.kind).toBe('offline');
+      expect(state.transportError).toBe('dns error');
+    });
+
+    it('reports rate limiting separately, with the retry hint', () => {
+      const s = status([provider({ retry_after_secs: 30 })]);
+      const state = deriveSectionState(s, { now: NOW });
+      expect(state.kind).toBe('rate_limited');
+      expect(state.retryAfterSecs).toBe(30);
+    });
+
+    it('prefers an auth problem over a transport one', () => {
+      // A rejected token is actionable; a network blip on top of it is noise.
+      const s = status([provider({ auth: { kind: 'rejected' }, transport_error: 'timeout' })]);
+      expect(deriveSectionState(s, { now: NOW }).kind).toBe('token_rejected');
+    });
+  });
+
+  it('admits when an answer has not been rechecked recently', () => {
+    const s = status([provider({ lookup: found({ phase: 'ready' }), fetched_at: NOW - 60_000 })]);
+    const state = deriveSectionState(s, { now: NOW, stalenessMs: 8_000 });
+    expect(state.isStale).toBe(true);
+  });
+
+  it('produces exactly one state for every input combination', () => {
+    const lookups: (Lookup | null)[] = [null, found({ phase: 'ready' }), { kind: 'not_found' }];
+    const auths = [
+      { kind: 'ok' as const },
+      { kind: 'no_token' as const },
+      { kind: 'rejected' as const },
+    ];
+
+    for (const lookup of lookups) {
+      for (const auth of auths) {
+        for (const transport of [undefined, 'boom']) {
+          for (const upstream of [true, false]) {
+            const s = status([provider({ auth, lookup, transport_error: transport })], {
+              has_upstream: upstream,
+            });
+            const state = deriveSectionState(s, { now: NOW });
+            expect(typeof state.kind).toBe('string');
+          }
+        }
+      }
+    }
+  });
+});
+
+describe('polling policy', () => {
+  it('polls fast only while something is moving', () => {
+    expect(isActive('building')).toBe(true);
+    expect(isActive('queued')).toBe(true);
+    expect(isActive('not_found_yet')).toBe(true);
+    expect(isActive('ready')).toBe(false);
+    expect(isActive('failed')).toBe(false);
+  });
+
+  it('stops entirely when only the user can change the outcome', () => {
+    expect(shouldPoll('no_token')).toBe(false);
+    expect(shouldPoll('token_rejected')).toBe(false);
+    expect(shouldPoll('no_link')).toBe(false);
+    expect(shouldPoll('not_pushed')).toBe(false);
+
+    expect(shouldPoll('building')).toBe(true);
+    expect(shouldPoll('offline')).toBe(true);
+  });
+});

--- a/src/lib/hosting.ts
+++ b/src/lib/hosting.ts
@@ -264,7 +264,15 @@ export interface SectionState {
   transportError?: string;
   retryAfterSecs?: number;
   tokenSource?: TokenSource;
-  /** True when the answer came from cache and is older than a poll interval. */
+  /**
+   * The answer hasn't been rechecked recently.
+   *
+   * Not shown next to a settled deployment: whether a twelve-day-old build was
+   * re-confirmed eight seconds ago is not information anyone wants, and saying
+   * so truncated to "· not ju…" in a 320px row is worse than saying nothing.
+   * Staleness only earns space where it changes what you'd believe — the
+   * `offline` state, whose copy already names when it last succeeded.
+   */
   isStale?: boolean;
 }
 

--- a/src/lib/hosting.ts
+++ b/src/lib/hosting.ts
@@ -79,8 +79,12 @@ export type DeploymentDetail =
   | { detail: 'superseded_by_newer' };
 
 export interface DeploymentUrls {
+  /** The address people visit — the project's production domain. */
+  site?: string | null;
+  /** This build's immutable permalink. Always this commit, never "current". */
   deployment?: string | null;
   aliases: string[];
+  /** Site if known, else this build. */
   primary?: string | null;
 }
 

--- a/src/lib/hosting.ts
+++ b/src/lib/hosting.ts
@@ -194,7 +194,7 @@ export function clearHostingLink(projectPath: string, provider: HostingProvider)
 export function listRecentDeployments(
   projectPath: string,
   provider: HostingProvider,
-  limit?: number,
+  limit?: number
 ): Promise<Deployment[]> {
   return invoke<Deployment[]>('list_recent_deployments', { projectPath, provider, limit });
 }
@@ -206,7 +206,7 @@ export function listRecentDeployments(
 export function getDeploymentLog(
   projectPath: string,
   provider: HostingProvider,
-  deploymentId: string,
+  deploymentId: string
 ): Promise<BuildLog> {
   return invoke<BuildLog>('get_deployment_log', { projectPath, provider, deploymentId });
 }

--- a/src/lib/hosting.ts
+++ b/src/lib/hosting.ts
@@ -99,6 +99,21 @@ export interface Deployment {
   ready_at?: number | null;
 }
 
+export type LogStream = 'stdout' | 'stderr';
+
+export interface LogLine {
+  at: number;
+  stream: LogStream;
+  text: string;
+}
+
+export interface BuildLog {
+  deployment_id: string;
+  lines: LogLine[];
+  /** The provider capped what it returned, so this isn't the whole log. */
+  truncated: boolean;
+}
+
 export type Lookup =
   | { kind: 'found'; deployment: Deployment }
   | { kind: 'not_found'; latest_on_branch?: Deployment | null };
@@ -167,6 +182,27 @@ export function setHostingLink(projectPath: string, link: HostingLink): Promise<
 
 export function clearHostingLink(projectPath: string, provider: HostingProvider): Promise<void> {
   return invoke('clear_hosting_link', { projectPath, provider });
+}
+
+/** Recent deployments for a project, newest first. */
+export function listRecentDeployments(
+  projectPath: string,
+  provider: HostingProvider,
+  limit?: number,
+): Promise<Deployment[]> {
+  return invoke<Deployment[]>('list_recent_deployments', { projectPath, provider, limit });
+}
+
+/**
+ * A deployment's build output — the reason a failure happened, which the
+ * deployments endpoints themselves don't carry.
+ */
+export function getDeploymentLog(
+  projectPath: string,
+  provider: HostingProvider,
+  deploymentId: string,
+): Promise<BuildLog> {
+  return invoke<BuildLog>('get_deployment_log', { projectPath, provider, deploymentId });
 }
 
 export function verifyHostingToken(

--- a/src/lib/hosting.ts
+++ b/src/lib/hosting.ts
@@ -90,6 +90,8 @@ export interface DeploymentUrls {
 
 export interface Deployment {
   id: string;
+  /** The provider's own status word, shown verbatim ("Ready", not a synonym). */
+  status_label: string;
   phase: DeploymentPhase;
   detail?: DeploymentDetail | null;
   environment: Environment;

--- a/src/lib/hosting.ts
+++ b/src/lib/hosting.ts
@@ -1,0 +1,366 @@
+/**
+ * Hosting status: did the commit I just pushed actually deploy?
+ *
+ * TS mirror of `src-tauri/src/commands/hosting/model.rs`, the invoke wrappers,
+ * and the reducer that turns a backend answer into the single state the section
+ * renders.
+ *
+ * The reducer is the interesting part. The backend reports what a provider
+ * said; it deliberately does not decide how long to keep hoping a missing
+ * deployment will appear, because only the frontend knows when the user pushed.
+ * `deriveSectionState` folds auth, link, transport, and timing into exactly one
+ * `SectionState`, and every state maps to one fixed-height row — which is what
+ * keeps the popover from resizing as answers arrive.
+ *
+ * @module lib/hosting
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+
+// ---------------------------------------------------------------------------
+// Mirrors of the Rust types
+// ---------------------------------------------------------------------------
+
+export type HostingProvider = 'vercel' | 'cloudflare' | 'netlify';
+
+export const PROVIDER_LABELS: Record<HostingProvider, string> = {
+  vercel: 'Vercel',
+  cloudflare: 'Cloudflare',
+  netlify: 'Netlify',
+};
+
+export type LinkSource = 'vercel_cli_file' | 'netlify_cli_file' | 'user_picked';
+
+export interface HostingLink {
+  provider: HostingProvider;
+  project_id: string;
+  scope_id?: string | null;
+  project_name?: string | null;
+  source: LinkSource;
+  linked_at: number;
+}
+
+export interface DetectedLink {
+  provider: HostingProvider;
+  project_id: string;
+  scope_id?: string | null;
+  project_name?: string | null;
+  source: LinkSource;
+}
+
+export interface CommitRef {
+  sha: string;
+  short_sha: string;
+  subject?: string | null;
+  committed_at?: number | null;
+  branch: string;
+  has_upstream: boolean;
+}
+
+export type Environment = 'production' | 'preview';
+
+export type DeploymentPhase =
+  | { phase: 'queued' }
+  | { phase: 'building' }
+  | { phase: 'publishing' }
+  | { phase: 'ready' }
+  | { phase: 'failed' }
+  | { phase: 'canceled' }
+  | { phase: 'skipped' }
+  | { phase: 'gated' }
+  | { phase: 'unknown'; raw: string };
+
+export type DeploymentDetail =
+  | { detail: 'not_yet_promoted' }
+  | { detail: 'rolling_out' }
+  | { detail: 'skipped_because'; reason?: string | null }
+  | { detail: 'awaiting_review'; reason?: string | null }
+  | { detail: 'review_rejected' }
+  | { detail: 'superseded_by_newer' };
+
+export interface DeploymentUrls {
+  deployment?: string | null;
+  aliases: string[];
+  primary?: string | null;
+}
+
+export interface Deployment {
+  id: string;
+  phase: DeploymentPhase;
+  detail?: DeploymentDetail | null;
+  environment: Environment;
+  branch?: string | null;
+  commit_sha: string;
+  commit_message?: string | null;
+  urls: DeploymentUrls;
+  dashboard_url?: string | null;
+  error_message?: string | null;
+  created_at: number;
+  ready_at?: number | null;
+}
+
+export type Lookup =
+  | { kind: 'found'; deployment: Deployment }
+  | { kind: 'not_found'; latest_on_branch?: Deployment | null };
+
+export type Auth = { kind: 'ok' } | { kind: 'no_token' } | { kind: 'rejected' };
+
+export type TokenSource = 'keychain' | 'cli_file';
+
+export interface ProviderStatus {
+  link: HostingLink;
+  auth: Auth;
+  token_source?: TokenSource | null;
+  lookup?: Lookup | null;
+  transport_error?: string | null;
+  retry_after_secs?: number | null;
+  fetched_at: number;
+  from_cache: boolean;
+}
+
+export interface HostingStatus {
+  commit: CommitRef;
+  providers: ProviderStatus[];
+  detected: DetectedLink[];
+}
+
+export interface HostingProjectChoice {
+  id: string;
+  name: string;
+  scope_id?: string | null;
+  scope_name?: string | null;
+}
+
+export interface TokenCheck {
+  auth: Auth;
+  token_source?: TokenSource | null;
+  account_label?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+export function getHostingStatus(projectPath: string): Promise<HostingStatus> {
+  return invoke<HostingStatus>('get_hosting_status', { projectPath });
+}
+
+export function detectHostingLinks(projectPath: string): Promise<DetectedLink[]> {
+  return invoke<DetectedLink[]>('detect_hosting_links', { projectPath });
+}
+
+export function listHostingProjects(
+  projectPath: string,
+  provider: HostingProvider,
+  scopeId?: string
+): Promise<HostingProjectChoice[]> {
+  return invoke<HostingProjectChoice[]>('list_hosting_projects', {
+    projectPath,
+    provider,
+    scopeId,
+  });
+}
+
+export function setHostingLink(projectPath: string, link: HostingLink): Promise<void> {
+  return invoke('set_hosting_link', { projectPath, link });
+}
+
+export function clearHostingLink(projectPath: string, provider: HostingProvider): Promise<void> {
+  return invoke('clear_hosting_link', { projectPath, provider });
+}
+
+export function verifyHostingToken(
+  projectPath: string,
+  provider: HostingProvider
+): Promise<TokenCheck> {
+  return invoke<TokenCheck>('verify_hosting_token', { projectPath, provider });
+}
+
+// ---------------------------------------------------------------------------
+// The reducer
+// ---------------------------------------------------------------------------
+
+/**
+ * How long a pushed commit may be missing from a provider before we stop
+ * showing hope and switch to a neutral "nothing reported" state.
+ *
+ * No provider documents how long it takes a pushed commit to appear in their
+ * API, so this is a product choice, not a guarantee. It is deliberately never
+ * used to claim the deploy *failed* — only to stop implying one is coming.
+ */
+export const NOT_FOUND_GRACE_MS = 90_000;
+
+/** Every state the hosting section can render. One row shape, one height. */
+export type SectionStateKind =
+  | 'checking'
+  | 'not_pushed'
+  | 'queued'
+  | 'building'
+  | 'publishing'
+  | 'ready'
+  | 'failed'
+  | 'canceled'
+  | 'skipped'
+  | 'gated'
+  | 'unknown'
+  | 'not_found_yet'
+  | 'not_found'
+  | 'no_token'
+  | 'token_rejected'
+  | 'no_link'
+  | 'offline'
+  | 'rate_limited';
+
+export interface SectionState {
+  kind: SectionStateKind;
+  provider?: HostingProvider;
+  /** The deployment being described, when there is one. */
+  deployment?: Deployment;
+  /** Offered as context in `not_found`, never as the answer. */
+  latestOnBranch?: Deployment;
+  detail?: DeploymentDetail | null;
+  /** Set on `offline` when we have something to show from last time. */
+  staleFrom?: number;
+  transportError?: string;
+  retryAfterSecs?: number;
+  tokenSource?: TokenSource;
+  /** True when the answer came from cache and is older than a poll interval. */
+  isStale?: boolean;
+}
+
+export interface DeriveContext {
+  /** When the user's push completed, if it happened in this session. */
+  pushedAt?: number;
+  /** Injected for tests. */
+  now?: number;
+  /** How long an answer may sit before the UI admits it hasn't rechecked. */
+  stalenessMs?: number;
+}
+
+function phaseToKind(phase: DeploymentPhase): SectionStateKind {
+  switch (phase.phase) {
+    case 'queued':
+      return 'queued';
+    case 'building':
+      return 'building';
+    case 'publishing':
+      return 'publishing';
+    case 'ready':
+      return 'ready';
+    case 'failed':
+      return 'failed';
+    case 'canceled':
+      return 'canceled';
+    case 'skipped':
+      return 'skipped';
+    case 'gated':
+      return 'gated';
+    case 'unknown':
+      return 'unknown';
+  }
+}
+
+/**
+ * Collapse a backend status into the one state to render.
+ *
+ * Order matters and encodes the honesty rules:
+ *
+ * 1. Nothing pushed beats everything — a provider cannot have deployed a commit
+ *    it never received.
+ * 2. Auth problems beat data. A rejected token means whatever we last saw is
+ *    unverifiable, so it is not shown as current.
+ * 3. Transport failures fall back to the last known deployment *labelled as
+ *    old*, rather than to silence or to a confident-looking blank.
+ * 4. A missing deployment is only ever "not found" — it never becomes "failed".
+ */
+export function deriveSectionState(
+  status: HostingStatus | null,
+  ctx: DeriveContext = {}
+): SectionState {
+  const now = ctx.now ?? Date.now();
+
+  if (!status) return { kind: 'checking' };
+  if (status.providers.length === 0) return { kind: 'no_link' };
+
+  // One provider for now; a second row repeats this reducer verbatim.
+  const p = status.providers[0];
+  const provider = p.link.provider;
+  const tokenSource = p.token_source ?? undefined;
+
+  if (!status.commit.has_upstream) return { kind: 'not_pushed', provider };
+
+  if (p.auth.kind === 'no_token') return { kind: 'no_token', provider };
+  if (p.auth.kind === 'rejected') return { kind: 'token_rejected', provider, tokenSource };
+
+  if (p.retry_after_secs != null || p.transport_error?.includes('rate limiting')) {
+    return {
+      kind: 'rate_limited',
+      provider,
+      retryAfterSecs: p.retry_after_secs ?? undefined,
+    };
+  }
+
+  if (p.transport_error) {
+    return {
+      kind: 'offline',
+      provider,
+      transportError: p.transport_error,
+      staleFrom: p.fetched_at || undefined,
+    };
+  }
+
+  const stalenessMs = ctx.stalenessMs ?? 0;
+  const isStale = stalenessMs > 0 && now - p.fetched_at > stalenessMs;
+
+  if (!p.lookup) return { kind: 'checking', provider };
+
+  if (p.lookup.kind === 'found') {
+    const deployment = p.lookup.deployment;
+    return {
+      kind: phaseToKind(deployment.phase),
+      provider,
+      deployment,
+      detail: deployment.detail,
+      tokenSource,
+      isStale,
+    };
+  }
+
+  // Not found. Only timing decides whether we still expect one — never a claim
+  // that the deploy failed, which no provider's API can actually tell us.
+  const since = ctx.pushedAt ?? status.commit.committed_at ?? 0;
+  const waiting = since > 0 && now - since < NOT_FOUND_GRACE_MS;
+
+  return {
+    kind: waiting ? 'not_found_yet' : 'not_found',
+    provider,
+    latestOnBranch: p.lookup.latest_on_branch ?? undefined,
+    tokenSource,
+    isStale,
+  };
+}
+
+/** States where a deployment is still moving, so polling should stay fast. */
+const ACTIVE_KINDS = new Set<SectionStateKind>([
+  'checking',
+  'queued',
+  'building',
+  'publishing',
+  'not_found_yet',
+]);
+
+export function isActive(kind: SectionStateKind): boolean {
+  return ACTIVE_KINDS.has(kind);
+}
+
+/** States where polling buys nothing until the user does something. */
+const IDLE_KINDS = new Set<SectionStateKind>([
+  'no_token',
+  'token_rejected',
+  'no_link',
+  'not_pushed',
+]);
+
+export function shouldPoll(kind: SectionStateKind): boolean {
+  return !IDLE_KINDS.has(kind);
+}

--- a/src/lib/hostingCopy.ts
+++ b/src/lib/hostingCopy.ts
@@ -46,13 +46,13 @@ function when(deployment?: Deployment): string {
 }
 
 /**
- * Where each environment is serving. "Production" and "Preview" are the two
- * words users actually see in every provider's own dashboard, so they are kept
- * — unlike "prod", which is nobody's word.
+ * Only a preview is worth naming. Production is what a push to the default
+ * branch does, so saying so adds a word the reader already knows and — in a
+ * 320px popover — pushes the timestamp off the end of the line. A preview is
+ * the surprising case, and the one where knowing changes what you do next.
  */
 function environmentLabel(deployment?: Deployment): string {
-  if (!deployment) return '';
-  return deployment.environment === 'production' ? ' · Production' : ' · Preview';
+  return deployment?.environment === 'preview' ? ' · Preview' : '';
 }
 
 /**

--- a/src/lib/hostingCopy.ts
+++ b/src/lib/hostingCopy.ts
@@ -62,6 +62,20 @@ export function compactAge(at: number, now = Date.now()): string {
   return `${Math.floor(hours / 24)}d ago`;
 }
 
+/**
+ * Capitalise a borrowed sentence that is about to start a line.
+ *
+ * Used only where the borrowed text is prose — a provider's humanised skip
+ * reason ("the commit message asked Cloudflare to skip it"). Deliberately not
+ * used on a transport error, which begins with a lowercase acronym and becomes
+ * "Dns error: …" if you capitalise it; that one is joined with a dash instead,
+ * so it never has to start a sentence.
+ */
+function capitalized(text?: string): string | undefined {
+  if (!text) return undefined;
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
 /** When the deployment happened, phrased for a sentence. */
 function when(deployment?: Deployment): string {
   const at = deployment?.ready_at || deployment?.created_at;
@@ -210,9 +224,12 @@ export function copyFor(
       return {
         title,
         status: `${statusWord(state.deployment, 'Skipped')}${env}${when(state.deployment)}`,
-        hint: detailSentence(state.detail)
-          ? `${host} skipped it: ${detailSentence(state.detail)}`
-          : `${host} chose not to build this push.`,
+        // The reason stands alone. Prefixing it with "<host> skipped it:"
+        // produced "Cloudflare skipped it: the commit message asked Cloudflare
+        // to skip it" — the provider's own humanised reason already names
+        // itself, and the status word and the brand mark have both said
+        // "skipped" before the eye reaches this line.
+        hint: capitalized(detailSentence(state.detail)) ?? `${host} chose not to build this push.`,
         action: dashboardLabelFor(state),
       };
 

--- a/src/lib/hostingCopy.ts
+++ b/src/lib/hostingCopy.ts
@@ -18,7 +18,6 @@
  * @module lib/hostingCopy
  */
 
-import { formatRelativeTime } from './branches';
 import {
   PROVIDER_LABELS,
   type Deployment,
@@ -43,10 +42,30 @@ function providerName(state: SectionState): string {
   return state.provider ? PROVIDER_LABELS[state.provider] : 'your host';
 }
 
+/**
+ * A compact age, the way every provider's own deployment list writes it.
+ *
+ * The app's `formatRelativeTime` spells it out — "23 minutes ago" — which is
+ * right in a list with room for it and wrong here: the status line gets 184px,
+ * and spending 14 characters on the age is what pushed
+ * "Ready · Production · 23 minutes ago" past the ellipsis in the single most
+ * common state this section has. Vercel, Netlify and Cloudflare all write
+ * "23m ago" in their own dashboards.
+ */
+export function compactAge(at: number, now = Date.now()): string {
+  const seconds = Math.max(0, Math.floor((now - at) / 1000));
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
 /** When the deployment happened, phrased for a sentence. */
 function when(deployment?: Deployment): string {
   const at = deployment?.ready_at || deployment?.created_at;
-  return at ? ` · ${formatRelativeTime(at)}` : '';
+  return at ? ` · ${compactAge(at)}` : '';
 }
 
 /** Vercel's own two environments, capitalised as its dashboard capitalises them. */
@@ -77,21 +96,30 @@ function dashboardLabelFor(state: SectionState): string | undefined {
   return state.provider ? `Open in ${PROVIDER_LABELS[state.provider]}` : 'Open';
 }
 
-function detailSuffix(detail?: DeploymentDetail | null): string {
-  if (!detail) return '';
+/**
+ * The provider's qualifier on a status, written as a sentence for line 3.
+ *
+ * These used to be appended to the status line after an em dash. The status
+ * line is 184px wide, so "Canceled · Production — a newer push replaced it"
+ * arrived on screen as "Canceled · Production — a ne…" — the ellipsis landing
+ * squarely on the only part the user didn't already know. The qualifier is the
+ * informative half, so it gets the full-width line instead.
+ */
+function detailSentence(detail?: DeploymentDetail | null): string | undefined {
+  if (!detail) return undefined;
   switch (detail.detail) {
     case 'not_yet_promoted':
-      return ' — built, but not serving visitors yet';
+      return 'Built, but not serving visitors yet.';
     case 'rolling_out':
-      return ' — rolling out to visitors';
+      return 'Rolling out to visitors.';
     case 'skipped_because':
-      return detail.reason ? ` — ${detail.reason}` : '';
+      return detail.reason?.trim() || undefined;
     case 'awaiting_review':
-      return detail.reason ? ` — ${detail.reason}` : '';
+      return detail.reason?.trim() || undefined;
     case 'review_rejected':
-      return '';
+      return undefined;
     case 'superseded_by_newer':
-      return ' — a newer push replaced it';
+      return 'A newer push replaced it.';
   }
 }
 
@@ -107,7 +135,15 @@ export function titleFor(
   return commitSubject?.trim() || deployment?.commit_message?.trim() || 'Your latest push';
 }
 
-/** Build both lines for a state. */
+/**
+ * Build the row's lines for a state.
+ *
+ * The two upper lines live in a 184px column and are ellipsised, so they are
+ * written to fit it: a status word, an environment, an age. Anything longer —
+ * a build error, a skip reason, a provider's qualifier — goes to line 3, which
+ * spans the section and may wrap. Every string here was measured in the UI
+ * harness; `harness-capture.mjs` lists anything that still overflows.
+ */
 export function copyFor(
   state: SectionState,
   commitSubject?: string | null,
@@ -115,7 +151,8 @@ export function copyFor(
 ): RowCopy {
   const host = providerName(state);
   const title = titleFor(commitSubject, state.deployment);
-  const sha = shortSha ? ` · ${shortSha}` : '';
+  const env = environmentLabel(state.deployment);
+  const commit = shortSha ? `commit ${shortSha}` : 'this commit';
 
   switch (state.kind) {
     case 'checking':
@@ -131,9 +168,7 @@ export function copyFor(
     case 'queued':
       return {
         title,
-        status: `${statusWord(state.deployment, 'Queued')}${environmentLabel(
-          state.deployment
-        )}${when(state.deployment)}${sha}`,
+        status: `${statusWord(state.deployment, 'Queued')}${env}${when(state.deployment)}`,
         action: dashboardLabelFor(state),
       };
 
@@ -141,28 +176,24 @@ export function copyFor(
     case 'publishing':
       return {
         title,
-        status: `${statusWord(state.deployment, 'Building')}${environmentLabel(
-          state.deployment
-        )}${when(state.deployment)}`,
+        status: `${statusWord(state.deployment, 'Building')}${env}${when(state.deployment)}`,
+        hint: detailSentence(state.detail),
         action: dashboardLabelFor(state),
       };
 
     case 'ready':
       return {
         title,
-        status: `${statusWord(state.deployment, 'Ready')}${environmentLabel(
-          state.deployment
-        )}${when(state.deployment)}${detailSuffix(state.detail)}`,
-        // No hint: the addresses get their own labelled rows below.
+        status: `${statusWord(state.deployment, 'Ready')}${env}${when(state.deployment)}`,
+        // Usually no hint: the addresses get their own labelled rows below.
+        hint: detailSentence(state.detail),
         action: dashboardLabelFor(state),
       };
 
     case 'failed':
       return {
         title,
-        status: `${statusWord(state.deployment, 'Error')}${environmentLabel(
-          state.deployment
-        )}${when(state.deployment)}`,
+        status: `${statusWord(state.deployment, 'Error')}${env}${when(state.deployment)}`,
         hint: state.deployment?.error_message?.split('\n')[0],
         action: dashboardLabelFor(state),
       };
@@ -170,42 +201,50 @@ export function copyFor(
     case 'canceled':
       return {
         title,
-        status: `${statusWord(state.deployment, 'Canceled')}${environmentLabel(
-          state.deployment
-        )}${detailSuffix(state.detail)}`,
+        status: `${statusWord(state.deployment, 'Canceled')}${env}${when(state.deployment)}`,
+        hint: detailSentence(state.detail),
         action: dashboardLabelFor(state),
       };
 
     case 'skipped':
       return {
         title,
-        status: `${host} skipped this push${detailSuffix(state.detail)}`,
+        status: `${statusWord(state.deployment, 'Skipped')}${env}${when(state.deployment)}`,
+        hint: detailSentence(state.detail)
+          ? `${host} skipped it: ${detailSentence(state.detail)}`
+          : `${host} chose not to build this push.`,
         action: dashboardLabelFor(state),
       };
 
     case 'gated':
-      return {
-        title,
-        status:
-          state.detail?.detail === 'review_rejected'
-            ? `${host} declined to build this push`
-            : `Waiting for approval on ${host}${detailSuffix(state.detail)}`,
-        action: dashboardLabelFor(state),
-      };
+      return state.detail?.detail === 'review_rejected'
+        ? {
+            title,
+            status: `Declined${env}`,
+            hint: `${host} declined to build this push.`,
+            action: dashboardLabelFor(state),
+          }
+        : {
+            title,
+            status: `Awaiting approval${env}`,
+            hint: detailSentence(state.detail) ?? `Waiting for approval on ${host}.`,
+            action: dashboardLabelFor(state),
+          };
 
     case 'unknown':
       return {
         title,
-        // Deliberately not translated into success or failure — we genuinely
-        // do not know which it is.
-        status: `${host} reported a status Ship Studio doesn't recognize`,
+        // The provider's own word, shown verbatim rather than translated into
+        // success or failure — we genuinely do not know which it is.
+        status: `${statusWord(state.deployment, 'Unknown')}${env}${when(state.deployment)}`,
+        hint: `Ship Studio doesn't recognize this status yet.`,
         action: dashboardLabelFor(state),
       };
 
     case 'not_found_yet':
       return {
         title,
-        status: `Waiting for ${host} to pick up this push…`,
+        status: `Waiting for ${host}…`,
         hint: 'This usually takes under a minute.',
       };
 
@@ -214,45 +253,51 @@ export function copyFor(
         title,
         // Never "failed to trigger": no provider's API can distinguish a push
         // that was ignored from one that simply hasn't arrived.
-        status: `${host} hasn't reported a deploy for this push`,
+        status: 'No deploy reported yet',
         hint: state.latestOnBranch
-          ? `Most recent on this branch: ${titleFor(null, state.latestOnBranch)}`
-          : undefined,
+          ? `${host} has nothing for ${commit}. Latest on this branch: ${titleFor(
+              null,
+              state.latestOnBranch
+            )}`
+          : `${host} has nothing for ${commit}.`,
       };
 
     case 'no_token':
       return {
-        title: `Connect ${host} to see your deployments`,
-        status: 'Your token is stored in the system keychain.',
-        hint: `Deploys still run — this only affects what Ship Studio can show you.`,
+        title: `Connect ${host}`,
+        status: 'See if each push went live',
+        hint: 'Your deploys run either way — this only changes what you see here.',
         action: 'Connect',
       };
 
     case 'token_rejected':
       return {
-        title: `${host} didn't accept the saved sign-in`,
+        title: `Reconnect ${host}`,
         status:
           state.tokenSource === 'cli_file'
-            ? `Its command-line login has expired.`
-            : 'The saved token may have expired or been revoked.',
-        hint: 'Connect again to keep seeing deployment status.',
+            ? 'Its CLI login has expired'
+            : 'The saved token was rejected',
+        hint: 'Deployment status is unavailable until you do.',
         action: 'Connect',
       };
 
     case 'no_link':
       return {
-        title: 'See whether each push went live',
-        status: 'Connect Vercel, Cloudflare Pages, or Netlify.',
+        title: 'See if each push went live',
+        status: 'Vercel, Cloudflare, or Netlify',
         action: 'Set up',
       };
 
     case 'offline':
       return {
         title,
-        status: state.staleFrom
-          ? `Couldn't reach ${host} · last checked ${formatRelativeTime(state.staleFrom)}`
-          : `Couldn't reach ${host}`,
-        hint: state.transportError,
+        status: `Couldn't reach ${host}`,
+        hint: [
+          state.staleFrom ? `Last checked ${compactAge(state.staleFrom)}.` : undefined,
+          state.transportError,
+        ]
+          .filter(Boolean)
+          .join(' '),
         action: 'Retry',
       };
 
@@ -260,8 +305,9 @@ export function copyFor(
       return {
         title,
         status: state.retryAfterSecs
-          ? `${host} asked us to slow down — retrying in ${state.retryAfterSecs}s`
-          : `${host} asked us to slow down`,
+          ? `Rate limited · retrying in ${state.retryAfterSecs}s`
+          : `Rate limited by ${host}`,
+        hint: `${host} asked us to slow down.`,
       };
   }
 }

--- a/src/lib/hostingCopy.ts
+++ b/src/lib/hostingCopy.ts
@@ -64,16 +64,17 @@ function statusWord(deployment: Deployment | undefined, fallback: string): strin
 }
 
 /**
- * What the row's own button opens, named for where the deployment went. A
- * preview never reached production, so "Open domain" would be wrong on a
- * feature branch.
+ * The row's button opens the deployment on the provider.
+ *
+ * It used to open the domain, which was already one click away on the address
+ * rows right below it — so the button spent its space duplicating them. The
+ * provider's own page is the thing the row cannot show: build logs, timings,
+ * redeploy, rollback. Absent when the provider gives us no link to it, which
+ * Cloudflare's API currently does not.
  */
-function openLabelFor(deployment?: Deployment): string | undefined {
-  if (!deployment) return undefined;
-  if (deployment.environment === 'preview') {
-    return deployment.urls.deployment ? 'Open preview' : undefined;
-  }
-  return deployment.urls.site ? 'Open domain' : undefined;
+function dashboardLabelFor(state: SectionState): string | undefined {
+  if (!state.deployment?.dashboard_url) return undefined;
+  return state.provider ? `Open in ${PROVIDER_LABELS[state.provider]}` : 'Open';
 }
 
 function detailSuffix(detail?: DeploymentDetail | null): string {
@@ -133,7 +134,7 @@ export function copyFor(
         status: `${statusWord(state.deployment, 'Queued')}${environmentLabel(
           state.deployment
         )}${when(state.deployment)}${sha}`,
-        action: state.deployment?.dashboard_url ? 'View' : undefined,
+        action: dashboardLabelFor(state),
       };
 
     case 'building':
@@ -143,7 +144,7 @@ export function copyFor(
         status: `${statusWord(state.deployment, 'Building')}${environmentLabel(
           state.deployment
         )}${when(state.deployment)}`,
-        action: state.deployment?.dashboard_url ? 'View' : undefined,
+        action: dashboardLabelFor(state),
       };
 
     case 'ready':
@@ -153,7 +154,7 @@ export function copyFor(
           state.deployment
         )}${when(state.deployment)}${detailSuffix(state.detail)}`,
         // No hint: the addresses get their own labelled rows below.
-        action: openLabelFor(state.deployment),
+        action: dashboardLabelFor(state),
       };
 
     case 'failed':
@@ -163,7 +164,7 @@ export function copyFor(
           state.deployment
         )}${when(state.deployment)}`,
         hint: state.deployment?.error_message?.split('\n')[0],
-        action: state.deployment?.dashboard_url ? 'View logs' : undefined,
+        action: dashboardLabelFor(state),
       };
 
     case 'canceled':
@@ -172,14 +173,14 @@ export function copyFor(
         status: `${statusWord(state.deployment, 'Canceled')}${environmentLabel(
           state.deployment
         )}${detailSuffix(state.detail)}`,
-        action: state.deployment?.dashboard_url ? 'View' : undefined,
+        action: dashboardLabelFor(state),
       };
 
     case 'skipped':
       return {
         title,
         status: `${host} skipped this push${detailSuffix(state.detail)}`,
-        action: state.deployment?.dashboard_url ? 'View' : undefined,
+        action: dashboardLabelFor(state),
       };
 
     case 'gated':
@@ -189,7 +190,7 @@ export function copyFor(
           state.detail?.detail === 'review_rejected'
             ? `${host} declined to build this push`
             : `Waiting for approval on ${host}${detailSuffix(state.detail)}`,
-        action: state.deployment?.dashboard_url ? 'View' : undefined,
+        action: dashboardLabelFor(state),
       };
 
     case 'unknown':
@@ -198,7 +199,7 @@ export function copyFor(
         // Deliberately not translated into success or failure — we genuinely
         // do not know which it is.
         status: `${host} reported a status Ship Studio doesn't recognize`,
-        action: state.deployment?.dashboard_url ? 'View' : undefined,
+        action: dashboardLabelFor(state),
       };
 
     case 'not_found_yet':

--- a/src/lib/hostingCopy.ts
+++ b/src/lib/hostingCopy.ts
@@ -210,7 +210,7 @@ export function copyFor(
         title: `${host} didn't accept the saved sign-in`,
         status:
           state.tokenSource === 'cli_file'
-            ? `The ${host} CLI's login has expired.`
+            ? `Its command-line login has expired.`
             : 'The saved token may have expired or been revoked.',
         hint: 'Connect again to keep seeing deployment status.',
         action: 'Connect',

--- a/src/lib/hostingCopy.ts
+++ b/src/lib/hostingCopy.ts
@@ -55,15 +55,6 @@ function environmentLabel(deployment?: Deployment): string {
   return deployment?.environment === 'preview' ? ' · Preview' : '';
 }
 
-/**
- * A URL trimmed to what fits a 320px popover: no scheme, no trailing slash.
- * The value still comes from the provider — this only shortens what's shown.
- */
-function displayUrl(url?: string | null): string | undefined {
-  if (!url) return undefined;
-  return url.replace(/^https?:\/\//, '').replace(/\/$/, '');
-}
-
 function detailSuffix(detail?: DeploymentDetail | null): string {
   if (!detail) return '';
   switch (detail.detail) {
@@ -144,11 +135,10 @@ export function copyFor(
         status: `Live on ${host}${when(state.deployment)}${environmentLabel(
           state.deployment
         )}${detailSuffix(state.detail)}`,
-        // The third line is reserved in every state to keep the row height
-        // fixed, so the live state fills it with the thing you'd actually want
-        // to read — the address it's serving on — rather than leaving a hole.
-        hint: displayUrl(state.deployment?.urls.primary),
-        action: state.deployment?.urls.primary ? 'Open' : undefined,
+        // No hint: the addresses get their own labelled rows below, where
+        // "Site" and "Build" can be told apart. One unlabelled URL here was
+        // how a per-build permalink ended up presented as the site.
+        action: state.deployment?.urls.site ? 'Open site' : undefined,
       };
 
     case 'failed':

--- a/src/lib/hostingCopy.ts
+++ b/src/lib/hostingCopy.ts
@@ -1,15 +1,19 @@
 /**
  * Every user-facing string in the hosting section.
  *
- * Centralised for two reasons. First, so the vocabulary can be tested: the
- * section it replaces surfaced Vercel's own words — "Prod", "READY", "Queued",
- * "scope", "Deploy" as a noun — which describe a build pipeline rather than
- * anything the user did. Second, so the two lines of every row are written
- * together and stay the right length for a 320px popover.
- *
  * The rule the copy follows: **line 1 names what the user shipped, line 2 says
- * what happened to it.** "Ready" answers "is Vercel's pipeline done". It does
- * not answer "did my change go live", which is the actual question.
+ * what the provider says happened to it** — in the provider's own words.
+ *
+ * An earlier version translated those words, on the theory that "Ready" is
+ * pipeline jargon. That was a mistake. This is a UI over what Vercel returns,
+ * and inventing synonyms only means a user comparing this against the Vercel
+ * dashboard has two vocabularies to reconcile. Status words come from
+ * `deployment.status_label`, which is the provider's; environments are
+ * Production and Preview, which is what all three providers call them.
+ *
+ * What this module still owns is the sentence around those words — the
+ * timestamp, which provider, and the states that have no provider status at
+ * all because nothing was found or no credential exists.
  *
  * @module lib/hostingCopy
  */
@@ -45,14 +49,31 @@ function when(deployment?: Deployment): string {
   return at ? ` · ${formatRelativeTime(at)}` : '';
 }
 
-/**
- * Only a preview is worth naming. Production is what a push to the default
- * branch does, so saying so adds a word the reader already knows and — in a
- * 320px popover — pushes the timestamp off the end of the line. A preview is
- * the surprising case, and the one where knowing changes what you do next.
- */
+/** Vercel's own two environments, capitalised as its dashboard capitalises them. */
 function environmentLabel(deployment?: Deployment): string {
-  return deployment?.environment === 'preview' ? ' · Preview' : '';
+  if (!deployment) return '';
+  return deployment.environment === 'production' ? ' · Production' : ' · Preview';
+}
+
+/**
+ * The provider's status word. Falls back only when a deployment predates the
+ * field or a provider sends nothing.
+ */
+function statusWord(deployment: Deployment | undefined, fallback: string): string {
+  return deployment?.status_label?.trim() || fallback;
+}
+
+/**
+ * What the row's own button opens, named for where the deployment went. A
+ * preview never reached production, so "Open domain" would be wrong on a
+ * feature branch.
+ */
+function openLabelFor(deployment?: Deployment): string | undefined {
+  if (!deployment) return undefined;
+  if (deployment.environment === 'preview') {
+    return deployment.urls.deployment ? 'Open preview' : undefined;
+  }
+  return deployment.urls.site ? 'Open domain' : undefined;
 }
 
 function detailSuffix(detail?: DeploymentDetail | null): string {
@@ -109,50 +130,48 @@ export function copyFor(
     case 'queued':
       return {
         title,
-        status: `Waiting to build on ${host}${when(state.deployment)}${sha}`,
-        hint: 'Links appear when the build finishes.',
+        status: `${statusWord(state.deployment, 'Queued')}${environmentLabel(
+          state.deployment
+        )}${when(state.deployment)}${sha}`,
         action: state.deployment?.dashboard_url ? 'View' : undefined,
       };
 
     case 'building':
-      return {
-        title,
-        status: `Building on ${host}${when(state.deployment)}`,
-        hint: 'Links appear when the build finishes.',
-        action: state.deployment?.dashboard_url ? 'View' : undefined,
-      };
-
     case 'publishing':
       return {
         title,
-        status: `Almost live on ${host} — finishing up`,
+        status: `${statusWord(state.deployment, 'Building')}${environmentLabel(
+          state.deployment
+        )}${when(state.deployment)}`,
         action: state.deployment?.dashboard_url ? 'View' : undefined,
       };
 
     case 'ready':
       return {
         title,
-        status: `Live on ${host}${when(state.deployment)}${environmentLabel(
+        status: `${statusWord(state.deployment, 'Ready')}${environmentLabel(
           state.deployment
-        )}${detailSuffix(state.detail)}`,
-        // No hint: the addresses get their own labelled rows below, where
-        // "Site" and "Build" can be told apart. One unlabelled URL here was
-        // how a per-build permalink ended up presented as the site.
-        action: state.deployment?.urls.site ? 'Open site' : undefined,
+        )}${when(state.deployment)}${detailSuffix(state.detail)}`,
+        // No hint: the addresses get their own labelled rows below.
+        action: openLabelFor(state.deployment),
       };
 
     case 'failed':
       return {
         title,
-        status: `Build failed on ${host}${when(state.deployment)}`,
+        status: `${statusWord(state.deployment, 'Error')}${environmentLabel(
+          state.deployment
+        )}${when(state.deployment)}`,
         hint: state.deployment?.error_message?.split('\n')[0],
-        action: state.deployment?.dashboard_url ? 'Details' : undefined,
+        action: state.deployment?.dashboard_url ? 'View logs' : undefined,
       };
 
     case 'canceled':
       return {
         title,
-        status: `Canceled on ${host}${detailSuffix(state.detail)}`,
+        status: `${statusWord(state.deployment, 'Canceled')}${environmentLabel(
+          state.deployment
+        )}${detailSuffix(state.detail)}`,
         action: state.deployment?.dashboard_url ? 'View' : undefined,
       };
 
@@ -247,12 +266,15 @@ export function copyFor(
 }
 
 /**
- * Words that mean something inside a provider's own product and nothing to the
- * person who pushed a commit. Asserted against every string this module can
- * produce; provider names and "Production"/"Preview" are deliberately allowed.
+ * Not a ban on the provider's vocabulary — this app deliberately uses it, so
+ * that "Ready" here and "Ready" on the dashboard are the same word.
+ *
+ * What stays banned is the shape nobody writes for a reader: SHOUTED enum
+ * values straight off the wire, API field names, and internal abbreviations.
+ * "Ready" is fine; `READY`, `readyState` and `prod` are not.
  */
 export const BANNED_JARGON =
-  /\b(prod|READY|BUILDING|QUEUED|CANCELED|INITIALIZING|scope|alias|uid|teamId|substate|readyState|deployment_trigger)\b/;
+  /\b(prod|READY|BUILDING|QUEUED|CANCELED|INITIALIZING|ERROR|scope|alias|uid|teamId|substate|readyState|aliasAssigned|deployment_trigger)\b/;
 
 /** Which provider each state's copy is about, for the icon. */
 export function providerFor(state: SectionState): HostingProvider | undefined {

--- a/src/lib/hostingCopy.ts
+++ b/src/lib/hostingCopy.ts
@@ -292,12 +292,17 @@ export function copyFor(
       return {
         title,
         status: `Couldn't reach ${host}`,
+        // Joined with a dash, not a full stop. The transport error is quoted
+        // verbatim — it is the one thing here we genuinely cannot interpret —
+        // and it arrives lowercase from the HTTP client. Ending the clause
+        // before it with a period made "dns error: …" read as a typo;
+        // capitalising it instead produced "Dns error", which is worse.
         hint: [
-          state.staleFrom ? `Last checked ${compactAge(state.staleFrom)}.` : undefined,
+          state.staleFrom ? `Last checked ${compactAge(state.staleFrom)}` : undefined,
           state.transportError,
         ]
           .filter(Boolean)
-          .join(' '),
+          .join(' — '),
         action: 'Retry',
       };
 

--- a/src/lib/hostingCopy.ts
+++ b/src/lib/hostingCopy.ts
@@ -1,0 +1,257 @@
+/**
+ * Every user-facing string in the hosting section.
+ *
+ * Centralised for two reasons. First, so the vocabulary can be tested: the
+ * section it replaces surfaced Vercel's own words — "Prod", "READY", "Queued",
+ * "scope", "Deploy" as a noun — which describe a build pipeline rather than
+ * anything the user did. Second, so the two lines of every row are written
+ * together and stay the right length for a 320px popover.
+ *
+ * The rule the copy follows: **line 1 names what the user shipped, line 2 says
+ * what happened to it.** "Ready" answers "is Vercel's pipeline done". It does
+ * not answer "did my change go live", which is the actual question.
+ *
+ * @module lib/hostingCopy
+ */
+
+import { formatRelativeTime } from './branches';
+import {
+  PROVIDER_LABELS,
+  type Deployment,
+  type DeploymentDetail,
+  type HostingProvider,
+  type SectionState,
+} from './hosting';
+
+/** What the two-line row should say for a given state. */
+export interface RowCopy {
+  /** Line 1 — normally the commit subject. */
+  title: string;
+  /** Line 2 — what happened to it. */
+  status: string;
+  /** The optional third line of links/hints. */
+  hint?: string;
+  /** Label for the trailing action button, when there is one. */
+  action?: string;
+}
+
+function providerName(state: SectionState): string {
+  return state.provider ? PROVIDER_LABELS[state.provider] : 'your host';
+}
+
+/** When the deployment happened, phrased for a sentence. */
+function when(deployment?: Deployment): string {
+  const at = deployment?.ready_at || deployment?.created_at;
+  return at ? ` · ${formatRelativeTime(at)}` : '';
+}
+
+/**
+ * Where each environment is serving. "Production" and "Preview" are the two
+ * words users actually see in every provider's own dashboard, so they are kept
+ * — unlike "prod", which is nobody's word.
+ */
+function environmentLabel(deployment?: Deployment): string {
+  if (!deployment) return '';
+  return deployment.environment === 'production' ? ' · Production' : ' · Preview';
+}
+
+function detailSuffix(detail?: DeploymentDetail | null): string {
+  if (!detail) return '';
+  switch (detail.detail) {
+    case 'not_yet_promoted':
+      return ' — built, but not serving visitors yet';
+    case 'rolling_out':
+      return ' — rolling out to visitors';
+    case 'skipped_because':
+      return detail.reason ? ` — ${detail.reason}` : '';
+    case 'awaiting_review':
+      return detail.reason ? ` — ${detail.reason}` : '';
+    case 'review_rejected':
+      return '';
+    case 'superseded_by_newer':
+      return ' — a newer push replaced it';
+  }
+}
+
+/**
+ * The commit subject, preferring what git told us locally. The provider's own
+ * commit message is a fallback because it is frequently null — a real Netlify
+ * production deploy returned `commit_message: null` and `title: null`.
+ */
+export function titleFor(
+  commitSubject: string | null | undefined,
+  deployment?: Deployment
+): string {
+  return commitSubject?.trim() || deployment?.commit_message?.trim() || 'Your latest push';
+}
+
+/** Build both lines for a state. */
+export function copyFor(
+  state: SectionState,
+  commitSubject?: string | null,
+  shortSha?: string
+): RowCopy {
+  const host = providerName(state);
+  const title = titleFor(commitSubject, state.deployment);
+  const sha = shortSha ? ` · ${shortSha}` : '';
+
+  switch (state.kind) {
+    case 'checking':
+      return { title, status: `Checking ${host}…` };
+
+    case 'not_pushed':
+      return {
+        title,
+        status: 'Not pushed yet',
+        hint: 'Deployments appear here after your first push.',
+      };
+
+    case 'queued':
+      return {
+        title,
+        status: `Waiting to build on ${host}${when(state.deployment)}${sha}`,
+        hint: 'Links appear when the build finishes.',
+        action: state.deployment?.dashboard_url ? 'View' : undefined,
+      };
+
+    case 'building':
+      return {
+        title,
+        status: `Building on ${host}${when(state.deployment)}`,
+        hint: 'Links appear when the build finishes.',
+        action: state.deployment?.dashboard_url ? 'View' : undefined,
+      };
+
+    case 'publishing':
+      return {
+        title,
+        status: `Almost live on ${host} — finishing up`,
+        action: state.deployment?.dashboard_url ? 'View' : undefined,
+      };
+
+    case 'ready':
+      return {
+        title,
+        status: `Live on ${host}${when(state.deployment)}${environmentLabel(
+          state.deployment
+        )}${detailSuffix(state.detail)}`,
+        action: state.deployment?.urls.primary ? 'Open' : undefined,
+      };
+
+    case 'failed':
+      return {
+        title,
+        status: `Build failed on ${host}${when(state.deployment)}`,
+        hint: state.deployment?.error_message?.split('\n')[0],
+        action: state.deployment?.dashboard_url ? 'Details' : undefined,
+      };
+
+    case 'canceled':
+      return {
+        title,
+        status: `Canceled on ${host}${detailSuffix(state.detail)}`,
+        action: state.deployment?.dashboard_url ? 'View' : undefined,
+      };
+
+    case 'skipped':
+      return {
+        title,
+        status: `${host} skipped this push${detailSuffix(state.detail)}`,
+        action: state.deployment?.dashboard_url ? 'View' : undefined,
+      };
+
+    case 'gated':
+      return {
+        title,
+        status:
+          state.detail?.detail === 'review_rejected'
+            ? `${host} declined to build this push`
+            : `Waiting for approval on ${host}${detailSuffix(state.detail)}`,
+        action: state.deployment?.dashboard_url ? 'View' : undefined,
+      };
+
+    case 'unknown':
+      return {
+        title,
+        // Deliberately not translated into success or failure — we genuinely
+        // do not know which it is.
+        status: `${host} reported a status Ship Studio doesn't recognize`,
+        action: state.deployment?.dashboard_url ? 'View' : undefined,
+      };
+
+    case 'not_found_yet':
+      return {
+        title,
+        status: `Waiting for ${host} to pick up this push…`,
+        hint: 'This usually takes under a minute.',
+      };
+
+    case 'not_found':
+      return {
+        title,
+        // Never "failed to trigger": no provider's API can distinguish a push
+        // that was ignored from one that simply hasn't arrived.
+        status: `${host} hasn't reported a deploy for this push`,
+        hint: state.latestOnBranch
+          ? `Most recent on this branch: ${titleFor(null, state.latestOnBranch)}`
+          : undefined,
+      };
+
+    case 'no_token':
+      return {
+        title: `Connect ${host} to see your deployments`,
+        status: 'Your token is stored in the system keychain.',
+        hint: `Deploys still run — this only affects what Ship Studio can show you.`,
+        action: 'Connect',
+      };
+
+    case 'token_rejected':
+      return {
+        title: `${host} didn't accept the saved sign-in`,
+        status:
+          state.tokenSource === 'cli_file'
+            ? `The ${host} CLI's login has expired.`
+            : 'The saved token may have expired or been revoked.',
+        hint: 'Connect again to keep seeing deployment status.',
+        action: 'Connect',
+      };
+
+    case 'no_link':
+      return {
+        title: 'See whether each push went live',
+        status: 'Connect Vercel, Cloudflare Pages, or Netlify.',
+        action: 'Set up',
+      };
+
+    case 'offline':
+      return {
+        title,
+        status: state.staleFrom
+          ? `Couldn't reach ${host} · last checked ${formatRelativeTime(state.staleFrom)}`
+          : `Couldn't reach ${host}`,
+        hint: state.transportError,
+        action: 'Retry',
+      };
+
+    case 'rate_limited':
+      return {
+        title,
+        status: state.retryAfterSecs
+          ? `${host} asked us to slow down — retrying in ${state.retryAfterSecs}s`
+          : `${host} asked us to slow down`,
+      };
+  }
+}
+
+/**
+ * Words that mean something inside a provider's own product and nothing to the
+ * person who pushed a commit. Asserted against every string this module can
+ * produce; provider names and "Production"/"Preview" are deliberately allowed.
+ */
+export const BANNED_JARGON =
+  /\b(prod|READY|BUILDING|QUEUED|CANCELED|INITIALIZING|scope|alias|uid|teamId|substate|readyState|deployment_trigger)\b/;
+
+/** Which provider each state's copy is about, for the icon. */
+export function providerFor(state: SectionState): HostingProvider | undefined {
+  return state.provider;
+}

--- a/src/lib/hostingCopy.ts
+++ b/src/lib/hostingCopy.ts
@@ -55,6 +55,15 @@ function environmentLabel(deployment?: Deployment): string {
   return deployment.environment === 'production' ? ' · Production' : ' · Preview';
 }
 
+/**
+ * A URL trimmed to what fits a 320px popover: no scheme, no trailing slash.
+ * The value still comes from the provider — this only shortens what's shown.
+ */
+function displayUrl(url?: string | null): string | undefined {
+  if (!url) return undefined;
+  return url.replace(/^https?:\/\//, '').replace(/\/$/, '');
+}
+
 function detailSuffix(detail?: DeploymentDetail | null): string {
   if (!detail) return '';
   switch (detail.detail) {
@@ -135,6 +144,10 @@ export function copyFor(
         status: `Live on ${host}${when(state.deployment)}${environmentLabel(
           state.deployment
         )}${detailSuffix(state.detail)}`,
+        // The third line is reserved in every state to keep the row height
+        // fixed, so the live state fills it with the thing you'd actually want
+        // to read — the address it's serving on — rather than leaving a hole.
+        hint: displayUrl(state.deployment?.urls.primary),
         action: state.deployment?.urls.primary ? 'Open' : undefined,
       };
 

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -89,6 +89,36 @@ export const HOSTING_PLUGIN_IDS = ['vercel', 'cloudflare', 'netlify'];
  */
 export const NATIVE_HOSTING_IDS = ['vercel', 'cloudflare', 'netlify'];
 
+/**
+ * Plugins the app now does itself, and what replaced each one.
+ *
+ * A superseded plugin is skipped at load, so it renders nothing and its
+ * background timers never run — but it is still on disk and still listed, and
+ * saying nothing would leave someone staring at a plugin that appears enabled
+ * and does nothing. The Plugin Manager reads this to explain and to offer
+ * removal.
+ *
+ * Removal is never automatic. Some of these are dev-linked checkouts pointed at
+ * a folder someone is working in, and deleting one of those is not ours to do
+ * on their behalf.
+ */
+export const SUPERSEDED_PLUGINS: Record<string, string> = {
+  vercel: 'Hosting is built in now — see the Hosting section when you push.',
+  cloudflare: 'Hosting is built in now — see the Hosting section when you push.',
+  netlify: 'Hosting is built in now — see the Hosting section when you push.',
+  'brand-guidelines': 'Replaced by the shipstudio-brand-guidelines skill — just ask your agent.',
+  hue: 'The Hue skill does this directly — just ask your agent.',
+  'url-to-code': 'Replaced by the shipstudio-site-to-code skill — just ask your agent.',
+  'webflow-to-code': 'Replaced by the shipstudio-site-to-code skill — just ask your agent.',
+  'weweb-to-code': 'Replaced by the shipstudio-site-to-code skill — just ask your agent.',
+  'wordpress-to-code': 'Replaced by the shipstudio-site-to-code skill — just ask your agent.',
+};
+
+/** Why this plugin no longer runs, or null if it still does. */
+export function supersededReason(pluginId: string): string | null {
+  return SUPERSEDED_PLUGINS[pluginId] ?? null;
+}
+
 const REGISTRY_URL =
   'https://raw.githubusercontent.com/ship-studio/plugin-registry/main/registry.json';
 

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -78,6 +78,17 @@ export const VERCEL_PLUGIN_REPO = 'https://github.com/ship-studio/plugin-vercel'
  */
 export const HOSTING_PLUGIN_IDS = ['vercel', 'cloudflare', 'netlify'];
 
+/**
+ * Hosting providers the app now handles itself (see `components/hosting`).
+ *
+ * A plugin claiming one of these is superseded and is skipped at load time —
+ * not merely hidden — so its activation hook and background timers never run.
+ * The installed copy is left alone on disk; some are dev-linked checkouts, and
+ * deleting one is not ours to do silently. The Plugin Manager labels them and
+ * offers removal.
+ */
+export const NATIVE_HOSTING_IDS = ['vercel', 'cloudflare', 'netlify'];
+
 const REGISTRY_URL =
   'https://raw.githubusercontent.com/ship-studio/plugin-registry/main/registry.json';
 

--- a/src/styles/features/agents-panel.css
+++ b/src/styles/features/agents-panel.css
@@ -395,6 +395,26 @@ button.dashboard-card-row {
   gap: var(--button-gap);
 }
 
+/* Used by the hosting link picker while it fetches the account's projects. */
+.connect-modal-loading {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-body-md);
+}
+
+/* Capped so an account with many projects scrolls the list rather than
+   growing the dialog past the viewport. */
+.connect-modal-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xs);
+  max-height: 240px;
+  overflow-y: auto;
+}
+
 /* Terminal phase — fills the (terminal-sized) modal: instructions on top, the
    embedded backend-PTY terminal taking the remaining height. */
 .connect-modal-terminal-phase {

--- a/src/styles/features/plugins.css
+++ b/src/styles/features/plugins.css
@@ -376,3 +376,21 @@
   border-top: 1px solid var(--border-default);
   margin-top: var(--spacing-xs);
 }
+
+/* A plugin the app now does itself. It is skipped at load, so the row exists
+   only to say why it stopped doing anything and to offer removal. */
+.plugin-row.is-superseded .plugin-name,
+.plugin-row.is-superseded .plugin-meta {
+  color: var(--text-muted);
+}
+
+.plugin-superseded-badge {
+  margin-left: var(--spacing-2xs);
+  padding: var(--spacing-3xs) var(--spacing-2xs);
+  background: var(--surface-control);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: var(--font-size-badge);
+  font-weight: var(--font-weight-medium);
+  text-transform: none;
+}

--- a/src/styles/features/publish/deployments.css
+++ b/src/styles/features/publish/deployments.css
@@ -1,0 +1,211 @@
+/* Deployments panel — recent deployments with their build output.
+ *
+ * Deliberately the same shape as the workflow run-history dialog: a list you
+ * pick from, the raw output beside it. Same job, same idiom. */
+
+.deployments-modal {
+  width: min(880px, 94vw);
+  /* Definite, not a max — `.modal-frame-content` is sized by its content, so
+     a max-height leaves the panes' `flex: 1` dividing nothing and the dialog
+     collapses to a stub. Same reason `.run-history-modal` does this. */
+  height: min(660px, 84vh);
+  overflow: hidden;
+}
+
+.deployments {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  gap: var(--spacing-md);
+  flex: 1;
+  min-height: 0;
+  padding: var(--spacing-lg) var(--spacing-xl) var(--spacing-lg);
+}
+
+.deployments-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xs);
+  padding-right: var(--spacing-2xs);
+  overflow-y: auto;
+}
+
+.deployments-empty {
+  color: var(--text-muted);
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-help);
+}
+
+/* Rows are separated by hover and selection contrast, not by dividers — the
+   convention every recent list surface in the app follows. */
+.deployments-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color var(--transition-interaction);
+}
+
+.deployments-item:hover {
+  background: var(--surface-control-hover);
+}
+
+.deployments-item.is-selected {
+  background: var(--surface-control);
+}
+
+.deployments-item-dot {
+  flex-shrink: 0;
+  width: 7px;
+  height: 7px;
+  margin-top: var(--spacing-xs);
+  border-radius: var(--radius-pill);
+  background: var(--text-muted);
+}
+
+.deployments-item-dot[data-state='ok'] {
+  background: var(--accent-success);
+}
+
+.deployments-item-dot[data-state='running'] {
+  background: var(--accent-warning);
+}
+
+.deployments-item-dot[data-state='failed'] {
+  background: var(--accent-error);
+}
+
+.deployments-item-dot[data-state='findings'] {
+  background: var(--accent-warning);
+}
+
+.deployments-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3xs);
+  min-width: 0;
+}
+
+.deployments-item-title {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: var(--font-size-body-md);
+  font-weight: var(--font-weight-label);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.deployments-item-meta {
+  color: var(--text-muted);
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-compact);
+}
+
+.deployments-detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  min-width: 0;
+  min-height: 0;
+}
+
+.deployments-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+}
+
+.deployments-detail-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-body-md);
+}
+
+.deployments-detail-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--button-gap);
+}
+
+/* Identifiers — a branch name, a commit hash — are read character by
+   character, so they get the code face and a contained surface. */
+.deployments-chip {
+  padding: var(--spacing-2xs) var(--spacing-xs);
+  background: var(--surface-control);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-family: var(--font-code);
+  font-size: var(--font-size-body-sm);
+  white-space: nowrap;
+}
+
+/* A failure's reason goes above the log, not inside it. Finding out why a
+   build broke should not require reading a hundred lines of output first. */
+.deployments-error {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2xs);
+  margin: 0;
+  color: var(--accent-error);
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-help);
+}
+
+.deployments-error svg {
+  flex-shrink: 0;
+  margin-top: var(--spacing-3xs);
+}
+
+/* Recessed, like every other place this app shows machine output. */
+.deployments-log {
+  flex: 1;
+  min-height: 0;
+  background: var(--surface-recessed);
+  border: var(--border-width-default) solid var(--border-subtle);
+  border-radius: var(--radius-card);
+  overflow: auto;
+}
+
+.deployments-log-body {
+  margin: 0;
+  padding: var(--spacing-md);
+  color: var(--text-terminal);
+  font-family: var(--font-code);
+  font-size: var(--font-size-body-sm);
+  line-height: var(--line-height-help);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.deployments-log-loading {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md);
+  color: var(--text-muted);
+}
+
+.deployments-log-note {
+  margin: 0;
+  padding: var(--spacing-md);
+  color: var(--text-muted);
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-help);
+}
+
+.deployments-note {
+  margin: 0;
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-body-md);
+}

--- a/src/styles/features/publish/dropdown.css
+++ b/src/styles/features/publish/dropdown.css
@@ -67,93 +67,11 @@
   letter-spacing: var(--tracking-code);
   text-transform: uppercase;
 }
-
-.publish-hosting-plugins,
-.publish-hosting-plugins .cf-dropdown-wrapper,
-.publish-hosting-plugins .vercel-button-container {
-  width: 100%;
-}
-
-/* The rules below inline the plugins' own toolbar popovers (they ship as
-   `position: absolute` hover menus) into this section's flow. They match the
-   plugins' class names, which have drifted before — `.vercel-dropdown-wrapper`
-   became `.vercel-button-container`. Containing block + stacking context here
-   means the next rename degrades to a misplaced card inside the section rather
-   than one floating over the push status line above it. */
-.publish-hosting-plugins {
-  position: relative;
-  isolation: isolate;
-}
-
-.publish-hosting-plugins .cf-dropdown-wrapper,
-.publish-hosting-plugins .cf-dropdown,
-.publish-hosting-plugins .vercel-button-container,
-.publish-hosting-plugins .vercel-site-dropdown {
-  position: static;
-}
-
-.publish-hosting-plugins .cf-dropdown-wrapper > .toolbar-icon-btn,
-.publish-hosting-plugins .vercel-button-container > .toolbar-icon-btn {
-  display: none;
-}
-
-.publish-hosting-plugins .toolbar-icon-btn {
-  justify-content: flex-start;
-  width: 100%;
-}
-
-.publish-hosting-plugins .cf-dropdown,
-.publish-hosting-plugins .vercel-site-dropdown {
-  box-sizing: border-box;
-  width: 100%;
-  min-width: 0;
-  max-width: none;
-  max-height: none;
-  height: auto;
-  overflow: visible;
-  background: var(--surface-panel);
-  box-shadow: none;
-}
-
-.publish-hosting-plugins .cf-dropdown-inner,
-.publish-hosting-plugins .vercel-site-dropdown-inner {
-  box-sizing: border-box;
-  width: 100%;
-  min-width: 0;
-  max-width: none;
-  max-height: none;
-  height: auto;
-  overflow: visible;
-  box-shadow: none;
-}
-
-.publish-hosting-plugins .cf-dropdown-action,
-.publish-hosting-plugins .cf-dropdown-divider,
-.publish-hosting-plugins .vercel-dropdown-action,
-.publish-hosting-plugins .vercel-dropdown-separator:has(+ .vercel-dropdown-action) {
-  display: none;
-}
-
-/* Expand the plugin's secondary action only while its visible card is
-   hovered/focused. The hosting section also contains the heading and inset
-   spacing, which should not activate the card's expanded state. */
-.publish-hosting-plugins .cf-dropdown-inner:hover .cf-dropdown-action,
-.publish-hosting-plugins .cf-dropdown-inner:focus-within .cf-dropdown-action,
-.publish-hosting-plugins .vercel-site-dropdown-inner:hover .vercel-dropdown-action,
-.publish-hosting-plugins .vercel-site-dropdown-inner:focus-within .vercel-dropdown-action {
-  display: flex;
-}
-
-.publish-hosting-plugins .cf-dropdown-inner:hover .cf-dropdown-divider,
-.publish-hosting-plugins .cf-dropdown-inner:focus-within .cf-dropdown-divider,
-.publish-hosting-plugins
-  .vercel-site-dropdown-inner:hover
-  .vercel-dropdown-separator:has(+ .vercel-dropdown-action),
-.publish-hosting-plugins
-  .vercel-site-dropdown-inner:focus-within
-  .vercel-dropdown-separator:has(+ .vercel-dropdown-action) {
-  display: block;
-}
+/* The rules that used to live here reached into the Vercel and Cloudflare
+   plugins' own class names to flatten their absolutely-positioned hover menus
+   into this section, and revealed their hidden actions on `:hover`. The section
+   is native now (see features/publish/hosting.css), so it owns its own markup
+   and its own height. */
 
 .publish-loading {
   display: flex;

--- a/src/styles/features/publish/dropdown.css
+++ b/src/styles/features/publish/dropdown.css
@@ -37,6 +37,12 @@
   top: calc(100% + 8px);
   right: 0;
   width: var(--popover-source-control-width);
+  /* Width was pinned but height was not, so a long changed-files list or a
+     slow-arriving hosting status could grow the panel past the bottom of the
+     screen with no way to reach the actions. Same viewport clamp the sibling
+     `.branches-menu-popover` already uses. */
+  max-height: calc(100vh - var(--spacing-2xl) - var(--panel-header-h));
+  overflow-y: auto;
   background: var(--surface-panel);
   border: 1px solid var(--border-default);
   border-radius: 10px;

--- a/src/styles/features/publish/hosting.css
+++ b/src/styles/features/publish/hosting.css
@@ -216,3 +216,13 @@
   line-height: 14px;
   text-overflow: ellipsis;
 }
+
+/* On a failure this line carries the build error — the reason the user would
+   otherwise open the provider's dashboard, and the whole point of the section
+   showing it. Muted is the right weight for a hint and the wrong weight for
+   that, so it steps up to the same colour as the status line above it. Not to
+   the error red: the dot and the status word already say "failed", and a
+   paragraph of compiler output in red is a wall, not an emphasis. */
+.hosting-links[data-state='failed'] .hosting-links-hint {
+  color: var(--text-secondary);
+}

--- a/src/styles/features/publish/hosting.css
+++ b/src/styles/features/publish/hosting.css
@@ -1,0 +1,143 @@
+/* Hosting section — fixed geometry.
+ *
+ * Every rule here exists to keep the row the same height in all 18 states. The
+ * section this replaced grew ~85px when deployment data arrived and another
+ * ~105px when the pointer entered it, because the host revealed the plugin's
+ * hidden actions on `:hover`. Nothing below may change `display`, `height`,
+ * `padding`, `margin`, or `visibility` on hover — asserted by a test that reads
+ * this file. */
+
+.hosting-row {
+  display: grid;
+  grid-template-columns: var(--hosting-icon-slot) minmax(0, 1fr) var(--hosting-action-w);
+  align-items: center;
+  gap: var(--spacing-sm);
+  height: var(--hosting-row-h);
+}
+
+/* Fixed square so a brand mark, a spinner, and a status dot all occupy exactly
+   the same footprint — the same trick SetupItem uses for its six statuses. */
+.hosting-row-icon {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--hosting-icon-slot);
+  height: var(--hosting-icon-slot);
+  color: var(--text-secondary);
+}
+
+.hosting-row-globe {
+  width: 12px;
+  height: 12px;
+  border: var(--stroke-1) solid var(--text-muted);
+  border-radius: var(--radius-full);
+}
+
+.hosting-row-spinner {
+  position: absolute;
+  right: -2px;
+  bottom: -2px;
+}
+
+.hosting-row-dot {
+  position: absolute;
+  right: -2px;
+  bottom: -2px;
+  width: 8px;
+  height: 8px;
+  border: var(--stroke-2) solid var(--surface-panel);
+  border-radius: var(--radius-full);
+}
+
+.hosting-row-dot--success {
+  background: var(--accent-success);
+}
+
+.hosting-row-dot--progress {
+  background: var(--accent-warning);
+}
+
+.hosting-row-dot--error {
+  background: var(--accent-error);
+}
+
+.hosting-row-dot--muted {
+  background: var(--text-muted);
+}
+
+.hosting-row-dot--hollow {
+  background: transparent;
+  border-color: var(--text-muted);
+}
+
+/* The "it worked" signal must persist. The previous implementation faded its
+   success dot to zero opacity after 5s and left it invisible forever. */
+.hosting-row-dot--pulsing {
+  animation: skeleton-pulse 1.6s ease-in-out infinite;
+}
+
+.hosting-row-text {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+  gap: var(--spacing-3xs);
+}
+
+/* Both lines are single-line and ellipsised. A wrapping status line is how the
+   old panel changed height depending on how long an account name happened to
+   be; the full text stays available via the title attribute. */
+.hosting-row-title,
+.hosting-row-status {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.hosting-row-title {
+  color: var(--text-primary);
+  font-size: var(--font-size-body-md);
+  line-height: 16px;
+}
+
+.hosting-row-status {
+  color: var(--text-secondary);
+  font-size: var(--font-size-body-sm);
+  line-height: 14px;
+}
+
+.hosting-row-stale {
+  color: var(--text-faint);
+}
+
+/* Always occupies its column, even with no action to offer, so the text column
+   never widens or narrows between states. */
+.hosting-row-action {
+  display: flex;
+  justify-content: flex-end;
+  width: var(--hosting-action-w);
+}
+
+.hosting-row-action[data-empty='true'] {
+  visibility: hidden;
+}
+
+/* Third line. Fixed height whether or not there's a hint, so a state that has
+   one and a state that doesn't are the same size. */
+.hosting-links {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  height: var(--hosting-links-h);
+  overflow: hidden;
+}
+
+.hosting-links-hint {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: var(--font-size-body-sm);
+  line-height: 14px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/src/styles/features/publish/hosting.css
+++ b/src/styles/features/publish/hosting.css
@@ -123,6 +123,65 @@
   visibility: hidden;
 }
 
+/* The addresses this deployment produced. Each row is a fixed height so the
+   section's height depends only on how many URLs exist — which is a property
+   of the deployment, not of loading. */
+.hosting-urls {
+  display: flex;
+  flex-direction: column;
+  margin-top: var(--spacing-2xs);
+}
+
+.hosting-url {
+  display: grid;
+  grid-template-columns: var(--hosting-url-label-w) minmax(0, 1fr) var(--hosting-url-open-w);
+  align-items: center;
+  gap: var(--spacing-xs);
+  height: var(--hosting-url-h);
+}
+
+.hosting-url-label {
+  color: var(--text-muted);
+  font-size: var(--font-size-body-sm);
+}
+
+.hosting-url-value {
+  min-width: 0;
+  color: var(--text-secondary);
+  font-family: var(--font-code);
+  font-size: var(--font-size-body-sm);
+}
+
+/* Revealed on hover/focus. `opacity` and not `display` or `visibility`:
+   nothing here may reflow, and the button's column is reserved either way, so
+   the row is the same height and width whether or not the pointer is on it. */
+.hosting-url-open {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--hosting-url-open-w);
+  height: var(--hosting-url-open-w);
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity var(--transition-interaction),
+    color var(--transition-interaction);
+}
+
+.hosting-url:hover .hosting-url-open,
+.hosting-url-open:focus-visible {
+  opacity: 1;
+}
+
+.hosting-url-open:hover {
+  color: var(--text-primary);
+}
+
 /* Third line. Fixed height whether or not there's a hint, so a state that has
    one and a state that doesn't are the same size. */
 .hosting-links {

--- a/src/styles/features/publish/hosting.css
+++ b/src/styles/features/publish/hosting.css
@@ -143,8 +143,15 @@
 }
 
 .hosting-url-label {
+  /* Clips rather than overflows. A label longer than its column used to spill
+     across the address beside it and paint over the text, because a grid item
+     with no min-width happily overflows its track. */
+  min-width: 0;
+  overflow: hidden;
   color: var(--text-muted);
   font-size: var(--font-size-body-sm);
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .hosting-url-value {

--- a/src/styles/features/publish/hosting.css
+++ b/src/styles/features/publish/hosting.css
@@ -87,7 +87,10 @@
 
 /* Both lines are single-line and ellipsised. A wrapping status line is how the
    old panel changed height depending on how long an account name happened to
-   be; the full text stays available via the title attribute. */
+   be. There is deliberately no `title` tooltip to recover the clipped text —
+   a native tooltip paints over the row beneath it and lags a state change — so
+   the copy in lib/hostingCopy is written to fit 184px instead, and anything
+   longer is moved to .hosting-links-hint below. */
 .hosting-row-title,
 .hosting-row-status {
   overflow: hidden;
@@ -184,21 +187,32 @@
   opacity: 1;
 }
 
-/* Third line. Fixed height whether or not there's a hint, so a state that has
-   one and a state that doesn't are the same size. */
+/* Third line: the one place a sentence gets room.
+ *
+ * It spans the section rather than sharing the row's 184px text column, and it
+ * may take a second line — a build error, a skip reason, or a provider's
+ * qualifier is the informative half of what the section has to say, and
+ * clipping it at 32 characters is how this panel used to render
+ * "Vercel skipped this push — [skip ci…". Two lines is the cap: past that a
+ * provider's stack trace would push the popover's actions off screen.
+ *
+ * The height still has a floor, so a one-line hint and a two-line hint don't
+ * make neighbouring states look like different components. */
 .hosting-links {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  height: var(--hosting-links-h);
+  min-height: var(--hosting-links-h);
   overflow: hidden;
 }
 
 .hosting-links-hint {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   overflow: hidden;
   color: var(--text-muted);
   font-size: var(--font-size-body-sm);
   line-height: 14px;
-  white-space: nowrap;
   text-overflow: ellipsis;
 }

--- a/src/styles/features/publish/hosting.css
+++ b/src/styles/features/publish/hosting.css
@@ -107,10 +107,6 @@
   line-height: 14px;
 }
 
-.hosting-row-stale {
-  color: var(--text-faint);
-}
-
 /* Always occupies its column, even with no action to offer, so the text column
    never widens or narrows between states. */
 .hosting-row-action {
@@ -133,6 +129,12 @@
 }
 
 .hosting-url {
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
   display: grid;
   grid-template-columns: var(--hosting-url-label-w) minmax(0, 1fr) var(--hosting-url-open-w);
   align-items: center;
@@ -152,8 +154,12 @@
   font-size: var(--font-size-body-sm);
 }
 
+.hosting-url:hover .hosting-url-value {
+  color: var(--text-primary);
+}
+
 /* Revealed on hover/focus. `opacity` and not `display` or `visibility`:
-   nothing here may reflow, and the button's column is reserved either way, so
+   nothing here may reflow, and the icon's column is reserved either way, so
    the row is the same height and width whether or not the pointer is on it. */
 .hosting-url-open {
   display: flex;
@@ -161,25 +167,14 @@
   justify-content: center;
   width: var(--hosting-url-open-w);
   height: var(--hosting-url-open-w);
-  padding: 0;
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-sm);
   color: var(--text-muted);
-  cursor: pointer;
   opacity: 0;
-  transition:
-    opacity var(--transition-interaction),
-    color var(--transition-interaction);
+  transition: opacity var(--transition-interaction);
 }
 
 .hosting-url:hover .hosting-url-open,
-.hosting-url-open:focus-visible {
+.hosting-url:focus-visible .hosting-url-open {
   opacity: 1;
-}
-
-.hosting-url-open:hover {
-  color: var(--text-primary);
 }
 
 /* Third line. Fixed height whether or not there's a hint, so a state that has

--- a/src/styles/global/token-inventory.json
+++ b/src/styles/global/token-inventory.json
@@ -3926,7 +3926,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": true,
-      "consumerCount": 341
+      "consumerCount": 342
     },
     {
       "name": "--text-muted",

--- a/src/styles/global/token-inventory.json
+++ b/src/styles/global/token-inventory.json
@@ -484,7 +484,7 @@
       "status": "migration",
       "pluginStable": false,
       "removalCondition": "Remove after internal consumers migrate to the canonical semantic role.",
-      "consumerCount": 34
+      "consumerCount": 36
     },
     {
       "name": "--shadow",
@@ -1067,6 +1067,69 @@
       "consumerCount": 0
     },
     {
+      "name": "--size-hosting-row",
+      "definitionFile": "src/styles/global/tokens-components.css",
+      "layer": "components",
+      "owner": "global/component",
+      "status": "canonical",
+      "pluginStable": false,
+      "consumerCount": 0
+    },
+    {
+      "name": "--size-hosting-links",
+      "definitionFile": "src/styles/global/tokens-components.css",
+      "layer": "components",
+      "owner": "global/component",
+      "status": "canonical",
+      "pluginStable": false,
+      "consumerCount": 0
+    },
+    {
+      "name": "--size-hosting-icon-slot",
+      "definitionFile": "src/styles/global/tokens-components.css",
+      "layer": "components",
+      "owner": "global/component",
+      "status": "canonical",
+      "pluginStable": false,
+      "consumerCount": 0
+    },
+    {
+      "name": "--size-hosting-action",
+      "definitionFile": "src/styles/global/tokens-components.css",
+      "layer": "components",
+      "owner": "global/component",
+      "status": "canonical",
+      "pluginStable": false,
+      "consumerCount": 0
+    },
+    {
+      "name": "--size-hosting-url-row",
+      "definitionFile": "src/styles/global/tokens-components.css",
+      "layer": "components",
+      "owner": "global/component",
+      "status": "canonical",
+      "pluginStable": false,
+      "consumerCount": 0
+    },
+    {
+      "name": "--size-hosting-url-label",
+      "definitionFile": "src/styles/global/tokens-components.css",
+      "layer": "components",
+      "owner": "global/component",
+      "status": "canonical",
+      "pluginStable": false,
+      "consumerCount": 0
+    },
+    {
+      "name": "--size-hosting-url-open",
+      "definitionFile": "src/styles/global/tokens-components.css",
+      "layer": "components",
+      "owner": "global/component",
+      "status": "canonical",
+      "pluginStable": false,
+      "consumerCount": 0
+    },
+    {
       "name": "--property-surface",
       "definitionFile": "src/styles/global/tokens-components.css",
       "layer": "components",
@@ -1451,7 +1514,7 @@
       "owner": "Button",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 45
+      "consumerCount": 46
     },
     {
       "name": "--button-radius",
@@ -2163,6 +2226,69 @@
       "status": "canonical",
       "pluginStable": false,
       "consumerCount": 5
+    },
+    {
+      "name": "--hosting-row-h",
+      "definitionFile": "src/styles/global/tokens-components.css",
+      "layer": "components",
+      "owner": "global/component",
+      "status": "canonical",
+      "pluginStable": false,
+      "consumerCount": 1
+    },
+    {
+      "name": "--hosting-links-h",
+      "definitionFile": "src/styles/global/tokens-components.css",
+      "layer": "components",
+      "owner": "global/component",
+      "status": "canonical",
+      "pluginStable": false,
+      "consumerCount": 1
+    },
+    {
+      "name": "--hosting-icon-slot",
+      "definitionFile": "src/styles/global/tokens-components.css",
+      "layer": "components",
+      "owner": "global/component",
+      "status": "canonical",
+      "pluginStable": false,
+      "consumerCount": 3
+    },
+    {
+      "name": "--hosting-action-w",
+      "definitionFile": "src/styles/global/tokens-components.css",
+      "layer": "components",
+      "owner": "global/component",
+      "status": "canonical",
+      "pluginStable": false,
+      "consumerCount": 2
+    },
+    {
+      "name": "--hosting-url-h",
+      "definitionFile": "src/styles/global/tokens-components.css",
+      "layer": "components",
+      "owner": "global/component",
+      "status": "canonical",
+      "pluginStable": false,
+      "consumerCount": 1
+    },
+    {
+      "name": "--hosting-url-label-w",
+      "definitionFile": "src/styles/global/tokens-components.css",
+      "layer": "components",
+      "owner": "global/component",
+      "status": "canonical",
+      "pluginStable": false,
+      "consumerCount": 1
+    },
+    {
+      "name": "--hosting-url-open-w",
+      "definitionFile": "src/styles/global/tokens-components.css",
+      "layer": "components",
+      "owner": "global/component",
+      "status": "canonical",
+      "pluginStable": false,
+      "consumerCount": 3
     },
     {
       "name": "--source-control-branch-max-width",
@@ -3287,7 +3413,7 @@
       "owner": "global/core",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 83
+      "consumerCount": 84
     },
     {
       "name": "--stroke-2",
@@ -3296,7 +3422,7 @@
       "owner": "global/core",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 21
+      "consumerCount": 22
     },
     {
       "name": "--stroke-hairline",
@@ -3503,7 +3629,7 @@
       "owner": "global/core",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 11
+      "consumerCount": 12
     },
     {
       "name": "--font-weight-semibold",
@@ -3719,7 +3845,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 319
+      "consumerCount": 322
     },
     {
       "name": "--surface-control-hover",
@@ -3728,7 +3854,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 30
+      "consumerCount": 31
     },
     {
       "name": "--surface-selected",
@@ -3746,7 +3872,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 25
+      "consumerCount": 26
     },
     {
       "name": "--surface-terminal-input",
@@ -3791,7 +3917,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": true,
-      "consumerCount": 429
+      "consumerCount": 432
     },
     {
       "name": "--text-secondary",
@@ -3800,7 +3926,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": true,
-      "consumerCount": 335
+      "consumerCount": 341
     },
     {
       "name": "--text-muted",
@@ -3809,7 +3935,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": true,
-      "consumerCount": 590
+      "consumerCount": 604
     },
     {
       "name": "--text-faint",
@@ -3827,7 +3953,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": true,
-      "consumerCount": 3
+      "consumerCount": 4
     },
     {
       "name": "--text-terminal-strong",
@@ -3863,7 +3989,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 60
+      "consumerCount": 61
     },
     {
       "name": "--border-strong",
@@ -3890,7 +4016,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 63
+      "consumerCount": 64
     },
     {
       "name": "--accent-active",
@@ -3953,7 +4079,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 65
+      "consumerCount": 67
     },
     {
       "name": "--accent-warning",
@@ -3962,7 +4088,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 68
+      "consumerCount": 71
     },
     {
       "name": "--accent-error",
@@ -3971,7 +4097,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 73
+      "consumerCount": 76
     },
     {
       "name": "--accent-error-light",
@@ -4070,7 +4196,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": true,
-      "consumerCount": 138
+      "consumerCount": 141
     },
     {
       "name": "--font-symbol",
@@ -4151,7 +4277,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 215
+      "consumerCount": 224
     },
     {
       "name": "--font-size-body-sm",
@@ -4160,7 +4286,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 229
+      "consumerCount": 235
     },
     {
       "name": "--font-size-control",
@@ -4214,7 +4340,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 115
+      "consumerCount": 116
     },
     {
       "name": "--font-size-3xl",
@@ -4259,7 +4385,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 23
+      "consumerCount": 24
     },
     {
       "name": "--font-weight-heading",
@@ -4313,7 +4439,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 22
+      "consumerCount": 23
     },
     {
       "name": "--line-height-help",
@@ -4322,7 +4448,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 26
+      "consumerCount": 30
     },
     {
       "name": "--line-height-reading",
@@ -4349,7 +4475,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 27
+      "consumerCount": 29
     },
     {
       "name": "--transition-interaction-slow",
@@ -4466,7 +4592,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 21
+      "consumerCount": 25
     },
     {
       "name": "--spacing-2xs",
@@ -4475,7 +4601,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 70
+      "consumerCount": 78
     },
     {
       "name": "--spacing-xs",
@@ -4484,7 +4610,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 243
+      "consumerCount": 248
     },
     {
       "name": "--spacing-sm",
@@ -4493,7 +4619,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 318
+      "consumerCount": 324
     },
     {
       "name": "--spacing-md",
@@ -4502,7 +4628,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 263
+      "consumerCount": 270
     },
     {
       "name": "--spacing-lg",
@@ -4511,7 +4637,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 124
+      "consumerCount": 126
     },
     {
       "name": "--spacing-xl",
@@ -4520,7 +4646,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 68
+      "consumerCount": 69
     },
     {
       "name": "--spacing-2xl",
@@ -4547,7 +4673,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 134
+      "consumerCount": 135
     },
     {
       "name": "--radius-sm",
@@ -4556,7 +4682,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 183
+      "consumerCount": 185
     },
     {
       "name": "--radius-lg",
@@ -4574,7 +4700,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 18
+      "consumerCount": 19
     },
     {
       "name": "--tint-subtle",

--- a/src/styles/global/token-inventory.json
+++ b/src/styles/global/token-inventory.json
@@ -2531,7 +2531,7 @@
       "owner": "global/component",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 3
+      "consumerCount": 4
     },
     {
       "name": "--preview-toolbar-h",
@@ -4529,7 +4529,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 24
+      "consumerCount": 25
     },
     {
       "name": "--radius-control",

--- a/src/styles/global/tokens-components.css
+++ b/src/styles/global/tokens-components.css
@@ -81,7 +81,8 @@
   --size-hosting-icon-slot: 24px;
   --size-hosting-action: 72px;
   --size-hosting-url-row: 20px;
-  --size-hosting-url-label: 34px;
+  /* Wide enough for the longest label the providers use ('Deployment'). */
+  --size-hosting-url-label: 72px;
   --size-hosting-url-open: 20px;
 
   --property-surface: var(--color-blue-700);

--- a/src/styles/global/tokens-components.css
+++ b/src/styles/global/tokens-components.css
@@ -80,6 +80,9 @@
   --size-hosting-links: 28px;
   --size-hosting-icon-slot: 24px;
   --size-hosting-action: 72px;
+  --size-hosting-url-row: 20px;
+  --size-hosting-url-label: 34px;
+  --size-hosting-url-open: 20px;
 
   --property-surface: var(--color-blue-700);
   --property-surface-hover: var(--color-blue-600);
@@ -225,6 +228,9 @@
   --hosting-links-h: var(--size-hosting-links);
   --hosting-icon-slot: var(--size-hosting-icon-slot);
   --hosting-action-w: var(--size-hosting-action);
+  --hosting-url-h: var(--size-hosting-url-row);
+  --hosting-url-label-w: var(--size-hosting-url-label);
+  --hosting-url-open-w: var(--size-hosting-url-open);
   --source-control-branch-max-width: var(--size-source-control-branch);
   --z-dropdown: 100;
   /* Pane separators (split-pane, docked preview panels). Above a docked panel

--- a/src/styles/global/tokens-components.css
+++ b/src/styles/global/tokens-components.css
@@ -73,6 +73,14 @@
   --size-source-control-popover: 320px;
   --size-source-control-branch: 140px;
 
+  /* Hosting section geometry. These are fixed on purpose: the row must be the
+     same height in every state so the popover never resizes as deployment
+     status arrives. */
+  --size-hosting-row: 56px;
+  --size-hosting-links: 28px;
+  --size-hosting-icon-slot: 24px;
+  --size-hosting-action: 72px;
+
   --property-surface: var(--color-blue-700);
   --property-surface-hover: var(--color-blue-600);
   --property-border: var(--color-blue-700);
@@ -213,6 +221,10 @@
   --extension-state-error-border: color-mix(in srgb, var(--accent-error-deep) 30%, transparent);
   --popover-color-picker-width: var(--size-color-picker-width);
   --popover-source-control-width: var(--size-source-control-popover);
+  --hosting-row-h: var(--size-hosting-row);
+  --hosting-links-h: var(--size-hosting-links);
+  --hosting-icon-slot: var(--size-hosting-icon-slot);
+  --hosting-action-w: var(--size-hosting-action);
   --source-control-branch-max-width: var(--size-source-control-branch);
   --z-dropdown: 100;
   /* Pane separators (split-pane, docked preview panels). Above a docked panel

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -80,6 +80,7 @@
 @import './features/browser-tools.css';
 @import './features/github.css';
 @import './features/publish/dropdown.css';
+@import './features/publish/hosting.css';
 @import './features/publish/rows.css';
 @import './features/publish/states.css';
 @import './features/publish/toasts.css';

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -80,6 +80,7 @@
 @import './features/browser-tools.css';
 @import './features/github.css';
 @import './features/publish/dropdown.css';
+@import './features/publish/deployments.css';
 @import './features/publish/hosting.css';
 @import './features/publish/rows.css';
 @import './features/publish/states.css';

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -8,7 +8,7 @@
  */
 
 import '@testing-library/jest-dom/vitest';
-import { vi, beforeEach, afterEach, beforeAll } from 'vitest';
+import { vi, beforeEach, afterEach } from 'vitest';
 import { mockIPC, mockWindows, clearMocks } from '@tauri-apps/api/mocks';
 
 // Pin the platform so the suite is independent of the host OS. jsdom's default
@@ -53,8 +53,16 @@ export function clearInvokeMocks() {
   invokeErrors.clear();
 }
 
-// Set up Tauri mocks before all tests
-beforeAll(() => {
+/**
+ * Install the Tauri window + IPC mocks.
+ *
+ * Registered per-test rather than once, because `clearMocks()` in `afterEach`
+ * tears `window.__TAURI_INTERNALS__` down — so with a one-time `beforeAll`
+ * every test after the first in a file had no IPC bridge at all, and any
+ * `invoke` silently failed with "invoke is not a function". Harmless for the
+ * many tests that never call one, and invisible until a component polls.
+ */
+function installTauriMocks() {
   // Mock windows
   mockWindows('main');
 
@@ -91,6 +99,22 @@ beforeAll(() => {
         ];
       case 'get_current_branch':
         return 'main';
+      // The Push popover asks for this on open. Default to a well-formed
+      // "deploys nowhere" answer so tests about the popover's structure don't
+      // have to know about hosting; override per-test via mockInvokeResponse.
+      case 'get_hosting_status':
+        return {
+          commit: {
+            sha: 'abc1234def',
+            short_sha: 'abc1234',
+            branch: 'main',
+            has_upstream: true,
+          },
+          providers: [],
+          detected: [],
+        };
+      case 'detect_hosting_links':
+        return [];
       case 'list_branches':
         return [
           {
@@ -115,7 +139,7 @@ beforeAll(() => {
         return undefined;
     }
   });
-});
+}
 
 // Mock tauri-pty (native module)
 vi.mock('tauri-pty', () => ({
@@ -148,6 +172,7 @@ vi.mock('@tauri-apps/plugin-process', () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   clearInvokeMocks();
+  installTauriMocks();
 });
 
 // Cleanup after each test


### PR DESCRIPTION
Replaces the plugin-based hosting integration with a native feature, and begins the plugin wind-down.

## Why

The Hosting section in the Push popover could not answer the question it exists for. It read row 1 of `vercel ls` — the newest deployment on the project across every branch, environment and teammate — and its data type carried no SHA, branch or id to tell them apart. "Ready" meant "something deployed recently", not "your push worked".

Three more defects fell out of the same design:

- **An expired token rendered as healthy.** Vercel answers an expired credential with `403`, the plugin mapped any non-200 to `'unknown'`, and then `'unknown'` was coerced to `'connected'`. The reported symptom — a stuck "Connecting…" with no URL — was a dead login being displayed as fine.
- **A failed production deploy fired a *success* toast** reading "Deploy is still running."
- **Preview URLs were assembled from a naming pattern.** Vercel truncates aliases at 63 characters with a hash substitution, so longer names produced clickable links that 404.
- **Every shell timeout was 1000x too long** — milliseconds passed to a seconds-valued API, clamped at the host's 600s ceiling. The "15-second" poll hung for ten minutes while showing stale status as current.

## What this does

Queries each provider by **commit SHA**, so the answer is about your push. A failed build fetches its own log and surfaces the actual error line. A Deployments panel (Cmd+K -> "View deployments") shows recent deploys with their build output inline, which is what people open the provider dashboard for.

All three adapters are **verified against live accounts**, not documentation. `docs/internal/hosting-provider-matrix.md` records what was observed versus what is still assumed. Testing found things the docs get wrong:

- Vercel returns `aliasAssigned` as a timestamp where the docs imply a boolean — that failed the whole lookup.
- Cloudflare's `stages` array contradicts `latest_stage` on a finished deployment; walking it reports a completed deploy as permanently queued.
- Cloudflare's documented macOS credential path is wrong; `wrangler login` writes somewhere else entirely.
- Netlify returns the branch URL the old plugin was assembling by hand.

The section uses each provider's own vocabulary — "Ready", "Production", "Domain", "Deployment" — rather than translating into synonyms, so this and the provider's dashboard never disagree.

## Plugin wind-down

Superseded plugins are skipped **at load**, not at render: merely not rendering one still runs its activation hook and background timers. The Plugin Manager labels them and explains what took over. Nothing is deleted — some are dev-linked checkouts pointing at a folder someone is working in.

Two bundled agent skills replace five plugins (`brand-guidelines`, `url-to-code`, `webflow-to-code`, `weweb-to-code`, `wordpress-to-code`). The skill installer is now a registry, so retiring the next one is a single entry.

## Notes for reviewers

- **`src/test/setup.ts` is a behavioural change worth a look.** `mockIPC` was registered once in `beforeAll` while `clearMocks()` runs in `afterEach`, so every test after the first in a file ran with no IPC bridge and any `invoke` failed silently with "invoke is not a function". It is now per-test. Some tests were passing for the wrong reason.
- **`check:patterns` gains one rule**, enforcing the hosting section's fixed geometry — nothing in that stylesheet may change layout on hover, which is what made the old section grow ~105px under the cursor.
- **Schema v4**: `ProjectMetadata.publish` is replaced by `hosting`. The old block had no SHA, provider or deployment id and was never read or written by anything.
- **Cloudflare's failing, skipped and git-triggered paths are still unobserved** — the testbed project deploys by direct upload. Those reducers are exercised against documented shapes only, and the matrix doc says so rather than implying coverage.

## Added after the first review pass

The UI harness (#892) landed while this was open, so the ten hosting states were captured and actually looked at. That found things the tests did not.

- **Every state clipped its own status line.** The row's text column is 184px — about 32 characters at 11px — and the copy was writing 44- to 54-character sentences into it, losing the informative half every time: `Vercel skipped this push — [skip ci…`, `Couldn't reach Vercel · last checke…`. Including the most common state, because `Ready · Production · 23 minutes ago` is 35 characters. The status line now carries only what fits (status word, environment, age), the sentence moved to a third line that wraps, and ages are written the way the providers' own dashboards write them ("23m ago"). A unit test holds every string we write to a character budget.
- **Two fixtures claimed a phase their provider cannot emit.** `hosting-publishing` was a Vercel deployment in a phase Vercel has no state for — an invented state this branch had already deleted, outliving the code it came from — and `hosting-skipped` was the same bug, found only by writing a test for the class rather than fixing the instance. `src/harness/scenarios/hosting.test.ts` now checks each fixture against the adapter it claims to come from, and was verified by reverting a fixture and watching it fail.
- **Three dead Tauri commands deleted.** `publish_to_github`, `publish_to_staging` and `publish_to_production` were registered in `lib.rs` with no caller anywhere in `src/`. Two returned `PublishResult { url: "", state: "QUEUED" }` — an unobserved deploy state about a URL nobody knew, which is the pattern this PR exists to remove. `publish_branch` is the live one and stays.
- **CLAUDE.md described the removed flow as current**, down to the `.shipstudio/project.json` publish record that schema v4 deleted early in this branch. It now documents a Hosting Flow with the rules the code actually enforces, and lists the two new modules.

## Known gaps, stated rather than implied

- **Netlify renders as a neutral circle.** There is no Netlify mark in the icon set, and drawing one from memory would be a brand mark that is nearly right — the same class of error as a URL that nearly resolves.
- **No analytics events** for the new section. `branch_published` still fires correctly, so nothing is orphaned; the new surface is simply uninstrumented.
- **Cloudflare's failing and git-triggered paths remain unobserved** (the testbed deploys by direct upload). The skipped path is now exercised in the harness against Cloudflare's documented shape, and `docs/internal/hosting-provider-matrix.md` says which is which.

`pnpm check:all` exit 0. 2269 frontend tests, 1252 Rust tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZfomaM76gpEyruurkUuKh



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in hosting status for Vercel, Cloudflare Pages, and Netlify, including per-commit progress, live URLs, errors, and build logs.
  * Added hosting project linking, credential connection, token verification, and automatic provider-link detection.
  * Added a Deployments view with recent deployments, build output, navigation, and provider links.
  * Added bundled skills for supported coding agents.

* **Changes**
  * Branch publishing now pushes changes; deployment status is shown separately through Hosting.
  * Hosting functionality previously provided by plugins is now built into the app.
  * Superseded hosting plugins are identified as built-in and are no longer loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->