### PR TITLE
Teach the agent preview bridge that the breakpoint canvas exists

### DIFF
--- a/docs/breakpoint-canvas.md
+++ b/docs/breakpoint-canvas.md
@@ -228,6 +228,39 @@ the editor hooks a ref whose object identity changes with the frame — that is
 what re-runs their setup. Focus mode passes the single preview iframe's own
 stable ref, so nothing about it changes.
 
+### The agent is a user of the active frame too
+
+The agent preview bridge (`src/lib/agentBridge.ts`) drives the preview through
+the same shim the inspector talks to, and it inherited a world where "every
+preview iframe" meant one. On a canvas it means four, and every place that
+assumption was left standing broke a different way:
+
+- **Actions went to all four frames.** One `preview_click` clicked in every
+  frame, so passive frames navigated on their own — independently of the host's
+  idea of where the preview is — and the call resolved from whichever frame
+  answered first, meaning the rect and match count could describe a frame the
+  user was not in. `execPreviewAction` now sends to the frame the inspector is
+  pinned to (`getInspectSource`), and only broadcasts in focus mode, where the
+  pin is null because there is genuinely one frame.
+- **Nothing said the agent was there.** The activity overlay was rendered only
+  in the focus-mode branch, so the canvas got no glow, no chip and no cursor.
+  It is now part of `activeFrameOverlay`, which scopes it to the active frame —
+  a glow around the whole canvas would claim the agent was working in all of
+  them. Like the comment layer it needs an explicit `pointer-events: none`
+  exception in `preview-canvas.css`, for exactly the reason documented there.
+- **The cursor could not land in the right place.** The page reports the target
+  as a fraction of its own viewport, and on a canvas its viewport is a device
+  fiction (`ssLieAboutViewport`, and `ssPinRootHeight` pins the root to the same
+  lie) while the frame renders the whole document — so anything below the device
+  fold came back clamped to the bottom edge. The raw pixel rect is honest in
+  both modes, so the host re-derives the fractions from the frame size it
+  already knows (`overlayFraction` + `getOverlayFrameSize`).
+- **The agent could not know any of this.** `preview_status` now says the canvas
+  is open, which frame is active, and that `preview_set_viewport` closes the
+  canvas — that tool has always collapsed the canvas to a single frame by
+  design, and an agent sweeping mobile→tablet→desktop was doing it three times
+  without ever saying so. Its result text now admits it.
+
 ### Messages
 
 Host → frame: `ss:canvas {on, vh}` — you are part of a canvas, this is the

--- a/src-tauri/src/webview_scripts.rs
+++ b/src-tauri/src/webview_scripts.rs
@@ -396,6 +396,12 @@ pub const INSPECTOR_SHIM: &str = r#"
         (t ? ' "' + t.slice(0, 80) + '"' : '');
     };
 
+    // These fractions are only meaningful when the frame's own viewport is the
+    // thing the host draws over. On the breakpoint canvas it is not: the canvas
+    // script redefines `innerHeight` to the device height (and pins the root to
+    // it) while the frame renders the whole page, so both denominators here are
+    // a device viewport, not the frame. The host re-derives fx/fy from the raw
+    // px below whenever it knows better — see `getOverlayFrameSize`.
     var rectOf = function (el) {
       var r = el.getBoundingClientRect();
       var vw = window.innerWidth || 1;

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -501,7 +501,16 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
       if (typeof value === 'number') resize.previewAtWidth(value);
       else resize.handleBreakpointClick(value);
     },
-    getViewportWidth: () => resize.customWidth,
+    // On the canvas the width that matters is the ACTIVE frame's — it is the
+    // frame the agent reads, clicks in, and screenshots. `resize.customWidth`
+    // there is the stale focus-mode width from before the canvas was opened.
+    getViewportWidth: () => (canvasMode ? canvasFrameWidth : resize.customWidth),
+    canvasMode,
+    // The activity overlay is drawn over the active frame's whole stage; on the
+    // canvas only the host knows that box, because the page in there has been
+    // told its viewport is a device.
+    getOverlayFrameSize: () =>
+      canvasMode ? { w: canvasFrameWidth, h: canvasFrameStageHeight } : null,
   });
 
   // Fullscreen: the container goes position:fixed over the window below the
