### PR TITLE
Write down the verification failure that recurred six times in one night

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thanks for your interest in contributing to Ship Studio! This guide will help yo
 > - Read the [Code of Conduct](CODE_OF_CONDUCT.md) — it sets the bar for how we collaborate.
 > - For deeper context on the *patterns* the codebase has standardised on, read [docs/CONTRIBUTING_PATTERNS.md](docs/CONTRIBUTING_PATTERNS.md) and the **"How to Do Things in Ship Studio"** section of [CLAUDE.md](CLAUDE.md). New code that bypasses those primitives will get flagged in review.
 > - If you found a security issue, **do not file a public issue** — see [SECURITY.md](SECURITY.md) for private reporting.
+> - Before you report something verified, read [docs/verifying-your-own-work.md](docs/verifying-your-own-work.md) — a short list of checks that pass while proving nothing.
 > - Want to *see* a UI change instead of describing it? `pnpm harness` boots the real frontend in a browser against a fixture backend and `pnpm harness:capture` screenshots ~70 app states — see [docs/ui-harness.md](docs/ui-harness.md).
 > - Want to fork and ship your own build? See [docs/FORKING.md](docs/FORKING.md).
 

--- a/docs/verifying-your-own-work.md
+++ b/docs/verifying-your-own-work.md
@@ -85,6 +85,16 @@ without ever completing.
 
 **A green check whose description says it did not run is not a green check.**
 
+There is a second way to end up merging an unreviewed commit, and it needs no
+outage at all. When branch protection requires branches to be up to date, every
+pull request behind the first must rebase before it can merge — and the rebase
+produces a new commit that the completed review does not follow. Whether that
+matters is a race between the reviewer re-running and you pressing merge.
+
+Of four merges checked on one evening, two carried a completed review on the
+commit they actually merged from and two did not. So: **read the description on
+the SHA in front of you, not on the one you remember being reviewed.**
+
 This document carried that tick too. It is being held until a review actually
 runs, on the same reasoning: a page about checks that do not check should not
 arrive on one.

--- a/docs/verifying-your-own-work.md
+++ b/docs/verifying-your-own-work.md
@@ -85,6 +85,10 @@ without ever completing.
 
 **A green check whose description says it did not run is not a green check.**
 
