### PR TITLE
Stop breaking projects whose remote isn't GitHub

### DIFF
--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -7,9 +7,11 @@
 //! - `branches` — list, create, delete, switch branches
 //! - `sync` — fetch, pull, merge, commit, discard
 //! - `stash` — stash management, backups, restore
+//! - `remote` — what forge a remote URL points at
 
 mod branches;
 mod graph;
+mod remote;
 mod stash;
 mod status;
 mod sync;
@@ -17,6 +19,7 @@ mod worktree;
 
 pub use branches::*;
 pub use graph::*;
+pub use remote::*;
 pub use stash::*;
 pub use status::*;
 pub use sync::*;
@@ -38,9 +41,41 @@ const GIT_NETWORK_TIMEOUT_SECS: u64 = 60;
 /// `BACKEND_HUMANIZED_GIT_PHRASES` keys on (same as github.rs's
 /// `GH_PUSH_TIMEOUT_MESSAGE`), so the frontend still recognizes it as
 /// already-humanized and doesn't re-word it.
+///
+/// Says "the remote" rather than "GitHub": this fires for *every* network git
+/// op, and `run_git_net` doesn't know the host. Naming GitHub here told GitLab
+/// and self-managed users their push timed out against a service they don't
+/// use. The GitHub-specific timeout copy lives on `GH_PUSH_TIMEOUT_MESSAGE`,
+/// which only ever wraps a `gh` invocation.
 pub(crate) const GIT_NET_TIMEOUT_MESSAGE: &str =
-    "GitHub took too long to respond and the operation timed out. Larger projects can take a \
+    "The remote took too long to respond and the operation timed out. Larger projects can take a \
      while to upload — check your internet connection and try again.";
+
+/// The `-c` arguments that route `github.com` credentials through `gh`.
+///
+/// Two entries, in order, both scoped to the `https://github.com` URL:
+/// 1. an empty value, which resets the helper list git has accumulated so far
+///    (so a stale `osxkeychain` entry can't shadow `gh`), and
+/// 2. `gh auth git-credential`.
+///
+/// Because the key is `credential.https://github.com.helper` rather than the
+/// bare `credential.helper`, git consults neither entry for a request to any
+/// other host — a GitLab remote keeps the machine's own credential helpers.
+/// See [`run_git_net`] for what the unscoped version broke.
+fn github_credential_helper_args(gh: &std::path::Path) -> [String; 2] {
+    [
+        "credential.https://github.com.helper=".to_string(),
+        // Git hands a `!`-prefixed helper to `sh -c`, which word-splits on
+        // spaces — so the path must be quoted or a default Windows install
+        // (`C:\Program Files\GitHub CLI\gh.exe`) becomes the command
+        // `C:\Program` (issue #265). Single quotes keep backslashes literal
+        // under POSIX sh.
+        format!(
+            "credential.https://github.com.helper=!'{}' auth git-credential",
+            gh.display()
+        ),
+    ]
+}
 
 /// Run a git command that touches the network (fetch / pull / push), scoped to
 /// the workspace the project at `cwd` belongs to.
@@ -59,6 +94,17 @@ pub(crate) const GIT_NET_TIMEOUT_MESSAGE: &str =
 /// back to the machine's native login — the same identity every other GitHub
 /// feature in the app already uses. If `gh` isn't installed we skip the override
 /// and fall back to git's native credential resolution.
+///
+/// The override is scoped to `github.com` by URL, because `gh auth
+/// git-credential` answers for no other host. Setting the *unscoped*
+/// `credential.helper` — as this did until the scoping was added — cleared the
+/// machine's own helper and substituted one that returns nothing for a GitLab
+/// (or any non-GitHub) remote. With `GIT_TERMINAL_PROMPT=0` below there is
+/// then no fallback left, so every push and fetch to such a remote failed with
+/// `could not read Username`, for users whose credentials were sitting in the
+/// keychain the whole time. Git matches `credential.<url>.helper` per request,
+/// so scoping it leaves non-GitHub remotes on the machine's normal
+/// credential resolution and changes nothing for GitHub.
 pub(crate) async fn run_git_net(
     args: &[&str],
     cwd: &std::path::Path,
@@ -70,21 +116,15 @@ pub(crate) async fn run_git_net(
     // sets the working directory.
     let mut cmd = crate::utils::git_command_in(cwd)?;
 
-    // Force HTTPS credential resolution through gh (which reads the GH_CONFIG_DIR
-    // injected below) for every workspace. The empty `credential.helper=` first
-    // clears any inherited helper (e.g. osxkeychain) so a globally-cached
-    // credential can't shadow gh. These are git *global* options, so they must
-    // precede the subcommand in `args`.
+    // Route github.com credentials through gh (which reads the GH_CONFIG_DIR
+    // injected below) for every workspace. Scoped to that host by URL so a
+    // remote on any other forge keeps the machine's own credential helpers —
+    // see github_credential_helper_args. These are git *global* options, so
+    // they must precede the subcommand in `args`.
     if let Some(gh) = find_executable("gh") {
-        cmd.arg("-c").arg("credential.helper=");
-        // Git hands a `!`-prefixed helper to `sh -c`, which word-splits on
-        // spaces — so the path must be quoted or a default Windows install
-        // (`C:\Program Files\GitHub CLI\gh.exe`) becomes the command `C:\Program`
-        // (issue #265). Single quotes keep backslashes literal under POSIX sh.
-        cmd.arg("-c").arg(format!(
-            "credential.helper=!'{}' auth git-credential",
-            gh.display()
-        ));
+        for arg in github_credential_helper_args(&gh) {
+            cmd.arg("-c").arg(arg);
+        }
     }
 
     cmd.args(args)
@@ -1006,6 +1046,154 @@ mod tests {
             result.get("main").copied(),
             Some((0, 0)),
             "unknown remote should degrade to (0,0)"
+        );
+    }
+
+    // --- credential helper scoping -------------------------------------
+    //
+    // These drive real `git credential fill` rather than asserting on the
+    // argument strings, because the thing that broke GitLab was git's
+    // *resolution* behaviour, not the spelling of the config key. A stub
+    // stands in for `gh auth git-credential` (which answers only for
+    // github.com) and another for the machine's own helper.
+
+    /// Write an executable shell stub and return its path.
+    fn write_stub(dir: &std::path::Path, name: &str, body: &str) -> std::path::PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, body).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        path
+    }
+
+    /// Ask git which credentials it resolves for `host`, with the machine
+    /// helper and the gh substitute both installed the way `run_git_net`
+    /// installs them. Returns the username git settled on, if any.
+    fn resolve_username(host: &str, use_scoped_helper: bool) -> Option<String> {
+        let tmp = TempDir::new().unwrap();
+        // Stands in for `gh auth git-credential`: answers for github.com only.
+        //
+        // git appends the operation to the configured command, so this is
+        // invoked as `<stub> auth git-credential get` — the operation is the
+        // *last* argument, not the first. Checking `$1` would silently never
+        // match and make the github.com case look broken.
+        let gh = write_stub(
+            tmp.path(),
+            "gh-stub",
+            "#!/bin/sh\n\
+             for a in \"$@\"; do op=$a; done\n\
+             [ \"$op\" = get ] || exit 0\n\
+             while read -r l; do [ \"$l\" = 'host=github.com' ] && ok=1; done\n\
+             [ -n \"$ok\" ] && printf 'username=via-gh\\npassword=x\\n'\n\
+             exit 0\n",
+        );
+        // Stands in for the machine's own helper (osxkeychain et al).
+        let machine = write_stub(
+            tmp.path(),
+            "machine-stub",
+            "#!/bin/sh\n\
+             [ \"$1\" = get ] && printf 'username=via-machine\\npassword=x\\n'\n\
+             exit 0\n",
+        );
+
+        let mut cmd = std::process::Command::new("git");
+        cmd.arg("-c")
+            .arg(format!("credential.helper=!'{}'", machine.display()));
+
+        if use_scoped_helper {
+            for arg in github_credential_helper_args(&gh) {
+                cmd.arg("-c").arg(arg);
+            }
+        } else {
+            // The pre-fix shape: an unscoped reset plus an unscoped gh helper.
+            cmd.arg("-c").arg("credential.helper=");
+            cmd.arg("-c").arg(format!(
+                "credential.helper=!'{}' auth git-credential",
+                gh.display()
+            ));
+        }
+
+        let out = cmd
+            .arg("credential")
+            .arg("fill")
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .and_then(|mut child| {
+                use std::io::Write;
+                write!(
+                    child.stdin.as_mut().unwrap(),
+                    "protocol=https\nhost={host}\n\n"
+                )?;
+                child.wait_with_output()
+            })
+            .unwrap();
+
+        String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .find_map(|l| l.strip_prefix("username=").map(str::to_string))
+    }
+
+    #[test]
+    fn github_credentials_still_resolve_through_gh() {
+        // The behaviour the unscoped version existed to guarantee: gh wins
+        // over a cached machine credential for github.com.
+        assert_eq!(
+            resolve_username("github.com", true).as_deref(),
+            Some("via-gh")
+        );
+    }
+
+    #[test]
+    fn non_github_remotes_keep_the_machines_own_credentials() {
+        // The regression this scoping fixes. Unscoped, git had only the gh
+        // helper to ask, gh declined to answer for a host it does not serve,
+        // and GIT_TERMINAL_PROMPT=0 left nothing to fall back to — so a
+        // GitLab push failed for a user whose credentials were right there.
+        assert_eq!(
+            resolve_username("gitlab.com", false),
+            None,
+            "pre-fix shape should resolve nothing for gitlab.com (the bug)"
+        );
+        assert_eq!(
+            resolve_username("gitlab.com", true).as_deref(),
+            Some("via-machine"),
+            "scoped helper should let the machine's own credentials through"
+        );
+        // Self-managed and other forges get the same treatment.
+        assert_eq!(
+            resolve_username("git.acme.com", true).as_deref(),
+            Some("via-machine")
+        );
+    }
+
+    #[test]
+    fn generic_git_timeout_copy_names_no_forge() {
+        // This message fires for every remote, so it must not claim the user
+        // was talking to GitHub...
+        assert!(!GIT_NET_TIMEOUT_MESSAGE.contains("GitHub"));
+        // ...while keeping the phrase errors.ts matches to recognise it as
+        // already humanized (BACKEND_HUMANIZED_GIT_PHRASES).
+        assert!(GIT_NET_TIMEOUT_MESSAGE
+            .to_lowercase()
+            .contains("check your internet connection"));
+    }
+
+    #[test]
+    fn github_helper_args_quote_the_gh_path() {
+        // Issue #265: an unquoted path with spaces is word-split by `sh -c`.
+        let args =
+            github_credential_helper_args(std::path::Path::new("/Program Files/GitHub CLI/gh.exe"));
+        assert_eq!(args[0], "credential.https://github.com.helper=");
+        assert!(
+            args[1].contains("!'/Program Files/GitHub CLI/gh.exe' auth git-credential"),
+            "gh path must stay quoted, got: {}",
+            args[1]
         );
     }
 }

--- a/src-tauri/src/commands/git/remote.rs
+++ b/src-tauri/src/commands/git/remote.rs
@@ -102,14 +102,19 @@ pub fn parse_remote(url: &str) -> Option<RemoteRef> {
         return None;
     }
 
