### PR TITLE
Remeasure breakpoint frames when late content changes

### DIFF
--- a/src-tauri/src/proxy/select_script.html
+++ b/src-tauri/src/proxy/select_script.html
@@ -1198,7 +1198,7 @@ function ssSyncPage(){
     ssVHTimer=0;ssPinRootHeight();ssRewriteViewportUnits();ssLoadEverything();ssReportPage();
   },200);
 }
-/* Watch for STYLESHEETS arriving, not for the page living its life. A canvas
+/* Watch for STYLESHEETS arriving without observing attribute changes. A canvas
    holds four of these pages at once; an observer over the whole document with
    attributes on fires on every class toggle a scroll animation makes, in every
    frame, and each firing schedules a walk of the CSSOM and a forced layout.
@@ -1206,6 +1206,34 @@ function ssSyncPage(){
    all this needs to see. NB: no literal opening head/html tag may appear
    anywhere in this file, comments included — the proxy splices its head-start
    snippet at the first such string it finds in the whole response. */
+/* Content can arrive after the initial settle window (async data, expanded
+   sections, images). Measure twice after actual content changes, then stop.
+   Ignore animation-related attribute churn and Ship Studio's own overlays. */
+var ssContentTimer=0;
+function ssSyncContent(){
+  if(!ssCanvas)return;
+  if(ssContentTimer)clearTimeout(ssContentTimer);
+  ssContentTimer=setTimeout(function(){
+    ssContentTimer=0;
+    if(!ssCanvas)return;
+    ssPageSeen=0;ssPageAgreed=0;ssPageWrites=0;ssPageCommitted=[];ssPageLocked=false;
+    ssReportPage();
+    ssContentTimer=setTimeout(function(){ssContentTimer=0;ssReportPage();},200);
+  },200);
+}
+function ssContentOwn(node){
+  var el=node.nodeType===1?node:node.parentElement;
+  return !!(el&&el.closest&&el.closest('[data-ss-overlay],[id^="ss-"]'));
+}
+function ssOnContentMutations(records){
+  for(var i=0;i<records.length;i++){
+    var r=records[i];
+    if(ssContentOwn(r.target))continue;
+    if(r.type==='characterData'){ssSyncContent();return;}
+    var nodes=Array.prototype.slice.call(r.addedNodes).concat(Array.prototype.slice.call(r.removedNodes));
+    for(var j=0;j<nodes.length;j++)if(!ssContentOwn(nodes[j])){ssSyncContent();return;}
+  }
+}
 /* Started only when a canvas takes this frame over, and never otherwise: the
    ordinary single-frame preview must cost exactly what it cost before this
    feature existed. */
@@ -1217,10 +1245,13 @@ function ssWatchPage(){
     new MutationObserver(ssOnHeadMutations).observe(document.head||document.documentElement,
       {childList:true,subtree:true});
   }
+  if(window.MutationObserver&&document.body){
+    new MutationObserver(ssOnContentMutations).observe(document.body,{childList:true,subtree:true,characterData:true});
+    document.body.addEventListener('load',ssSyncContent,true);
+  }
   window.addEventListener('load',ssSyncPage);
-  /* Everything else that changes a page's length — fonts landing, images
-     sizing, content revealed on load — happens early and then stops. A few
-     checks over the first few seconds cover it without watching forever. */
+  /* Cover startup layout and fonts with a bounded settle window. Later
+     content and image loads are handled by the debounced content watcher. */
   var ticks=0;
   var settle=setInterval(function(){
     if(++ticks>24){clearInterval(settle);return;}

--- a/src/components/edit/selectScriptCanvas.test.ts
+++ b/src/components/edit/selectScriptCanvas.test.ts
@@ -58,3 +58,31 @@ it('pins the root height for a canvas without touching the site around it', asyn
   observer.disconnect();
   expect(mutations).toEqual([]);
 });
+
+it('remeasures late content after settling and shrinks again without idle polling', async () => {
+  document.body.innerHTML = '<main></main>';
+  window.dispatchEvent(
+    new MessageEvent('message', { data: { type: 'ss:canvas', on: true, vh: 700 } })
+  );
+  document.body.style.margin = '0';
+  const main = document.querySelector('main')!;
+  vi.spyOn(main, 'getBoundingClientRect').mockReturnValue({ bottom: 900 } as DOMRect);
+  await vi.advanceTimersByTimeAsync(11000);
+  const post = vi.spyOn(window.parent, 'postMessage');
+  const extra = document.createElement('section');
+  vi.spyOn(extra, 'getBoundingClientRect').mockReturnValue({ bottom: 2800 } as DOMRect);
+  document.body.appendChild(extra);
+  await vi.advanceTimersByTimeAsync(800);
+  expect(post).toHaveBeenCalledWith({ type: 'ss:pageHeight', height: 2800 }, '*');
+  extra.remove();
+  await vi.advanceTimersByTimeAsync(800);
+  expect(post).toHaveBeenCalledWith({ type: 'ss:pageHeight', height: 900 }, '*');
+  const count = post.mock.calls.filter(
+    ([d]) => (d as { type?: string }).type === 'ss:pageHeight'
+  ).length;
+  await vi.advanceTimersByTimeAsync(12000);
+  expect(
+    post.mock.calls.filter(([d]) => (d as { type?: string }).type === 'ss:pageHeight')
+  ).toHaveLength(count);
+  post.mockRestore();
+});


### PR DESCRIPTION
Carries **@yeezyslide's** commit `6bc7924e` onto main, unchanged and with his authorship intact. This is his work, not mine — see #890, which is where it was written and reviewed.

## Why this is a separate PR

The canvas landed in #893 **without** this fix. #890 targeted the canvas branch, was still a draft when #893 merged, and its content did not come along. Verified on main rather than inferred from SHAs: `select_script.html` has zero occurrences of `ssSyncContent`, and `selectScriptCanvas.test.ts` is 60 lines rather than 88.

I could not un-draft #890 — that action is blocked in my session, and I am not going to reach around a permission decision by another route or ask another session to do it for me. So rather than leave the gap on main, this lands the same commit through a PR I am allowed to open. **#890 should be closed by its author, not by me** — nothing here supersedes his judgement about his own work.

## What the gap actually was

Measurement on main is covered by a bounded settle window — a `setInterval` capped at 24 ticks, so roughly the first five seconds after load. Content arriving later (async data, an expanded section, a late image) never triggers a remeasure, and the frame shows short or clipped. Mason's fix replaces the tail of that polling with a debounced content observer: it measures twice after real content changes and then stops, deliberately avoids `attributes: true` (the churn the existing head-observer comment warns about), and ignores Ship Studio's own overlays.

His test asserts the shrink case as well as the grow case, and that nothing polls once things settle.

## Verification

Cherry-picked cleanly onto `21679300`, no conflicts. Locally: `check:all`, `lint:strict`, typecheck, **2176** frontend tests (one more than main — his new test) and **1176** Rust tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMXU5Xkzu3SpnGKx9hzJfQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Page height now updates automatically when content loads or changes asynchronously.
  * Canvas sizing correctly adjusts when content is added or removed after initial loading.
  * Prevents unnecessary continued polling once the page has stabilized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->