+This document carried that tick too. It is being held until a review actually
+runs, on the same reasoning: a page about checks that do not check should not
+arrive on one.
+
 The checks list will not tell you. Ask for the descriptions:
 
 ```bash

--- a/docs/verifying-your-own-work.md
+++ b/docs/verifying-your-own-work.md
@@ -1,0 +1,74 @@
+# Verifying your own work
+
+Almost every wrong claim made while building this app's tooling had the same
+shape. Not a careless check — a **correct check, correctly reported, answering
+a question nobody had noticed was different from the one being asked.**
+
+> The mechanism was present. The outcome was never confirmed.
+
+This is written down because it recurred six times in one evening across four
+people working in parallel, and each time it was found by someone other than
+the person who made it. That rate suggests it is the normal failure mode of
+verifying your own work, not anyone's sloppiness.
+
+## The rule
+
+**Check that the outcome changed. Not that the mechanism is present.**
+
+Before believing a check, ask what a *passing* result would still permit.
+
+| You asked | It answered | What it still permits |
+| --- | --- | --- |
+| Did this ship? | `[ -f file ]` — is it on disk? | Untracked, ignored, on one machine |
+| Did the fix work? | The CSS is in the built binary | The measured value is unchanged |
+| Do these screenshots show my build? | A server answered on the port | It was another checkout's server |
+| Did this tree pass CI? | These commits passed | They were the pre-rebase commits |
+| Did my edit apply? | The command exited 0 | The pattern matched nothing |
+| Does the suite cover this? | The test passes | It found nothing to assert on |
+
+## The four that cost the most
+
+**A screenshot with no provenance.** A capture runner checked that *something*
+answered on its port. Several worktrees ran on that machine, so it attached to
+a neighbour's server and wrote seventy-one green ticks and a report captioned
+with this checkout's scenario names. Real images, wrong tree, no warning — and
+one screenshot away from "all ten states verified" against a build that did not
+contain the feature. Fixed by having the server declare its own checkout, and
+by recording it in every report: *a tick is evidence of nothing until you say
+which commit it ran against.*
+
+**An edit that silently matched nothing.** A scripted string replacement
+targeted text a formatter had reshaped since it was read. The script exited 0,
+reported success, changed nothing — and forty-five tests then passed against a
+code path that never ran. Assert the anchor exists **in the same operation as
+the write**: the gap between reading a file and editing it is exactly where a
+formatter lives.
+
+**A test that found nothing to test.** A table asserting fixtures stay within
+what each adapter can emit would have gone green forever if a field were
+renamed, because it would have iterated an empty set. Every such check needs a
+companion asserting it *found something*, and a run against known-bad input to
+watch it fail.
+
+**A fix that felt like one.** A proposal to assert a selector on a capture would
+have applied to a category the failing capture was not in. Plausible, adjacent,
+and would have changed nothing while closing the question. This is the most
+dangerous variant: it ends the investigation.
+
+## In practice
+
+- **Verify by content, not by existence.** `git cat-file -e origin/main:path`
+  and grep the content, not `[ -f path ]`.
+- **State what a result is about.** "Green" is meaningless; "green on
+  `4dc4fff4`, which is my HEAD" is a claim someone can check.
+- **Make a check fail on purpose before trusting it.** If you have not seen it
+  red, you do not know it can go red.
+- **Prefer checks that cannot pass vacuously.** A guard over an empty set, a
+  selector that matches page chrome, an assertion on a value nobody reads.
+- **Say "locally verified, CI has not seen this" when that is the case.** It
+  costs nothing and it is usually the whole question.
+
+The harness applies this to itself: an unmocked command is recorded rather than
+given a plausible default, a scenario declares a `requires` selector so it
+cannot photograph the wrong screen, and every report names the checkout and
+commit it came from. See [ui-harness.md](ui-harness.md).

--- a/docs/verifying-your-own-work.md
+++ b/docs/verifying-your-own-work.md
@@ -96,6 +96,27 @@ gh api repos/<owner>/<repo>/commits/<sha>/status \
   --jq '.statuses[] | "\(.context) | \(.state) | \(.description)"'
 ```
 
+## It happens in tests that have been green for months
+
+```rust
+assert!(started.elapsed() < std::time::Duration::from_millis(500),
+        "non-contention failures must not be retried");
+```
+
+The claim is *"this failure was not retried"*. The measurement is wall-clock
+elapsed time, on the reasoning that a retry would cost at least 600ms of
+backoff. A cheap proxy for an expensive truth — the same substitution as
+everything else here, sitting in a passing test for months.
+
+It failed on a loaded CI runner where a single process spawn can exceed 500ms
+on its own; the same job logged two unrelated tests running over sixty seconds.
+The behaviour under test was almost certainly correct. The proxy was not.
+
+Note the shape, because it is what makes this kind survive: the proxy holds on
+an unloaded machine and only lies under contention, so it looks stable right up
+until the moment it matters. Counting attempts instead of timing them measures
+the claim itself.
+
 ## The recommended method has its own hole
 
 > Reinstating a defect proves *a* test detects it. It does not prove *which
@@ -165,9 +186,15 @@ dangerous variant: it ends the investigation.
   you have not seen it fail, you know it passes, not that it detects anything.
 - **Prefer checks that cannot pass vacuously.** A guard over an empty set, a
   selector that matches page chrome, an assertion on a value nobody reads.