-    let (authority, path) = if let Some(rest) = url
-        .strip_prefix("https://")
-        .or_else(|| url.strip_prefix("http://"))
-        .or_else(|| url.strip_prefix("ssh://"))
-        .or_else(|| url.strip_prefix("git://"))
-    {
+    // URL schemes are case-insensitive and git honours that — it will happily
+    // fetch from `HTTPS://github.com/owner/repo.git`. Matching the scheme
+    // case-sensitively made that spelling unparseable, which for a GitHub
+    // remote meant reporting no remote at all: the very bug this module exists
+    // to fix. Only the scheme is lowercased; a repo path is case-sensitive.
+    let scheme = url
+        .find("://")
+        .map(|idx| (url[..idx].to_ascii_lowercase(), idx))
+        .filter(|(scheme, _)| matches!(scheme.as_str(), "https" | "http" | "ssh" | "git"));
+
+    let (authority, path) = if let Some((_, idx)) = scheme {
         // scheme://[user@]host[:port]/path
-        let (authority, path) = rest.split_once('/')?;
+        let (authority, path) = url[idx + 3..].split_once('/')?;
         (authority, path)
     } else if let Some((authority, path)) = url.split_once(':') {
         // scp-like: [user@]host:path. Windows drive letters (`C:\…`) and any
@@ -162,6 +167,45 @@ mod tests {
     #[test]
     fn parses_https_remotes_without_the_git_suffix() {
         assert_eq!(parsed("https://github.com/owner/repo").path, "owner/repo");
+    }
+
+    /// Every spelling in this list was confirmed against real git: each one
+    /// reaches the host when handed to `git ls-remote`, so treating any of them
+    /// as unparseable would report "no remote" for a working GitHub project.
+    #[test]
+    fn parses_every_url_form_real_git_accepts() {
+        for url in [
+            "https://github.com/owner/repo.git",
+            "https://github.com/owner/repo/",
+            "https://github.com:443/owner/repo.git",
+            "https://user:tok@github.com/owner/repo.git",
+            "ssh://git@github.com/owner/repo.git",
+            "git@github.com:owner/repo.git",
+            // Schemes are case-insensitive; git fetches from this happily.
+            "HTTPS://github.com/owner/repo.git",
+            "Git@GitHub.com:owner/repo.git",
+        ] {
+            let r = parsed(url);
+            assert_eq!(r.host, "github.com", "host for {url}");
+            assert_eq!(r.path, "owner/repo", "path for {url}");
+            assert!(r.is_github(), "{url} should be GitHub");
+        }
+    }
+
+    /// Credentials embedded in the URL must not be mistaken for the host.
+    #[test]
+    fn userinfo_is_not_the_host() {
+        let r = parsed("https://user:tok@gitlab.com/group/app.git");
+        assert_eq!(r.host, "gitlab.com");
+        assert_eq!(r.forge, GitForge::GitLab);
+    }
+
+    /// A scheme we do not speak is not a remote we can classify.
+    #[test]
+    fn rejects_schemes_that_are_not_git_transports() {
+        for url in ["file:///tmp/repo.git", "ftp://host.com/repo.git"] {
+            assert_eq!(parse_remote(url), None, "{url} should not parse");
+        }
     }
 
     #[test]

--- a/src-tauri/src/commands/git/remote.rs
+++ b/src-tauri/src/commands/git/remote.rs
@@ -1,0 +1,244 @@
+//! What a git remote actually points at.
+//!
+//! The app integrates with exactly one forge — GitHub, via `gh` — but a
+//! project's `origin` can point anywhere. Before this module the only question
+//! ever asked of a remote URL was "is this a GitHub repo?" ([`parse_github_repo`]
+//! in `commands::github`), and every "no" collapsed into the same answer as
+//! "this project has no remote at all". A GitLab project therefore rendered as
+//! unconnected and was offered a GitHub repo to fix it.
+//!
+//! [`parse_remote`] keeps the two apart: it reports the host and path for any
+//! remote it can parse, and names the forge *only* when the host says so.
+//!
+//! # Why there is no self-managed detection
+//!
+//! `gitlab.com` is GitLab. `git.acme.com` might be GitLab, Gitea, a bare git
+//! server, or anything else — the URL cannot tell us, and neither can the
+//! filesystem. Per the project's "Never Assume Data" rule those land in
+//! [`GitForge::Unknown`], which the UI renders as "not GitHub" without putting
+//! a guessed vendor name in front of the user. Naming the forge is a job for
+//! something that actually asks the host, not for a substring match.
+//!
+//! [`parse_github_repo`]: crate::commands::github::parse_github_repo
+
+/// The forge a remote's host identifies, where the host identifies one at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitForge {
+    /// `github.com` — the forge the app's repo/PR features talk to.
+    GitHub,
+    /// `gitlab.com`. Recognised by name so copy can say "GitLab" rather than
+    /// "this remote"; the app has no GitLab integration behind it.
+    GitLab,
+    /// A host we can read but cannot classify: self-managed instances, other
+    /// forges, plain git servers. Known address, unknown vendor.
+    Unknown,
+}
+
+/// A parsed git remote.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteRef {
+    /// Bare hostname, lowercased, no port or userinfo (`gitlab.example.com`).
+    pub host: String,
+    /// Path to the repo with no leading slash or `.git` suffix. GitLab
+    /// subgroups keep their full depth (`group/subgroup/repo`).
+    pub path: String,
+    /// What [`host`](Self::host) identifies, if anything.
+    pub forge: GitForge,
+}
+
+impl RemoteRef {
+    /// Whether the app's GitHub integration applies to this remote.
+    pub fn is_github(&self) -> bool {
+        self.forge == GitForge::GitHub
+    }
+
+    /// The forge's name for the user, when one is known.
+    ///
+    /// `None` for [`GitForge::Unknown`] — the caller shows the bare host
+    /// instead of inventing a vendor.
+    pub fn forge_name(&self) -> Option<&'static str> {
+        match self.forge {
+            GitForge::GitHub => Some("GitHub"),
+            GitForge::GitLab => Some("GitLab"),
+            GitForge::Unknown => None,
+        }
+    }
+}
+
+/// Classify a hostname. Exact matches only — see the module docs.
+fn forge_for_host(host: &str) -> GitForge {
+    match host {
+        "github.com" | "www.github.com" => GitForge::GitHub,
+        "gitlab.com" | "www.gitlab.com" => GitForge::GitLab,
+        _ => GitForge::Unknown,
+    }
+}
+
+/// Strip a trailing `.git` and any surrounding slashes from a repo path.
+fn clean_path(path: &str) -> String {
+    let path = path.trim_matches('/');
+    path.strip_suffix(".git").unwrap_or(path).to_string()
+}
+
+/// Parse a git remote URL into its host and repo path.
+///
+/// Handles the forms git itself writes and accepts:
+/// - `https://host/owner/repo.git` (and `http://`, and with `user@` / `:port`)
+/// - `ssh://git@host:22/owner/repo.git`
+/// - `git@host:owner/repo.git` (scp-like syntax)
+/// - `git://host/owner/repo.git`
+///
+/// Returns `None` for local paths, `file://` URLs, and anything without both a
+/// host and a non-empty path — none of which a forge integration applies to.
+pub fn parse_remote(url: &str) -> Option<RemoteRef> {
+    let url = url.trim();
+    if url.is_empty() {
+        return None;
+    }
+
+    // A local path or file:// remote has no forge. Checked before the scp-like
+    // branch below, which would otherwise read `C:\repos\thing` as host `C`.
+    if url.starts_with("file://") || url.starts_with('/') || url.starts_with('.') {
+        return None;
+    }
+
+    let (authority, path) = if let Some(rest) = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .or_else(|| url.strip_prefix("ssh://"))
+        .or_else(|| url.strip_prefix("git://"))
+    {
+        // scheme://[user@]host[:port]/path
+        let (authority, path) = rest.split_once('/')?;
+        (authority, path)
+    } else if let Some((authority, path)) = url.split_once(':') {
+        // scp-like: [user@]host:path. Windows drive letters (`C:\…`) and any
+        // other single-character "host" are not remotes.
+        let host_part = authority.rsplit('@').next().unwrap_or(authority);
+        if host_part.len() < 2 || !host_part.contains('.') {
+            return None;
+        }
+        (authority, path)
+    } else {
+        return None;
+    };
+
+    // Drop userinfo (`git@`) and any port.
+    let host = authority.rsplit('@').next().unwrap_or(authority);
+    let host = host.split(':').next().unwrap_or(host).to_lowercase();
+    if host.is_empty() {
+        return None;
+    }
+
+    let path = clean_path(path);
+    if path.is_empty() {
+        return None;
+    }
+
+    Some(RemoteRef {
+        forge: forge_for_host(&host),
+        host,
+        path,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parsed(url: &str) -> RemoteRef {
+        parse_remote(url).unwrap_or_else(|| panic!("expected {url} to parse"))
+    }
+
+    #[test]
+    fn parses_https_github_remotes() {
+        let r = parsed("https://github.com/owner/repo.git");
+        assert_eq!(r.host, "github.com");
+        assert_eq!(r.path, "owner/repo");
+        assert_eq!(r.forge, GitForge::GitHub);
+        assert!(r.is_github());
+    }
+
+    #[test]
+    fn parses_https_remotes_without_the_git_suffix() {
+        assert_eq!(parsed("https://github.com/owner/repo").path, "owner/repo");
+    }
+
+    #[test]
+    fn parses_scp_like_ssh_remotes() {
+        let r = parsed("git@github.com:owner/repo.git");
+        assert_eq!(r.host, "github.com");
+        assert_eq!(r.path, "owner/repo");
+        assert_eq!(r.forge, GitForge::GitHub);
+    }
+
+    #[test]
+    fn parses_ssh_scheme_remotes_with_a_port() {
+        let r = parsed("ssh://git@gitlab.com:22/group/repo.git");
+        assert_eq!(r.host, "gitlab.com");
+        assert_eq!(r.path, "group/repo");
+        assert_eq!(r.forge, GitForge::GitLab);
+    }
+
+    #[test]
+    fn gitlab_com_is_named_but_not_github() {
+        let r = parsed("https://gitlab.com/owner/repo.git");
+        assert_eq!(r.forge, GitForge::GitLab);
+        assert!(!r.is_github());
+        assert_eq!(r.forge_name(), Some("GitLab"));
+    }
+
+    #[test]
+    fn gitlab_subgroups_keep_their_full_path() {
+        // GitLab nests groups arbitrarily deep; truncating to owner/repo would
+        // address the wrong project.
+        let r = parsed("https://gitlab.com/acme/platform/web/app.git");
+        assert_eq!(r.path, "acme/platform/web/app");
+    }
+
+    #[test]
+    fn self_managed_hosts_are_unknown_not_guessed() {
+        // The whole point: a host we cannot classify keeps its address and
+        // admits it has no vendor name, rather than being sniffed for
+        // "gitlab" and labelled on a substring match.
+        let r = parsed("https://git.acme.com/team/repo.git");
+        assert_eq!(r.host, "git.acme.com");
+        assert_eq!(r.forge, GitForge::Unknown);
+        assert_eq!(r.forge_name(), None);
+
+        let r = parsed("https://gitlab.acme.com/team/repo.git");
+        assert_eq!(r.forge, GitForge::Unknown);
+        assert_eq!(r.forge_name(), None);
+    }
+
+    #[test]
+    fn hosts_are_lowercased() {
+        assert_eq!(
+            parsed("https://GitHub.com/Owner/Repo.git").host,
+            "github.com"
+        );
+        // Only the host is normalised: repo paths are case-sensitive.
+        assert_eq!(
+            parsed("https://GitHub.com/Owner/Repo.git").path,
+            "Owner/Repo"
+        );
+    }
+
+    #[test]
+    fn rejects_local_paths_and_non_remotes() {
+        assert_eq!(parse_remote(""), None);
+        assert_eq!(parse_remote("   "), None);
+        assert_eq!(parse_remote("not a url"), None);
+        assert_eq!(parse_remote("/Users/me/repos/thing"), None);
+        assert_eq!(parse_remote("./thing"), None);
+        assert_eq!(parse_remote("file:///Users/me/repos/thing"), None);
+        // A Windows drive letter is not a host.
+        assert_eq!(parse_remote(r"C:\repos\thing"), None);
+    }
+
+    #[test]
+    fn rejects_urls_with_a_host_but_no_repo() {
+        assert_eq!(parse_remote("https://github.com/"), None);
+        assert_eq!(parse_remote("https://github.com"), None);
+    }
+}

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -265,8 +265,36 @@ pub async fn get_github_orgs(project_path: Option<String>) -> Result<Vec<String>
     Ok(orgs)
 }
 
+/// A project with no usable `origin` at all.
+fn no_remote() -> ProjectGitHubStatus {
+    ProjectGitHubStatus {
+        status: "no-remote".to_string(),
+        github_repo: None,
+        github_url: None,
+        remote_host: None,
+        remote_forge: None,
+    }
+}
+
+/// A project whose `origin` points somewhere the GitHub integration doesn't
+/// reach. Carries the host so the UI can name where the code actually lives.
+fn other_remote(remote: &crate::commands::git::RemoteRef) -> ProjectGitHubStatus {
+    ProjectGitHubStatus {
+        status: "other-remote".to_string(),
+        github_repo: None,
+        github_url: None,
+        remote_host: Some(remote.host.clone()),
+        remote_forge: remote.forge_name().map(str::to_string),
+    }
+}
+
 /// Checks GitHub status by verifying with the GitHub CLI.
 /// Asks GitHub directly instead of inferring from local files.
+///
+/// Distinguishes "no remote" from "a remote we don't integrate with": a GitLab
+/// or self-managed `origin` returns `other-remote`, not `no-remote`, so the UI
+/// stops offering to create a GitHub repo for a project that already has one
+/// somewhere else.
 #[tauri::command]
 #[tracing::instrument(fields(project = %project_path))]
 pub async fn get_project_github_status(project_path: String) -> ProjectGitHubStatus {
@@ -274,6 +302,8 @@ pub async fn get_project_github_status(project_path: String) -> ProjectGitHubSta
         status: "not-a-repo".to_string(),
         github_repo: None,
         github_url: None,
+        remote_host: None,
+        remote_forge: None,
     };
 
     // Validate path
@@ -314,35 +344,31 @@ pub async fn get_project_github_status(project_path: String) -> ProjectGitHubSta
         Ok(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr);
             debug!(elapsed_ms = step_start.elapsed().as_millis() as u64, stderr = %stderr, "git remote get-url origin: no remote configured");
-            return ProjectGitHubStatus {
-                status: "no-remote".to_string(),
-                github_repo: None,
-                github_url: None,
-            };
+            return no_remote();
         }
         Err(e) => {
             warn!(elapsed_ms = step_start.elapsed().as_millis() as u64, error = %e, "git remote get-url origin failed/timed out");
-            return ProjectGitHubStatus {
-                status: "no-remote".to_string(),
-                github_repo: None,
-                github_url: None,
-            };
+            return no_remote();
         }
     };
 
