### PR TITLE
Harness: refuse to capture a checkout that isn't yours

### DIFF
--- a/.claude/skills/ui-harness/SKILL.md
+++ b/.claude/skills/ui-harness/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: ui-harness
+description: Look at Ship Studio's actual UI. Boots the real frontend in headless Chrome against a fixture backend and captures screenshots of any app state — dashboard, onboarding, workspace, modals, deploy states — without a Tauri build, a real machine state, or any third-party account. Use whenever you need to check what a screen looks like, verify a UI change, reproduce a state that is awkward to reach for real, or answer "does this look right" instead of guessing from code.
+---
+
+# Seeing Ship Studio
+
+You can look at this app. Do that instead of reasoning about the UI from source.
+
+## Run it
+
+```bash
+pnpm harness &                             # dev server on 127.0.0.1:1425
+node scripts/harness-capture.mjs --all     # ~70 PNGs + harness/shots/report.md
+```
+
+Then read `harness/shots/report.md` and open the PNGs you care about. Narrow the
+sweep while iterating:
+
+```bash
+node scripts/harness-capture.mjs hosting-        # id prefix filter
+node scripts/harness-capture.mjs --commands      # palette sweep only
+node scripts/harness-capture.mjs --out /tmp/a    # somewhere else
+```
+
+The runner exits non-zero if anything crashed, never settled, or asked for a
+Tauri command with no fixture.
+
+## The two modes
+
+**Scenarios** (`src/harness/scenarios/`) are hand-written states that are slow
+or awkward to reach for real: an empty account, a fresh machine, 24 projects, a
+failed deploy, an expired token, merge conflicts. Each carries a
+`looksRightWhen` line saying what to check.
+
+**Commands** (`--commands`) sweeps every action registered in the Cmd+K palette,
+one page load each. `CLAUDE.md` requires every user-facing feature to register
+there, so this list is the app's own inventory and tracks new features
+automatically.
+
+## Check the screenshots are of YOUR tree
+
+The runner does this for you: the harness serves `/__harness/identity` and the
+capture aborts if the server on the port belongs to a different checkout. If you
+see that error, another worktree is holding the port — give yours its own:
+
+```bash
+SHIPSTUDIO_HARNESS_PORT=1426 pnpm harness &
+SHIPSTUDIO_HARNESS_PORT=1426 node scripts/harness-capture.mjs --all
+```
+
+Every `report.md` records the checkout path and HEAD it came from. When you cite
+a screenshot as evidence, that line is what makes it evidence rather than an
+image. This guard exists because a capture once attached to a neighbouring
+worktree's harness and produced a complete, confidently-labelled set of
+screenshots of the wrong tree.
+
+## Give every new scenario a `requires`
+
+`requires: '<selector>'` fails the capture when nothing matches. Without it, a
+scenario whose surface stopped rendering still yields a clean screenshot of
+whatever else was on screen, under that scenario's name. Point it at the thing
+the scenario is actually about — the popover, the panel, the list — not at
+page chrome that is always present.
+
+## Read the "Text being cut off" section
+
+`report.md` lists elements whose content is wider than the box drawn for it.
+Truncation is a few pixels of "…" in a screenshot — easy to read straight past,
+and easy to conclude a capture passes when a status line lost its informative
+half. Check what got cut, not just that something did. It never fails a run;
+some truncation is intended.
+
+## The rule you must not break
+
+**A Tauri command with no fixture is never given a plausible default.** It is
+recorded, badged in the UI, and fails the capture run.
+
+If a scenario reports unmocked commands, its screenshot is *incomplete* and is
+not evidence. Add the fixture first. Copy the shape from the `invoke<...>` type
+at the real call site — including its snake_case/camelCase inconsistency, which
+is not uniform across the backend. A fixture that tidies the casing tests a
+response the app never receives.
+
+An empty array is fine — "nothing configured yet" is a real backend answer. A
+*made-up* value is not.
+
+## Adding a scenario
+
+```ts
+{
+  id: 'branches-many',
+  title: 'Branches — a busy repo',
+  looksRightWhen: 'Long names truncate rather than overflow.',
+  project: WORKSPACE_PROJECT,                    // open a workspace
+  openSelector: '.source-control-push-button',   // click once settled
+  clipSelector: '.publish-dropdown-menu',        // capture just this element
+  storage: { 'shipstudio.onboardingMode': 'classic' },
+  commands: { ...workspaceCommands, list_branches: [...] },
+}
+```
+
+Register it in `src/harness/scenarios/index.ts`.
+
+Use `clipSelector` for popovers and modals. The harness has no dev server and
+no PTY, so the surrounding workspace shows a permanent "Starting dev server…"
+spinner and an idle agent pane; clipping keeps those artifacts out of frame.
+
+## What it cannot tell you
+
+- **Nothing about Rust.** Backend logic, path validation, and the git/provider
+  adapters have their own `cargo test` suites.
+- **Chrome, not WebKit.** Ship Studio ships in a WKWebView. WebKit-specific
+  layout bugs will not appear — the CSP/terminal-font gotcha in `CLAUDE.md` is
+  the standing example.
+- **No real PTY, dev server, or network.** External DNS is blocked so runs are
+  hermetic.
+- It proves the UI renders a given backend answer correctly. It does not prove
+  any backend ever sends that answer.
+
+## Reproducibility
+
+Motion is frozen, storage is wiped per load, external DNS is blocked, and each
+capture shoots until two consecutive frames agree. Roughly 80% of captures are
+byte-identical across runs; the rest vary in async regions (terminal output,
+workspace panel toggles). `report.json` carries `stable` per capture. Do not
+treat a byte diff between runs as a regression on its own — look at the image.

--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,13 @@ dist-ssr
 *.sw?
 ShipStudio.zip
 
-# Claude Code skills
+# Claude Code local state. `.claude/` also holds settings.local.json and the
+# worktrees, which must stay out of the repo — but skills are instructions for
+# whoever works here next, and a skill that lives on one machine is not
+# documentation. Ignore the directory, re-include just the skills.
 .agents/
