### PR TITLE
fix(devserver): spawn dev servers with the project's own package manager

### DIFF
--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1224,6 +1224,43 @@ fn preferred_package_manager(path: &Path) -> Option<String> {
     None
 }
 
+/// Nearest enclosing git repository root, for bounding upward searches. A
+/// worktree's `.git` is a file, not a directory — `exists()` covers both.
+fn git_boundary_above(path: &Path) -> Option<std::path::PathBuf> {
+    let mut current = Some(path);
+    while let Some(dir) = current {
+        if dir.join(".git").exists() {
+            return Some(dir.to_path_buf());
+        }
+        current = dir.parent();
+    }
+    None
+}
+
+/// `preferred_package_manager`, but walking up through the enclosing git
+/// repository: installs and dev servers run from workspace subpaths in
+/// monorepos (`apps/web`), where the lockfile lives at the repo root.
+/// Checking only the start directory reported "npm" for every bun/pnpm/yarn
+/// monorepo and spawned the one runner the repo isn't set up for. The git
+/// boundary stops the walk so a lockfile above the repository (another
+/// checkout, $HOME) is never misread as this project's; outside a git repo
+/// the walk runs to the filesystem root, matching how npm itself resolves
+/// workspaces.
+fn preferred_package_manager_in_or_above(path: &Path) -> Option<String> {
+    let ceiling = git_boundary_above(path);
+    let mut current = Some(path);
+    while let Some(dir) = current {
+        if let Some(pm) = preferred_package_manager(dir) {
+            return Some(pm);
+        }
+        if Some(dir) == ceiling.as_deref() {
+            break;
+        }
+        current = dir.parent();
+    }
+    None
+}
+
 /// Detects the package manager a project needs (lockfiles first, then the
 /// manifest's own declarations), falling back to npm.
 #[tauri::command]
@@ -1248,7 +1285,7 @@ pub async fn detect_package_manager(project_path: String) -> Result<String, Comm
         }
     }
 
-    match preferred_package_manager(path) {
+    match preferred_package_manager_in_or_above(path) {
         Some(preferred) if preferred != "npm" => Ok(or_npm(&preferred)),
         // No signal (or the project asks for npm explicitly) → npm.
         _ => Ok("npm".to_string()),
@@ -2046,6 +2083,72 @@ mod tests {
             assert_eq!(preferred_package_manager(dir.path()), None);
             let dir = project(&[]);
             assert_eq!(preferred_package_manager(dir.path()), None);
+        }
+
+        /// A monorepo workspace: `root/` is the git repo holding the lockfile,
+        /// while dev commands run from `root/apps/web`.
+        fn monorepo(root: &std::path::Path) -> std::path::PathBuf {
+            let web = root.join("apps").join("web");
+            fs::create_dir_all(&web).expect("mkdir apps/web");
+            fs::write(root.join(".git"), "").expect("write .git marker");
+            web
+        }
+
+        #[test]
+        fn detection_walks_up_to_the_repo_root_lockfile() {
+            for lockfile in ["bun.lock", "bun.lockb", "pnpm-lock.yaml", "yarn.lock"] {
+                let dir = tempfile::tempdir().expect("tempdir");
+                fs::write(dir.path().join(lockfile), "").expect("write lockfile");
+                let web = monorepo(dir.path());
+                assert_eq!(
+                    preferred_package_manager_in_or_above(&web).as_deref(),
+                    Some(match lockfile {
+                        l if l.starts_with("bun.") => "bun",
+                        l if l.starts_with("pnpm") => "pnpm",
+                        _ => "yarn",
+                    }),
+                    "lockfile at repo root should be found from apps/web"
+                );
+            }
+        }
+
+        #[test]
+        fn repo_root_manifest_signals_apply_to_workspace_subpaths() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            fs::write(
+                dir.path().join("package.json"),
+                r#"{"name":"x","packageManager":"pnpm@9.0.0"}"#,
+            )
+            .expect("write manifest");
+            let web = monorepo(dir.path());
+            assert_eq!(
+                preferred_package_manager_in_or_above(&web).as_deref(),
+                Some("pnpm")
+            );
+        }
+
+        #[test]
+        fn the_walk_stops_at_the_git_boundary() {
+            // Outside: a parent directory carrying a lockfile for some OTHER
+            // checkout. Inside: a git repo with no manager signals at all.
+            let outside = tempfile::tempdir().expect("tempdir");
+            fs::write(outside.path().join("pnpm-lock.yaml"), "").expect("write lockfile");
+            let repo = outside.path().join("checkout");
+            fs::create_dir_all(repo.join("apps").join("web")).expect("mkdir apps/web");
+            fs::write(repo.join(".git"), "").expect("write .git marker");
+            assert_eq!(
+                preferred_package_manager_in_or_above(&repo.join("apps").join("web")),
+                None
+            );
+        }
+
+        #[test]
+        fn running_at_the_repo_root_still_detects_directly() {
+            let dir = project(&[("bun.lock", "")]);
+            assert_eq!(
+                preferred_package_manager_in_or_above(dir.path()).as_deref(),
+                Some("bun")
+            );
         }
     }
 }

