### PR TITLE
Stop a click inside a modal from dismissing the popover beneath it

### DIFF
--- a/src/components/branches/BranchesMenu.createRepo.test.tsx
+++ b/src/components/branches/BranchesMenu.createRepo.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * The Create GitHub Repository dialog is rendered by GitHubButton, which lives
+ * inside the Branches dropdown's menu. The dialog portals to the modal root, so
+ * every click in it lands outside the dropdown's container — and the dropdown's
+ * click-outside dismissal used to close the menu, unmounting GitHubButton and
+ * the dialog's own `showCreateModal` state with it. The dialog vanished on the
+ * first click into any of its fields, which made creating a repository from the
+ * menu impossible.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { useState } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BranchesMenu } from './BranchesMenu';
+import { pushToGitHub } from '../../lib/github';
+import type { PullRequestInfo } from '../../lib/branches';
+
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn() }));
+
+// Plain async implementations, not `mockResolvedValue`: the suite resets mocks
+// between tests, which would strip a one-shot resolved value and leave the
+// component awaiting `undefined`.
+vi.mock('../../lib/github', () => ({
+  pushToGitHub: vi.fn(() => Promise.resolve()),
+  getGitHubOrgs: vi.fn(() => Promise.resolve(['acme-co'])),
+  getGitHubUsername: vi.fn(() => Promise.resolve('martin')),
+}));
+
+/** Mirrors the app: the menu's open state is owned by its parent. */
+function Harness() {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <BranchesMenu
+      githubState={{
+        cliStatus: { installed: true, authenticated: true },
+        username: 'martin',
+      }}
+      // Not connected — the setup pane with "Create Repo" renders.
+      projectStatus={{ status: 'no-remote', github_repo: null, github_url: null }}
+      projectPath="/test/project"
+      projectName="ship-studio"
+      currentBranch="main"
+      branches={[]}
+      openPRs={[] as PullRequestInfo[]}
+      isPulling={false}
+      isBranchSwitching={false}
+      isRepositoryViewActive={false}
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+      onPullLatest={vi.fn()}
+      onBranchSwitch={vi.fn()}
+      onViewBranches={vi.fn()}
+      onCreateBranch={vi.fn()}
+      onViewPRs={vi.fn()}
+      onStartPR={vi.fn()}
+      onGitHubConnect={vi.fn()}
+      onGitHubStatusChange={vi.fn()}
+    />
+  );
+}
+
+const dialog = () => screen.queryByRole('dialog', { name: 'Create GitHub Repository' });
+
+async function openDialog() {
+  const user = userEvent.setup();
+  render(<Harness />);
+  await user.click(screen.getByTitle('Create GitHub repository'));
+  await waitFor(() => expect(dialog()).not.toBeNull());
+  return user;
+}
+
+describe('Create GitHub Repository dialog', () => {
+  it('stays open when the user clicks its repository-name field', async () => {
+    const user = await openDialog();
+
+    await user.click(screen.getByPlaceholderText('my-project'));
+
+    expect(dialog()).not.toBeNull();
+  });
+
+  it('stays open across the whole form, and creates the repository', async () => {
+    const user = await openDialog();
+
+    const name = screen.getByPlaceholderText('my-project');
+    await user.clear(name);
+    await user.type(name, 'my-new-repo');
+    await user.click(screen.getByText('Public'));
+    await user.selectOptions(screen.getByRole('combobox'), 'acme-co');
+
+    expect(dialog()).not.toBeNull();
+    expect(screen.getByDisplayValue('my-new-repo')).toBeTruthy();
+
+    await user.click(screen.getByRole('button', { name: 'Create Repository' }));
+
+    await waitFor(() =>
+      expect(pushToGitHub).toHaveBeenCalledWith({
+        projectPath: '/test/project',
+        repoName: 'acme-co/my-new-repo',
+        isPrivate: false,
+      })
+    );
+  });
+
+  it('still closes when the user clicks the backdrop outside it', async () => {
+    const user = await openDialog();
+
+    await user.click(document.querySelector('.modal-frame-overlay') as HTMLElement);
+
+    await waitFor(() => expect(dialog()).toBeNull());
+  });
+});

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -37,6 +37,17 @@ export function useClickOutside<T extends HTMLElement>(
     const handleClickOutside = (e: MouseEvent) => {
       const target = e.target as Node;
       if (ref.current && !ref.current.contains(target)) {
+        // A modal is a layer *above* whatever is watching for outside clicks,
+        // not a sibling of it. ModalFrame already marks every other body child
+        // `inert` while a dialog is open, but a document-level listener is not
+        // subject to `inert` — so without this, filling in a dialog dismisses
+        // the popover underneath it. When that popover owns the dialog's mount
+        // (a dropdown rendering a modal in its own subtree) the dialog goes
+        // with it, and the feature is simply unusable: this is what made the
+        // Create GitHub Repository dialog close on its first click.
+        if ((target as Element).closest?.('[data-modal-root]')) {
+          return;
+        }
         // Check if click is on an excluded element
         if (excludeSelector && (target as Element).closest?.(excludeSelector)) {
           return;


### PR DESCRIPTION
## The bug

The **Create GitHub Repository** dialog closed on the first click into any of its own fields, so creating a repository from the Branches menu was impossible. Live in production.

## Cause

`GitHubButton` renders the dialog inside the Branches dropdown's menu, but `ModalFrame` portals it to `[data-modal-root]` on `<body>`. `Dropdown`'s click-outside watcher (`useClickOutside`) fires on `mousedown` and only excluded `.ss-dropdown__menu` — so a click in the dialog read as a click *outside* the dropdown. The menu closed, `GitHubButton` unmounted, and the dialog's own `showCreateModal` state went with it.

`PublishBranchDropdown.tsx:162` had already worked this around privately by adding `.modal-frame-overlay` to its exclusions. The shared `Dropdown` primitive never got one.

## Fix

`ModalFrame` already marks every other body child `inert` while a dialog is open — a document-level listener simply is not subject to `inert`. So the rule belongs in `useClickOutside`: a click inside the modal layer is never an outside click for anything beneath it. This is the general form of the per-site workaround and covers all seven call sites.

11 lines in `src/hooks/useClickOutside.ts`.

## Verification

- New `src/components/branches/BranchesMenu.createRepo.test.tsx` drives the real components: it fails on the old code and passes now. Covers the name field, owner select, visibility radios and submit, and asserts backdrop dismissal still works.
- Full suite 2496/2496, plus `tsc`, `lint`, `check:patterns`, `check:loc`.

## What I did not verify

Because the hook is shared, this changes dismissal behaviour for seven popovers, not just the GitHub button. The suite covers them, but **I never saw the dialog work in a real browser** — I built a UI-harness scenario for the not-connected state and it could not reach the screen, so I reverted it rather than land a failing capture.

That failure looks like a separate bug worth its own issue: against a `no-remote` fixture the Branches menu will not open at all, even when its click handler is invoked directly. `WorkspaceHeader` is called as a plain function (`const { titlebar, toolbar } = WorkspaceHeader(props)`) rather than rendered as a component, so its `useState` lives on the caller's fiber — and the caller's render path differs when GitHub is not connected. Not investigated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAQt9wN6r7zKLB9sfW8f76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal interaction so clicks inside dialog content no longer trigger outside-click actions.
  * Modal dialogs remain open while users interact with their fields and controls.
* **Tests**
  * Added coverage for creating a GitHub repository from the Branches menu, including form interaction, repository creation, and backdrop closing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->