@@ -1925,6 +1934,10 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
               onBackgroundClick={deselectOnCanvas}
               activeFrameOverlay={(scale) => (
                 <>
+                  {/* Agent activity layer. On the canvas it belongs to the
+                    ACTIVE frame — that is the only frame the agent acts in,
+                    and a glow around the whole canvas would claim otherwise. */}
+                  <AgentActivityOverlay />
                   {comments.pins(scale, {
                     w: canvasFrameWidth * scale,
                     h: canvasFrameStageHeight * scale,

--- a/src/hooks/useAgentBridge.ts
+++ b/src/hooks/useAgentBridge.ts
@@ -40,6 +40,11 @@ interface UseAgentBridgeParams {
   setViewport: (value: number | ViewportPreset) => void;
   /** Current custom viewport width in px, or null = full pane width. */
   getViewportWidth: () => number | null;
+  /** True while the breakpoint canvas is showing every breakpoint at once. */
+  canvasMode: boolean;
+  /** Size of the box the agent activity overlay covers, in the frame's own
+   *  pixels — null when the page's own viewport fractions can be trusted. */
+  getOverlayFrameSize: () => { w: number; h: number } | null;
 }
 
 export function useAgentBridge({
@@ -52,6 +57,8 @@ export function useAgentBridge({
   reload,
   setViewport,
   getViewportWidth,
+  canvasMode,
+  getOverlayFrameSize,
 }: UseAgentBridgeParams) {
   // Live values for the long-lived listener — rebinding the Tauri listener on
   // every URL change would race in-flight requests.
@@ -65,6 +72,8 @@ export function useAgentBridge({
     reload,
     setViewport,
     getViewportWidth,
+    canvasMode,
+    getOverlayFrameSize,
   });
   useEffect(() => {
     ctxRef.current = {
@@ -77,6 +86,8 @@ export function useAgentBridge({
       reload,
       setViewport,
       getViewportWidth,
+      canvasMode,
+      getOverlayFrameSize,
     };
   });
 
@@ -137,6 +148,8 @@ export function useAgentBridge({
             reload: live.reload,
             setViewport: live.setViewport,
             getViewportWidth: live.getViewportWidth,
+            canvasMode: live.canvasMode,
+            getOverlayFrameSize: live.getOverlayFrameSize,
           });
           endActivity();
           void trackEvent('agent_bridge_tool_used', {

--- a/src/lib/agentBridge.test.ts
+++ b/src/lib/agentBridge.test.ts
@@ -12,6 +12,7 @@ vi.mock('./logger', () => ({
 import {
   executeBridgeTool,
   isValidPreviewPath,
+  overlayFraction,
   registerPreviewMcpServer,
   type BridgeToolContext,
 } from './agentBridge';
@@ -29,11 +30,42 @@ const makeCtx = (overrides: Partial<BridgeToolContext> = {}): BridgeToolContext 
   reload: vi.fn(),
   setViewport: vi.fn(),
   getViewportWidth: () => null,
+  canvasMode: false,
+  getOverlayFrameSize: () => null,
   ...overrides,
 });
 
 beforeEach(() => {
   invokeMock.mockReset();
+});
+
+describe('overlayFraction', () => {
+  const rect = { x: 100, y: 4000, w: 200, h: 100, fx: 0.5, fy: 1 };
+
+  it('trusts the page when the host has no frame size (focus mode)', () => {
+    expect(overlayFraction(rect, null)).toEqual({ fx: 0.5, fy: 1 });
+  });
+
+  it('re-derives from raw pixels against the canvas frame', () => {
+    // The page reported fy: 1 — clamped, because on the canvas its own
+    // viewport is a 900px device fiction while the frame is 6000px of page.
+    // The cursor belongs two thirds down, not pinned to the bottom edge.
+    expect(overlayFraction(rect, { w: 1200, h: 6000 })).toEqual({
+      fx: 200 / 1200,
+      fy: 4050 / 6000,
+    });
+  });
+
+  it('falls back to the page fractions before the stage has been measured', () => {
+    expect(overlayFraction(rect, { w: 1200, h: 0 })).toEqual({ fx: 0.5, fy: 1 });
+  });
+
+  it('clamps a rect that sits outside the frame', () => {
+    expect(overlayFraction({ ...rect, y: -500 }, { w: 1200, h: 6000 })).toEqual({
+      fx: 200 / 1200,
+      fy: 0,
+    });
+  });
 });
 
 describe('isValidPreviewPath', () => {
@@ -147,6 +179,35 @@ describe('executeBridgeTool', () => {
       ctx
     );
     expect(bad.isError).toBe(true);
+  });
+
+  it('preview_status tells the agent the breakpoint canvas is open', async () => {
+    const result = await executeBridgeTool(
+      { requestId: 24, tool: 'preview_status' },
+      makeCtx({ canvasMode: true, getViewportWidth: () => 1024 })
+    );
+    const report = (result.content[0] as { text: string }).text;
+    // Without this the agent reads a plain width, calls preview_set_viewport
+    // to "test a breakpoint", and silently collapses the user's canvas.
+    expect(report).toContain('breakpoint canvas is open');
+    expect(report).toContain('1024px frame active');
+    expect(report).toContain('CLOSES the canvas');
+  });
+
+  it('preview_set_viewport says so when it closed the canvas', async () => {
+    const onCanvas = await executeBridgeTool(
+      { requestId: 33, tool: 'preview_set_viewport', arguments: { preset: 'mobile' } },
+      makeCtx({ canvasMode: true })
+    );
+    expect((onCanvas.content[0] as { text: string }).text).toContain(
+      'closed the breakpoint canvas'
+    );
+
+    const offCanvas = await executeBridgeTool(
+      { requestId: 34, tool: 'preview_set_viewport', arguments: { width: 900 } },
+      makeCtx()
+    );
+    expect((offCanvas.content[0] as { text: string }).text).not.toContain('breakpoint canvas');
   });
 
   it('screenshot captures at the preview viewport width', async () => {

--- a/src/lib/agentBridge.ts
+++ b/src/lib/agentBridge.ts
@@ -25,7 +25,11 @@ import {
   isExpectedCommandError,
 } from './errors';
 import { isResourcePressureError } from './errorReporting';
-import { execPreviewAction, type PreviewActionResult } from './previewActions';
+import {
+  execPreviewAction,
+  type PreviewActionResult,
+  type PreviewActionRect,
+} from './previewActions';
 import { agentCursorAt } from './agentActivityStore';
 import { logger } from './logger';
 
@@ -65,8 +69,19 @@ export interface BridgeToolContext {
   reload: () => void;
   /** Resize the preview viewport (device preset or exact px width). */
   setViewport: (value: number | ViewportPreset) => void;
-  /** Current custom viewport width in px, or null = full pane width. */
+  /** Current custom viewport width in px, or null = full pane width. On the
+   *  breakpoint canvas this is the ACTIVE frame's width — the one the agent's
+   *  actions and screenshots go to. */
   getViewportWidth: () => number | null;
+  /** True while the breakpoint canvas is showing every breakpoint at once.
+   *  The agent has to be told: it changes what a viewport request does (it
+   *  closes the canvas) and which frame it is acting in. */
+  canvasMode: boolean;
+  /** Size, in the frame's own CSS pixels, of the box the activity overlay is
+   *  drawn over — or null to trust the fractions the page reported. Only the
+   *  host knows this on the breakpoint canvas: there the page's own viewport
+   *  is a device-sized fiction while the frame renders the whole document. */
+  getOverlayFrameSize: () => { w: number; h: number } | null;
 }
 
 export const PREVIEW_MCP_SERVER_NAME = 'shipstudio-preview';
@@ -334,16 +349,42 @@ function freshDomSnapshot(
 }
 
 /**
+ * Where to fly the agent cursor, as fractions of the box the overlay covers.
+ *
+ * The page reports fractions of its OWN viewport, which is the right answer in
+ * focus mode and a wrong one on the breakpoint canvas: there the canvas script
+ * redefines the page's viewport to the device height while the frame renders
+ * the whole document, so anything below the device fold came back clamped to
+ * the bottom edge. The raw pixel rect is honest in both, so when the host knows
+ * the frame's real size it re-derives the fractions from that.
+ */
+export function overlayFraction(
+  rect: PreviewActionRect,
+  frame: { w: number; h: number } | null
+): { fx: number; fy: number } {
+  if (!frame || frame.w <= 0 || frame.h <= 0) return { fx: rect.fx, fy: rect.fy };
+  const clamp = (n: number) => Math.min(Math.max(n, 0), 1);
+  return {
+    fx: clamp((rect.x + rect.w / 2) / frame.w),
+    fy: clamp((rect.y + rect.h / 2) / frame.h),
+  };
+}
+
+/**
  * Convert a shim action result into an MCP result. On success, fly the agent
  * cursor to the real element position so the user sees exactly where the
  * agent acted.
  */
 function actionToolResult(
   result: PreviewActionResult,
+  ctx: BridgeToolContext,
   describe: (data: Record<string, unknown>) => string
 ): McpToolResult {
   if (!result.ok) return errorResult(result.error ?? 'The action failed for an unknown reason.');
-  if (result.rect) agentCursorAt(result.rect.fx, result.rect.fy);
+  if (result.rect) {
+    const { fx, fy } = overlayFraction(result.rect, ctx.getOverlayFrameSize());
+    agentCursorAt(fx, fy);
+  }
   return text(describe(result.data ?? {}));
 }
 
@@ -358,11 +399,17 @@ function buildStatusReport(ctx: BridgeToolContext): string {
     lines.push('Dev server: running, preview connected.');
     lines.push(`Current page: ${ctx.currentPath || '/'} (${ctx.getCurrentUrl() ?? 'URL unknown'})`);
     const width = ctx.getViewportWidth();
-    lines.push(
-      width === null
-        ? 'Viewport: full pane width (use preview_set_viewport to test breakpoints).'
-        : `Viewport: ${width}px (custom — preview_set_viewport preset 'full' resets it).`
-    );
+    if (ctx.canvasMode) {
+      lines.push(
+        `Viewport: the breakpoint canvas is open — the user is looking at every breakpoint side by side, with the ${width ?? '?'}px frame active. Reads, clicks and screenshots all go to that active frame. preview_set_viewport CLOSES the canvas and returns to a single frame, so only call it if you actually need one width.`
+      );
+    } else {
+      lines.push(
+        width === null
+          ? 'Viewport: full pane width (use preview_set_viewport to test breakpoints).'
+          : `Viewport: ${width}px (custom — preview_set_viewport preset 'full' resets it).`
+      );
+    }
   }
   if (ctx.pages.length > 0) {
     lines.push(`Available pages (${ctx.pages.length}): ${ctx.pages.join(', ')}`);
@@ -509,19 +556,24 @@ export async function executeBridgeTool(
         return await captureScreenshot(ctx, args.full_page === true);
       }
       case 'preview_set_viewport': {
+        // Read before the call: setting a viewport closes the canvas, and the
+        // user deserves to be told in the transcript why their view collapsed.
+        const leftCanvas = ctx.canvasMode
+          ? ' This also closed the breakpoint canvas the user had open — the preview is a single frame again.'
+          : '';
         if (typeof args.width === 'number' && Number.isFinite(args.width)) {
           const width = Math.round(Math.min(Math.max(args.width, 200), 3000));
           ctx.setViewport(width);
           return text(
-            `Preview viewport set to ${width}px — the page re-laid-out at that true width. Screenshots now capture at ${width}px too.`
+            `Preview viewport set to ${width}px — the page re-laid-out at that true width. Screenshots now capture at ${width}px too.${leftCanvas}`
           );
         }
         if (VIEWPORT_PRESETS.includes(args.preset as ViewportPreset)) {
           ctx.setViewport(args.preset as ViewportPreset);
           return text(
-            args.preset === 'full'
+            (args.preset === 'full'
               ? 'Preview viewport reset to full pane width.'
-              : `Preview viewport set to the ${String(args.preset)} preset.`
+              : `Preview viewport set to the ${String(args.preset)} preset.`) + leftCanvas
           );
         }
         return errorResult(
@@ -541,7 +593,7 @@ export async function executeBridgeTool(
           text: typeof args.text === 'string' ? args.text : undefined,
           index: typeof args.index === 'number' ? args.index : undefined,
         });
-        return actionToolResult(result, (data) => {
+        return actionToolResult(result, ctx, (data) => {
           const matches =
             typeof data.matches === 'number' && data.matches > 1
               ? ` (${data.matches} elements matched — clicked the first; pass 'index' or narrow the selector to target another)`
@@ -566,6 +618,7 @@ export async function executeBridgeTool(
         });
         return actionToolResult(
           result,
+          ctx,
           (data) =>
             `Entered ${String(data.valueLength)} characters into ${String(data.typedInto)}${args.submit === true ? ' and submitted' : ''}.`
         );
@@ -578,7 +631,7 @@ export async function executeBridgeTool(
           to: args.to === 'top' || args.to === 'bottom' ? args.to : undefined,
           y: typeof args.y === 'number' ? args.y : undefined,
         });
-        return actionToolResult(result, (data) => `Scrolled to ${String(data.scrolledTo)}.`);
+        return actionToolResult(result, ctx, (data) => `Scrolled to ${String(data.scrolledTo)}.`);
       }
       case 'preview_query': {
         if (typeof args.selector !== 'string' || !args.selector) {

--- a/src/lib/inspectStore.ts
+++ b/src/lib/inspectStore.ts
@@ -87,12 +87,24 @@ const notify = () => {
 const isPreviewOrigin = (origin: string) =>
   /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
 
-/** When set, only this frame's telemetry is collected and only this frame is
- *  asked for DOM snapshots. The breakpoint canvas runs several preview frames
- *  at once; without this the inspector would interleave four copies of every
- *  console line and pay for four DOM serializations. Null (focus mode, where
- *  there is only one preview frame) accepts every preview-origin frame. */
+/** When set, this is the ONE preview frame the host talks to: only its
+ *  telemetry is collected, only it is asked for DOM snapshots, and only it
+ *  executes agent actions (see `execPreviewAction`). The breakpoint canvas
+ *  runs several preview frames at once; without this the inspector would
+ *  interleave four copies of every console line, pay for four DOM
+ *  serializations, and the agent would click four times. Null (focus mode,
+ *  where there is only one preview frame) accepts every preview-origin
+ *  frame. */
 let inspectSource: Window | null = null;
+
+/**
+ * The frame the host is talking to, or null in focus mode ("whichever preview
+ * frame is there"). Exported so the agent's action channel targets the same
+ * frame the inspector reads — a canvas where the agent clicks in a frame the
+ * user isn't in, and reports back what a different frame answered, is worse
+ * than no canvas at all.
+ */
+export const getInspectSource = (): Window | null => inspectSource;
 
 const handleMessage = (event: MessageEvent) => {
   if (!isPreviewOrigin(event.origin)) return;

--- a/src/lib/previewActions.test.ts
+++ b/src/lib/previewActions.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The agent's action channel must reach exactly one preview frame.
+ *
+ * On the breakpoint canvas four preview frames are live at once. Before this
+ * was scoped, one `preview_click` was delivered to all four: the page was
+ * clicked four times, passive frames navigated independently of the host's
+ * idea of where the preview is, and the result resolved from whichever frame
+ * answered first — so the rect the agent cursor flew to, and the match count
+ * it reported, could describe a frame the user was not even in.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { execPreviewAction } from './previewActions';
+import { setInspectSource } from './inspectStore';
+
+type PostSpy = ReturnType<typeof vi.fn>;
+
+/** A stand-in for a preview iframe's contentWindow that records its posts. */
+const makeFrame = (): { win: Window; post: PostSpy } => {
+  const post = vi.fn();
+  const win = { postMessage: post } as unknown as Window;
+  return { win, post };
+};
+
+/** Mount `count` iframes whose contentWindow is a recording stub. */
+const mountFrames = (count: number): { win: Window; post: PostSpy }[] => {
+  const frames = Array.from({ length: count }, () => makeFrame());
+  frames.forEach((frame) => {
+    const el = document.createElement('iframe');
+    document.body.appendChild(el);
+    Object.defineProperty(el, 'contentWindow', { value: frame.win, configurable: true });
+  });
+  return frames;
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  setInspectSource(null);
+  vi.useRealTimers();
+});
+
+describe('execPreviewAction targeting', () => {
+  it('sends to only the pinned frame when the canvas has an active frame', async () => {
+    const frames = mountFrames(4);
+    setInspectSource(frames[2].win);
+
+    const pending = execPreviewAction({ action: 'click', selector: 'a' });
+    vi.advanceTimersByTime(6000);
+    await pending;
+
+    expect(frames[2].post).toHaveBeenCalledTimes(1);
+    expect(frames[2].post.mock.calls[0][0]).toMatchObject({
+      source: 'shipstudio-inspect-host',
+      type: 'exec-action',
+      action: 'click',
+      selector: 'a',
+    });
+    for (const other of [frames[0], frames[1], frames[3]]) {
+      expect(other.post).not.toHaveBeenCalled();
+    }
+  });
+
+  it('broadcasts in focus mode, where there is only one preview frame', async () => {
+    const frames = mountFrames(2);
+    setInspectSource(null);
+
+    const pending = execPreviewAction({ action: 'scroll', to: 'bottom' });
+    vi.advanceTimersByTime(6000);
+    await pending;
+
+    expect(frames[0].post).toHaveBeenCalledTimes(1);
+    expect(frames[1].post).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves with an agent-readable answer when the frame never replies', async () => {
+    mountFrames(1);
+    const pending = execPreviewAction({ action: 'click', selector: 'a' });
+    vi.advanceTimersByTime(6000);
+    const result = await pending;
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('did not respond');
+  });
+
+  it('resolves from the pinned frame’s reply', async () => {
+    const frames = mountFrames(3);
+    setInspectSource(frames[0].win);
+
+    const pending = execPreviewAction({ action: 'click', selector: 'button' });
+    const sent = frames[0].post.mock.calls[0][0] as { id: string };
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          source: 'shipstudio-inspect',
+          type: 'action-result',
+          id: sent.id,
+          ok: true,
+          data: { clicked: 'button', matches: 1 },
+          rect: { x: 0, y: 0, w: 10, h: 10, fx: 0.5, fy: 0.25 },
+        },
+      })
+    );
+    const result = await pending;
+
+    expect(result.ok).toBe(true);
+    expect(result.rect?.fy).toBe(0.25);
+  });
+});

--- a/src/lib/previewActions.ts
+++ b/src/lib/previewActions.ts
@@ -4,9 +4,19 @@
  * scrolling, and element queries inside the preview page, on behalf of the
  * agent preview bridge.
  *
- * Requests broadcast to every preview iframe (there's one in practice);
- * responses match on a unique request id.
+ * The request goes to ONE frame: the active one the inspector is pinned to
+ * (`getInspectSource`), or — in focus mode, where the store has no pin because
+ * there is only ever one preview frame — every preview iframe. Broadcasting
+ * unconditionally was fine while "every preview iframe" meant one; on the
+ * breakpoint canvas it meant a single `preview_click` clicked in all four
+ * frames, navigated four pages independently of the host's idea of where the
+ * preview is, and then resolved from whichever frame answered first — so the
+ * rect and match count could describe a frame the user was not in.
+ *
+ * Responses still match on a unique request id.
  */
+
+import { getInspectSource } from './inspectStore';
 
 const HOST_CHANNEL = 'shipstudio-inspect-host';
 const SHIM_CHANNEL = 'shipstudio-inspect';
@@ -88,13 +98,21 @@ export function execPreviewAction(
 
     window.addEventListener('message', onMessage);
 
+    const message = { source: HOST_CHANNEL, type: 'exec-action', id, ...action };
+    const target = getInspectSource();
+    if (target) {
+      try {
+        target.postMessage(message, '*');
+      } catch {
+        // The frame went away between selection and send; the timeout below
+        // turns that into an agent-readable answer.
+      }
+      return;
+    }
     const iframes = document.querySelectorAll('iframe');
     iframes.forEach((iframe) => {
       try {
-        iframe.contentWindow?.postMessage(
-          { source: HOST_CHANNEL, type: 'exec-action', id, ...action },
-          '*'
-        );
+        iframe.contentWindow?.postMessage(message, '*');
       } catch {
         // Cross-origin frames that refuse postMessage are not the preview.
       }

--- a/src/styles/features/preview-canvas.css
+++ b/src/styles/features/preview-canvas.css
@@ -196,6 +196,15 @@
   pointer-events: none;
 }
 
+/* Same exception, same reason: the agent activity layer is a full-bleed
+   `inset: 0` overlay that informs and must never block. Its own
+   `pointer-events: none` ties with the blanket rule above on specificity, and
+   this file loads later — so without this it would win and swallow every
+   click meant for the active frame while the agent was working. */
+.preview-canvas-outline > .agent-activity-overlay {
+  pointer-events: none;
+}
+
 /* Inactive frames sit behind a transparent target: one click makes the frame
    active (and interactive) rather than reaching a link in a page the user is
    only reviewing. */


### PR DESCRIPTION
Reported as: "when the ship studio preview agent activates while you have the canvas view open everything tweaks out a bit."

The bridge was written when "every preview iframe" meant one. The breakpoint canvas makes it four, and every place that assumption was left standing broke in a different way. The canvas doc never mentioned the agent, and the agent never mentioned the canvas.

## What was wrong

**Actions went to every frame.** `execPreviewAction` broadcast `exec-action` to every iframe in the document — the comment above it even said "there's one in practice". On a canvas one `preview_click` clicked in all four frames, so passive frames followed links on their own, independently of the host's idea of where the preview is. The call then resolved from whichever frame answered first, so the rect the cursor flew to and the match count reported to the agent could describe a frame the user was not in.

Now it sends to the one frame the inspector is already pinned to (`getInspectSource`), and only broadcasts in focus mode, where that pin is null because there genuinely is one frame. `inspectStore` had already solved exactly this for console/network/DOM; `previewActions` just never got the same treatment.

**Nothing said the agent was there.** `AgentActivityOverlay` was rendered only in the focus-mode branch of `Preview.tsx`, so on a canvas the agent drove four frames with no glow, no chip and no cursor. It is now part of `activeFrameOverlay`, scoped to the active frame — a glow around the whole canvas would claim the agent was working in all of them.

That placement needs the same explicit `pointer-events: none` exception the comment layer needs, and for the same reason already documented in `preview-canvas.css`: its own rule ties with `.preview-canvas-outline > *` on specificity and this file loads later. Without it the informational overlay would have swallowed every click meant for the active frame.

**The cursor could not land in the right place anyway.** The page reports its target as a fraction of its own viewport, and on a canvas that viewport is a device-sized fiction — `ssLieAboutViewport` redefines `innerHeight`, and `ssPinRootHeight` pins the root to the same lie — while the frame renders the whole document. Everything below the device fold came back clamped to the bottom edge.

The raw pixel rect is honest in both modes, so the host now re-derives the fractions from the frame size it already knows (`overlayFraction` + `getOverlayFrameSize`) — the same box the comment pins and the element toolbar are already measured against.

**And the agent could not know any of it.** `preview_status` now reports that the canvas is open, which frame is active, and that `preview_set_viewport` closes it. That tool has always collapsed the canvas by design; an agent sweeping mobile→tablet→desktop was doing it three times without ever saying so. Its result text now admits it. `getViewportWidth` also returns the active frame's width on a canvas instead of the stale pre-canvas one, so screenshots capture what the user is looking at.

## Verification

- `src/lib/previewActions.test.ts` is new and is a real regression guard: neutralising the targeting fix makes the "sends to only the pinned frame" case fail with *expected "spy" to not be called at all, but actually been called 1 times*.
- The `pointer-events` exception was checked against the real bundled cascade in the UI harness, not reasoned about: `auto` with the rule neutralised via CSSOM, `none` with it live, and a control child of the same parent resolving `auto` throughout.
- Overlay placement was eyeballed in the real canvas chrome classes — the glow and chip scope to the active frame, the passive frame is untouched.
- `overlayFraction` is unit-tested for the canvas re-derivation, the focus-mode passthrough, the not-yet-measured stage (falls back rather than dividing by zero), and out-of-frame clamping.
- Full sweep green: 2528 tests, typecheck, eslint, prettier, `check:patterns`, `check:loc`, `cargo check`.

**Not verified:** none of this ran in a real Tauri build against a live dev server — the UI harness has no dev server, so the canvas cannot render frames in it. The frame-targeting, fraction maths and CSS cascade are verified; "an agent drives a real canvas end to end" is not.

One deliberate non-change: `preview_set_viewport` still closes the canvas. That is the existing design (a viewport request means one width), so this PR makes it honest rather than changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017J8B4wCveteG5ms2sdDSLb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preview actions now target the selected breakpoint-canvas frame instead of all frames.
  - Agent activity overlays remain visible without blocking interactions with the active frame.
  - Cursor positioning is more accurate across breakpoint-canvas and focus modes.
  - Preview status now identifies when the breakpoint canvas is open and which frame is active.
  - Changing the viewport now clearly indicates that the canvas closes.

- **Documentation**
  - Added guidance explaining agent behavior on the breakpoint canvas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->