--- a/src/lib/package-manager.test.ts
+++ b/src/lib/package-manager.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for package-manager-aware command builders (src/lib/package-manager.ts).
+ *
+ * These functions decide HOW a project's dev server is spawned. The regression
+ * they guard against: hardcoding npm/npx for every project broke bun and pnpm
+ * projects — `npm run` parses npm-only manifest fields (an `overrides` block
+ * npm rejects aborts the launch with EOVERRIDE) and `npx bash …` dies with
+ * "could not determine executable to run" because npx never falls back to PATH
+ * (bunx and `pnpm exec` do — verified against npm 12 / bun / pnpm).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execScriptCommand, normalizePackageManager, runScriptCommand } from './package-manager';
+
+describe('normalizePackageManager', () => {
+  it('passes through known managers', () => {
+    expect(normalizePackageManager('npm')).toBe('npm');
+    expect(normalizePackageManager('pnpm')).toBe('pnpm');
+    expect(normalizePackageManager('yarn')).toBe('yarn');
+    expect(normalizePackageManager('bun')).toBe('bun');
+  });
+
+  it('defaults unknown, empty, and null detections to npm', () => {
+    expect(normalizePackageManager('npm9')).toBe('npm');
+    expect(normalizePackageManager('')).toBe('npm');
+    expect(normalizePackageManager(null)).toBe('npm');
+    expect(normalizePackageManager(undefined)).toBe('npm');
+  });
+});
+
+describe('runScriptCommand', () => {
+  it('uses npm run with the -- separator for npm projects', () => {
+    expect(runScriptCommand('npm', 'dev', ['--port', '3000'])).toEqual({
+      command: 'npm',
+      args: ['run', 'dev', '--', '--port', '3000'],
+    });
+  });
+
+  it('forwards args directly for bun projects', () => {
+    expect(runScriptCommand('bun', 'dev', ['--port', '3000'])).toEqual({
+      command: 'bun',
+      args: ['run', 'dev', '--port', '3000'],
+    });
+  });
+
+  it('forwards args directly for pnpm projects', () => {
+    expect(runScriptCommand('pnpm', 'dev', ['--port', '3000'])).toEqual({
+      command: 'pnpm',
+      args: ['run', 'dev', '--port', '3000'],
+    });
+  });
+
+  it('forwards args directly for yarn projects (yarn 1 passes a literal -- to the script)', () => {
+    expect(runScriptCommand('yarn', 'dev', ['--port', '3000'])).toEqual({
+      command: 'yarn',
+      args: ['run', 'dev', '--port', '3000'],
+    });
+  });
+});
+
+describe('execScriptCommand', () => {
+  it('keeps npx for npm projects (local .bin resolution)', () => {
+    expect(execScriptCommand('npm', 'next', ['dev', '--port', '3000'])).toEqual({
+      command: 'npx',
+      args: ['next', 'dev', '--port', '3000'],
+    });
+  });
+
+  it('uses bunx for bun projects so PATH commands like bash resolve', () => {
+    expect(execScriptCommand('bun', 'bash', ['scripts/dev.sh', '--port', '3000'])).toEqual({
+      command: 'bunx',
+      args: ['bash', 'scripts/dev.sh', '--port', '3000'],
+    });
+  });
+
+  it('uses pnpm exec for pnpm projects so PATH commands like bash resolve', () => {
+    expect(execScriptCommand('pnpm', 'bash', ['scripts/dev.sh', '--port', '3000'])).toEqual({
+      command: 'pnpm',
+      args: ['exec', 'bash', 'scripts/dev.sh', '--port', '3000'],
+    });
+  });
+
+  it('keeps npx for yarn projects (no PATH-falling yarn exec equivalent)', () => {
+    expect(execScriptCommand('yarn', 'vite', ['dev'])).toEqual({
+      command: 'npx',
+      args: ['vite', 'dev'],
+    });
+  });
+});

