### PR TITLE
Carry the universal DMG forward so the site's Mac download stops 404ing

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -247,11 +247,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASES_PAT }}
         run: |
+          set -euo pipefail
           mkdir -p carry-forward
-          MAC_TAG=$(gh release list --repo ship-studio/releases --limit 50 \
-            --json tagName --jq '[.[] | select(.tagName | endswith("-win") | not)][0].tagName // empty')
+          # Pick the newest PUBLISHED macOS release. `gh release list` returns
+          # drafts first, so a plain `[0]` can select a draft that has no
+          # assets at all — the same bug that shipped a stale Windows manifest
+          # from release.yml. Exclude drafts and take the most recently
+          # published non -win tag.
+          MAC_TAG=$(gh release list --repo ship-studio/releases --limit 100 \
+            --json tagName,isDraft,publishedAt \
+            --jq '[.[] | select(.isDraft == false) | select(.tagName | endswith("-win") | not)]
+                  | sort_by(.publishedAt) | last | .tagName // empty')
           if [ -z "$MAC_TAG" ]; then
-            echo "No macOS release found to carry forward" >&2
+            echo "::error::No published macOS release found to carry forward" >&2
             exit 1
           fi
           echo "Carrying forward macOS assets from $MAC_TAG"
@@ -261,6 +269,25 @@ jobs:
             --pattern "ShipStudio_darwin-*.dmg" \
             --dir carry-forward
           ls -la carry-forward/
+
+          # Gate: every asset the site and the docs link to under the
+          # /releases/latest/download/ alias must be present before this
+          # release is allowed to become "latest". ShipStudio_darwin-universal.dmg
+          # is the one the marketing site's "Download for Mac" button uses
+          # (lib/constants.ts DOWNLOAD_LINKS.mac); it was missing from the
+          # upload list below, so v1.2.0-win flipped the alias and 404'd every
+          # Mac download from the web.
+          missing=()
+          for f in latest.json \
+                   ShipStudio_darwin-universal.dmg \
+                   ShipStudio_darwin-aarch64.dmg \
+                   ShipStudio_darwin-x86_64.dmg; do
+            [ -f "carry-forward/$f" ] || missing+=("$f")
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::macOS assets missing from $MAC_TAG: ${missing[*]}. Publishing would 404 the site's Mac download."
+            exit 1
+          fi
 
       - name: Upload artifacts to main repo draft release
         uses: softprops/action-gh-release@v2
@@ -296,5 +323,6 @@ jobs:
             artifacts/ShipStudio_windows-x86_64-setup.exe.sig \
             latest-windows.json \
             carry-forward/latest.json \
+            carry-forward/ShipStudio_darwin-universal.dmg \
             carry-forward/ShipStudio_darwin-aarch64.dmg \
             carry-forward/ShipStudio_darwin-x86_64.dmg

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -273,10 +273,12 @@ jobs:
           # Gate: every asset the site and the docs link to under the
           # /releases/latest/download/ alias must be present before this
           # release is allowed to become "latest". ShipStudio_darwin-universal.dmg
-          # is the one the marketing site's "Download for Mac" button uses
-          # (lib/constants.ts DOWNLOAD_LINKS.mac); it was missing from the
-          # upload list below, so v1.2.0-win flipped the alias and 404'd every
-          # Mac download from the web.
+          # is the one the marketing site's "Download for Mac" button resolves
+          # to; it was missing from the upload list below, so v1.2.0-win flipped
+          # the alias and 404'd every Mac download from the web. The site now
+          # falls back to the legacy arch-named copies rather than 404ing, but
+          # that serves the universal build under a misleading name and hides
+          # this bug — so the gate below stays strict.
           missing=()
           for f in latest.json \
                    ShipStudio_darwin-universal.dmg \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -211,11 +211,19 @@ After the workflow completes (~15–25 min for the Windows build):
       "https://github.com/ship-studio/releases/releases/latest/download/$f"
   done   # all four should print 206
   ```
-  `ShipStudio_darwin-universal.dmg` is the one that actually matters: it is what
-  the marketing site's "Download for Mac" button points at (`DOWNLOAD_LINKS.mac`
-  in `ship-studio-marketing/lib/constants.ts`), and what `lib/releases.ts` reads
-  the displayed file size from. The `-aarch64` / `-x86_64` names are legacy
-  copies — checking only those passes while every Mac download 404s.
+  `ShipStudio_darwin-universal.dmg` is the one that actually matters: it is the
+  asset the marketing site's "Download for Mac" button resolves to, and what it
+  reads the displayed file size from. The `-aarch64` / `-x86_64` names are
+  legacy copies — checking only those passes while the universal download 404s.
+
+  Since the v1.2.0-win incident the site (`ship-studio-marketing/lib/releases.ts`)
+  resolves the button from the release's real asset list, preferring
+  `darwin-universal.dmg` and falling back through the legacy names, so a missing
+  universal DMG now degrades to a legacy copy instead of 404ing. That is a
+  safety net, not a licence to publish without it: the fallback serves the right
+  bytes under a misleading arch-specific name, and it silently hides exactly the
+  pipeline bug this checklist exists to catch. The site also caches the resolved
+  URL (Vercel ISR, 1h), so a late asset upload takes up to an hour to appear.
 - [ ] A draft release also lands in the main repo (the build-artifact dump); publishing it is optional — the public repo is what users and the updater read.
 
 ### History: the silent-draft gap

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -203,13 +203,19 @@ After the workflow completes (~15–25 min for the Windows build):
   ```bash
   curl -sL https://github.com/ship-studio/releases/releases/latest/download/latest.json | jq '.version'
   ```
-- [ ] The site's static download links all still resolve (every release must carry the other platform's installers forward, or flipping the "latest" alias 404s them — this bit us when v0.6.8-win shipped without the DMGs):
+- [ ] The site's static download links all still resolve (every release must carry the other platform's installers forward, or flipping the "latest" alias 404s them — this bit us when v0.6.8-win shipped without the DMGs, and again when v1.2.0-win shipped without `ShipStudio_darwin-universal.dmg`):
   ```bash
-  for f in ShipStudio_darwin-aarch64.dmg ShipStudio_darwin-x86_64.dmg ShipStudio_windows-x86_64-setup.exe; do
+  for f in ShipStudio_darwin-universal.dmg ShipStudio_darwin-aarch64.dmg \
+           ShipStudio_darwin-x86_64.dmg ShipStudio_windows-x86_64-setup.exe; do
     curl -s -o /dev/null -w "$f -> %{http_code}\n" -L -r 0-0 \
       "https://github.com/ship-studio/releases/releases/latest/download/$f"
-  done   # all three should print 206
+  done   # all four should print 206
   ```
+  `ShipStudio_darwin-universal.dmg` is the one that actually matters: it is what
+  the marketing site's "Download for Mac" button points at (`DOWNLOAD_LINKS.mac`
+  in `ship-studio-marketing/lib/constants.ts`), and what `lib/releases.ts` reads
+  the displayed file size from. The `-aarch64` / `-x86_64` names are legacy
+  copies — checking only those passes while every Mac download 404s.
 - [ ] A draft release also lands in the main repo (the build-artifact dump); publishing it is optional — the public repo is what users and the updater read.
 
 ### History: the silent-draft gap


### PR DESCRIPTION
Reported from the wild: the macOS download on the site 404'd.

## Root cause

The site's "Download for Mac" button resolves to:

```
https://github.com/ship-studio/releases/releases/latest/download/ShipStudio_darwin-universal.dmg
```

GitHub's `latest` alias is the most recently **published** release — that was `v1.2.0-win` (01:08Z), cut 19 minutes after `v1.2.0` (00:49Z). So the Mac link resolves against the *Windows* release.

That release is supposed to carry the Mac DMGs forward for exactly this reason, and it does — but the carry-forward step downloaded every `ShipStudio_darwin-*.dmg` and then re-uploaded only the legacy `-aarch64` / `-x86_64` copies. It dropped `ShipStudio_darwin-universal.dmg`, the one name the site actually asks for.

Measured before the fix:

```
404  ShipStudio_darwin-universal.dmg      <- the site's button
200  ShipStudio_darwin-aarch64.dmg
200  ShipStudio_darwin-x86_64.dmg
200  ShipStudio_windows-x86_64-setup.exe
```

The site's displayed Mac file size was blank for the same reason — it read the size from that same asset name.

**macOS auto-update was never affected.** `latest.json` pins its tarball to a versioned tag URL (`/download/v1.2.0/...`), not the `latest` alias. Verified 200 throughout.

## Already resolved outside this PR

`ShipStudio_darwin-universal.dmg` has been uploaded to the existing `v1.2.0-win` release, so the live button already works. The bytes are byte-identical to the `-aarch64` copy already on that release (`5af8db75…` — `release.yml` copies one universal DMG to three names), and the file downloaded back from the live URL is notarized, stapled and `spctl --assess` accepted.

This PR stops it recurring.

## Changes

- **`release-windows.yml` uploads the universal DMG**, and **hard-fails the release** if any of the three DMGs is missing from carry-forward. A `-win` tag can no longer become `latest` with the site's download broken.
- **Resolve the macOS tag the way `release.yml` already does** — exclude drafts, take the newest by `publishedAt`. `gh release list` returns drafts first, so the plain `[0]` could select a draft with no assets at all. That is the same class of bug that previously shipped a stale Windows manifest.
- **`RELEASING.md`'s post-release checklist** verified the two legacy names and *not* the one the site uses, so it went green through a total outage. It now checks the universal DMG first, and says why that one is the one that matters.

## Why the gate stays strict

The site has since been made resilient: it resolves the button from the release's real asset list, preferring `darwin-universal.dmg` and falling back through the legacy names. That is a good change, but it removes the *only* symptom — a malformed release now renders a perfect page while handing Intel users a file named "aarch64". This incident announced itself on Twitter; the next one wouldn't. So the release-time gate here is now the primary detector, not a belt-and-braces nicety. Both are documented in `RELEASING.md`.

## Verification

Against the live `latest` alias after the asset upload:

```
206  ShipStudio_darwin-universal.dmg
206  ShipStudio_darwin-aarch64.dmg
206  ShipStudio_darwin-x86_64.dmg
206  ShipStudio_windows-x86_64-setup.exe
```

Downloaded from the site's exact URL: 44,986,175 bytes, sha256 `5af8db75…`, `spctl` → `accepted / source=Notarized Developer ID`.

Workflow YAML parses. These paths are release-only, so CI here does not exercise them — the next `-win` tag is the real test of the carry-forward change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xb1RSrcBc1BWWKdKqf7mKx