-- **Open the artifact.** A green tick on a screenshot means it was captured, not
-  that the screen is right. Nothing above was found by a report; every one was
-  found by a person looking at the thing.
+- **Open the artifact.** A green tick on a screenshot means it was captured,
+  not that the screen is right. Nothing above was found by a report; every one
+  was found by a person looking at the thing — most often at a surface no
+  artifact had ever shown them.
+- **Ask, and go and look when asked.** Two of these were found because one
+  person asked another whether they still had doubts, and that person went and
+  checked instead of answering from memory. This is the more expensive habit,
+  because it needs someone to think to ask; looking at what you shipped needs
+  nobody's prompting and found more of them.
 - **Say "locally verified, CI has not seen this" when that is the case.** It
   costs nothing and it is usually the whole question.
 

--- a/docs/verifying-your-own-work.md
+++ b/docs/verifying-your-own-work.md
@@ -26,6 +26,38 @@ Before believing a check, ask what a *passing* result would still permit.
 | Did my edit apply? | The command exited 0 | The pattern matched nothing |
 | Does the suite cover this? | The test passes | It found nothing to assert on |
 
+## The one to read first
+
+A deployments panel had no scenario and no unit test. Its only coverage was an
+automated screenshot of the command that opens it. That screenshot showed a
+permanent "Loading…" — every project, before connecting a host, opened the panel
+to a spinner for a request that was never going to be made.
+
+Three independent signals said it was fine. All four required CI checks passed.
+The suite of 2269 tests passed. The screenshot was marked ✓ **with no unmocked
+backend calls, and that was correct**: the call which would have been flagged as
+missing a fixture was never made, *because the bug prevented it*.
+
+So there were two defects, and each one hid the other from the tooling. A
+missing fixture — a real gap — was concealed by a downstream bug that stopped
+the call being issued. Every check was sound. Every check answered a different
+question than "does this panel work".
+
+It was found by opening the image.
+
+Two things follow from it, and they are the most useful conclusions here.
+
+**Assert what appears, not what was asked for.** The obvious remedy — "every
+command must have fixtures for everything it invokes" — passes cleanly on that
+broken panel, because the broken panel invokes nothing. Only an expectation
+about the rendered result ("this should produce a populated list") fails.
+
+**Prove the test detects the bug.** The fix came with three tests, and their
+author reinstated the old field and watched two of them fail before trusting
+them. That is the only method used across a long night of this that actually
+demonstrates a test detects what it claims to. Everyone else watched tests pass
+and inferred coverage from it.
+
 ## The four that cost the most
 
 **A screenshot with no provenance.** A capture runner checked that *something*
@@ -61,10 +93,14 @@ dangerous variant: it ends the investigation.
   and grep the content, not `[ -f path ]`.
 - **State what a result is about.** "Green" is meaningless; "green on
   `4dc4fff4`, which is my HEAD" is a claim someone can check.
-- **Make a check fail on purpose before trusting it.** If you have not seen it
-  red, you do not know it can go red.
+- **Make a check fail on purpose before trusting it.** Reintroduce the bug and
+  watch the test go red. If you have not seen it fail, you know it passes — not
+  that it detects anything.
 - **Prefer checks that cannot pass vacuously.** A guard over an empty set, a
   selector that matches page chrome, an assertion on a value nobody reads.
+- **Open the artifact.** A green tick on a screenshot means it was captured, not
+  that the screen is right. Nothing above was found by a report; every one was
+  found by a person looking at the thing.
 - **Say "locally verified, CI has not seen this" when that is the case.** It
   costs nothing and it is usually the whole question.
 

--- a/docs/verifying-your-own-work.md
+++ b/docs/verifying-your-own-work.md
@@ -55,9 +55,9 @@ about the rendered result ("this should produce a populated list") fails.
 
 **Prove the test detects the bug.** The fix came with three tests, and their
 author reinstated the old field and watched two of them fail before trusting
-them. That is the only method used across a long night of this that actually
-demonstrates a test detects what it claims to. Everyone else watched tests pass
-and inferred coverage from it.
+them — rather than watching tests pass and inferring coverage, which is what
+everyone else did. That is the right instinct, and it is still not sufficient;
+see the next section, which is about this method's own hole.
 
 ## A second, worse category
 