-.claude/
+.claude/*
+!.claude/skills/
 
 # Local Cargo config (contains build-time secrets)
 src-tauri/.cargo/

--- a/docs/ui-harness.md
+++ b/docs/ui-harness.md
@@ -91,6 +91,14 @@ with both paths named. Two shapes of failure are caught: a server that cannot
 answer the endpoint at all (stale, or unrelated), and one that answers with a
 different root.
 
+The check runs before **every** capture, not once at startup. `strictPort`
+frees the port the moment a harness dies, so a server can be replaced partway
+through a run — and when that happened, `ready` and `stable` both reported
+healthy for pages serving a different product entirely. Those signals describe
+the page that answered; neither can tell you it was the wrong page. If the root
+or HEAD changes mid-run the sweep aborts and names the scenario it stopped at,
+so captures taken before that point stay usable.
+
 To run harnesses from several worktrees at once, give each its own port:
 
 ```bash
@@ -100,6 +108,22 @@ SHIPSTUDIO_HARNESS_PORT=1426 node scripts/harness-capture.mjs --all
 
 `strictPort` is deliberately still on: a harness that silently moved to another
 port would reintroduce exactly the ambiguity this section is about.
+
+## Text being cut off
+
+`report.md` lists every visible element whose content is wider than its box
+(`text-overflow: ellipsis` or a line clamp, with `scrollWidth > clientWidth`),
+per capture.
+
+This is reported, never failed — plenty of truncation is deliberate. It exists
+because truncation is technically visible in a screenshot and practically
+invisible to a reviewer: a sentence clipped in a 184px column ends in a few
+pixels of "…", and it is entirely possible to read a set of captures twice,
+conclude they pass, and have missed that every status line lost its informative
+half. That is a real account of what happened, not a hypothetical. The list
+turns "look carefully" into something the runner can point at.
+
+Check what got cut, not just that something did.
 
 ## The one rule that makes it trustworthy
 

--- a/docs/ui-harness.md
+++ b/docs/ui-harness.md
@@ -31,6 +31,14 @@ node scripts/harness-capture.mjs hosting-       # filter by id prefix
 node scripts/harness-capture.mjs --out /tmp/a   # capture somewhere else
 ```
 
+A full run owns the output directory and clears it, so nothing stale can be
+mistaken for current. A **filtered** run does not: it overwrites only what it
+captures, leaves the rest of the directory alone, and stamps `report.md` with a
+"Partial run" banner naming the filter. Otherwise re-capturing one scenario
+would delete the set a reviewer is halfway through, and the report replacing
+theirs would describe four files while the directory quietly held two runs at
+once.
+
 Interactively, open `http://127.0.0.1:1425/harness.html?scenario=<id>`. A
 switcher at the bottom lists every scenario and states what the screen is
 supposed to look like. Useful query parameters:

--- a/docs/ui-harness.md
+++ b/docs/ui-harness.md
@@ -67,6 +67,40 @@ palette gates on where you are. Non-visual and navigational commands are skipped
 via `SKIP_COMMANDS` in the runner, and every skip is listed in the report so the
 list cannot quietly hide a broken feature.
 
+## Provenance: which tree did these screenshots come from?
+
+The capture runner refuses to screenshot a harness that is serving a different
+checkout, and every report records the checkout path and HEAD it came from.
+
+This exists because of a real failure. The runner originally checked only that
+*something* answered on the harness port. On a machine running several
+worktrees — four agent sessions and five worktrees, on the day this was
+written — a capture attached to a neighbour's harness, screenshotted their
+tree, and wrote seventy-one green checkmarks plus a report captioned with
+*this* checkout's scenario names. Real images, wrong tree, no warning. Someone
+was one screenshot away from reporting ten deployment states verified against a
+build that did not contain the feature.
+
+That is worse than any bug the harness was built to catch, because every other
+failure here is loud: a missing fixture badges red, a crash fails the run, an
+unsettled frame is marked unstable. This one wrote ✓.
+
+So the harness now serves `/__harness/identity` (absolute repo root + git HEAD)
+and the runner compares it against the directory it was invoked from, aborting
+with both paths named. Two shapes of failure are caught: a server that cannot
+answer the endpoint at all (stale, or unrelated), and one that answers with a
+different root.
+
+To run harnesses from several worktrees at once, give each its own port:
+
+```bash
+SHIPSTUDIO_HARNESS_PORT=1426 pnpm harness &
+SHIPSTUDIO_HARNESS_PORT=1426 node scripts/harness-capture.mjs --all
+```
+
+`strictPort` is deliberately still on: a harness that silently moved to another
+port would reintroduce exactly the ambiguity this section is about.
+
 ## The one rule that makes it trustworthy
 
 **A command with no fixture is never given a plausible default.**
@@ -171,5 +205,5 @@ itself.
 | `src/harness/freeze.css` | Capture determinism |
 | `src/harness/scenarios/` | The fixture layers above |
 | `src/harness/stubs/` | Inert `tauri-pty`, screenshots, updater |
-| `scripts/harness-capture.mjs` | Headless capture, `report.md`, `report.json` |
+| `scripts/harness-capture.mjs` | Headless capture, identity guard, `report.md`, `report.json` |
 | `.claude/skills/ui-harness/SKILL.md` | So an agent discovers this without being told |

--- a/docs/ui-harness.md
+++ b/docs/ui-harness.md
@@ -267,6 +267,19 @@ itself.
 - It proves the UI renders a given backend answer correctly. It does not prove
   that any provider or backend ever sends that answer.
 
+## How an agent finds this
+
+The entry point is the **"Looking at the UI" section of `CLAUDE.md`**, which is
+tracked and loaded for every agent working in this repo, plus the pointer in
+`CONTRIBUTING.md` and this document.
+
+There is deliberately no skill file in the repo: `.gitignore` excludes
+`.claude/` (see the "Claude Code skills" comment there), so anything written
+under it would exist on one machine and nowhere else — which is the failure
+this document spends a section warning about. A local `.claude/skills/` copy is
+fine as a personal convenience; it is not a way to ship instructions to anyone
+else.
+
 ## Files
 
 | Path | Role |
@@ -281,4 +294,3 @@ itself.
 | `src/harness/scenarios/` | The fixture layers above |
 | `src/harness/stubs/` | Inert `tauri-pty`, screenshots, updater |
 | `scripts/harness-capture.mjs` | Headless capture, identity guard, `report.md`, `report.json` |
-| `.claude/skills/ui-harness/SKILL.md` | So an agent discovers this without being told |

--- a/docs/ui-harness.md
+++ b/docs/ui-harness.md
@@ -128,13 +128,29 @@ fixture written before or after its subject exists has an expiry date, and
 nothing in a repo marks it. `requires` marks it.
 
 Adding it found two of this repo's own scenarios reviewing nothing: `conflicts`
-and `prs-open` carry populated fixtures but never navigate to the surface they
-describe, so they were capturing the Preview tab. They now run a palette
-command (`command: 'branch.viewPRs'`) to get there, and `conflicts` still does
-not reach its panel — the command is gated on state the fixtures do not
-satisfy. Both are deliberately left without `requires` until they genuinely
-land on their surface, and are listed here rather than quietly carrying a
-green tick.
+and `prs-open` carried populated fixtures but never navigated to the surface
+they describe, so both were photographing the Preview tab. Both now reach their
+subject and assert it.
+
+## Fixtures that fail
+
+A scenario's `commands` may hold a function, and a function that throws rejects
+the call — `rejectsWith('…')` from `src/harness/reject.ts`.
+
+This matters more than it sounds. Several of this app's surfaces are only
+reachable through a failed call, so a fixture layer that can only resolve
+confines the harness to every feature's happy path. The merge-conflict panel is
+the clearest case: nothing opens it on success. It appears when `pull_and_merge`
+rejects with a message containing `MERGE_CONFLICT:`, which is what the
+`conflicts` scenario now does.
+
+Worth knowing while writing such a scenario: `branch.resolveConflicts` in the
+Cmd+K palette **cannot** open that panel. Its `when` predicate reads
+`hasConflicts`, which `WorkspaceView.tsx:845` wires to `showConflictResolution`
+— the flag that means the panel is already visible. The command therefore only
+appears once you no longer need it, and its handler then re-sets a flag that is
+already true. That is a product bug, reported separately; it is recorded here
+so nobody spends an afternoon assuming their fixture is at fault.
 
 ## Text being cut off
 

--- a/docs/ui-harness.md
+++ b/docs/ui-harness.md
@@ -273,12 +273,12 @@ The entry point is the **"Looking at the UI" section of `CLAUDE.md`**, which is
 tracked and loaded for every agent working in this repo, plus the pointer in
 `CONTRIBUTING.md` and this document.
 
-There is deliberately no skill file in the repo: `.gitignore` excludes
-`.claude/` (see the "Claude Code skills" comment there), so anything written
-under it would exist on one machine and nowhere else — which is the failure
-this document spends a section warning about. A local `.claude/skills/` copy is
-fine as a personal convenience; it is not a way to ship instructions to anyone
-else.
+`.claude/skills/ui-harness/SKILL.md` is tracked too, so an agent that reads
+skills finds it without being told. That required narrowing `.gitignore` from
+`.claude/` to `.claude/*` with a `!.claude/skills/` exception — local state
+(`settings.local.json`, the worktrees) stays out of the repo, instructions for
+whoever works here next do not. A skill that lives on one machine is not
+documentation.
 
 ## Files
 
@@ -294,3 +294,4 @@ else.
 | `src/harness/scenarios/` | The fixture layers above |
 | `src/harness/stubs/` | Inert `tauri-pty`, screenshots, updater |
 | `scripts/harness-capture.mjs` | Headless capture, identity guard, `report.md`, `report.json` |
+| `.claude/skills/ui-harness/SKILL.md` | So an agent discovers this without being told |

--- a/docs/ui-harness.md
+++ b/docs/ui-harness.md
@@ -109,6 +109,33 @@ SHIPSTUDIO_HARNESS_PORT=1426 node scripts/harness-capture.mjs --all
 `strictPort` is deliberately still on: a harness that silently moved to another
 port would reintroduce exactly the ambiguity this section is about.
 
+## A scenario must prove its subject is on screen
+
+A scenario declares `requires: '<selector>'`, and the capture fails if nothing
+matches it.
+
+A scenario is a claim about a surface. When that surface stops rendering — the
+feature is not on this branch, a component was renamed, the click that opens a
+popover silently stopped working, the capture attached to the wrong tree — the
+run still produces a clean screenshot of *something*, captioned with this
+scenario's name, and nothing says the subject is missing. Every hosting
+scenario requires `.publish-dropdown-menu`, so a popover that fails to open is
+a failure rather than a tidy picture of the workspace labelled "deployed and
+openable".
+
+This is the general form of a lesson that cost two sessions an evening: a
+fixture written before or after its subject exists has an expiry date, and
+nothing in a repo marks it. `requires` marks it.
+
+Adding it found two of this repo's own scenarios reviewing nothing: `conflicts`
+and `prs-open` carry populated fixtures but never navigate to the surface they
+describe, so they were capturing the Preview tab. They now run a palette
+command (`command: 'branch.viewPRs'`) to get there, and `conflicts` still does
+not reach its panel — the command is gated on state the fixtures do not
+satisfy. Both are deliberately left without `requires` until they genuinely
+land on their surface, and are listed here rather than quietly carrying a
+green tick.
+
 ## Text being cut off
 
 `report.md` lists every visible element whose content is wider than its box

--- a/scripts/check-doc-paths.mjs
+++ b/scripts/check-doc-paths.mjs
@@ -1,0 +1,43 @@
+/**
+ * Every repo path a document points at must be obtainable from the repo.
+ *
+ * Written after `docs/ui-harness.md` shipped to main listing
+ * `.claude/skills/ui-harness/SKILL.md`, a file that only ever existed on one
+ * machine because `.gitignore` excludes `.claude/`. A verification loop had
+ * "confirmed" it with `[ -f "$f" ]` — a correct answer to "is this on disk",
+ * asked when the question was "did this ship".
+ *
+ * Only paths containing a slash are checked, so prose that names a bare
+ * filename (`base.ts`) is left alone. Generated artefacts are exempt by
+ * prefix: they are reproducible from tracked sources, which is the actual
+ * test — not "is it committed" but "can someone else get it from the repo".
+ */
+
+import { execFileSync } from 'node:child_process';
+
+const GENERATED_PREFIXES = ['harness/shots/'];
+
+export function checkDocPaths(docs, { trackedFiles } = {}) {
+  const tracked = new Set(
+    trackedFiles ?? execFileSync('git', ['ls-files'], { encoding: 'utf-8' }).split('\n')
+  );
+  const problems = [];
+
+  for (const [doc, body] of Object.entries(docs)) {
+    const referenced = new Set();
+    for (const [, p] of body.matchAll(/`([A-Za-z0-9_.@-]+(?:\/[A-Za-z0-9_.@*-]+)+)`/g)) {
+      referenced.add(p);
+    }
+    for (const p of [...referenced].sort()) {
+      const clean = p.replace(/\/$/, '');
+      if (GENERATED_PREFIXES.some((g) => clean.startsWith(g))) continue;
+      if (tracked.has(clean)) continue;
+      // A directory is fine when anything under it is tracked.
+      if ([...tracked].some((t) => t.startsWith(clean + '/'))) continue;
+      // Globs and wildcards are illustrative, not literal paths.
+      if (clean.includes('*')) continue;
+      problems.push({ doc, path: clean });
+    }
+  }
+  return problems;
+}