-    // Parse GitHub repo from remote URL (handles HTTPS and SSH)
-    let github_repo = parse_github_repo(&remote_url);
-    let github_repo = match github_repo {
-        Some(repo) => repo,
+    // Read the remote before asking whether it's GitHub. A remote that parses
+    // but points elsewhere is a different answer from no remote at all — see
+    // ProjectGitHubStatus::status.
+    let remote = match crate::commands::git::parse_remote(&remote_url) {
+        Some(remote) => remote,
         None => {
-            debug!(remote_url = %remote_url, "Could not parse GitHub repo from remote URL");
-            return ProjectGitHubStatus {
-                status: "no-remote".to_string(),
-                github_repo: None,
-                github_url: None,
-            };
+            debug!(remote_url = %remote_url, "origin is not a parseable remote URL");
+            return no_remote();
         }
     };
+
+    if !remote.is_github() {
+        debug!(remote_url = %remote_url, host = %remote.host, "origin points at a non-GitHub forge");
+        return other_remote(&remote);
+    }
+
+    let github_repo = remote.path.clone();
 
     // Verify repo exists on GitHub using gh CLI (with timeout). Scope to the
     // project's workspace so a repo private to that workspace's GitHub login
@@ -370,24 +396,18 @@ pub async fn get_project_github_status(project_path: String) -> ProjectGitHubSta
                 status: "connected".to_string(),
                 github_repo: Some(github_repo),
                 github_url: Some(url),
+                remote_host: None,
+                remote_forge: None,
             }
         }
         Ok(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr);
             debug!(elapsed_ms = step_start.elapsed().as_millis() as u64, stderr = %stderr, "gh repo view: repo not found or no access");
-            ProjectGitHubStatus {
-                status: "no-remote".to_string(),
-                github_repo: None,
-                github_url: None,
-            }
+            no_remote()
         }
         Err(e) => {
             warn!(elapsed_ms = step_start.elapsed().as_millis() as u64, error = %e, "gh repo view failed/timed out");
-            ProjectGitHubStatus {
-                status: "no-remote".to_string(),
-                github_repo: None,
-                github_url: None,
-            }
+            no_remote()
         }
     };
 
@@ -1269,6 +1289,39 @@ mod tests {
         assert!(GH_PUSH_TIMEOUT_MESSAGE
             .to_lowercase()
             .contains("check your internet connection"));
+    }
+
+    /// The distinction this status exists to make: a GitLab `origin` is not
+    /// the same answer as no `origin`. Reporting it as "no-remote" is what put
+    /// a "Create Repo" button in front of projects that already had one.
+    #[test]
+    fn other_remote_reports_the_host_instead_of_claiming_no_remote() {
+        let remote = crate::commands::git::parse_remote("https://gitlab.com/acme/app.git").unwrap();
+        let status = other_remote(&remote);
+        assert_eq!(status.status, "other-remote");
+        assert_eq!(status.remote_host.as_deref(), Some("gitlab.com"));
+        assert_eq!(status.remote_forge.as_deref(), Some("GitLab"));
+        // Nothing GitHub-shaped is invented for a repo that isn't on GitHub.
+        assert_eq!(status.github_repo, None);
+        assert_eq!(status.github_url, None);
+    }
+
+    #[test]
+    fn other_remote_names_no_forge_for_a_host_it_cannot_classify() {
+        let remote = crate::commands::git::parse_remote("git@git.acme.com:team/app.git").unwrap();
+        let status = other_remote(&remote);
+        assert_eq!(status.status, "other-remote");
+        assert_eq!(status.remote_host.as_deref(), Some("git.acme.com"));
+        // A self-managed host gets its address shown, not a guessed vendor.
+        assert_eq!(status.remote_forge, None);
+    }
+
+    #[test]
+    fn no_remote_carries_no_host() {
+        let status = no_remote();
+        assert_eq!(status.status, "no-remote");
+        assert_eq!(status.remote_host, None);
+        assert_eq!(status.remote_forge, None);
     }
 
     #[test]

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -92,21 +92,18 @@ pub fn get_gh_command_for_project(project_path: &std::path::Path) -> Command {
     cmd
 }
 
-/// Parse "owner/repo" from a GitHub URL (HTTPS or SSH format)
+/// Parse "owner/repo" from a GitHub URL (HTTPS or SSH format).
+///
+/// Delegates to [`parse_remote`](crate::commands::git::parse_remote) so there
+/// is exactly one answer in the codebase to "is this remote GitHub?". This used
+/// to be a substring search for `github.com/`, which took the *first* match
+/// anywhere in the string: `https://evil.com/github.com/owner/repo.git` parsed
+/// as the GitHub repo `owner/repo`, and `github.com.example.com` was rejected
+/// only by luck of punctuation. Matching on the parsed host cannot be spoofed
+/// by a path.
 pub fn parse_github_repo(url: &str) -> Option<String> {
-    // HTTPS: https://github.com/owner/repo.git
-    if let Some(start) = url.find("github.com/") {
-        let rest = &url[start + 11..];
-        let end = rest.find(".git").unwrap_or(rest.len());
-        return Some(rest[..end].trim_end_matches('/').to_string());
-    }
-    // SSH: git@github.com:owner/repo.git
-    if let Some(start) = url.find("github.com:") {
-        let rest = &url[start + 11..];
-        let end = rest.find(".git").unwrap_or(rest.len());
-        return Some(rest[..end].trim_end_matches('/').to_string());
-    }
-    None
+    let remote = crate::commands::git::parse_remote(url)?;
+    remote.is_github().then_some(remote.path)
 }
 
 #[tauri::command]
@@ -1338,6 +1335,20 @@ mod tests {
             parse_github_repo("https://github.com/owner/repo").as_deref(),
             Some("owner/repo")
         );
