### PR TITLE
Let the size control use the standard button gap

### DIFF
--- a/src/styles/features/preview-size.css
+++ b/src/styles/features/preview-size.css
@@ -45,7 +45,6 @@
    it looks and behaves like the comment/edit toggles beside it. Only the bits
    specific to showing a measurement live here. */
 .preview-dimensions {
-  gap: var(--spacing-3xs);
   font-size: var(--font-size-body-md);
   font-variant-numeric: tabular-nums;
   user-select: none;

--- a/src/styles/global/token-inventory.json
+++ b/src/styles/global/token-inventory.json
@@ -4799,7 +4799,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 30
+      "consumerCount": 29
     },
     {
       "name": "--spacing-2xs",


### PR DESCRIPTION
The ⋯ and the dimensions readout sit flush against each other, so the dots read as a prefix on the number rather than as the separate control they are.

## Cause

`.preview-dimensions` overrode the button's own gap:

```css
.preview-dimensions {
  gap: var(--spacing-3xs);   /* → --space-01 → 1px */
}
```

`--spacing-3xs` is 1px. Against a 14px icon that reads as no gap at all. Every other icon-and-label button in the toolbar uses `--button-gap` (6px), which is why this one looks wrong next to them.

## Fix

Drop the override and inherit `--button-gap`. No new token, no magic number.

That is also what the comment directly above the rule already promises:

> A normal Button — base.css owns its resting, hover and pressed surfaces, so it looks and behaves like the comment/edit toggles beside it. Only the bits specific to showing a measurement live here.

A gap is not one of those bits. The `font-variant-numeric`, `tabular-nums` and `white-space` declarations are.

## Layout risk

None at the wider widths. The ⋯ is `display: none` until the toolbar container is under 820px, and at that breakpoint `.preview-size-wrap` is already `width: auto; min-width: 0`. So the fixed `--size-preview-dimensions` (84px) budget is never the constraint in the state where both children actually render.

## Verification

Measured against the real app stylesheets, with the ⋯ forced visible:

| | computed `gap` | visual px between the dots and the `8` |
|---|---|---|
| before | `1px` | 1 |
| after | `6px` | 6 |

`pnpm test:run src/components/preview/PreviewSizeControl.test.tsx` — 7 passed. `pnpm check:patterns` — passes (the token inventory is regenerated in this PR, since the file no longer references `--spacing-3xs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xb1RSrcBc1BWWKdKqf7mKx