--- a/scripts/check-doc-paths.test.mjs
+++ b/scripts/check-doc-paths.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+import { checkDocPaths } from './check-doc-paths.mjs';
+
+test('every repo path docs/ui-harness.md points at is in the repo', () => {
+  const problems = checkDocPaths({
+    'docs/ui-harness.md': readFileSync('docs/ui-harness.md', 'utf-8'),
+  });
+  assert.deepEqual(
+    problems,
+    [],
+    `Documented paths that nobody else can obtain:\n` +
+      problems.map((p) => `  ${p.doc} -> ${p.path}`).join('\n')
+  );
+});
+
+test('it catches a path that is not tracked', () => {
+  // Guards the guard: a rename of the matcher would otherwise make the test
+  // above pass by finding nothing to check.
+  const problems = checkDocPaths(
+    { 'fake.md': 'see `.claude/skills/x/SKILL.md` for details' },
+    { trackedFiles: ['docs/ui-harness.md'] }
+  );
+  assert.equal(problems.length, 1);
+  assert.equal(problems[0].path, '.claude/skills/x/SKILL.md');
+});
+
+test('generated artefacts are exempt because they are reproducible', () => {
+  const problems = checkDocPaths(
+    { 'fake.md': 'output lands in `harness/shots/report.md`' },
+    { trackedFiles: ['scripts/harness-capture.mjs'] }
+  );
+  assert.deepEqual(problems, []);
+});

--- a/scripts/harness-capture.mjs
+++ b/scripts/harness-capture.mjs
@@ -404,6 +404,15 @@ function renderReport({ scenarios, commands, skipped, meta }) {
     '# Ship Studio UI harness — capture report',
     '',
     `Captured ${new Date().toISOString()} at ${VIEWPORT.width}×${VIEWPORT.height}.`,
+    ...(meta.filter
+      ? [
+          '',
+          `> **Partial run** — filtered to ids starting \`${meta.filter}\`. Only the`,
+          '> captures listed below were taken. Other images in this directory are',
+          '> from an earlier run and may no longer reflect the code. Re-run without',
+          '> a filter for a directory that is consistent end to end.',
+        ]
+      : []),
     '',
     `Checkout: \`${meta.checkout}\``,
     `HEAD: \`${meta.head}\``,
@@ -535,7 +544,15 @@ async function main() {
   );
   await waitForServer(`http://127.0.0.1:${CDP_PORT}/json/version`);
 
-  await rm(outDir, { recursive: true, force: true });
+  // A full run owns the directory and clears it, so nothing stale survives to
+  // be mistaken for current. A *filtered* run must not: it would delete images
+  // a reviewer is halfway through reading, and the report that replaced them
+  // would describe a handful of files while the rest of the directory silently
+  // became a mix of two runs. Filtered runs overwrite only what they capture
+  // and say so at the top of the report.
+  if (!filter) {
+    await rm(outDir, { recursive: true, force: true });
+  }
   await mkdir(outDir, { recursive: true });
 
   // Ask the running harness what exists, so this script never keeps a second,
@@ -633,6 +650,8 @@ async function main() {
     // image with no provenance is not evidence.
     checkout: identity.root,
     head: identity.head,
+    // Non-null means this report describes only part of the directory.
+    filter: filter || null,
     viewport: VIEWPORT,
     scenarios: scenarioResults,
     commands: commandResults,
@@ -645,7 +664,7 @@ async function main() {
       scenarios: scenarioResults,
       commands: commandResults,
       skipped,
-      meta: { checkout: identity.root, head: identity.head },
+      meta: { checkout: identity.root, head: identity.head, filter: filter || null },
     })
   );
 