+    }
+
+    /// A host that merely *contains* github.com, or a path that does, is not
+    /// GitHub. The old substring parser answered "owner/repo" to the first of
+    /// these, which turned another forge's remote into a GitHub link.
+    #[test]
+    fn parse_github_repo_cannot_be_spoofed_by_the_path_or_host() {
+        for url in [
+            "https://evil.com/github.com/owner/repo.git",
+            "https://github.com.evil.com/owner/repo.git",
+            "git@gitlab.com:owner/github.com/repo.git",
+        ] {
+            assert_eq!(parse_github_repo(url), None, "{url} is not GitHub");
+        }
     }
 
     #[test]

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -374,12 +374,25 @@ pub struct GitHubCliStatus {
 /// GitHub connection status - verified against GitHub API
 #[derive(Serialize)]
 pub struct ProjectGitHubStatus {
-    /// "not-a-repo" | "no-remote" | "connected"
+    /// "not-a-repo" | "no-remote" | "other-remote" | "connected"
+    ///
+    /// `other-remote` means the project has an `origin` that parses fine but
+    /// isn't GitHub — a GitLab repo, a self-managed instance, any other forge.
+    /// It was folded into `no-remote` until this variant existed, which made
+    /// the UI tell those users their project had no remote and offer to create
+    /// a GitHub repo to fix it.
     pub status: String,
     /// e.g., "username/repo-name" - only set if connected
     pub github_repo: Option<String>,
     /// e.g., "https://github.com/username/repo-name" - only set if connected
     pub github_url: Option<String>,
+    /// Host of the configured `origin` - only set for "other-remote".
+    pub remote_host: Option<String>,
+    /// Display name of the forge that host identifies ("GitLab"), when it
+    /// identifies one at all. `None` for a host we can read but can't classify;
+    /// callers show [`remote_host`](Self::remote_host) rather than guessing a
+    /// vendor. Only set for "other-remote".
+    pub remote_forge: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -346,6 +346,10 @@ function AppContents({ initialProjectPath }: AppProps) {
     resetLayout,
   } = useWorkspaceLayout({
     isGitHubConnected: integrations.projectGithub?.status === 'connected',
+    // Any remote can have branches; only GitHub has pull requests.
+    canManageBranches:
+      integrations.projectGithub?.status === 'connected' ||
+      integrations.projectGithub?.status === 'other-remote',
   });
 
   // Plugin state

--- a/src/commands/useWorkspaceCommands.tsx
+++ b/src/commands/useWorkspaceCommands.tsx
@@ -1,5 +1,6 @@
 import { useCommands } from './useCommands';
 import { useOpenModal } from '../contexts/ModalContext';
+import { hasPushableRemote, remoteLabel, type ProjectGitHubStatus } from '../lib/github';
 import {
   BranchIcon,
   PlusIcon,
@@ -36,10 +37,14 @@ export interface UseWorkspaceCommandsParams {
   /** Pulls the latest changes from GitHub (routes conflicts to the resolver) */
   handlePullLatest: () => void;
   /**
-   * Push/pull need a remote, and the Branches/PRs panes only render for a
-   * connected repo — commands that land there are hidden otherwise (#612).
+   * The project's remote, as the backend reported it.
+   *
+   * Everything here used to hang off one "is GitHub connected" boolean, which
+   * hid a distinction that matters: push, pull, switch and create are plain git
+   * and work against any forge, while pull requests are GitHub's. Gating all of
+   * them together cost a GitLab project every branch command in the palette.
    */
-  isGitHubConnected: boolean;
+  projectStatus: ProjectGitHubStatus | null;
   /** Opens the "New worktree" modal. */
   openWorktreeCreate: () => void;
   /** Worktree commands only make sense in a git repo (list is empty otherwise). */
@@ -57,11 +62,17 @@ export function useWorkspaceCommands({
   openBranchesMenu,
   openCreateBranch,
   handlePullLatest,
-  isGitHubConnected,
+  projectStatus,
   openWorktreeCreate,
   hasWorktreeData,
 }: UseWorkspaceCommandsParams) {
   const openModal = useOpenModal();
+  /** Pull requests are GitHub's. */
+  const isGitHubConnected = projectStatus?.status === 'connected';
+  /** Branch and sync commands need a remote, not a particular forge. */
+  const repoAvailable = hasPushableRemote(projectStatus);
+  /** "GitHub", "GitLab", or a bare host — never a guessed vendor. */
+  const target = remoteLabel(projectStatus) ?? 'the remote';
 
   useCommands(
     () => [
@@ -77,20 +88,20 @@ export function useWorkspaceCommands({
       },
       {
         id: 'git.push',
-        title: 'Push to GitHub',
+        title: `Push to ${target}`,
         subtitle: hasUncommittedChanges ? 'Commits your changes, then pushes' : undefined,
         icon: <PushIcon size={14} />,
         category: 'branch',
-        when: ({ kind }) => kind === 'project' && isGitHubConnected,
+        when: ({ kind }) => kind === 'project' && repoAvailable,
         keywords: ['publish', 'sync', 'upload', 'commit', 'git'],
         run: openPushDropdown,
       },
       {
         id: 'git.pull',
-        title: 'Pull latest from GitHub',
+        title: `Pull latest from ${target}`,
         icon: <PullIcon size={14} />,
         category: 'branch',
-        when: ({ kind }) => kind === 'project' && isGitHubConnected,
+        when: ({ kind }) => kind === 'project' && repoAvailable,
         keywords: ['sync', 'fetch', 'update', 'download', 'git'],
         run: handlePullLatest,
       },
@@ -100,10 +111,11 @@ export function useWorkspaceCommands({
         subtitle: currentBranch ? `Currently on ${currentBranch}` : undefined,
         icon: <BranchIcon size={14} />,
         category: 'branch',
-        // `useWorkspaceLayout` projects the branches/prs tabs back to preview
-        // when GitHub isn't connected, so without this gate the command was
-        // listed, selectable, and did nothing at all (issue #612).
-        when: ({ kind }) => kind === 'project' && isGitHubConnected,
+        // `useWorkspaceLayout` projects the branches tab back to preview when
+        // the project has no remote, so without this gate the command was
+        // listed, selectable, and did nothing at all (issue #612). It tracks
+        // that projection, which is now "has a remote" rather than "is GitHub".
+        when: ({ kind }) => kind === 'project' && repoAvailable,
         keywords: ['checkout', 'change', 'git'],
         run: openBranchesMenu,
       },
@@ -112,7 +124,7 @@ export function useWorkspaceCommands({
         title: 'Create new branch…',
         icon: <PlusIcon size={14} />,
         category: 'branch',
-        when: ({ kind }) => kind === 'project' && isGitHubConnected,
+        when: ({ kind }) => kind === 'project' && repoAvailable,
         keywords: ['new', 'git', 'checkout -b'],
         run: openCreateBranch,
       },
@@ -125,9 +137,14 @@ export function useWorkspaceCommands({
         icon: <PullRequestIcon size={14} />,
         category: 'branch',
         // Only available on a feature branch — opening a PR from main/
-        // master into itself isn't a real workflow.
+        // master into itself isn't a real workflow — and only where pull
+        // requests exist at all. Without the GitHub gate the palette offered
+        // this to a GitLab project, where it opens a modal that ends in
+        // `gh pr create` against a repo GitHub has never heard of. Every
+        // other GitHub command here was already gated; this one was missed.
         when: ({ kind }) =>
           kind === 'project' &&
+          isGitHubConnected &&
           currentBranch !== null &&
           currentBranch !== 'main' &&
           currentBranch !== 'master',
@@ -158,8 +175,9 @@ export function useWorkspaceCommands({
         title: 'Manage worktrees',
         icon: <BranchIcon size={14} />,
         category: 'branch',
-        // Lives inside the Branches pane, so it needs the same gate (#612).
-        when: ({ kind }) => kind === 'project' && hasWorktreeData && isGitHubConnected,
+        // Lives inside the Branches pane, so it needs the same gate (#612) —
+        // which is now "has a remote", since that pane no longer needs GitHub.
+        when: ({ kind }) => kind === 'project' && hasWorktreeData && repoAvailable,
         keywords: ['worktree', 'remove', 'prune', 'git'],
         run: () => setWorkspaceTab('branches'),
       },
@@ -185,6 +203,8 @@ export function useWorkspaceCommands({
       openCreateBranch,
       handlePullLatest,
       isGitHubConnected,
+      repoAvailable,
+      target,
       openWorktreeCreate,
       hasWorktreeData,
     ]

--- a/src/components/ConnectOverlay.tsx
+++ b/src/components/ConnectOverlay.tsx
@@ -6,6 +6,8 @@
  * @module components/ConnectOverlay
  */
 
+import type { ReactNode } from 'react';
+
 import { GitHubIcon } from '@/components/icons';
 import { Button } from './primitives/Button';
 
@@ -14,10 +16,20 @@ interface ConnectOverlayProps {
   title: string;
   /** Description text with more details */
   description: string;
-  /** Called when user clicks the Connect button */
-  onConnect: () => void;
+  /**
+   * Called when the user clicks the Connect button.
+   *
+   * Optional: omit it to explain rather than sell. A pane can be unavailable
+   * because GitHub isn't connected *or* because the project's remote isn't
+   * GitHub at all, and only the first is fixed by connecting. Offering
+   * "Connect GitHub" to someone whose code lives on GitLab points them at the
+   * wrong problem.
+   */
+  onConnect?: () => void;
   /** Whether connect action is in progress */
   isConnecting?: boolean;
+  /** Defaults to the GitHub mark; pass a neutral one when GitHub isn't the subject. */
+  icon?: ReactNode;
 }
 
 export function ConnectOverlay({
@@ -25,18 +37,19 @@ export function ConnectOverlay({
   description,
   onConnect,
   isConnecting,
+  icon,
 }: ConnectOverlayProps) {
   return (
     <div className="connect-overlay">
       <div className="connect-overlay-content">
-        <div className="connect-overlay-icon">
-          <GitHubIcon size={48} />
-        </div>
+        <div className="connect-overlay-icon">{icon ?? <GitHubIcon size={48} />}</div>
         <h3 className="connect-overlay-title">{title}</h3>
         <p className="connect-overlay-description">{description}</p>
-        <Button variant="primary" onClick={onConnect} disabled={isConnecting}>
-          {isConnecting ? 'Connecting...' : 'Connect GitHub'}
-        </Button>
+        {onConnect && (
+          <Button variant="primary" onClick={onConnect} disabled={isConnecting}>
+            {isConnecting ? 'Connecting...' : 'Connect GitHub'}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/components/branches/BranchesMenu.createRepo.test.tsx
+++ b/src/components/branches/BranchesMenu.createRepo.test.tsx
@@ -24,6 +24,9 @@ vi.mock('../../lib/github', () => ({
   pushToGitHub: vi.fn(() => Promise.resolve()),
   getGitHubOrgs: vi.fn(() => Promise.resolve(['acme-co'])),
   getGitHubUsername: vi.fn(() => Promise.resolve('martin')),
+  // The menu names the remote in its copy. This is the real implementation's
+  // answer for a project with no remote: nothing to name.
+  remoteLabel: vi.fn(() => null),
 }));
 
 /** Mirrors the app: the menu's open state is owned by its parent. */
@@ -35,8 +38,15 @@ function Harness() {
         cliStatus: { installed: true, authenticated: true },
         username: 'martin',
       }}
-      // Not connected — the setup pane with "Create Repo" renders.
-      projectStatus={{ status: 'no-remote', github_repo: null, github_url: null }}
+      // Not connected — the setup pane with "Create Repo" renders. A project
+      // with no remote at all has no host or forge to report either.
+      projectStatus={{
+        status: 'no-remote',
+        github_repo: null,
+        github_url: null,
+        remote_host: null,
+        remote_forge: null,
+      }}
       projectPath="/test/project"
       projectName="ship-studio"
       currentBranch="main"

--- a/src/components/branches/BranchesMenu.test.tsx
+++ b/src/components/branches/BranchesMenu.test.tsx
@@ -28,6 +28,8 @@ const connectedStatus = {
   status: 'connected' as const,
   github_repo: 'martin/ship-studio',
   github_url: 'https://github.com/martin/ship-studio',
+  remote_host: null,
+  remote_forge: null,
 };
 
 function makeProps(overrides: Partial<Parameters<typeof BranchesMenu>[0]> = {}) {
@@ -227,7 +229,13 @@ describe('BranchesMenu', () => {
             cliStatus: { installed: true, authenticated: false },
             username: null,
           },
-          projectStatus: { status: 'no-remote', github_repo: null, github_url: null },
+          projectStatus: {
+            status: 'no-remote',
+            github_repo: null,
+            github_url: null,
+            remote_host: null,
+            remote_forge: null,
+          },
         })}
       />
     );

--- a/src/components/branches/BranchesMenu.tsx
+++ b/src/components/branches/BranchesMenu.tsx
@@ -9,7 +9,7 @@
 import { useCallback, useMemo } from 'react';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import type { BranchInfo, PullRequestInfo } from '../../lib/branches';
-import type { ProjectGitHubStatus } from '../../lib/github';
+import { remoteLabel, type ProjectGitHubStatus } from '../../lib/github';
 import type { GitHubState } from '../../hooks/useIntegrationStatus';
 import {
   AddIcon,
@@ -81,10 +81,19 @@ export function BranchesMenu({
 }: BranchesMenuProps) {
   const close = useCallback(() => onOpenChange(false), [onOpenChange]);
 
+  // Pulling and switching branches are plain git. A project on another forge
+  // is ready for all of it without `gh` — it just can't have the GitHub-only
+  // extras (the repo link, reviews), which are each conditional below.
   const repositoryReady =
-    githubState.cliStatus.installed &&
-    githubState.cliStatus.authenticated &&
-    projectStatus?.status === 'connected';
+    (githubState.cliStatus.installed &&
+      githubState.cliStatus.authenticated &&
+      projectStatus?.status === 'connected') ||
+    projectStatus?.status === 'other-remote';
+
+  /** "GitHub", "GitLab", or a bare host — never a guessed vendor. */
+  const remoteName = remoteLabel(projectStatus) ?? 'GitHub';
+  /** Gates the pull-request section: GitHub owns PRs, git doesn't. */
+  const isGitHubRepo = projectStatus?.status === 'connected';
 
   const recentBranches = useMemo(
     () =>
@@ -201,7 +210,7 @@ export function BranchesMenu({
                 disabled={isPulling}
                 leftIcon={isPulling ? <Spinner size="sm" /> : <PullIcon size={14} />}
               >
-                {isPulling ? 'Pulling latest...' : 'Pull latest from GitHub'}
+                {isPulling ? 'Pulling latest...' : `Pull latest from ${remoteName}`}
               </Button>
             </section>
 
@@ -278,79 +287,86 @@ export function BranchesMenu({
               </Button>
             </section>
 
-            <section className="branches-menu-section" aria-labelledby="branches-menu-prs">
-              <div className="branches-menu-section-heading">
-                <div className="branches-menu-section-heading-main">
-                  <div className="branches-menu-section-title" id="branches-menu-prs">
-                    Pull requests
+            {/* Pull requests are the one thing here that is GitHub's, not
+                git's — `gh pr create` against a GitLab repo cannot work, so a
+                non-GitHub project gets the rest of the menu without it. */}
+            {isGitHubRepo && (
+              <section className="branches-menu-section" aria-labelledby="branches-menu-prs">
+                <div className="branches-menu-section-heading">
+                  <div className="branches-menu-section-heading-main">
+                    <div className="branches-menu-section-title" id="branches-menu-prs">
+                      Pull requests
+                    </div>
+                    <span className="branches-menu-count" aria-label={`${openPRs.length} open`}>
+                      {openPRs.length}
+                    </span>
                   </div>
-                  <span className="branches-menu-count" aria-label={`${openPRs.length} open`}>
-                    {openPRs.length}
-                  </span>
+                  <TextButton
+                    className="branches-menu-section-view-all"
+                    onClick={() => runAndClose(onViewPRs)}
+                  >
+                    View all pull requests
+                  </TextButton>
                 </div>
-                <TextButton
-                  className="branches-menu-section-view-all"
-                  onClick={() => runAndClose(onViewPRs)}
-                >
-                  View all pull requests
-                </TextButton>
-              </div>
-              {currentOpenPR && (
-                <button
-                  type="button"
-                  className="branches-menu-row branches-menu-pr-row"
-                  onClick={() => {
-                    close();
-                    void openUrl(currentOpenPR.url);
-                  }}
-                >
-                  <span className="branches-menu-pr-leading-icon">
-                    <PullRequestIcon size={14} />
-                  </span>
-                  <span className="branches-menu-pr-content">
-                    <span className="branches-menu-pr-main">
-                      <span className="branches-menu-pr-inline">
-                        <span className="branches-menu-pr-number">#{currentOpenPR.number}</span>
-                        {currentOpenPR.title}
+                {currentOpenPR && (
+                  <button
+                    type="button"
+                    className="branches-menu-row branches-menu-pr-row"
+                    onClick={() => {
+                      close();
+                      void openUrl(currentOpenPR.url);
+                    }}
+                  >
+                    <span className="branches-menu-pr-leading-icon">
+                      <PullRequestIcon size={14} />
+                    </span>
+                    <span className="branches-menu-pr-content">
+                      <span className="branches-menu-pr-main">
+                        <span className="branches-menu-pr-inline">
+                          <span className="branches-menu-pr-number">#{currentOpenPR.number}</span>
+                          {currentOpenPR.title}
+                        </span>
+                      </span>
+                      <span className="branches-menu-pr-meta">
+                        <span className="branches-menu-pr-branches">
+                          <span className="branches-menu-pr-branch">{currentOpenPR.headRef}</span>
+                          <span aria-hidden="true">→</span>
+                          <span className="branches-menu-pr-branch">{currentOpenPR.baseRef}</span>
+                        </span>
+                        <span aria-hidden="true">·</span>
+                        <span className="branches-menu-pr-author">{currentOpenPR.author}</span>
                       </span>
                     </span>
-                    <span className="branches-menu-pr-meta">
-                      <span className="branches-menu-pr-branches">
-                        <span className="branches-menu-pr-branch">{currentOpenPR.headRef}</span>
-                        <span aria-hidden="true">→</span>
-                        <span className="branches-menu-pr-branch">{currentOpenPR.baseRef}</span>
+                  </button>
+                )}
+                <Button
+                  width="fill"
+                  variant="ghost"
+                  className="branches-menu-action"
+                  disabled={!pullRequestBranch}
+                  title={
+                    pullRequestBranch
+                      ? `Create a pull request from ${pullRequestBranch}`
+                      : 'Create a feature branch first'
+                  }
+                  onClick={() =>
+                    pullRequestBranch && runAndClose(() => onStartPR(pullRequestBranch))
+                  }
+                >
+                  <span className="branches-menu-action-content">
+                    <span className="branches-menu-action-main">
+                      <span className="branches-menu-action-icon">
+                        <AddIcon size={14} />
                       </span>
-                      <span aria-hidden="true">·</span>
-                      <span className="branches-menu-pr-author">{currentOpenPR.author}</span>
+                      <span className="branches-menu-row-label">New pull request</span>
                     </span>
+                    {pullRequestBranch && (
+                      <span className="branches-menu-row-meta">{pullRequestBranch}</span>
+                    )}
                   </span>
-                </button>
-              )}
-              <Button
-                width="fill"
-                variant="ghost"
-                className="branches-menu-action"
-                disabled={!pullRequestBranch}
-                title={
-                  pullRequestBranch
-                    ? `Create a pull request from ${pullRequestBranch}`
-                    : 'Create a feature branch first'
-                }
-                onClick={() => pullRequestBranch && runAndClose(() => onStartPR(pullRequestBranch))}
-              >
-                <span className="branches-menu-action-content">
-                  <span className="branches-menu-action-main">
-                    <span className="branches-menu-action-icon">
-                      <AddIcon size={14} />
-                    </span>
-                    <span className="branches-menu-row-label">New pull request</span>
-                  </span>
-                  {pullRequestBranch && (
-                    <span className="branches-menu-row-meta">{pullRequestBranch}</span>
-                  )}
-                </span>
-              </Button>
-            </section>
+                </Button>
+              </section>
+            )}
           </>
         )}
       </Dropdown>

--- a/src/components/branches/BranchesTab.pullRequests.test.tsx
+++ b/src/components/branches/BranchesTab.pullRequests.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * "Submit for Review" must not appear for a project whose remote isn't GitHub.
+ *
+ * Everything else on this tab is plain git and works against any forge, but
+ * that button ends in `gh pr create` against a repo GitHub has never heard of.
+ * The tab used to be unreachable for those projects, which hid the problem;
+ * now that a GitLab project can open it, the action has to be gated.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { BranchesTab } from './BranchesTab';
+import { ToastContext } from '../../contexts/ToastContext';
+import type { BranchInfo } from '../../lib/branches';
+
+vi.mock('../../lib/branches', () => ({
+  switchBranch: vi.fn(),
+  deleteBranch: vi.fn(),
+  createBranch: vi.fn(),
+  discardChanges: vi.fn().mockResolvedValue(undefined),
+  formatRelativeTime: vi.fn(() => 'just now'),
+  getBranchPrefixPreference: vi.fn().mockResolvedValue(true),
+  setBranchPrefixPreference: vi.fn().mockResolvedValue(undefined),
+  getDefaultBaseBranch: vi.fn().mockResolvedValue(null),
+  pushBranch: vi.fn(),
+  sanitizeBranchName: vi.fn((s: string) => s),
+}));
+vi.mock('../../lib/git', () => ({ gitPull: vi.fn() }));
+vi.mock('../../lib/worktrees', () => ({
+  listWorktrees: vi.fn().mockResolvedValue([]),
+  removeWorktree: vi.fn(),
+  pruneWorktrees: vi.fn(),
+}));
+vi.mock('../../lib/project', () => ({ openProjectInNewWindow: vi.fn() }));
+vi.mock('../../lib/conflicts', () => ({ getConflictInfo: vi.fn() }));
+vi.mock('../../lib/analytics', () => ({ trackEvent: vi.fn(), trackError: vi.fn() }));
+vi.mock('../../lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('./BranchGraph', () => ({ BranchGraph: () => null }));
+vi.mock('./UnsavedChangesModal', () => ({ UnsavedChangesModal: () => null }));
+vi.mock('./MergeConflictModal', () => ({ MergeConflictModal: () => null }));
+vi.mock('./CreateBranchConflictModal', () => ({ CreateBranchConflictModal: () => null }));
+
+import {
+  formatRelativeTime,
+  getBranchPrefixPreference,
+  getDefaultBaseBranch,
+  sanitizeBranchName,
+} from '../../lib/branches';
+import { listWorktrees } from '../../lib/worktrees';
+
+const featureBranch: BranchInfo = {
+  name: 'feat/pricing',
+  isCurrent: true,
+  isRemote: false,
+  isDefault: false,
+  lastCommitDate: Date.now(),
+  lastCommitAuthor: 'Test',
+  aheadOfMain: 1,
+  behindOfMain: 0,
+  pushed: true,
+};
+
+function renderTab(ui: ReactNode) {
+  render(
+    <ToastContext.Provider value={{ toasts: [], showToast: vi.fn(), dismissToast: vi.fn() }}>
+      {ui}
+    </ToastContext.Provider>
+  );
+}
+
+describe('BranchesTab — pull requests need a GitHub remote', () => {
+  const props = {
+    branches: [featureBranch],
+    currentBranch: 'feat/pricing',
+    projectPath: '/test/project',
+    githubUsername: null,
+    openPRs: [],
+    onBranchSwitch: vi.fn(),
+    onSubmitForReview: vi.fn(),
+    onRefresh: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getBranchPrefixPreference).mockResolvedValue(true);
+    vi.mocked(getDefaultBaseBranch).mockResolvedValue(null);
+    vi.mocked(formatRelativeTime).mockReturnValue('just now');
+    vi.mocked(sanitizeBranchName).mockImplementation((s: string) => s);
+    vi.mocked(listWorktrees).mockResolvedValue([]);
+  });
+
+  it('offers Submit for Review on a GitHub project', async () => {
+    renderTab(<BranchesTab {...props} canOpenPullRequests />);
+
+    expect(await screen.findByRole('button', { name: /submit for review/i })).toBeTruthy();
+  });
+
+  it('hides it when the remote is not GitHub', async () => {
+    renderTab(<BranchesTab {...props} canOpenPullRequests={false} />);
+
+    // The branch itself is still listed — only the PR action is gone.
+    expect(await screen.findByText(/feat\/pricing/)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /submit for review/i })).toBeNull();
+  });
+
+  it('defaults to offering it, so existing callers are unchanged', async () => {
+    renderTab(<BranchesTab {...props} />);
+
+    expect(await screen.findByRole('button', { name: /submit for review/i })).toBeTruthy();
+  });
+});

--- a/src/components/branches/BranchesTab.tsx
+++ b/src/components/branches/BranchesTab.tsx
@@ -115,6 +115,24 @@ interface BranchesTabProps {
   onBranchSwitch: (branchName: string) => void;
   /** Callback to open submit for review modal */
   onSubmitForReview: (branchName: string) => void;
+  /**
+   * Whether this project can have pull requests at all.
+   *
+   * False for a remote that isn't GitHub: everything else on this tab is plain
+   * git and works, but "Submit for Review" would call `gh pr create` against a
+   * repo GitHub has never heard of. Defaults to true so existing callers and
+   * tests are unaffected.
+   */
+  canOpenPullRequests?: boolean;
+  /**
+   * What to call the remote in copy — "GitHub", "GitLab", or a bare host.
+   *
+   * Sending a branch and reverting to the remote version are plain git; only
+   * the wording was ever GitHub-specific, and it read as a lie on a project
+   * that pushes somewhere else. Defaults to "GitHub", so every existing caller
+   * renders exactly as before.
+   */
+  remoteName?: string;
   /** Callback to navigate to the PRs tab */
   onViewPR?: () => void;
   /** Callback to refresh branch list */
@@ -144,6 +162,8 @@ export function BranchesTab({
   onBranchSwitch,
   onSubmitForReview,
   onViewPR,
+  canOpenPullRequests = true,
+  remoteName = 'GitHub',
   onRefresh,
   onSendToAgent,
   worktrees = [],
@@ -417,7 +437,7 @@ export function BranchesTab({
     try {
       await pushBranch(projectPath, branchName);
       void trackEvent('branch_published', { $screen_name: 'Workspace' });
-      onToast?.(`Sent ${branchName} to GitHub`, 'success');
+      onToast?.(`Sent ${branchName} to ${remoteName}`, 'success');
       setSendToGitHubBranch(null);
       onRefresh();
     } catch (e) {
@@ -468,7 +488,7 @@ export function BranchesTab({
       // Pull latest from remote
       await gitPull(projectPath);
 
-      onToast?.(`Reverted to GitHub version`, 'success');
+      onToast?.(`Reverted to the ${remoteName} version`, 'success');
       onRefresh();
     } catch (e) {
       trackError('branch_revert', e, 'Workspace');
@@ -570,8 +590,8 @@ export function BranchesTab({
                   className={`branch-sync-badge ${currentBranchInfo.pushed ? 'synced' : 'local'}`}
                   title={
                     currentBranchInfo.pushed
-                      ? 'This branch exists on GitHub'
-                      : 'This branch is only on your machine. Send it to GitHub to put it there.'
+                      ? `This branch exists on ${remoteName}`
+                      : `This branch is only on your machine. Send it to ${remoteName} to put it there.`
                   }
                 >
                   {currentBranchInfo.pushed ? 'On GitHub' : 'Local only'}
@@ -586,7 +606,8 @@ export function BranchesTab({
               </div>
             </div>
             <div className="branch-card-actions">
-              {!currentBranchInfo.isDefault &&
+              {canOpenPullRequests &&
+                !currentBranchInfo.isDefault &&
                 currentBranchInfo.name !== 'staging' &&
                 (() => {
                   const existingPR = openPRs.find((pr) => pr.headRef === currentBranchInfo.name);
@@ -615,12 +636,12 @@ export function BranchesTab({
                   size="compact"
                   onClick={() => setSendToGitHubBranch(currentBranchInfo.name)}
                   disabled={publishingBranch === currentBranchInfo.name}
-                  title="Push this branch to GitHub (no pull request)"
+                  title={`Push this branch to ${remoteName} (no pull request)`}
                   leftIcon={
                     publishingBranch === currentBranchInfo.name ? undefined : <PushIcon size={14} />
                   }
                 >
-                  Send to GitHub
+                  Send to {remoteName}
                 </Button>
               )}
               <Button
@@ -631,7 +652,7 @@ export function BranchesTab({
                 title="Discard local changes and pull from GitHub"
                 leftIcon={isReverting ? undefined : <PullIcon size={14} />}
               >
-                {isReverting ? 'Reverting...' : 'Revert to GitHub'}
+                {isReverting ? 'Reverting...' : `Revert to ${remoteName}`}
               </Button>
             </div>
           </div>
@@ -743,6 +764,7 @@ export function BranchesTab({
           <div className="branches-tab-section-header">Your Branches</div>
           {userBranches.map((branch) => (
             <BranchCard
+              remoteName={remoteName}
               key={branch.name}
               branch={branch}
               isCurrent={false}
@@ -766,6 +788,7 @@ export function BranchesTab({
           <div className="branches-tab-section-header">Team Branches</div>
           {teamBranches.map((branch) => (
             <BranchCard
+              remoteName={remoteName}
               key={branch.name}
               branch={branch}
               isCurrent={false}
@@ -789,6 +812,7 @@ export function BranchesTab({
           <div className="branches-tab-section-header">Main Branches</div>
           {mainBranches.map((branch) => (
             <BranchCard
+              remoteName={remoteName}
               key={branch.name}
               branch={branch}
               isCurrent={false}
@@ -1027,13 +1051,13 @@ export function BranchesTab({
           isOpen
           onClose={() => setSendToGitHubBranch(null)}
           dismissable={!publishingBranch}
-          title="Send to GitHub?"
+          title={`Send to ${remoteName}?`}
           className="post-merge-content"
         >
           <div className="post-merge-body">
             <p>
-              This puts <strong>{sendToGitHubBranch}</strong> on GitHub so it's saved there and your
-              teammates can see it.
+              This puts <strong>{sendToGitHubBranch}</strong> on {remoteName} so it's saved there
+              and your teammates can see it.
             </p>
             <p>
               It <strong>won't</strong> open a pull request or merge anything. It just uploads the
@@ -1055,7 +1079,7 @@ export function BranchesTab({
               disabled={!!publishingBranch}
               leftIcon={publishingBranch ? undefined : <PushIcon size={14} />}
             >
-              {publishingBranch ? 'Sending...' : 'Send to GitHub'}
+              {publishingBranch ? 'Sending...' : `Send to ${remoteName}`}
             </Button>
           </div>
         </ModalFrame>
@@ -1067,7 +1091,7 @@ export function BranchesTab({
           isOpen
           onClose={() => setShowRevertConfirm(false)}
           dismissable={!isReverting}
-          title="Revert to GitHub?"
+          title={`Revert to ${remoteName}?`}
           className="post-merge-content"
         >
           <div className="post-merge-body">
@@ -1158,6 +1182,8 @@ interface BranchCardProps {
   isPublishing: boolean;
   showDelete?: boolean;
   showSubmitForReview?: boolean;
+  /** What to call the remote — see BranchesTabProps.remoteName. */
+  remoteName?: string;
 }
 
 function BranchCard({
@@ -1172,6 +1198,7 @@ function BranchCard({
   isPublishing,
   showDelete = false,
   showSubmitForReview = false,
+  remoteName = 'GitHub',
 }: BranchCardProps) {
   // Non-current cards act as a big "switch to this branch" button.
   const cardIsClickable = !isCurrent && !isSwitching;
@@ -1205,8 +1232,8 @@ function BranchCard({
             className={`branch-sync-badge ${branch.pushed ? 'synced' : 'local'}`}
             title={
               branch.pushed
-                ? 'This branch exists on GitHub'
-                : 'This branch is only on your machine. Send it to GitHub to put it there.'
+                ? `This branch exists on ${remoteName}`
+                : `This branch is only on your machine. Send it to ${remoteName} to put it there.`
             }
           >
             {branch.pushed ? 'On GitHub' : 'Local only'}
@@ -1246,7 +1273,7 @@ function BranchCard({
             disabled={isPublishing}
             leftIcon={isPublishing ? undefined : <PushIcon size={14} />}
           >
-            Send to GitHub
+            Send to {remoteName}
           </Button>
         )}
         {showDelete && (

--- a/src/components/branches/GitHubButton.test.tsx
+++ b/src/components/branches/GitHubButton.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Tests for GitHubButton's handling of remotes that aren't GitHub.
+ *
+ * The contract: a project whose code lives elsewhere is never pushed toward
+ * GitHub — not to create a repo it already has, and not to install or sign in
+ * to a CLI it has no use for.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { GitHubButton } from './GitHubButton';
+import type { ProjectGitHubStatus } from '../../lib/github';
+
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn() }));
+
+function status(overrides: Partial<ProjectGitHubStatus>): ProjectGitHubStatus {
+  return {
+    status: 'no-remote',
+    github_repo: null,
+    github_url: null,
+    remote_host: null,
+    remote_forge: null,
+    ...overrides,
+  };
+}
+
+function makeProps(overrides?: Partial<Parameters<typeof GitHubButton>[0]>) {
+  return {
+    githubState: {
+      cliStatus: { installed: true, authenticated: true },
+      username: 'someone',
+    } as Parameters<typeof GitHubButton>[0]['githubState'],
+    projectStatus: null,
+    projectPath: '/test/path',
+    projectName: 'acme',
+    onStatusChange: vi.fn(),
+    onGitHubConnect: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('GitHubButton with a non-GitHub remote', () => {
+  const gitlab = status({
+    status: 'other-remote',
+    remote_host: 'gitlab.com',
+    remote_forge: 'GitLab',
+  });
+
+  it('names the forge instead of offering to create a repo', () => {
+    render(<GitHubButton {...makeProps({ projectStatus: gitlab })} />);
+
+    expect(screen.getByText('GitLab')).toBeInTheDocument();
+    expect(screen.queryByText('Create Repo')).not.toBeInTheDocument();
+  });
+
+  it('shows the bare host when the forge is unknown', () => {
+    const selfManaged = status({
+      status: 'other-remote',
+      remote_host: 'git.acme.com',
+      remote_forge: null,
+    });
+
+    render(<GitHubButton {...makeProps({ projectStatus: selfManaged })} />);
+
+    expect(screen.getByText('git.acme.com')).toBeInTheDocument();
+  });
+
+  it('does not tell a GitLab project to install the GitHub CLI', () => {
+    // The remote is the answer regardless of gh's state — this check has to
+    // come before the install/connect prompts, not after them.
+    render(
+      <GitHubButton
+        {...makeProps({
+          projectStatus: gitlab,
+          githubState: {
+            cliStatus: { installed: false, authenticated: false },
+            username: null,
+          } as Parameters<typeof GitHubButton>[0]['githubState'],
+        })}
+      />
+    );
+
+    expect(screen.queryByText('Install CLI')).not.toBeInTheDocument();
+    expect(screen.getByText('GitLab')).toBeInTheDocument();
+  });
+
+  it('does not tell a GitLab project to connect a GitHub account', () => {
+    render(
+      <GitHubButton
+        {...makeProps({
+          projectStatus: gitlab,
+          githubState: {
+            cliStatus: { installed: true, authenticated: false },
+            username: null,
+          } as Parameters<typeof GitHubButton>[0]['githubState'],
+        })}
+      />
+    );
+
+    expect(screen.queryByText('Connect')).not.toBeInTheDocument();
+    expect(screen.getByText('GitLab')).toBeInTheDocument();
+  });
+
+  it('still offers to create a repo when there is genuinely no remote', () => {
+    render(<GitHubButton {...makeProps({ projectStatus: status({ status: 'no-remote' }) })} />);
+
+    expect(screen.getByText('Create Repo')).toBeInTheDocument();
+  });
+});

--- a/src/components/branches/GitHubButton.tsx
+++ b/src/components/branches/GitHubButton.tsx
@@ -136,6 +136,29 @@ export function GitHubButton({
     }
   }, [projectStatus?.status]);
 
+  // Checked before the gh install/connect prompts below: a project whose code
+  // lives on GitLab has no reason to be told to install the GitHub CLI or sign
+  // in to GitHub. Its remote is the answer, whatever gh's state is.
+  //
+  // The project already has a remote, just not one we integrate with. Say so
+  // and name it — offering "Create Repo" here would be offering to solve a
+  // problem the user doesn't have, and creating a second home for their code.
+  if (projectStatus?.status === 'other-remote') {
+    const where = projectStatus.remote_forge ?? projectStatus.remote_host;
+    return (
+      <Button
+        disabled
+        title={
+          `This project's remote is ${where ?? 'not on GitHub'}. Git operations work; ` +
+          `repository and pull request features are GitHub-only.`
+        }
+      >
+        <GitHubIcon size={12} />
+        <span className="github-button-label">{where ?? 'Not GitHub'}</span>
+      </Button>
+    );
+  }
+
   // If gh CLI not installed, show install prompt
   if (!cliStatus.installed) {
     return (
@@ -203,7 +226,7 @@ export function GitHubButton({
         title="Create GitHub repository"
       >
         <GitHubIcon size={12} />
-        <span style={{ whiteSpace: 'nowrap' }}>Create Repo</span>
+        <span className="github-button-label">Create Repo</span>
       </Button>
 
       {/* Create Repo Modal */}

--- a/src/components/branches/PublishBranchDropdown.test.tsx
+++ b/src/components/branches/PublishBranchDropdown.test.tsx
@@ -259,4 +259,96 @@ describe('PublishBranchDropdown open panel', () => {
     expect(screen.getByText(/Nothing to push/i)).toBeInTheDocument();
     expectNoBannedLabels();
   });
+
+  describe('remotes that are not GitHub', () => {
+    const gitlabStatus = {
+      status: 'other-remote',
+      github_repo: null,
+      github_url: null,
+      remote_host: 'gitlab.com',
+      remote_forge: 'GitLab',
+    } as unknown as ProjectGitHubStatus;
+
+    const selfManagedStatus = {
+      status: 'other-remote',
+      github_repo: null,
+      github_url: null,
+      remote_host: 'git.acme.com',
+      remote_forge: null,
+    } as unknown as ProjectGitHubStatus;
+
+    it('lets a GitLab project push', () => {
+      // The regression: Push was gated on having a *GitHub* repo, so a GitLab
+      // project got a permanently disabled button telling it to create one.
+      // `publish_branch` is plain `git push` and always would have worked.
+      render(<PublishBranchDropdown {...makeProps({ projectGithubStatus: gitlabStatus })} />);
+
+      const trigger = screen.getByText('Push').closest('button');
+      expect(trigger).not.toBeDisabled();
+    });
+
+    it('names the actual forge instead of saying GitHub', () => {
+      const { container } = render(
+        <PublishBranchDropdown
+          {...makeProps({ projectGithubStatus: gitlabStatus, currentBranch: 'main' })}
+        />
+      );
+
+      fireEvent.click(screen.getByText('Push'));
+
+      expect(container.querySelector('.publish-branch-description')).toHaveTextContent(
+        'Commits your changes and pushes the main branch to GitLab.'
+      );
+      expect(screen.getByRole('heading', { name: 'Push to GitLab' })).toBeInTheDocument();
+      expect(container.textContent).not.toContain('GitHub');
+    });
+
+    it('falls back to the host when the forge is unknown', () => {
+      // A self-managed instance gets its address shown, not a guessed vendor.
+      const { container } = render(
+        <PublishBranchDropdown
+          {...makeProps({ projectGithubStatus: selfManagedStatus, currentBranch: 'main' })}
+        />
+      );
+
+      fireEvent.click(screen.getByText('Push'));
+
+      expect(container.querySelector('.publish-branch-description')).toHaveTextContent(
+        'Commits your changes and pushes the main branch to git.acme.com.'
+      );
+      expect(container.textContent).not.toContain('GitHub');
+    });
+
+    it('does not offer PR creation for a non-GitHub remote', () => {
+      // `gh pr create` has nothing to talk to here.
+      const onCreatePR = vi.fn();
+      render(
+        <PublishBranchDropdown
+          {...makeProps({
+            projectGithubStatus: gitlabStatus,
+            currentBranch: 'feature/x',
+            onCreatePR,
+          })}
+        />
+      );
+
+      fireEvent.click(screen.getByText('Push'));
+
+      expect(screen.queryByText(/create a PR/i)).not.toBeInTheDocument();
+    });
+
+    it('still disables push when there is no remote at all', () => {
+      const noRemote = {
+        status: 'no-remote',
+        github_repo: null,
+        github_url: null,
+        remote_host: null,
+        remote_forge: null,
+      } as unknown as ProjectGitHubStatus;
+
+      render(<PublishBranchDropdown {...makeProps({ projectGithubStatus: noRemote })} />);
+
+      expect(screen.getByText('Push').closest('button')).toBeDisabled();
+    });
+  });
 });

--- a/src/components/branches/PublishBranchDropdown.tsx
+++ b/src/components/branches/PublishBranchDropdown.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { ProjectGitHubStatus } from '../../lib/github';
+import { ProjectGitHubStatus, hasPushableRemote, remoteLabel } from '../../lib/github';
 import { publishBranch } from '../../lib/branches';
 import { ChevronIcon, BranchIcon, SuccessIcon, ErrorIcon, PushIcon } from '@/components/icons';
 import { Spinner } from '../primitives/Spinner';
@@ -119,6 +119,12 @@ export function PublishBranchDropdown({
 
   const hasGitHubRepo =
     projectGithubStatus?.status === 'connected' && projectGithubStatus?.github_repo;
+  // Pushing is plain `git push` (publishing.rs) and works against any remote.
+  // Gating it on hasGitHubRepo disabled the button outright for GitLab and
+  // self-managed projects, which could push perfectly well.
+  const canPush = hasPushableRemote(projectGithubStatus);
+  // Never say "GitHub" to a project whose code isn't there.
+  const where = remoteLabel(projectGithubStatus) ?? 'the remote';
   const isMainBranch = currentBranch === 'main' || currentBranch === 'master';
   const isOpen = controlledOpen ?? internalOpen;
 
@@ -304,8 +310,8 @@ export function PublishBranchDropdown({
     );
   }
 
-  // If no GitHub repo, show disabled state
-  if (!hasGitHubRepo) {
+  // No remote at all — nothing to push to.
+  if (!canPush) {
     return (
       <div
         className={`publish-dropdown${grouped ? ' publish-dropdown--grouped' : ''}`}
@@ -317,7 +323,7 @@ export function PublishBranchDropdown({
           className="source-control-push-button"
           data-education-id="publish-button"
           disabled
-          title="Create a GitHub repository first"
+          title="Create a repository for this project first"
         >
           <span className="source-control-push-content">
             <PushIcon size={16} />
@@ -363,8 +369,9 @@ export function PublishBranchDropdown({
               </div>
               {!isMainBranch && (
                 <div className="publish-branch-hint">
-                  Your changes are on the <strong>{currentBranch}</strong> branch on GitHub.
-                  {onCreatePR && (
+                  Your changes are on the <strong>{currentBranch}</strong> branch on {where}.
+                  {/* PR creation is `gh pr create` — GitHub only. */}
+                  {hasGitHubRepo && onCreatePR && (
                     <>
                       {' '}
                       When they are ready for review,{' '}
@@ -396,7 +403,7 @@ export function PublishBranchDropdown({
                 {publishState.errorType === 'push_rejected'
                   ? 'Push was rejected. Someone else pushed changes to this branch.'
                   : publishState.errorType === 'auth_error'
-                    ? 'Authentication failed. Please check your GitHub connection.'
+                    ? `Authentication failed. Please check your ${where} connection.`
                     : publishState.message}
               </div>
             </>
@@ -407,7 +414,7 @@ export function PublishBranchDropdown({
             <>
               <div className="publish-in-progress-header">
                 <Spinner />
-                <span>Pushing to GitHub...</span>
+                <span>Pushing to {where}...</span>
               </div>
             </>
           )}
@@ -416,7 +423,7 @@ export function PublishBranchDropdown({
           {publishState.status === 'idle' && canSync && (
             <>
               <div className="publish-branch-header">
-                <h3>Push to GitHub</h3>
+                <h3>Push to {where}</h3>
               </div>
 
               <div className="publish-branch-body">
@@ -426,8 +433,8 @@ export function PublishBranchDropdown({
                 </div>
 
                 <div className="publish-branch-description">
-                  Commits your changes and pushes the <strong>{currentBranch}</strong> branch to
-                  GitHub.
+                  Commits your changes and pushes the <strong>{currentBranch}</strong> branch to{' '}
+                  {where}.
                 </div>
               </div>
 
@@ -440,7 +447,7 @@ export function PublishBranchDropdown({
             <>
               <div className="publish-success">
                 <SuccessIcon />
-                <span>Nothing to push — GitHub is up to date</span>
+                <span>Nothing to push — {where} is up to date</span>
               </div>
             </>
           )}

--- a/src/components/workspace/BranchPRTabContainer.tsx
+++ b/src/components/workspace/BranchPRTabContainer.tsx
@@ -6,6 +6,7 @@
  * @module components/workspace/BranchPRTabContainer
  */
 
+import { PullRequestIcon } from '@/components/icons';
 import { BranchesTab } from '../branches/BranchesTab';
 import { PullRequestsTab } from '../branches/PullRequestsTab';
 import { ConnectOverlay } from '../ConnectOverlay';
@@ -83,11 +84,24 @@ export function BranchPRTabContainer({
     integrations.github.cliStatus.authenticated &&
     integrations.projectGithub?.status === 'connected';
 
+  // A remote that isn't GitHub is still a remote. Branch management is plain
+  // git — switching, creating, deleting, worktrees — and none of it has ever
+  // needed GitHub, but this pane was gated on a GitHub connection, so a GitLab
+  // project got an overlay asking it to connect GitHub instead of its branches.
+  const otherRemote = integrations.projectGithub?.status === 'other-remote';
+  const canManageBranches = githubConnected || otherRemote;
+  // What to call the remote in copy: "GitLab" where the host says so, else the
+  // host itself. Never a guessed vendor — see lib/github.ts remoteLabel.
+  const remoteName =
+    integrations.projectGithub?.remote_forge ?? integrations.projectGithub?.remote_host ?? null;
+
   return (
     <>
       {showBranchesPane &&
-        (githubConnected ? (
+        (canManageBranches ? (
           <BranchesTab
+            canOpenPullRequests={githubConnected}
+            remoteName={remoteName ?? 'GitHub'}
             branches={branches}
             currentBranch={currentBranch || ''}
             projectPath={projectPath}
@@ -133,11 +147,22 @@ export function BranchPRTabContainer({
           />
         ) : (
           <div style={{ position: 'relative', flex: 1 }}>
-            <ConnectOverlay
-              title="Connect GitHub to view pull requests"
-              description="Submit code for review, merge changes, and track your team's work."
-              onConnect={() => void handleGitHubConnect()}
-            />
+            {otherRemote ? (
+              // Connecting GitHub would not give this project pull requests —
+              // its code is somewhere else. Say what's true instead of offering
+              // a button that fixes nothing.
+              <ConnectOverlay
+                icon={<PullRequestIcon size={48} />}
+                title="Pull requests need a GitHub remote"
+                description={`This project pushes to ${remoteName ?? 'another remote'}. Branches, pushing and syncing all work as usual — reviewing pull requests from Ship Studio is GitHub-only.`}
+              />
+            ) : (
+              <ConnectOverlay
+                title="Connect GitHub to view pull requests"
+                description="Submit code for review, merge changes, and track your team's work."
+                onConnect={() => void handleGitHubConnect()}
+              />
+            )}
           </div>
         ))}
     </>

--- a/src/components/workspace/WorkspaceHeader.tsx
+++ b/src/components/workspace/WorkspaceHeader.tsx
@@ -28,6 +28,7 @@ import { BranchIndicator } from '../branches/BranchIndicator';
 import { BranchesMenu } from '../branches/BranchesMenu';
 import { openInFinder } from '../../lib/ide';
 import { PublishBranchDropdown } from '../branches/PublishBranchDropdown';
+import { hasPushableRemote } from '../../lib/github';
 import { PluginSlot } from '../plugins/PluginSlot';
 import {
   AgentsIcon,
@@ -340,11 +341,12 @@ export function WorkspaceHeader({
     currentBranch !== null &&
     (branches.find((branch) => branch.name === currentBranch)?.isDefault ?? false);
   // PublishBranchDropdown renders a bare disabled trigger (no menu at all)
-  // until the project has a GitHub repo, so anything that claims to "open
-  // Push" has to be gated on the same condition or it opens nothing.
-  const pushMenuAvailable =
-    integrations.projectGithub?.status === 'connected' &&
-    Boolean(integrations.projectGithub?.github_repo);
+  // until the project has a remote, so anything that claims to "open Push"
+  // has to be gated on the same condition or it opens nothing. Share the
+  // predicate rather than restating it — the two drifted once already, which
+  // is why a GitLab project's Push menu stayed shut after the dropdown itself
+  // had learned to open it.
+  const pushMenuAvailable = hasPushableRemote(integrations.projectGithub);
   const projectPathContainerRef = useRef<HTMLDivElement>(null);
   const [expandedProjectPathWidth, setExpandedProjectPathWidth] = useState<number | null>(null);
 

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -846,7 +846,7 @@ export const WorkspaceView = memo(function WorkspaceView({
       setCreateBranchRequest((request) => request + 1);
     },
     handlePullLatest: () => void handlePullLatest(),
-    isGitHubConnected: integrations.projectGithub?.status === 'connected',
+    projectStatus: integrations.projectGithub ?? null,
     openWorktreeCreate: worktree.openCreate,
     hasWorktreeData: worktree.worktrees.length > 0,
   });

--- a/src/harness/scenarios/features.ts
+++ b/src/harness/scenarios/features.ts
@@ -95,6 +95,52 @@ export const featureScenarios: Scenario[] = [
     commands: { ...workspaceCommands },
   },
   {
+    id: 'gitlab-remote-push',
+    title: 'Push popover — a GitLab remote',
+    looksRightWhen:
+      'Push is enabled and the copy says GitLab throughout — heading, description, and the hint. ' +
+      'The word "GitHub" appears nowhere, and nothing offers to create a GitHub repository.',
+    project: WORKSPACE_PROJECT,
+    openSelector: '.source-control-push-button',
+    clipSelector: '.publish-dropdown-menu',
+    requires: '.publish-dropdown-menu',
+    commands: {
+      ...workspaceCommands,
+      get_project_github_status: {
+        status: 'other-remote',
+        github_repo: null,
+        github_url: null,
+        remote_host: 'gitlab.com',
+        remote_forge: 'GitLab',
+      },
+      // Show the popover with work to push, so the heading and description
+      // are on screen — the strings that used to hardcode "GitHub".
+      check_git_has_changes: true,
+    },
+  },
+  {
+    id: 'self-managed-remote-push',
+    title: 'Push popover — a self-managed remote',
+    looksRightWhen:
+      'The host (git.acme.com) is named literally. No vendor is guessed from the hostname, ' +
+      'and push still works.',
+    project: WORKSPACE_PROJECT,
+    openSelector: '.source-control-push-button',
+    clipSelector: '.publish-dropdown-menu',
+    requires: '.publish-dropdown-menu',
+    commands: {
+      ...workspaceCommands,
+      get_project_github_status: {
+        status: 'other-remote',
+        github_repo: null,
+        github_url: null,
+        remote_host: 'git.acme.com',
+        remote_forge: null,
+      },
+      check_git_has_changes: true,
+    },
+  },
+  {
     id: 'branches-many',
     // Nothing opened the branches menu, so this photographed the workspace —
     // no branch list, no ahead/behind counts, none of what the caption checks.

--- a/src/harness/scenarios/features.ts
+++ b/src/harness/scenarios/features.ts
@@ -141,6 +141,61 @@ export const featureScenarios: Scenario[] = [
     },
   },
   {
+    id: 'gitlab-branches-tab',
+    // Reached via `branch.create`, which is itself one of the commands that
+    // used to be hidden for a non-GitHub remote — if the gate regresses, the
+    // palette won't have the command and this capture fails rather than
+    // quietly photographing the preview tab.
+    command: 'branch.create',
+    requires: '.branch-card',
+    title: 'Branches tab — a GitLab remote',
+    looksRightWhen:
+      'The branch list is fully usable: switch, create, delete, worktrees. No "Connect GitHub" ' +
+      'overlay, and no "Submit for Review" button, because pull requests need a GitHub remote.',
+    project: WORKSPACE_PROJECT,
+    commands: {
+      ...workspaceCommands,
+      get_project_github_status: {
+        status: 'other-remote',
+        github_repo: null,
+        github_url: null,
+        remote_host: 'gitlab.com',
+        remote_forge: 'GitLab',
+      },
+      list_branches: [
+        branch('main', { is_current: false, is_default: true }),
+        branch('feat/pricing-page', { is_current: true, ahead_of_main: 3, behind_main: 1 }),
+        branch('chore/deps', { behind_main: 2 }),
+      ],
+    },
+  },
+  {
+    id: 'gitlab-branches-menu',
+    command: 'branch.switch',
+    requires: '.branches-menu-branch-row',
+    title: 'Branches menu — a GitLab remote',
+    looksRightWhen:
+      'The menu is fully populated — sync and the branch list — rather than the "Connect this ' +
+      'project to GitHub" setup panel. Pull says GitLab, and there is no "Open in GitHub" link, ' +
+      'because we have no GitLab URL to open.',
+    project: WORKSPACE_PROJECT,
+    commands: {
+      ...workspaceCommands,
+      get_project_github_status: {
+        status: 'other-remote',
+        github_repo: null,
+        github_url: null,
+        remote_host: 'gitlab.com',
+        remote_forge: 'GitLab',
+      },
+      list_branches: [
+        branch('main', { is_current: true, is_default: true }),
+        branch('feat/pricing-page', { ahead_of_main: 3, behind_main: 1 }),
+        branch('chore/deps', { behind_main: 2 }),
+      ],
+    },
+  },
+  {
     id: 'branches-many',
     // Nothing opened the branches menu, so this photographed the workspace —
     // no branch list, no ahead/behind counts, none of what the caption checks.

--- a/src/harness/scenarios/workspace.ts
+++ b/src/harness/scenarios/workspace.ts
@@ -42,11 +42,19 @@ export const workspaceCommands: CommandMap = {
     workspace_has_package_json: false,
   },
 
+  // Asked for on every workspace open. Unmocked it badged every workspace
+  // capture incomplete, which by this harness's own rule means none of their
+  // screenshots counted as evidence. `true` is the backend's default
+  // (settings.rs: element_breadcrumb_enabled.unwrap_or(true)).
+  get_element_breadcrumb_enabled: true,
+
   // ---- git / github ------------------------------------------------------
   get_project_github_status: {
     status: 'connected',
     github_repo: 'harness-user/acme-marketing',
     github_url: 'https://github.com/harness-user/acme-marketing',
+    remote_host: null,
+    remote_forge: null,
   },
   list_pull_requests: [],
   // Asked for on every workspace open (`useBranchManagement`). Without it

--- a/src/hooks/useIntegrationStatus.test.ts
+++ b/src/hooks/useIntegrationStatus.test.ts
@@ -6,9 +6,13 @@ import { useIntegrationStatus, GITHUB_STATUS_FALLBACK } from './useIntegrationSt
 vi.mock('../lib/github', () => ({
   checkGitHubCliStatus: vi.fn().mockResolvedValue({ installed: false, authenticated: false }),
   getGitHubUsername: vi.fn().mockResolvedValue(null),
-  getProjectGitHubStatus: vi
-    .fn()
-    .mockResolvedValue({ status: 'no-remote', github_repo: null, github_url: null }),
+  getProjectGitHubStatus: vi.fn().mockResolvedValue({
+    status: 'no-remote',
+    github_repo: null,
+    github_url: null,
+    remote_host: null,
+    remote_forge: null,
+  }),
 }));
 
 vi.mock('../lib/claude', () => ({
@@ -276,6 +280,8 @@ describe('useIntegrationStatus', () => {
         status: 'connected' as const,
         github_repo: 'user/repo',
         github_url: 'https://github.com/user/repo',
+        remote_host: null,
+        remote_forge: null,
       };
       vi.mocked(github.getProjectGitHubStatus).mockResolvedValue(projectStatus);
 
@@ -297,6 +303,8 @@ describe('useIntegrationStatus', () => {
         status: 'connected' as const,
         github_repo: 'org/repo',
         github_url: 'https://github.com/org/repo',
+        remote_host: null,
+        remote_forge: null,
       };
 
       act(() => {
@@ -314,6 +322,8 @@ describe('useIntegrationStatus', () => {
           status: 'connected',
           github_repo: 'org/repo',
           github_url: 'https://github.com/org/repo',
+          remote_host: null,
+          remote_forge: null,
         });
       });
 

--- a/src/hooks/useIntegrationStatus.ts
+++ b/src/hooks/useIntegrationStatus.ts
@@ -151,11 +151,19 @@ export interface UseIntegrationStatusReturn {
   fetchProjectGitHubStatus: (projectPath: string) => Promise<ProjectGitHubStatus>;
 }
 
-/** Fallback GitHub status when check fails */
+/**
+ * Fallback GitHub status when the check fails.
+ *
+ * Stays `no-remote` rather than `other-remote`: a failed check tells us
+ * nothing about where the code lives, and naming a host we never read would
+ * be exactly the invention this status was split up to avoid.
+ */
 export const GITHUB_STATUS_FALLBACK: ProjectGitHubStatus = {
   status: 'no-remote',
   github_repo: null,
   github_url: null,
+  remote_host: null,
+  remote_forge: null,
 };
 
 /**

--- a/src/hooks/useWorkspaceLayout.test.ts
+++ b/src/hooks/useWorkspaceLayout.test.ts
@@ -83,4 +83,41 @@ describe('useWorkspaceLayout', () => {
     });
     expect(result.current.isPreviewHidden).toBe(true);
   });
+
+  // A GitLab project is not a GitHub project, but it does have branches.
+  describe('a remote that is not GitHub', () => {
+    const gitlabProject = { isGitHubConnected: false, canManageBranches: true };
+
+    it('can still reach its branches', () => {
+      const { result } = renderHook(() => useWorkspaceLayout(gitlabProject));
+
+      act(() => {
+        result.current.setWorkspaceTab('branches');
+      });
+
+      // Before this, branches was projected to preview whenever GitHub was
+      // absent, so the tab could not be opened at all.
+      expect(result.current.workspaceTab).toBe('branches');
+    });
+
+    it('still cannot reach pull requests, which are GitHub-only', () => {
+      const { result } = renderHook(() => useWorkspaceLayout(gitlabProject));
+
+      act(() => {
+        result.current.setWorkspaceTab('prs');
+      });
+
+      expect(result.current.workspaceTab).toBe('preview');
+    });
+  });
+
+  it('keeps the old behaviour when canManageBranches is not passed', () => {
+    const { result } = renderHook(() => useWorkspaceLayout({ isGitHubConnected: false }));
+
+    act(() => {
+      result.current.setWorkspaceTab('branches');
+    });
+
+    expect(result.current.workspaceTab).toBe('preview');
+  });
 });

--- a/src/hooks/useWorkspaceLayout.ts
+++ b/src/hooks/useWorkspaceLayout.ts
@@ -13,6 +13,16 @@ import { trackPageview } from '../lib/analytics';
 interface UseWorkspaceLayoutParams {
   /** Whether GitHub is connected for the current project */
   isGitHubConnected: boolean;
+  /**
+   * Whether the branches tab has anything to show — true for any project with
+   * a remote, GitHub or not.
+   *
+   * Branch management is plain git. Gating it on GitHub meant a GitLab project
+   * selecting "Branches" was silently returned to the preview tab, with no way
+   * to reach its own branches. Defaults to `isGitHubConnected`, so a caller
+   * that doesn't pass it keeps the old behaviour.
+   */
+  canManageBranches?: boolean;
 }
 
 type WorkspaceTab = 'preview' | 'code' | 'branches' | 'prs';
@@ -24,7 +34,11 @@ const TAB_SCREEN: Record<WorkspaceTab, string> = {
   prs: 'Workspace - Pull Requests',
 };
 
-export function useWorkspaceLayout({ isGitHubConnected }: UseWorkspaceLayoutParams) {
+export function useWorkspaceLayout({
+  isGitHubConnected,
+  canManageBranches,
+}: UseWorkspaceLayoutParams) {
+  const branchesAvailable = canManageBranches ?? isGitHubConnected;
   // Health-logs panel visibility (takes over the terminal pane when the user
   // opens the code-health log feed).
   const [showHealthLogs, setShowHealthLogs] = useState(false);
@@ -33,21 +47,24 @@ export function useWorkspaceLayout({ isGitHubConnected }: UseWorkspaceLayoutPara
   const [isPreviewHidden, setIsPreviewHidden] = useState(false);
 
   // Workspace tab state (preview/code/branches/prs). The raw value is what the
-  // user selected; `workspaceTab` below projects it through the GitHub-connected
-  // gate so branches/prs fall back to preview when GitHub isn't available. We
-  // keep the raw value so the user's last selection comes back on reconnect.
+  // user selected; `workspaceTab` below projects each of branches/prs through
+  // its own gate and falls back to preview when that tab can't apply. We keep
+  // the raw value so the user's last selection comes back on reconnect.
   const [workspaceTabRaw, setWorkspaceTabRaw] = useState<WorkspaceTab>('preview');
 
   // Tab switches are recorded as the `$pageview` below, not as a separate
   // click event — one screen change, one event.
   const setWorkspaceTab = setWorkspaceTabRaw;
 
-  const workspaceTab: WorkspaceTab =
-    !isGitHubConnected && (workspaceTabRaw === 'branches' || workspaceTabRaw === 'prs')
-      ? 'preview'
-      : workspaceTabRaw;
+  // Branches needs a repo; pull requests need GitHub specifically. Collapsing
+  // the two sent GitLab projects to preview when they asked for branches.
+  const tabUnavailable =
+    (workspaceTabRaw === 'branches' && !branchesAvailable) ||
+    (workspaceTabRaw === 'prs' && !isGitHubConnected);
 
-  // Pageview tracks the *projected* tab (after the GitHub-connected gate),
+  const workspaceTab: WorkspaceTab = tabUnavailable ? 'preview' : workspaceTabRaw;
+
+  // Pageview tracks the *projected* tab (after the availability gates),
   // so a forced fallback when GitHub disconnects is recorded as a screen
   // change. Also fires once on mount with the initial resolved tab — replaces
   // the seed previously fired from useProjectLifecycle.

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for the remote-naming helpers.
+ *
+ * These exist to keep one rule enforceable in one place: the app never puts
+ * the word "GitHub" in front of a project whose code isn't on GitHub, and
+ * never invents a vendor name for a host it couldn't classify.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { remoteLabel, hasPushableRemote, type ProjectGitHubStatus } from './github';
+
+function status(overrides: Partial<ProjectGitHubStatus>): ProjectGitHubStatus {
+  return {
+    status: 'no-remote',
+    github_repo: null,
+    github_url: null,
+    remote_host: null,
+    remote_forge: null,
+    ...overrides,
+  };
+}
+
+describe('remoteLabel', () => {
+  it('names GitHub for a connected project', () => {
+    expect(remoteLabel(status({ status: 'connected', github_repo: 'a/b' }))).toBe('GitHub');
+  });
+
+  it('names the forge when the host identifies one', () => {
+    expect(
+      remoteLabel(
+        status({ status: 'other-remote', remote_host: 'gitlab.com', remote_forge: 'GitLab' })
+      )
+    ).toBe('GitLab');
+  });
+
+  it('falls back to the bare host rather than guessing a vendor', () => {
+    // A self-managed instance could be GitLab, Gitea, or a plain git server.
+    // Showing the address is honest; showing "GitLab" because the hostname
+    // happens to contain it is not.
+    expect(
+      remoteLabel(
+        status({ status: 'other-remote', remote_host: 'gitlab.acme.com', remote_forge: null })
+      )
+    ).toBe('gitlab.acme.com');
+  });
+
+  it('names nothing when there is no remote to name', () => {
+    expect(remoteLabel(null)).toBeNull();
+    expect(remoteLabel(status({ status: 'no-remote' }))).toBeNull();
+    expect(remoteLabel(status({ status: 'not-a-repo' }))).toBeNull();
+  });
+});
+
+describe('hasPushableRemote', () => {
+  it('is true for any configured remote, GitHub or not', () => {
+    expect(hasPushableRemote(status({ status: 'connected', github_repo: 'a/b' }))).toBe(true);
+    expect(hasPushableRemote(status({ status: 'other-remote', remote_host: 'gitlab.com' }))).toBe(
+      true
+    );
+  });
+
+  it('is false when there is nowhere to push', () => {
+    expect(hasPushableRemote(null)).toBe(false);
+    expect(hasPushableRemote(status({ status: 'no-remote' }))).toBe(false);
+    expect(hasPushableRemote(status({ status: 'not-a-repo' }))).toBe(false);
+  });
+});

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -24,12 +24,56 @@ export interface GitHubCliStatus {
 
 /** Project's GitHub repository connection status */
 export interface ProjectGitHubStatus {
-  /** Connection state */
-  status: 'not-a-repo' | 'no-remote' | 'connected';
+  /**
+   * Connection state.
+   *
+   * `other-remote` is a project whose `origin` points somewhere the GitHub
+   * integration doesn't reach — GitLab, a self-managed instance, another
+   * forge. It is deliberately distinct from `no-remote`: the code has a home,
+   * we just don't talk to it, so the UI must not offer to create a GitHub
+   * repository as though the project had none.
+   */
+  status: 'not-a-repo' | 'no-remote' | 'other-remote' | 'connected';
   /** Repository identifier (e.g., "username/repo-name") - only set if connected */
   github_repo: string | null;
   /** Full repository URL (e.g., "https://github.com/username/repo-name") - only set if connected */
   github_url: string | null;
+  /** Host of the configured `origin` (e.g. "gitlab.com") - only set for `other-remote` */
+  remote_host: string | null;
+  /**
+   * Display name of the forge that host identifies ("GitLab"), where it
+   * identifies one. `null` for a host we can read but can't classify — show
+   * {@link remote_host} rather than guessing a vendor. Only set for
+   * `other-remote`.
+   */
+  remote_forge: string | null;
+}
+
+/**
+ * What to call the place this project's code lives, in UI copy.
+ *
+ * Returns `"GitHub"` for a connected project, the forge name or bare host for
+ * a remote we don't integrate with, and `null` when there's no remote to name.
+ * Prefer this over hardcoding "GitHub" in any string a non-GitHub project can
+ * reach — that copy is how a GitLab user gets told their push went to the
+ * wrong place.
+ */
+export function remoteLabel(status: ProjectGitHubStatus | null): string | null {
+  if (!status) return null;
+  if (status.status === 'connected') return 'GitHub';
+  if (status.status === 'other-remote') return status.remote_forge ?? status.remote_host;
+  return null;
+}
+
+/**
+ * Whether `git push` has somewhere to go.
+ *
+ * True for any configured remote, GitHub or not — pushing is plain git and
+ * never needed the GitHub integration. Gating the Push button on a *GitHub*
+ * repo is what left GitLab projects unable to push from the app at all.
+ */
+export function hasPushableRemote(status: ProjectGitHubStatus | null): boolean {
+  return status?.status === 'connected' || status?.status === 'other-remote';
 }
 
 /**

--- a/src/styles/features/github.css
+++ b/src/styles/features/github.css
@@ -332,3 +332,11 @@
 .github-modal .modal-actions button:first-child:hover {
   background: var(--border-default);
 }
+
+/* The GitHub button's label must not wrap — it sits in a fixed-width header
+   slot beside the branch controls, and a two-line label pushes that row's
+   height. Used by both the "Create Repo" call to action and the disabled
+   label shown for a remote that isn't GitHub. */
+.github-button-label {
+  white-space: nowrap;
+}


### PR DESCRIPTION
## What

Projects whose `origin` isn't GitHub couldn't push from the app, and were told
they had no remote. This closes that gap. It adds **no** GitLab integration —
no merge requests, no repo browsing, no `glab`.

## The bug

`run_git_net` — which every network git op goes through — set the *unscoped*
`credential.helper`: an empty value to clear the machine's own helpers, then
`gh auth git-credential`. `gh` answers for github.com and nothing else, and
`GIT_TERMINAL_PROMPT=0` leaves no fallback. A GitLab push died with
`could not read Username` for users whose credentials were in the keychain the
whole time.

Scoping both entries to `credential.https://github.com.helper` fixes it: git
matches credential config per request, so GitHub resolves exactly as before and
every other host keeps normal credential resolution.

Verified against a local authenticating git server: the old shape reproduces
the exact `could not read Username` failure, the new one pushes and the commit
lands. Measured, not assumed, for the awkward URL forms too — `github.com:443`
and an embedded username still route through `gh`; git normalises the default
port.

## The dishonesty

`get_project_github_status` collapsed every unparseable-as-GitHub origin into
`no-remote`. A GitLab project rendered as unconnected, was offered a GitHub repo
to fix it, and had Push disabled behind "Create a GitHub repository first" — for
a push that is plain `git push`.

New `other-remote` status carries the host, and the forge name only where the
host says so: `gitlab.com` → "GitLab"; `git.acme.com` → its own address, never
sniffed for a vendor ("Never Assume Data").

## The wider gap

The first fix made pushing work; the rest of the workspace still equated
"GitHub connected" with "has version control". A GitLab project could not reach
its own branches at all — the Branches tab bounced back to preview, the header
menu said "Connect this project to GitHub to pull, switch branches", and the
palette hid Push, Pull, Switch branch and Create branch. None of those is
GitHub's.

Branches now need a remote; pull requests need GitHub. What stays GitHub-only is
**hidden** rather than offered-and-broken: the PR tab, the menu's PR section,
"Submit for Review", and `branch.submitReview` — which had no gate at all, so
the palette offered it to any forge and it ended in `gh pr create` against a
repo GitHub has never heard of.

## Two fixes found by testing, not by review

- `parse_remote` rejected `HTTPS://github.com/…`, a spelling real git fetches
  from. Since it had become the gatekeeper for GitHub status, that would have
  shown a connected GitHub project as having no remote — the same bug, from the
  other side. Schemes are now case-insensitive.
- `parse_github_repo` was a substring search: `https://evil.com/github.com/owner/repo.git`
  parsed as the GitHub repo `owner/repo`. Pre-existing, but this PR made it the
  more dangerous half of a split brain. It now delegates to `parse_remote`, and
  all its existing tests pass unchanged.

## Verification

- `cargo test` 1328, `pnpm test:run` 2515, `pnpm check:all` green
- 98-shot harness sweep; the 2 pre-existing unmocked-command failures unchanged
- New GitLab and self-managed scenarios for the Push popover, branches tab and
  branches menu; `branches-many` confirms the GitHub path is untouched
- The GitLab branches scenario is reached via `branch.create` — one of the
  commands this restores — so a regression in that gate fails the capture
  rather than passing quietly

**Not verified:** any real network operation against an actual GitLab host;
there's no GitLab account on this machine.

## Deliberately left alone

Local-only repos (no remote at all) are still gated behind "Connect GitHub".
Same class of bug, but it's an onboarding-funnel decision rather than a
correctness one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXuxkd2EGQcmHweHdByDTE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pushing, pulling, switching branches, and managing worktrees with GitLab and other configured Git remotes.
  * Remote names and self-managed hosts are now shown in relevant interface actions.
  * Added remote detection for GitHub, GitLab, and unknown hosts.
* **Bug Fixes**
  * GitHub credential handling no longer overrides credentials for non-GitHub remotes.
  * Pull-request actions remain limited to GitHub repositories.
  * Improved remote detection prevents misleading GitHub connection prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->