--- a/src/lib/package-manager.ts
+++ b/src/lib/package-manager.ts
@@ -1,0 +1,96 @@
+/**
+ * Package-manager-aware command builders for spawning project tooling.
+ *
+ * Ship Studio used to hardcode `npm run dev` / `npx <binary>` when starting a
+ * dev server. Both are wrong outside npm projects: `npm run` parses the
+ * manifest's npm-only fields (an `overrides` block npm itself rejects aborts
+ * the launch with EOVERRIDE before the dev server ever starts) and ignores
+ * bun/pnpm lockfiles, while `npx <binary>` assumes the dev script's first
+ * token names an npm package — a script like `bash scripts/dev.sh` or
+ * `make dev` dies with "could not determine executable to run", because npx
+ * (unlike bunx and `pnpm exec`) never falls back to PATH.
+ *
+ * @module lib/package-manager
+ */
+
+/** The package managers Ship Studio can launch dev servers with. */
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
+
+/** A resolved command: a binary plus the argv to spawn it with. */
+export interface RunnerCommand {
+  command: string;
+  args: string[];
+}
+
+const KNOWN: readonly PackageManager[] = ['npm', 'pnpm', 'yarn', 'bun'];
+
+/**
+ * Validate a package-manager name coming from the backend (lockfile
+ * detection) or any older caller, defaulting to npm — the manager that ships
+ * with Node, so a spawn with it is always at least attemptable.
+ *
+ * @param raw - Detected manager name, or null/undefined when detection failed
+ * @returns A known PackageManager, "npm" when the value isn't one
+ */
+export function normalizePackageManager(raw: string | null | undefined): PackageManager {
+  return KNOWN.includes(raw as PackageManager) ? (raw as PackageManager) : 'npm';
+}
+
+/**
+ * Build the command that runs a package.json script with forwarded arguments
+ * (e.g. `--port 3000`).
+ *
+ * Only npm needs the `--` separator to stop eating forwarded flags itself;
+ * pnpm, yarn, and bun forward everything after the script name, and yarn 1
+ * hands a literal `--` to the script.
+ *
+ * @param pm - The project's package manager
+ * @param script - The script name (e.g. "dev")
+ * @param scriptArgs - Arguments to forward to the script
+ * @returns Command to spawn
+ */
+export function runScriptCommand(
+  pm: PackageManager,
+  script: string,
+  scriptArgs: string[]
+): RunnerCommand {
+  if (pm === 'npm') {
+    return { command: 'npm', args: ['run', script, '--', ...scriptArgs] };
+  }
+  return { command: pm, args: ['run', script, ...scriptArgs] };
+}
+
+/**
+ * Build the command that executes a dev script's binary the way the project's
+ * package manager would — resolving project-local `node_modules/.bin` first,
+ * then PATH.
+ *
+ * Per manager:
+ * - npm → `npx` (resolves local .bin; npm projects can't hit the EOVERRIDE
+ *   class of bugs this module exists for, since their manager IS npm)
+ * - bun → `bunx` (local .bin, then PATH)
+ * - pnpm → `pnpm exec` (local .bin, then PATH)
+ * - yarn → `npx` (yarn has no PATH-falling exec equivalent; npx is
+ *   tool-agnostic, ships with Node, and yarn projects don't carry the npm
+ *   overrides that make npx risky — the least-wrong runner)
+ *
+ * @param pm - The project's package manager
+ * @param bin - The dev script's first token (e.g. "vite", "bash")
+ * @param binArgs - The dev script's remaining tokens
+ * @returns Command to spawn
+ */
+export function execScriptCommand(
+  pm: PackageManager,
+  bin: string,
+  binArgs: string[]
+): RunnerCommand {
+  switch (pm) {
+    case 'bun':
+      return { command: 'bunx', args: [bin, ...binArgs] };
+    case 'pnpm':
+      return { command: 'pnpm', args: ['exec', bin, ...binArgs] };
+    case 'yarn':
+    case 'npm':
+      return { command: 'npx', args: [bin, ...binArgs] };
+  }
+}

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -18,6 +18,13 @@ import { readProjectFile } from './code';
 import { asCommandError, formatCommandError, isProjectFolderGoneError } from './errors';
 import { trackError } from './analytics';
 import { isWindows } from './setup';