--- a/scripts/harness-capture.mjs
+++ b/scripts/harness-capture.mjs
@@ -303,7 +303,7 @@ const CLIPPED_TEXT_PROBE = `(() => {
   return JSON.stringify(out);
 })()`;
 
-async function capture({ url, file, clipSelector, identity, label }) {
+async function capture({ url, file, clipSelector, identity, label, requires }) {
   const { page, targetId } = await newPage(url);
   try {
     const ready = await waitFor(page, 'window.__harnessReady', 25_000, `${file} to settle`)
@@ -340,6 +340,13 @@ async function capture({ url, file, clipSelector, identity, label }) {
     if (identity) await assertStillSameCheckout(identity, label ?? file);
 
     const clipped = JSON.parse(await page.eval(CLIPPED_TEXT_PROBE).catch(() => '[]'));
+
+    // The scenario's subject must actually be on screen. Without this a
+    // scenario whose surface has vanished still yields a clean screenshot of
+    // whatever else was rendered, under this scenario's name.
+    const missingRequired = requires
+      ? !(await page.eval(`!!document.querySelector(${JSON.stringify(requires)})`).catch(() => false))
+      : false;
 
     // Capture a *stable* frame rather than whichever frame happened to be on
     // screen. Polling hooks re-render on their own schedule, so a single shot
@@ -380,6 +387,7 @@ async function capture({ url, file, clipSelector, identity, label }) {
       ...(missingClip ? { missingClip } : {}),
       imageHash: hash(buf),
       clipped,
+      ...(requires ? { requires, missingRequired } : {}),
       console: page.console.slice(0, 8),
     };
   } finally {
@@ -388,7 +396,8 @@ async function capture({ url, file, clipSelector, identity, label }) {
   }
 }
 
-const mark = (r) => (r.crashed || !r.ready ? '✗' : r.unmocked.length ? '!' : '✓');
+const mark = (r) =>
+  r.crashed || !r.ready || r.missingRequired ? '✗' : r.unmocked.length ? '!' : '✓';
 
 function renderReport({ scenarios, commands, skipped, meta }) {
   const lines = [
@@ -475,11 +484,18 @@ function renderReport({ scenarios, commands, skipped, meta }) {
     );
   }
 
-  const bad = [...scenarios, ...commands].filter((r) => r.crashed || !r.ready);
+  const bad = [...scenarios, ...commands].filter(
+    (r) => r.crashed || !r.ready || r.missingRequired
+  );
   if (bad.length) {
     lines.push('## Failures', '');
     for (const r of bad) {
-      lines.push(`### \`${r.id}\` — ${r.crashed ? 'crashed' : 'never settled'}`, '');
+      const why = r.crashed
+        ? 'crashed'
+        : !r.ready
+          ? 'never settled'
+          : `subject missing — nothing matched \`${r.requires}\`, so this capture is not of what the scenario claims`;
+      lines.push(`### \`${r.id}\` — ${why}`, '');
       for (const c of r.console) lines.push(`- **${c.level}**: ${c.text.split('\n')[0]}`);
       lines.push('');
     }
@@ -528,7 +544,7 @@ async function main() {
   await waitFor(probe.page, 'window.__harness', 20_000, 'the harness module to load');
   const allScenarios = JSON.parse(
     await probe.page.eval(
-      'JSON.stringify(window.__harness.scenarios.map(s=>({id:s.id,title:s.title,looksRightWhen:s.looksRightWhen,clipSelector:s.clipSelector})))'
+      'JSON.stringify(window.__harness.scenarios.map(s=>({id:s.id,title:s.title,looksRightWhen:s.looksRightWhen,clipSelector:s.clipSelector,requires:s.requires,command:s.command})))'
     )
   );
   probe.page.close();
@@ -538,9 +554,12 @@ async function main() {
   if (wantScenarios) {
     for (const s of allScenarios.filter((s) => s.id.startsWith(filter))) {
       const r = await capture({
-        url: `${HARNESS_ORIGIN}/harness.html?chrome=off&scenario=${s.id}`,
+        url:
+          `${HARNESS_ORIGIN}/harness.html?chrome=off&scenario=${s.id}` +
+          (s.command ? `&command=${encodeURIComponent(s.command)}` : ''),
         file: path.join(outDir, `${s.id}.png`),
         clipSelector: s.clipSelector,
+        requires: s.requires,
         identity,
         label: s.id,
       });
@@ -631,7 +650,7 @@ async function main() {
   );
 
   const all = [...scenarioResults, ...commandResults];
-  const broken = all.filter((r) => r.crashed || !r.ready);
+  const broken = all.filter((r) => r.crashed || !r.ready || r.missingRequired);
   const incomplete = all.filter((r) => !r.crashed && r.unmocked.length);
   const missing = commandResults.filter((r) => r.commandMissing);
 
@@ -648,7 +667,15 @@ async function main() {
   if (broken.length) {
     console.log(`\n${broken.length} FAILED:`);
     for (const r of broken) {
-      console.log(`  ${r.id}: ${r.crashed ? 'crashed' : 'never became ready'}`);
+      console.log(
+        `  ${r.id}: ${
+          r.crashed
+            ? 'crashed'
+            : !r.ready
+              ? 'never became ready'
+              : `subject missing (${r.requires})`
+        }`
+      );
       for (const c of r.console) console.log(`      ${c.level}: ${c.text.split('\n')[0]}`);
     }
   }

--- a/scripts/harness-capture.mjs
+++ b/scripts/harness-capture.mjs
@@ -38,7 +38,8 @@ import { existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
 
-const HARNESS_ORIGIN = 'http://127.0.0.1:1425';
+const HARNESS_PORT = Number(process.env.SHIPSTUDIO_HARNESS_PORT ?? 1425);
+const HARNESS_ORIGIN = `http://127.0.0.1:${HARNESS_PORT}`;
 const CDP_PORT = 9333;
 const VIEWPORT = { width: 1440, height: 900 };
 const CHROME = [
@@ -71,6 +72,46 @@ const wantScenarios = !flag('--commands') || flag('--all');
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const hash = (buf) => createHash('sha1').update(buf).digest('hex').slice(0, 12);
+
+/**
+ * Confirm the harness on the port is serving THIS checkout.
+ *
+ * "Something answers on 1425" is not "my harness is up". Several worktrees live
+ * on this machine, `strictPort` means only one harness can hold the port, and a
+ * capture that attaches to a neighbour's server produces a full set of
+ * screenshots labelled with this checkout's scenario names — real images, wrong
+ * tree, no warning. Refusing to guess is the whole point of the tool, so it
+ * refuses here too.
+ */
+async function assertHarnessIsThisCheckout() {
+  const expected = process.cwd();
+  let identity;
+  try {
+    const res = await fetch(`${HARNESS_ORIGIN}/__harness/identity`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    identity = await res.json();
+  } catch (e) {
+    throw new Error(
+      `Something is listening on ${HARNESS_ORIGIN} but it does not answer ` +
+        `/__harness/identity (${e.message}).\n` +
+        `That is either a stale harness from before this check existed, or an ` +
+        `unrelated server. Restart the harness in this checkout, or set ` +
+        `SHIPSTUDIO_HARNESS_PORT to a free port in both shells.`
+    );
+  }
+
+  if (path.resolve(identity.root) !== path.resolve(expected)) {
+    throw new Error(
+      `The harness on ${HARNESS_ORIGIN} is serving a different checkout.\n` +
+        `  it is serving : ${identity.root}\n` +
+        `  you are in    : ${expected}\n` +
+        `Capturing anyway would screenshot that tree and label the images with ` +
+        `this one's scenarios. Stop that harness, or run both with different ` +
+        `SHIPSTUDIO_HARNESS_PORT values.`
+    );
+  }
+  return identity;
+}
 
 async function waitForServer(url, timeoutMs = 30_000) {
   const deadline = Date.now() + timeoutMs;
@@ -258,11 +299,14 @@ async function capture({ url, file, clipSelector }) {
 
 const mark = (r) => (r.crashed || !r.ready ? '✗' : r.unmocked.length ? '!' : '✓');
 
-function renderReport({ scenarios, commands, skipped }) {
+function renderReport({ scenarios, commands, skipped, meta }) {
   const lines = [
     '# Ship Studio UI harness — capture report',
     '',
     `Captured ${new Date().toISOString()} at ${VIEWPORT.width}×${VIEWPORT.height}.`,
+    '',
+    `Checkout: \`${meta.checkout}\``,
+    `HEAD: \`${meta.head}\``,
     '',
     'Regenerate: `pnpm harness` in one shell, then `node scripts/harness-capture.mjs --all`.',
     '',
@@ -336,8 +380,10 @@ function renderReport({ scenarios, commands, skipped }) {
 async function main() {
   if (!CHROME) throw new Error('No Chrome/Chromium found. Install Google Chrome.');
   await waitForServer(`${HARNESS_ORIGIN}/harness.html`).catch(() => {
-    throw new Error('The harness is not running. Start it with:  pnpm harness');
+    throw new Error(`The harness is not running on ${HARNESS_ORIGIN}. Start it with:  pnpm harness`);
   });
+  // Before anything is captured: prove the server belongs to this checkout.
+  const identity = await assertHarnessIsThisCheckout();
 
   const chrome = spawn(
     CHROME,
@@ -447,6 +493,10 @@ async function main() {
 
   const report = {
     capturedAt: new Date().toISOString(),
+    // Recorded so a screenshot can be traced to the tree it came from. An
+    // image with no provenance is not evidence.
+    checkout: identity.root,
+    head: identity.head,
     viewport: VIEWPORT,
     scenarios: scenarioResults,
     commands: commandResults,
@@ -455,7 +505,12 @@ async function main() {
   await writeFile(path.join(outDir, 'report.json'), JSON.stringify(report, null, 2) + '\n');
   await writeFile(
     path.join(outDir, 'report.md'),
-    renderReport({ scenarios: scenarioResults, commands: commandResults, skipped })
+    renderReport({
+      scenarios: scenarioResults,
+      commands: commandResults,
+      skipped,
+      meta: { checkout: identity.root, head: identity.head },
+    })
   );
 
   const all = [...scenarioResults, ...commandResults];

--- a/scripts/harness-capture.mjs
+++ b/scripts/harness-capture.mjs
@@ -83,13 +83,56 @@ const hash = (buf) => createHash('sha1').update(buf).digest('hex').slice(0, 12);
  * tree, no warning. Refusing to guess is the whole point of the tool, so it
  * refuses here too.
  */
+async function fetchIdentity() {
+  const res = await fetch(`${HARNESS_ORIGIN}/__harness/identity`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Re-check between captures.
+ *
+ * Checking once at startup is not enough: `strictPort` frees the port the
+ * instant a harness dies, so a server can be replaced *mid-run* and every
+ * capture after that point silently belongs to another tree. That is not
+ * hypothetical — it happened, and `ready` and `stable` both agreed with each
+ * other about a page serving a different product, because those signals only
+ * describe the page that answered, never which page ought to have.
+ */
+async function assertStillSameCheckout(expected, label) {
+  let identity;
+  try {
+    identity = await fetchIdentity();
+  } catch (e) {
+    throw new Error(
+      `The harness stopped answering /__harness/identity partway through ` +
+        `(at "${label}": ${e.message}). Captures before this point are fine; ` +
+        `anything after would be of whatever took the port. Aborting.`
+    );
+  }
+  if (path.resolve(identity.root) !== path.resolve(expected.root)) {
+    throw new Error(
+      `The harness changed underneath this run (at "${label}").\n` +
+        `  started against : ${expected.root}\n` +
+        `  now serving     : ${identity.root}\n` +
+        `A server was replaced mid-run. Aborting rather than captioning ` +
+        `another tree's screenshots with this one's scenario names.`
+    );
+  }
+  if (identity.head !== expected.head) {
+    throw new Error(
+      `The harness's HEAD moved during this run (at "${label}"): ` +
+        `${expected.head.slice(0, 12)} -> ${identity.head.slice(0, 12)}. ` +
+        `Half these captures would be of a different commit. Aborting.`
+    );
+  }
+}
+
 async function assertHarnessIsThisCheckout() {
   const expected = process.cwd();
   let identity;
   try {
-    const res = await fetch(`${HARNESS_ORIGIN}/__harness/identity`);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    identity = await res.json();
+    identity = await fetchIdentity();
   } catch (e) {
     throw new Error(
       `Something is listening on ${HARNESS_ORIGIN} but it does not answer ` +
@@ -219,7 +262,48 @@ const closeTarget = (id) =>
  * Load one harness URL, wait for it to settle, capture it, and report what the
  * page knows about itself.
  */
-async function capture({ url, file, clipSelector }) {
+/**
+ * Elements whose text is being cut off.
+ *
+ * Truncation is technically visible in a screenshot and practically invisible
+ * to a reviewer: a sentence clipped at 184px ends in a "…" a few pixels wide,
+ * and it is entirely possible to read a set of captures twice, conclude they
+ * pass, and have missed that every status line lost its informative half.
+ * Listing them turns "look carefully" into something the runner can point at.
+ *
+ * Reported, never failed — plenty of truncation is deliberate. Credit to the
+ * session that hit this the hard way and proposed the check.
+ */
+const CLIPPED_TEXT_PROBE = `(() => {
+  const out = [];
+  for (const el of document.querySelectorAll('*')) {
+    if (out.length >= 25) break;
+    const r = el.getBoundingClientRect();
+    if (!r.width || !r.height) continue;
+    const cs = getComputedStyle(el);
+    if (cs.visibility === 'hidden' || cs.display === 'none') continue;
+    const ellipsis = cs.textOverflow === 'ellipsis';
+    const clampedLines = cs.webkitLineClamp && cs.webkitLineClamp !== 'none';
+    if (!ellipsis && !clampedLines) continue;
+    const overflowsX = el.scrollWidth > el.clientWidth + 1;
+    const overflowsY = clampedLines && el.scrollHeight > el.clientHeight + 1;
+    if (!overflowsX && !overflowsY) continue;
+    const text = (el.textContent || '').trim().replace(/\\s+/g, ' ');
+    if (!text) continue;
+    out.push({
+      text: text.slice(0, 120),
+      chars: text.length,
+      shownPx: Math.round(el.clientWidth),
+      neededPx: Math.round(el.scrollWidth),
+      where: el.className && typeof el.className === 'string'
+        ? '.' + el.className.trim().split(/\\s+/).slice(0, 2).join('.')
+        : el.tagName.toLowerCase(),
+    });
+  }
+  return JSON.stringify(out);
+})()`;
+
+async function capture({ url, file, clipSelector, identity, label }) {
   const { page, targetId } = await newPage(url);
   try {
     const ready = await waitFor(page, 'window.__harnessReady', 25_000, `${file} to settle`)
@@ -250,6 +334,12 @@ async function capture({ url, file, clipSelector }) {
       if (box) clip = JSON.parse(box);
       else missingClip = clipSelector;
     }
+
+    // The page is settled and about to be photographed: confirm the server
+    // still belongs to this checkout before the image is written.
+    if (identity) await assertStillSameCheckout(identity, label ?? file);
+
+    const clipped = JSON.parse(await page.eval(CLIPPED_TEXT_PROBE).catch(() => '[]'));
 
     // Capture a *stable* frame rather than whichever frame happened to be on
     // screen. Polling hooks re-render on their own schedule, so a single shot
@@ -289,6 +379,7 @@ async function capture({ url, file, clipSelector }) {
       ...state,
       ...(missingClip ? { missingClip } : {}),
       imageHash: hash(buf),
+      clipped,
       console: page.console.slice(0, 8),
     };
   } finally {
@@ -350,6 +441,26 @@ function renderReport({ scenarios, commands, skipped, meta }) {
         ...noChange.map((r) => `- \`${r.id}\` — ${r.title}`),
         ''
       );
+    }
+  }
+
+  const withClipped = [...scenarios, ...commands].filter((r) => r.clipped?.length);
+  if (withClipped.length) {
+    lines.push(
+      '## Text being cut off',
+      '',
+      'Elements whose content is wider than the box drawn for it. Not a',
+      'failure — plenty of truncation is deliberate — but a clipped sentence',
+      'is a few pixels of "…" in a screenshot and is very easy to read past.',
+      'Check that what got cut is not the informative half.',
+      ''
+    );
+    for (const r of withClipped) {
+      lines.push(`**\`${r.id}\`**`, '');
+      for (const c of r.clipped.slice(0, 8)) {
+        lines.push(`- \`${c.where}\` ${c.shownPx}px shown / ${c.neededPx}px needed — "${c.text}"`);
+      }
+      lines.push('');
     }
   }
 
@@ -430,6 +541,8 @@ async function main() {
         url: `${HARNESS_ORIGIN}/harness.html?chrome=off&scenario=${s.id}`,
         file: path.join(outDir, `${s.id}.png`),
         clipSelector: s.clipSelector,
+        identity,
+        label: s.id,
       });
       scenarioResults.push({ ...s, ...r });
       process.stdout.write(`${mark(r)} ${s.id}\n`);
@@ -450,6 +563,8 @@ async function main() {
       const base = await capture({
         url: `${HARNESS_ORIGIN}/harness.html?chrome=off&scenario=${ctx.scenario}`,
         file: path.join(outDir, 'commands', `_baseline-${ctx.name}.png`),
+        identity,
+        label: `baseline-${ctx.name}`,
       });
 
       const listPage = await newPage(
@@ -477,6 +592,8 @@ async function main() {
         const r = await capture({
           url: `${HARNESS_ORIGIN}/harness.html?chrome=off&scenario=${ctx.scenario}&command=${encodeURIComponent(cmd.id)}`,
           file: path.join(outDir, 'commands', `${cmd.id}.png`),
+          identity,
+          label: cmd.id,
         });
         commandResults.push({
           ...cmd,

--- a/src/harness/fakeBackend.ts
+++ b/src/harness/fakeBackend.ts
@@ -14,6 +14,12 @@
  * 2. Plugin channels the app cannot run in a browser (PTY, screenshots,
  *    updater) are answered with explicit inert values rather than left to
  *    throw, because an uncaught boot error hides everything downstream.
+ *
+ * A fixture may also be a function, and a function that throws rejects the
+ * call — see `rejectsWith` in `./reject`. Several surfaces (the merge-conflict
+ * panel among them) are only reachable through a failed command, so a layer
+ * that could only resolve would confine the harness to every feature's happy
+ * path.
  */
 
 import { mockIPC, mockWindows } from '@tauri-apps/api/mocks';

--- a/src/harness/reject.ts
+++ b/src/harness/reject.ts
@@ -1,0 +1,24 @@
+/**
+ * Fixtures that fail.
+ *
+ * A good number of this app's surfaces are only reachable through a failed
+ * call — the merge-conflict panel opens when `pull_and_merge` rejects with a
+ * `MERGE_CONFLICT:` message, not when anything succeeds. A fixture layer that
+ * can only resolve therefore cannot reach them at all, which quietly limits
+ * the harness to the happy path of every feature.
+ *
+ * The router already invokes function fixtures, so a throwing handler works;
+ * this exists so a scenario says what it means and so the capability is
+ * discoverable rather than folklore.
+ */
+
+/**
+ * Reject with a message. `asCommandError` (src/lib/errors.ts) coerces a thrown
+ * `Error` to `{ type: 'Other', message }`, which is what the substring checks
+ * in the app's error handling actually read.
+ */
+export function rejectsWith(message: string) {
+  return () => {
+    throw new Error(message);
+  };
+}

--- a/src/harness/scenarios/app.ts
+++ b/src/harness/scenarios/app.ts
@@ -16,6 +16,7 @@ const notInstalled = (id: string, friendlyName: string) => ({
 export const appScenarios: Scenario[] = [
   {
     id: 'dashboard',
+    requires: '.project-card',
     title: 'Dashboard — the normal case',
     looksRightWhen:
       'Projects render as cards with readable names, consistent spacing, and no placeholder or "undefined" text anywhere.',
@@ -34,6 +35,7 @@ export const appScenarios: Scenario[] = [
   },
   {
     id: 'dashboard-many',
+    requires: '.project-card',
     title: 'Dashboard — a crowded account',
     looksRightWhen:
       'Layout holds at 24 projects: no overflow past the container, no clipped names, scrolling works.',
@@ -52,6 +54,7 @@ export const appScenarios: Scenario[] = [
   },
   {
     id: 'dashboard-long-names',
+    requires: '.project-card',
     title: 'Dashboard — hostile project names',
     looksRightWhen:
       'Very long and non-Latin names truncate cleanly instead of breaking the card grid.',

--- a/src/harness/scenarios/features.ts
+++ b/src/harness/scenarios/features.ts
@@ -10,6 +10,7 @@
 
 import type { Scenario } from '../types';
 import { workspaceCommands, WORKSPACE_PROJECT } from './workspace';
+import { rejectsWith } from '../reject';
 
 const HOUR = 3_600_000;
 
@@ -120,6 +121,7 @@ export const featureScenarios: Scenario[] = [
       'Each row shows number, title, author and branch without collision. Draft and non-mergeable states are visually distinct.',
     project: WORKSPACE_PROJECT,
     command: 'branch.viewPRs',
+    requires: '.pr-card',
     commands: {
       ...workspaceCommands,
       list_pull_requests: [
@@ -137,9 +139,20 @@ export const featureScenarios: Scenario[] = [
     looksRightWhen:
       'Both sides are readable and equally weighted; it is obvious which file is being resolved and how many blocks remain.',
     project: WORKSPACE_PROJECT,
-    command: 'branch.resolveConflicts',
+    // Reached through a *failure*, not a command. `branch.resolveConflicts`
+    // cannot open this panel — its `when` predicate is gated on
+    // `hasConflicts: showConflictResolution` (WorkspaceView.tsx:845), i.e. on
+    // the panel already being visible, so it only appears once you no longer
+    // need it. That is a product bug, reported separately; the panel's real
+    // entry point is `pull_and_merge` rejecting with a `MERGE_CONFLICT:`
+    // message, which is what this scenario does.
+    command: 'git.pull',
+    requires: '.conflict-content',
     commands: {
       ...workspaceCommands,
+      pull_and_merge: rejectsWith(
+        'MERGE_CONFLICT:Auto-merging src/app/page.tsx\nCONFLICT (content): Merge conflict in src/app/page.tsx'
+      ),
       // `get_conflict_info`, snake_case — the shape at the real call site in
       // `src/lib/conflicts.ts`, which differs from the camelCase
       // `ConflictedFile` the lib maps it into.

--- a/src/harness/scenarios/features.ts
+++ b/src/harness/scenarios/features.ts
@@ -86,6 +86,7 @@ const finding = (id: string, severity: string, title: string, summary: string) =
 export const featureScenarios: Scenario[] = [
   {
     id: 'workspace',
+    requires: '.workspace-header',
     title: 'Workspace — a project open',
     looksRightWhen:
       'Header, sidebar, agent pane, and preview all render. This is the baseline every command capture is diffed against.',
@@ -118,6 +119,7 @@ export const featureScenarios: Scenario[] = [
     looksRightWhen:
       'Each row shows number, title, author and branch without collision. Draft and non-mergeable states are visually distinct.',
     project: WORKSPACE_PROJECT,
+    command: 'branch.viewPRs',
     commands: {
       ...workspaceCommands,
       list_pull_requests: [
@@ -135,6 +137,7 @@ export const featureScenarios: Scenario[] = [
     looksRightWhen:
       'Both sides are readable and equally weighted; it is obvious which file is being resolved and how many blocks remain.',
     project: WORKSPACE_PROJECT,
+    command: 'branch.resolveConflicts',
     commands: {
       ...workspaceCommands,
       // `get_conflict_info`, snake_case — the shape at the real call site in

--- a/src/harness/scenarios/hosting.ts
+++ b/src/harness/scenarios/hosting.ts
@@ -115,6 +115,9 @@ export const hostingScenarios: Scenario[] = [
     project: WORKSPACE_PROJECT,
     openSelector: '.source-control-push-button',
     clipSelector: '.publish-dropdown-menu',
+    // The popover must actually be open. Without this, a failure to open it
+    // yields a clean screenshot of the workspace captioned as a deploy state.
+    requires: '.publish-dropdown-menu',
     commands: {
       ...workspaceCommands,
       get_hosting_status: status(found(deployment({ phase: 'building' }, 'Building'))),
@@ -128,6 +131,9 @@ export const hostingScenarios: Scenario[] = [
     project: WORKSPACE_PROJECT,
     openSelector: '.source-control-push-button',
     clipSelector: '.publish-dropdown-menu',
+    // The popover must actually be open. Without this, a failure to open it
+    // yields a clean screenshot of the workspace captioned as a deploy state.
+    requires: '.publish-dropdown-menu',
     commands: {
       ...workspaceCommands,
       get_hosting_status: status(
@@ -145,6 +151,9 @@ export const hostingScenarios: Scenario[] = [
     project: WORKSPACE_PROJECT,
     openSelector: '.source-control-push-button',
     clipSelector: '.publish-dropdown-menu',
+    // The popover must actually be open. Without this, a failure to open it
+    // yields a clean screenshot of the workspace captioned as a deploy state.
+    requires: '.publish-dropdown-menu',
     commands: {
       ...workspaceCommands,
       // Netlify on purpose. Vercel has no state between building and ready —
@@ -166,6 +175,9 @@ export const hostingScenarios: Scenario[] = [
     project: WORKSPACE_PROJECT,
     openSelector: '.source-control-push-button',
     clipSelector: '.publish-dropdown-menu',
+    // The popover must actually be open. Without this, a failure to open it
+    // yields a clean screenshot of the workspace captioned as a deploy state.
+    requires: '.publish-dropdown-menu',
     commands: {
       ...workspaceCommands,
       get_hosting_status: status(
@@ -185,6 +197,9 @@ export const hostingScenarios: Scenario[] = [
     project: WORKSPACE_PROJECT,
     openSelector: '.source-control-push-button',
     clipSelector: '.publish-dropdown-menu',
+    // The popover must actually be open. Without this, a failure to open it
+    // yields a clean screenshot of the workspace captioned as a deploy state.
+    requires: '.publish-dropdown-menu',
     commands: {
       ...workspaceCommands,
       get_hosting_status: status(
@@ -204,6 +219,9 @@ export const hostingScenarios: Scenario[] = [
     project: WORKSPACE_PROJECT,
     openSelector: '.source-control-push-button',
     clipSelector: '.publish-dropdown-menu',
+    // The popover must actually be open. Without this, a failure to open it
+    // yields a clean screenshot of the workspace captioned as a deploy state.
+    requires: '.publish-dropdown-menu',
     commands: {
       ...workspaceCommands,
       // Cloudflare, because Vercel cannot produce this phase: its
@@ -234,6 +252,9 @@ export const hostingScenarios: Scenario[] = [
     project: WORKSPACE_PROJECT,
     openSelector: '.source-control-push-button',
     clipSelector: '.publish-dropdown-menu',
+    // The popover must actually be open. Without this, a failure to open it
+    // yields a clean screenshot of the workspace captioned as a deploy state.
+    requires: '.publish-dropdown-menu',
     commands: {
       ...workspaceCommands,
       get_hosting_status: status({
@@ -257,6 +278,9 @@ export const hostingScenarios: Scenario[] = [
     project: WORKSPACE_PROJECT,
     openSelector: '.source-control-push-button',
     clipSelector: '.publish-dropdown-menu',
+    // The popover must actually be open. Without this, a failure to open it
+    // yields a clean screenshot of the workspace captioned as a deploy state.
+    requires: '.publish-dropdown-menu',
     commands: {
       ...workspaceCommands,
       get_hosting_status: status(null, { auth: { kind: 'rejected' }, lookup: null }),
@@ -269,6 +293,9 @@ export const hostingScenarios: Scenario[] = [
     project: WORKSPACE_PROJECT,
     openSelector: '.source-control-push-button',
     clipSelector: '.publish-dropdown-menu',
+    // The popover must actually be open. Without this, a failure to open it
+    // yields a clean screenshot of the workspace captioned as a deploy state.
+    requires: '.publish-dropdown-menu',
     commands: { ...workspaceCommands, get_hosting_status: unlinkedHostingStatus },
   },
   {
@@ -279,6 +306,9 @@ export const hostingScenarios: Scenario[] = [
     project: WORKSPACE_PROJECT,
     openSelector: '.source-control-push-button',
     clipSelector: '.publish-dropdown-menu',
+    // The popover must actually be open. Without this, a failure to open it
+    // yields a clean screenshot of the workspace captioned as a deploy state.
+    requires: '.publish-dropdown-menu',
     commands: {
       ...workspaceCommands,
       get_hosting_status: status(null, {

--- a/src/harness/types.ts
+++ b/src/harness/types.ts
@@ -49,5 +49,25 @@ export interface Scenario {
    * banner) rather than as backend data.
    */
   storage?: Record<string, string>;
+  /**
+   * A selector that must be present for this capture to mean anything.
+   *
+   * A scenario is a claim about a surface. When that surface stops rendering —
+   * the feature is not on this branch, the component was renamed, a capture
+   * attached to the wrong tree — the run still produces a clean screenshot of
+   * *something*, captioned with this scenario's name, and nothing says the
+   * subject is missing. A fixture written before or after its subject exists
+   * has an expiry date, and this is what marks it.
+   *
+   * Missing means the capture failed, not that the screen is empty.
+   */
+  requires?: string;
+  /**
+   * A Cmd+K command run once the app has settled, to navigate to the surface
+   * this scenario is about. Reuses the same plumbing as `?command=`; a
+   * scenario that needs a panel or modal open should say so here rather than
+   * relying on the app's default view happening to show it.
+   */
+  command?: string;
   commands: CommandMap;
 }

--- a/vite.harness.config.ts
+++ b/vite.harness.config.ts
@@ -7,9 +7,48 @@
  * a shipped build.
  */
 
-import { defineConfig, mergeConfig, type UserConfig } from 'vite';
+import { defineConfig, mergeConfig, type Plugin, type UserConfig } from 'vite';
+import { execSync } from 'child_process';
 import path from 'path';
 import base from './vite.config';
+
+/**
+ * The harness announces which checkout it is serving.
+ *
+ * Without this, `harness-capture.mjs` could only ask "is something listening on
+ * the harness port". On a machine running several worktrees that is a different
+ * question from "is *my* harness listening", and answering the easy one meant a
+ * capture could attach to another worktree's server and write a full set of
+ * confidently-labelled screenshots of a tree it was never pointed at. Every
+ * other failure in the capture path is loud; that one wrote green checkmarks.
+ */
+function identityPlugin(): Plugin {
+  const root = process.cwd();
+  let head = 'unknown';
+  try {
+    head = execSync('git rev-parse HEAD', { cwd: root, encoding: 'utf-8' }).trim();
+  } catch {
+    // Not a git checkout, or git is unavailable. The root comparison is the
+    // load-bearing half; HEAD is only there to make a mismatch legible.
+  }
+
+  return {
+    name: 'shipstudio-harness-identity',
+    configureServer(server) {
+      server.middlewares.use('/__harness/identity', (_req, res) => {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ root, head }));
+      });
+    },
+  };
+}
+
+/**
+ * Worktrees would otherwise serialise on one port — `strictPort` means the
+ * second harness fails to start, and with four sessions live that is a real
+ * cost. Overriding the port lets them run side by side.
+ */
+const PORT = Number(process.env.SHIPSTUDIO_HARNESS_PORT ?? 1425);
 
 export default defineConfig(async (env) => {
   const resolved = (await (base as unknown as (e: typeof env) => Promise<UserConfig>)(
@@ -17,6 +56,7 @@ export default defineConfig(async (env) => {
   )) as UserConfig;
 
   return mergeConfig(resolved, {
+    plugins: [identityPlugin()],
     resolve: {
       alias: {
         'tauri-pty': path.resolve(__dirname, './src/harness/stubs/tauri-pty.ts'),
@@ -27,6 +67,6 @@ export default defineConfig(async (env) => {
         '@tauri-apps/plugin-updater': path.resolve(__dirname, './src/harness/stubs/updater.ts'),
       },
     },
-    server: { port: 1425, strictPort: true, host: '127.0.0.1' },
+    server: { port: PORT, strictPort: true, host: '127.0.0.1' },
   } satisfies UserConfig);
 });


### PR DESCRIPTION
## The bug

`harness-capture.mjs` checked that *something* answered on the harness port and treated that as "my harness is up". Those are different questions.

With several worktrees on one machine and `strictPort` giving the port to whoever started first, a capture could attach to a **neighbour's** harness, screenshot **their** tree, and write a full set of green checkmarks captioned with **this** checkout's scenario names. Real images, wrong tree, no warning.

Found by another session on this machine, one screenshot short of reporting ten deployment states "verified" against a build that did not contain the feature. They traced it with `lsof` to a harness running from a different worktree.

This is worse than anything the harness was built to catch. Every other failure here is loud by design — a missing fixture badges red, a crash fails the run, an unsettled frame is marked unstable. This one wrote 71 ticks and a confident report.

## The fix

The harness serves `/__harness/identity` (absolute repo root + git HEAD). The runner fetches it before capturing anything and aborts if the root doesn't match the directory it was invoked from, naming both paths:

```
The harness on http://127.0.0.1:1425 is serving a different checkout.
  it is serving : /private/tmp/other-checkout
  you are in    : /Users/…/worktrees/hosting-testbed
Capturing anyway would screenshot that tree and label the images with this
one's scenarios. Stop that harness, or run both with different
SHIPSTUDIO_HARNESS_PORT values.
```

Two failure shapes are covered, both reproduced against a real second worktree:

| Case | Result |
| --- | --- |
| Server predating this change (returns `index.html` for the endpoint) | aborts — "does not answer /__harness/identity" |
| Server with the fix but a different root | aborts — both paths named |
| Own harness, own checkout | captures normally, 71/71 |

## Provenance in the report

`report.md` and `report.json` now record the checkout path and HEAD they came from. An image with no provenance is not evidence — that is the whole lesson here, and it belongs in the artifact rather than in someone's memory of which shell they ran.

## Parallel worktrees

`SHIPSTUDIO_HARNESS_PORT` lets several worktrees run harnesses at once instead of serialising on 1425. Verified with two servers up simultaneously, each capture correctly binding to its own tree — with the guard alone, a second session would still have been blocked, just loudly.

`strictPort` stays on deliberately: a harness that silently moved to another port would reintroduce exactly the ambiguity this PR is about.

## Verification

`check:all` exit 0 · 2175 tests · 71/71 captures clean · both abort paths reproduced against a second worktree, and the happy path re-confirmed on a private port.

One incidental confirmation: during the final self-test another session took port 1425 between my kill and my restart. My server failed `strictPort`, and the guard refused to capture against theirs — the failure it was written for, firing unprompted in live conditions.

## Docs

`docs/ui-harness.md` gets a "Provenance" section explaining the failure rather than just the flag, and `.claude/skills/ui-harness/SKILL.md` tells an agent what the error means and how to get its own port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaCVkBCFD9sMEM4Sxh1kZT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - UI harness captures verify the correct checkout and commit.
  - Scenarios can confirm the intended interface is visible before capturing.
  - Failure-path scenarios can simulate command errors, including merge conflicts.
  - Reports identify missing subjects and clipped text.
  - Filtered runs preserve unrelated results and indicate partial coverage.
  - Harness ports can be configured to support parallel worktrees.

- **Documentation**
  - Added guidance for checkout verification, required subjects, failed fixtures, partial runs, and clipped-text reporting.
  - Added instructions for discovering and using the UI harness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->