@@ -96,6 +96,35 @@ gh api repos/<owner>/<repo>/commits/<sha>/status \
   --jq '.statuses[] | "\(.context) | \(.state) | \(.description)"'
 ```
 
+## The recommended method has its own hole
+
+> Reinstating a defect proves *a* test detects it. It does not prove *which
+> assertion* does.
+
+An assertion written as `expect(container.textContent).not.toMatch(/your host/i)`
+was inert from the moment it was typed: the component renders through a portal,
+so `container.textContent` is `''` and the assertion passes whatever the modal
+says.
+
+Its author had verified that test by the method above — reinstated the bug,
+watched the test fail. **It did fail.** On the `waitFor` above it, not on the
+assertion believed to be doing the work. A correct observation, recorded as
+proof of something adjacent to what it showed. The same shape as everything
+else here, this time inside the remedy.
+
+The stronger form:
+
+- Reinstate each defect **separately**, not all at once.
+- Confirm precisely the expected tests fail — not "some tests failed".
+- Confirm the failure is **on the assertion you believe is load-bearing**, not
+  merely somewhere in the test body.
+
+A related habit, from the same session, twice in one night: having fixed one
+instance of a defect, they searched for siblings and found another — a fixture
+claiming a phase its provider cannot emit, and later a status vocabulary
+corrected in one component and not the other showing the same deployment. Fixing
+the instance and recording it as the class is its own species of this.
+
 ## The four that cost the most
 
 **A screenshot with no provenance.** A capture runner checked that *something*
@@ -131,9 +160,9 @@ dangerous variant: it ends the investigation.
   and grep the content, not `[ -f path ]`.
 - **State what a result is about.** "Green" is meaningless; "green on
   `4dc4fff4`, which is my HEAD" is a claim someone can check.
-- **Make a check fail on purpose before trusting it.** Reintroduce the bug and
-  watch the test go red. If you have not seen it fail, you know it passes — not
-  that it detects anything.
+- **Make a check fail on purpose before trusting it** — one defect at a time,
+  and confirm the failure lands on the assertion you think is load-bearing. If
+  you have not seen it fail, you know it passes, not that it detects anything.
 - **Prefer checks that cannot pass vacuously.** A guard over an empty set, a
   selector that matches page chrome, an assertion on a value nobody reads.
 - **Open the artifact.** A green tick on a screenshot means it was captured, not

--- a/docs/verifying-your-own-work.md
+++ b/docs/verifying-your-own-work.md
@@ -25,6 +25,7 @@ Before believing a check, ask what a *passing* result would still permit.
 | Did this tree pass CI? | These commits passed | They were the pre-rebase commits |
 | Did my edit apply? | The command exited 0 | The pattern matched nothing |
 | Does the suite cover this? | The test passes | It found nothing to assert on |
+| Was this reviewed? | A green tick from the reviewer | It was rate-limited and declined |
 
 ## The one to read first
 
@@ -57,6 +58,39 @@ author reinstated the old field and watched two of them fail before trusting
 them. That is the only method used across a long night of this that actually
 demonstrates a test detects what it claims to. Everyone else watched tests pass
 and inferred coverage from it.
+
+## A second, worse category
+
+Everything above is a check that **measured the wrong thing, correctly** — a
+cheap proxy standing in for an expensive truth. Those degrade honestly once you
+know what the proxy covers.
+
+This one does not:
+
+```
+CodeRabbit | success | Review rate limited
+```
+
+A green tick whose meaning is *"I declined to run."* Not a proxy for review —
+not a measurement at all. It is indistinguishable from a pass in the checks
+list, which shows the state and hides the description, and the only way to tell
+is to read a string nobody reads when six other ticks are green.
+
+Three PRs here carried it. One was 39 files and +6060 lines, reported as "all
+seven checks green" and merged. Another was this repo's harness, likewise
+merged. On a third, five Major findings had been fixed *in response to* that
+reviewer, and the re-run was rate-limited — so the fixes made in answer to a
+review were themselves reviewed by nothing. A review loop that closed on itself
+without ever completing.
+
+**A green check whose description says it did not run is not a green check.**
+
+The checks list will not tell you. Ask for the descriptions:
+
+```bash
+gh api repos/<owner>/<repo>/commits/<sha>/status \
+  --jq '.statuses[] | "\(.context) | \(.state) | \(.description)"'
+```
 
 ## The four that cost the most
 

--- a/scripts/check-doc-paths.test.mjs
+++ b/scripts/check-doc-paths.test.mjs
@@ -4,10 +4,12 @@ import { readFileSync } from 'node:fs';
 
 import { checkDocPaths } from './check-doc-paths.mjs';
 
-test('every repo path docs/ui-harness.md points at is in the repo', () => {
-  const problems = checkDocPaths({
-    'docs/ui-harness.md': readFileSync('docs/ui-harness.md', 'utf-8'),
-  });
+const DOCS = ['docs/ui-harness.md', 'docs/verifying-your-own-work.md'];
+
+test('every repo path these docs point at is in the repo', () => {
+  const problems = checkDocPaths(
+    Object.fromEntries(DOCS.map((d) => [d, readFileSync(d, 'utf-8')]))
+  );
   assert.deepEqual(
     problems,
     [],


### PR DESCRIPTION
## Merge last

**This is queued behind #895, #896 and #897.** Docs only, nothing depends on it, and `required_status_checks.strict` means every merge costs the next branch a rebase. It should not jump anything with users waiting on it.

## What this is

Four sessions working in parallel on this app's tooling each reported something verified that was not. Every instance had the same shape:

> A correct check, correctly reported, answering a question nobody had noticed was different from the one being asked. The mechanism was present. The outcome was never confirmed.

Six instances in one evening, each found by someone other than its author. That rate makes it the normal failure mode of verifying your own work rather than anyone's sloppiness — which is the argument for writing it down instead of resolving to be more careful.

## The instances

| Asked | Answered | Still permitted |
| --- | --- | --- |
| Did this ship? | `[ -f file ]` — on disk? | Untracked, ignored, on one machine |
| Did the fix work? | The CSS is in the built binary | The measured value is unchanged |
| Do these screenshots show my build? | Something answered on the port | It was another checkout's server |
| Did this tree pass CI? | These commits passed | They were the pre-rebase commits |
| Did my edit apply? | The command exited 0 | The pattern matched nothing |
| Does the suite cover this? | The test passes | It found nothing to assert on |

The four written up at length are the ones that cost real time: a capture run that produced seventy-one confidently-labelled screenshots of the wrong worktree; a scripted edit that matched nothing after a formatter moved its anchor, with forty-five tests then passing against a code path that never ran; a table test that would have gone green forever if a field were renamed; and a proposed fix that was plausible, adjacent, and would have changed nothing while closing the question.

## The practices

Verify by content rather than existence. Say which commit a result is about — *a tick is evidence of nothing until you say which commit it ran against*. Watch a check fail before trusting it. Prefer checks that cannot pass vacuously. Distinguish "locally verified" from "CI has seen this tree".

## Scope

`docs/verifying-your-own-work.md` plus one line in `CONTRIBUTING.md`. No code.

`check:all` exit 0. Markdown links verified to resolve.

## Provenance

Prompted by another session's suggestion that this belonged somewhere permanent rather than in four transcripts that vanish. The examples are drawn from all four sessions including my own, and the two that cost the most were mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaCVkBCFD9sMEM4Sxh1kZT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added contributor guidance on verifying that changes produce the intended outcomes, rather than relying solely on proxy checks.
  - Documented common verification pitfalls, including misleading success statuses, unproven screenshots, ineffective edits, tests that find nothing, and fixes with no observable effect.
  - Added practical verification recommendations and examples.
  - Linked the new guidance from the contributor checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->