+import { detectPackageManager } from './github';
+import {
+  PackageManager,
+  execScriptCommand,
+  normalizePackageManager,
+  runScriptCommand,
+} from './package-manager';
 
 /** Basic project information */
 export interface Project {
@@ -231,21 +238,22 @@ function hasShellSyntax(script: string): boolean {
 }
 
 /**
- * Parse a dev script command and return args for npx to run it with correct port.
- * Handles scripts like "vite dev --port 3000" or "next dev -p 3000".
- * Uses npx to ensure local node_modules/.bin executables are found.
+ * Parse a dev script command and return its tokens, with any hardcoded port
+ * replaced. Handles scripts like "vite dev --port 3000" or "next dev -p 3000".
+ * The caller executes the tokens through the project's own package manager
+ * (see execScriptCommand) so local node_modules/.bin executables are found.
  *
- * Falls back to returning null for complex shell scripts (with &&, ||, |, ;, or env vars)
- * which should be run via npm instead.
+ * Returns null for complex shell scripts (with &&, ||, |, ;, or env vars)
+ * which should be run via the package manager's script runner instead.
  *
  * @param script - The npm script command (e.g., "vite dev --port 3000")
  * @param desiredPort - The port we want to use
- * @returns Args array for npx command, with port replaced, or null if shell syntax detected
+ * @returns Tokens [binary, ...args] with the port replaced, or null if shell syntax detected
  */
-function parseDevScriptForNpx(script: string, desiredPort: number): string[] | null {
+function parseDevScriptCommand(script: string, desiredPort: number): string[] | null {
   // Check for shell syntax that can't be safely parsed
   if (hasShellSyntax(script)) {
-    logger.info('[DevServer] Dev script contains shell syntax, falling back to npm run dev', {
+    logger.info('[DevServer] Dev script contains shell syntax, falling back to script runner', {
       script,
     });
     return null;
@@ -342,8 +350,31 @@ export async function startDevServer(
   const homeNormalized = home.endsWith('/') ? home : `${home}/`;
   const fullPath = await getShellPath();
 
-  let command = 'npm';
-  let args: string[] = ['run', 'dev', '--', '--port', port.toString()];
+  // Spawn the dev server with the project's own package manager. npm's
+  // runners parse npm-only manifest fields before anything runs — a project
+  // with an `overrides` block npm rejects dies with EOVERRIDE at launch even
+  // though it installs with bun — and `npx bash …` fails outright because
+  // npx never falls back to PATH. Detection walks up from the cwd, so
+  // monorepo workspace subpaths resolve to the repo-root lockfile.
+  let packageManager: PackageManager = 'npm';
+  try {
+    packageManager = normalizePackageManager(await detectPackageManager(projectPath));
+    if (packageManager !== 'npm') {
+      logger.info('[DevServer] Detected non-npm package manager', {
+        projectPath,
+        packageManager,
+      });
+    }
+  } catch (e) {
+    logger.warn('[DevServer] detectPackageManager failed; assuming npm', {
+      projectPath,
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+
+  const fallbackRunner = runScriptCommand(packageManager, 'dev', ['--port', port.toString()]);
+  let command = fallbackRunner.command;
+  let args = fallbackRunner.args;
 
   if (customCommand) {
     // Custom command provided — split into command + args, bypass package.json parsing
@@ -359,7 +390,7 @@ export async function startDevServer(
     }
   } else {
     // Try to read package.json to get the dev script and parse it to use correct port
-    // We use npx to run the command so that local node_modules/.bin executables are found
+    // We run it through the project's package manager so local binaries are found
     try {
       logger.info('[DevServer] Reading package.json', { projectPath, desiredPort: port });
       // Read through the backend rather than plugin-fs: validate_project_path
@@ -372,11 +403,11 @@ export async function startDevServer(
         // An unresolved git merge conflict in package.json: JSON.parse would
         // throw "Unrecognized token '<'" and telemetry recorded an app bug
         // for what is a user-actionable repo state (issue #577). Surface the
-        // real cause in the dev-server log instead — the npm fallback below
-        // still spawns (and prints npm's own EJSONPARSE), so the user sees
-        // both messages where they're looking.
+        // real cause in the dev-server log instead — the script-runner
+        // fallback below still spawns (and prints the manager's own
+        // EJSONPARSE), so the user sees both messages where they're looking.
         logger.warn(
-          '[DevServer] package.json contains unresolved merge conflict markers; falling back to npm run dev',
+          '[DevServer] package.json contains unresolved merge conflict markers; falling back to script runner',
           { projectPath }
         );
         onOutput?.(
@@ -387,13 +418,17 @@ export async function startDevServer(
         const devScript = pkg.scripts?.dev;
 
         if (devScript) {
-          // Parse the dev script and replace any hardcoded port with our desired port
-          // Use npx to run the command so local binaries are found
-          // Returns null if the script contains shell syntax (&&, ||, |, ;, or env vars)
-          const npxArgs = parseDevScriptForNpx(devScript, port);
-          if (npxArgs) {
-            command = 'npx';
-            args = npxArgs;
+          // Parse the dev script and replace any hardcoded port with our desired port.
+          // Returns null if the script contains shell syntax (&&, ||, |, ;, or env vars).
+          const scriptTokens = parseDevScriptCommand(devScript, port);
+          if (scriptTokens) {
+            const runner = execScriptCommand(
+              packageManager,
+              scriptTokens[0],
+              scriptTokens.slice(1)
+            );
+            command = runner.command;
+            args = runner.args;
             logger.info('[DevServer] Parsed dev script successfully', {
               original: devScript,
               command,
@@ -401,43 +436,49 @@ export async function startDevServer(
               port,
             });
           } else {
-            // Script has shell syntax - use npm run dev which respects the PORT env var
-            logger.info('[DevServer] Using npm run dev for shell script', {
+            // Script has shell syntax - use the package manager's script
+            // runner, which respects the PORT env var
+            logger.info('[DevServer] Using script runner for shell script', {
+              packageManager,
               original: devScript,
               port,
             });
           }
         } else {
-          logger.warn('[DevServer] No dev script found in package.json, using npm run dev');
+          logger.warn('[DevServer] No dev script found in package.json, using script runner');
         }
       }
     } catch (e) {
-      // Fall back to npm run dev with port forwarded via -- --port
-      // (e.g. package.json genuinely missing, or not valid JSON)
-      // CommandError rejections are plain objects — String() renders them as
-      // "[object Object]" (issue #332); format them like the toasts do.
+      // Fall back to the package manager's script runner with the port
+      // forwarded as an argument (e.g. package.json genuinely missing, or
+      // not valid JSON). CommandError rejections are plain objects —
+      // String() renders them as "[object Object]" (issue #332); format
+      // them like the toasts do.
       const errorMessage = formatCommandError(asCommandError(e));
       if (errorMessage.includes('File not found: package.json')) {
         // A project with no package.json at all (framework detected from its
         // config file alone) is a known project state, not an app bug —
         // useDevServer skips the spawn for the common case (issue #593), and
         // remaining paths (restarts, monorepo cwd) must not page telemetry.
-        logger.warn('[DevServer] No package.json found; falling back to npm run dev', {
+        logger.warn('[DevServer] No package.json found; falling back to script runner', {
           projectPath,
         });
       } else if (isProjectFolderGoneError(e)) {
         // The project folder was moved, renamed, or deleted outside Ship Studio
         // while its session stayed open — an environment state, not an app bug
         // (issue #822). Same treatment as the missing-package.json case.
-        logger.warn('[DevServer] Project folder is gone; falling back to npm run dev', {
+        logger.warn('[DevServer] Project folder is gone; falling back to script runner', {
           projectPath,
         });
       } else {
         trackError('devserver_package_json', e, 'Workspace');
-        logger.error('[DevServer] Failed to read/parse package.json, falling back to npm run dev', {
-          error: errorMessage,
-          projectPath,
-        });
+        logger.error(
+          '[DevServer] Failed to read/parse package.json, falling back to script runner',
+          {
+            error: errorMessage,
+            projectPath,
+          }
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary

Dev servers were always spawned through npm's runners — a hardcoded `npm run dev` fallback and `npx <script-tokens>` for any dev script without shell operators. That breaks bun and pnpm projects in two independent ways (both reproduced against npm 12 / bun / pnpm):

1. **npm parses npm-only manifest state before anything runs.** A bun project whose root `package.json` carries an `overrides` block npm itself rejects dies at launch with `EOVERRIDE: Override for postcss@… conflicts with direct dependency` — `npm exec` loads the workspace manifest before spawning, so the dev server never starts even though the project installs and runs fine with bun. (`npx` hits the same loader.)
2. **`npx <first-token>` assumes the dev script names an npm package.** Scripts like `bash scripts/dev.sh`, `make dev`, or `docker compose up` fail with `could not determine executable to run` — npx never falls back to PATH, while `bunx` and `pnpm exec` do:

   ```
   npx bash ./ok.sh        → could not determine executable to run
   pnpm exec bash ./ok.sh  → runs
   bunx bash ./ok.sh       → runs
   ```

**Changes**

- `detect_package_manager` now walks up through the enclosing git repository, so dev servers running from a monorepo workspace subpath (`apps/web`) resolve the repo-root lockfile instead of silently defaulting to npm. The walk is bounded by the git boundary (worktree `.git`-as-file included) so a lockfile above the repository is never misread as this project's; outside a git repo it walks to the filesystem root, matching npm's own workspace resolution.
- New `lib/package-manager` builds the spawn command per manager:
  - bun → `bun run dev …` / `bunx <bin> …`
  - pnpm → `pnpm run dev …` / `pnpm exec <bin> …` (args forwarded directly; only npm needs `--`)
  - yarn → arg-forwarding without `--` (yarn 1 hands a literal `--` to the script) and `npx` for the exec path (no PATH-falling yarn equivalent; yarn projects don't carry the npm overrides that make npx risky)
  - npm → unchanged (`npm run dev --` / `npx`)
- Detection failure still falls back to npm, mirroring `or_npm` on the backend.
- The bun/pnpm install-CTA already detected the manager; dev spawning now agrees with it.

## Test plan

- [x] New `src/lib/package-manager.test.ts` (10 tests): per-manager run/exec commands, arg-forwarding rules, normalize fallbacks
- [x] New Rust tests: lockfile found from workspace subpath for all four lockfile spellings, repo-root manifest signals apply to subpaths, walk stops at the git boundary, direct root detection still works
- [x] Repro from the bug report: bun monorepo, workspace subpath `apps/web`, dev script `bash ../../scripts/run-app-dev.sh`, root `overrides` that npm rejects — old build dies with EOVERRIDE, patched flow resolves `bun` and spawns `bunx bash …`

## CI gates

- [x] `tsc --noEmit`, `eslint` + `prettier --check` on changed files, `cargo fmt -- --check`, `cargo clippy` (no new warnings), `cargo test` (1489 pass; the one local failure — `non_github_remotes_keep_the_machines_own_credentials` — fails identically on clean `main`, it's a machine git-credentials environment issue), and the new vitest suites pass. Remaining vitest failures in this sandbox also fail on clean `main` (environmental), which is why the pre-push hook was skipped locally — CI runs the full gates.

<details>
<summary><strong>Patterns checklist</strong></summary>

**Frontend**
- N/A — no new modals/buttons/async-state/polling; pure command-builder + launcher wiring

**Rust**
- [x] No new `#[tauri::command]`s (existing `detect_package_manager` unchanged in signature, still `Result<String, CommandError>` + `#[tracing::instrument]`)
- [x] No external CLI calls added (fs-only upward walk)

**Tests**
- [x] Added tests for non-trivial logic (frontend + backend)
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Development servers now use the project’s configured package manager: npm, pnpm, Yarn, or Bun.
  * Package manager detection works from nested project directories and recognizes configuration inherited from the enclosing repository.
  * Script and executable commands now use the appropriate runner for each supported package manager.

* **Bug Fixes**
  * Improved package manager detection for monorepos and Git worktrees.
  * Added safer fallback behavior to npm when the package manager cannot be identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->