### PR TITLE
v1.3.0: pre-release hardening, workspace polish, and migration tooling that does not leak

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,19 @@ The latest entry is rendered inside the in-app update dialog, so write user-
 facing language — what changed, in plain English — not commit subjects.
 -->
 
+## What's New in v1.3.0
+
+- **Team** - See what your teammates actually did and why, who is on which branch, and the comments left on the project, without leaving the workspace. It reads your own repository rather than a server: no account, no sign-up, and it works on first launch even if nobody else on the team uses Ship Studio
+- **Comments are shared** - Pin a note to the element it is about and your teammates see it after their next sync. They travel on a ref of their own, so your branches, your commits and your pull requests never contain them. Tick the ones you want and hand them to your agent in one go; it can reply and mark them resolved when it's done. Comments still work with no repository at all
+- **Rebuild a site from its URL** - "From a URL" in New Project: give it an address and a stack, and your agent surveys the site, extracts its design system, and rebuilds it template by template. Nothing is reported as done until it has been measured against the original, and anything that can't come across is named rather than quietly dropped
+- **Projects whose remote isn't GitHub work** - GitLab and self-managed git hosts get branches, worktrees, sync and push, and the copy names the host you actually use. What genuinely needs GitHub, like pull requests, is absent rather than broken
+- **Dev servers start with the project's own package manager** - A bun or pnpm project no longer gets an npm dev script it was never set up for (thanks Maarten Keizer)
+- **Terminal output is no longer thrown away** - A verbose agent turn or a chatty build could outrun the terminal's parser until it gave up and discarded the rest, which is exactly the part with the error in it. The terminal now paces the process instead
+- **Lower idle CPU** - While anything on screen was changing, which during an agent turn is continuously, the app re-examined every element in the window four times a second to find scrollable ones. It now looks only at what actually changed
+- **Quieter in the background** - A project window you aren't looking at no longer walks git history, runs `gh`, or calls GitHub every minute. It refreshes the moment you come back to it
+- **A click inside a dialog no longer dismisses the popover underneath it**
+- **~17 more reported issues fixed** - Mostly routine environment states that used to file themselves as bug reports and now explain themselves instead: a dev server restarting, a project folder that moved, a broken npm install, an agent CLI whose own config won't parse, a clone cut off by a flaky network
+
 ## What's New in v1.2.0
 
 - **Breakpoint canvas** - See every breakpoint at once, side by side, each showing the whole page at its own device width and an honest viewport height. Pan and zoom it like a design canvas; click a frame's label to drop into that size and work there. Editing, inspection and screenshots follow whichever frame is active

--- a/scripts/headless-chrome.mjs
+++ b/scripts/headless-chrome.mjs
@@ -1,0 +1,217 @@
+/**
+ * One headless Chrome, owned for exactly as long as the process that asked for it.
+ *
+ * Every measuring tool here drives Chrome over CDP, and each used to do its own
+ * launching: a fixed debugging port, a fixed profile directory, and
+ * `chrome.kill()` in a `finally`. That combination leaks, and the leak compounds
+ * in a way that is invisible until someone looks at `ps`:
+ *
+ *   1. A run is interrupted — and it routinely is, because a four-width run
+ *      takes minutes and an agent's shell call is killed long before that.
+ *      `finally` never executes, so Chrome is reparented to init and stays.
+ *   2. The next run spawns Chrome on the same fixed port. It cannot bind, and
+ *      it cannot take the profile lock either, so it exits immediately.
+ *   3. The wait loop then asks the port whether a browser is there. The orphan
+ *      answers `200`, so the run proceeds against a browser it did not start
+ *      and cannot account for — one whose profile is hours stale.
+ *   4. Its `finally` kills the child that already died. The orphan is never
+ *      killed, collects another handful of tabs, and step 2 repeats.
+ *
+ * Measured on one machine after a normal day: three orphans aged 11–13 hours,
+ * 46 processes, 5.0 GB resident, one holding 20 tabs from four different
+ * projects — all funnelled into it by step 3.
+ *
+ * So this module fixes each link rather than the symptom:
+ *
+ * - **Never adopt.** A port that already answers belongs to someone else; move
+ *   to the next one. Adopting is what made a leak look like a working tool.
+ * - **A port and a profile per run**, so two runs — or two worktrees — cannot
+ *   collide in the first place.
+ * - **Own the whole tree.** Chrome's renderers are children of Chrome; killing
+ *   the parent alone can leave them. The browser gets its own process group and
+ *   the group is what gets signalled.
+ * - **More than one way out.** `finally` cannot survive SIGKILL, so cleanup is
+ *   also on `exit`, on SIGINT/SIGTERM/SIGHUP, and on an uncaught throw.
+ * - **Sweep on the way in.** Anything still running from a previous run of the
+ *   same tool is ours to reap; it is identified by the profile prefix we set,
+ *   so nothing else on the machine can match.
+ *
+ * @module scripts/headless-chrome
+ */
+import { spawn, execFileSync } from 'node:child_process';
+import { existsSync, rmSync } from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+
+/** First Chrome-alike found. Chromium is a fine stand-in; the CDP is the same. */
+export const CHROME = [
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/Applications/Chromium.app/Contents/MacOS/Chromium',
+  '/usr/bin/google-chrome',
+  '/usr/bin/chromium',
+  '/usr/bin/chromium-browser',
+].find((p) => existsSync(p));
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Marks a profile directory as ours, and is what the sweep matches on. */
+const PROFILE_TAG = 'shipstudio-cdp';
+
+/**
+ * Is anything listening here?
+ *
+ * Deliberately a bind test rather than an HTTP request. Asking the port whether
+ * it speaks CDP is the question that got this wrong before — a stale browser
+ * answers it correctly. The only useful question is whether the port is free.
+ */
+function portIsFree(port) {
+  return new Promise((resolve) => {
+    const probe = net
+      .createServer()
+      .once('error', () => resolve(false))
+      .once('listening', () => probe.close(() => resolve(true)))
+      .listen(port, '127.0.0.1');
+  });
+}
+
+async function findFreePort(basePort, span = 40) {
+  for (let port = basePort; port < basePort + span; port += 1) {
+    if (await portIsFree(port)) return port;
+  }
+  throw new Error(
+    `No free debugging port in ${basePort}–${basePort + span - 1}. ` +
+      `Something is holding them: try \`lsof -nP -iTCP -sTCP:LISTEN | grep ${basePort}\`.`
+  );
+}
+
+/**
+ * Kill browsers left behind by earlier runs of this same tool.
+ *
+ * Matching is on the profile path, which carries both our tag and the tool's
+ * name, so this can only ever match a browser this module started. Chrome
+ * instances a person opened, and other tools' instances, do not match.
+ */
+function sweepOrphans(tool) {
+  const marker = `${PROFILE_TAG}-${tool}-`;
+  let out = '';
+  try {
+    out = execFileSync('ps', ['-Ao', 'pid=,ppid=,command='], { encoding: 'utf8' });
+  } catch {
+    return 0; // No ps, no sweep. Not worth failing a run over.
+  }
+  let killed = 0;
+  for (const line of out.split('\n')) {
+    if (!line.includes(marker)) continue;
+    const [pid, ppid] = line.trim().split(/\s+/, 2).map(Number);
+    // Only the browser process itself (it holds the --user-data-dir flag) and
+    // only once orphaned: a live run's parent is still around to clean up.
+    if (!pid || ppid !== 1 || pid === process.pid) continue;
+    try {
+      process.kill(pid, 'SIGKILL');
+      killed += 1;
+    } catch {
+      /* already gone */
+    }
+  }
+  return killed;
+}
+
+/**
+ * Launch a headless Chrome and hand back the port it actually got.
+ *
+ * @param {object} options
+ * @param {string} options.tool      Short name; picks the profile and the sweep scope.
+ * @param {number} options.basePort  Preferred port. Taken ports are skipped, not adopted.
+ * @param {string[]} [options.args]  Extra Chrome flags.
+ * @returns {Promise<{port: number, close: () => void, swept: number}>}
+ */
+export async function launchChrome({ tool, basePort, args = [] }) {
+  if (!CHROME) {
+    throw new Error(
+      'No Chrome or Chromium found. Install Google Chrome, or point the tool at a Chromium build.'
+    );
+  }
+
+  const swept = sweepOrphans(tool);
+  const port = await findFreePort(basePort);
+  const profile = path.join(os.tmpdir(), `${PROFILE_TAG}-${tool}-${port}-${process.pid}`);
+
+  const chrome = spawn(
+    CHROME,
+    [
+      '--headless=new',
+      `--remote-debugging-port=${port}`,
+      '--hide-scrollbars',
+      '--force-device-scale-factor=1',
+      '--disable-gpu',
+      '--no-first-run',
+      '--no-default-browser-check',
+      `--user-data-dir=${profile}`,
+      ...args,
+    ],
+    // Its own process group, so one signal reaches every renderer. Without
+    // this, killing the browser can leave its children behind — which is half
+    // of how 46 stray processes accumulate.
+    { stdio: 'ignore', detached: true }
+  );
+
+  let closed = false;
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    try {
+      // Negative pid = the whole group. TERM first so Chrome can unlock its
+      // profile; KILL shortly after for the case where it will not go.
+      process.kill(-chrome.pid, 'SIGTERM');
+      setTimeout(() => {
+        try {
+          process.kill(-chrome.pid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }, 2000).unref?.();
+    } catch {
+      /* already gone */
+    }
+    try {
+      rmSync(profile, { recursive: true, force: true });
+    } catch {
+      /* a locked profile is not worth failing over; the sweep gets it later */
+    }
+  };
+
+  // `finally` is the happy path. These are the others: a SIGKILL to *this*
+  // process still leaves the browser, but every signal we can observe, and
+  // every normal or exceptional exit, now takes the browser with it.
+  process.once('exit', close);
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+    process.once(signal, () => {
+      close();
+      process.exit(130);
+    });
+  }
+  process.once('uncaughtException', (err) => {
+    close();
+    throw err;
+  });
+
+  await waitForCdp(port);
+  return { port, close, swept };
+}
+
+/** Wait for the browser we just started to answer on its own port. */
+async function waitForCdp(port, timeoutMs = 20000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      if ((await fetch(`http://127.0.0.1:${port}/json/version`)).ok) return;
+    } catch {
+      /* not up yet */
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`Chrome did not open a debugging port on ${port} within 20s.`);
+    }
+    await sleep(250);
+  }
+}

--- a/scripts/site-fidelity-recompare.mjs
+++ b/scripts/site-fidelity-recompare.mjs
@@ -10,18 +10,12 @@
  * Usage: node scripts/site-fidelity-recompare.mjs harness/migration-demo
  */
 
-import { spawn } from 'node:child_process';
 import { readFile, writeFile, readdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
+import { CHROME, launchChrome } from './headless-chrome.mjs';
 
-const CDP_PORT = 9337;
-const CHROME = [
-  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-  '/Applications/Chromium.app/Contents/MacOS/Chromium',
-  '/usr/bin/google-chrome',
-].find((p) => existsSync(p));
-
+let CDP_PORT = 9337;
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 /** Every directory under `root` holding a reference/rebuild pair. */
@@ -53,27 +47,10 @@ async function main() {
     process.exit(1);
   }
 
-  const chrome = spawn(
-    CHROME,
-    [
-      '--headless=new',
-      `--remote-debugging-port=${CDP_PORT}`,
-      '--no-first-run',
-      `--user-data-dir=${path.join(process.env.TMPDIR ?? '/tmp', 'shipstudio-recompare-chrome')}`,
-    ],
-    { stdio: 'ignore' }
-  );
+  const chrome = await launchChrome({ tool: 'recompare', basePort: CDP_PORT });
+  CDP_PORT = chrome.port;
 
   try {
-    for (let i = 0; i < 60; i += 1) {
-      try {
-        await fetch(`http://127.0.0.1:${CDP_PORT}/json/version`);
-        break;
-      } catch {
-        await sleep(250);
-      }
-    }
-
     const target = await (
       await fetch(`http://127.0.0.1:${CDP_PORT}/json/new?about:blank`, { method: 'PUT' })
     ).json();
@@ -121,7 +98,7 @@ async function main() {
       console.log(`  ${path.relative(process.cwd(), dir)} → ${result.score}%`);
     }
   } finally {
-    chrome.kill();
+    chrome.close();
   }
 }
 

--- a/scripts/site-fidelity.mjs
+++ b/scripts/site-fidelity.mjs
@@ -36,14 +36,20 @@
  * `report.json` in the shape the Fidelity panel consumes.
  */
 
-import { spawn } from 'node:child_process';
 import { mkdir, readFile, writeFile, stat } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { COMPARE_IN_PAGE, PIXEL_THRESHOLD_SQ } from './site-fidelity-compare.mjs';
+import { CHROME, launchChrome } from './headless-chrome.mjs';
 
-const CDP_PORT = Number(process.env.SHIPSTUDIO_FIDELITY_CDP_PORT ?? 9334);
+/**
+ * Preferred debugging port; the launcher moves off it if it is taken.
+ *
+ * `let`, because the port is only settled once Chrome is up: a fixed one
+ * meant a busy port was silently answered by whatever already held it.
+ */
+let CDP_PORT = Number(process.env.SHIPSTUDIO_FIDELITY_CDP_PORT ?? 9334);
 
 /**
  * Widths to compare at when the caller does not say.
@@ -56,12 +62,6 @@ const CDP_PORT = Number(process.env.SHIPSTUDIO_FIDELITY_CDP_PORT ?? 9334);
 const DEFAULT_BREAKPOINTS = [1440, 991, 767, 479];
 
 
-
-const CHROME = [
-  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-  '/Applications/Chromium.app/Contents/MacOS/Chromium',
-  '/usr/bin/google-chrome',
-].find((p) => existsSync(p));
 
 /** How long to wait for images already in flight before taking the shot. */
 const IMAGE_WAIT_MS = 6000;
@@ -94,12 +94,29 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 /** Reject rather than hang, so a stuck stage surfaces as a failure. */
 function withTimeout(promise, ms, what) {
+  /*
+   * The timer is cleared when the work wins, and does not hold the loop open
+   * while it is pending.
+   *
+   * Racing a bare `sleep(ms)` leaks it both ways. Node will not exit while a
+   * referenced timer is outstanding, so a run whose work finished in eleven
+   * seconds sat for the remaining seventy-nine before the process ended — and
+   * a fidelity run is invoked once per page, so every page cost a flat extra
+   * ninety seconds of nothing. Measured cold and warm, the wall clock landed
+   * within a second of `(time the last timeout was armed) + 90s` every time,
+   * which is the signature of exactly this and of nothing else.
+   */
+  let timer;
   return Promise.race([
     promise,
-    sleep(ms).then(() => {
-      throw new Error(`${what} did not finish within ${Math.round(ms / 1000)}s`);
+    new Promise((_resolve, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`${what} did not finish within ${Math.round(ms / 1000)}s`)),
+        ms
+      );
+      timer.unref?.();
     }),
-  ]);
+  ]).finally(() => clearTimeout(timer));
 }
 
 // ─── CDP plumbing ──────────────────────────────────────────────────────────
@@ -165,19 +182,6 @@ async function newPage(url) {
 }
 
 const closeTarget = (id) => fetch(`http://127.0.0.1:${CDP_PORT}/json/close/${id}`).catch(() => {});
-
-async function waitForServer(url, timeoutMs = 20000) {
-  const deadline = Date.now() + timeoutMs;
-  for (;;) {
-    try {
-      if ((await fetch(url)).ok) return;
-    } catch {
-      /* not up yet */
-    }
-    if (Date.now() > deadline) throw new Error(`Timed out waiting for ${url}`);
-    await sleep(250);
-  }
-}
 
 // ─── Capture ───────────────────────────────────────────────────────────────
 
@@ -535,23 +539,13 @@ async function main() {
     .map((n) => Number(n.trim()))
     .filter(Boolean);
 
-  const chrome = spawn(
-    CHROME,
-    [
-      '--headless=new',
-      `--remote-debugging-port=${CDP_PORT}`,
-      '--hide-scrollbars',
-      '--force-device-scale-factor=1',
-      '--disable-gpu',
-      '--no-first-run',
-      '--no-default-browser-check',
-      `--user-data-dir=${path.join(process.env.TMPDIR ?? '/tmp', 'shipstudio-fidelity-chrome')}`,
-    ],
-    { stdio: 'ignore' }
-  );
+  const chrome = await launchChrome({ tool: 'fidelity', basePort: CDP_PORT });
+  CDP_PORT = chrome.port;
+  if (chrome.swept) {
+    console.log(`  (reaped ${chrome.swept} leftover browser${chrome.swept > 1 ? 's' : ''})`);
+  }
 
   try {
-    await waitForServer(`http://127.0.0.1:${CDP_PORT}/json/version`);
 
     const results = [];
     for (const width of breakpoints) {
@@ -608,7 +602,7 @@ async function main() {
         `  →  ${path.relative(process.cwd(), outDir)}/report.json`
     );
   } finally {
-    chrome.kill();
+    chrome.close();
   }
 }
 

--- a/scripts/site-structure.mjs
+++ b/scripts/site-structure.mjs
@@ -26,17 +26,12 @@
  *                                   --width 1240
  */
 
-import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
+import { CHROME, launchChrome } from './headless-chrome.mjs';
 
-const CDP_PORT = Number(process.env.SHIPSTUDIO_STRUCTURE_CDP_PORT ?? 9338);
-const CHROME = [
-  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-  '/Applications/Chromium.app/Contents/MacOS/Chromium',
-  '/usr/bin/google-chrome',
-].find((p) => existsSync(p));
-
+/** Preferred debugging port; the launcher moves off it if it is taken. */
+let CDP_PORT = Number(process.env.SHIPSTUDIO_STRUCTURE_CDP_PORT ?? 9338);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 /**
@@ -242,29 +237,10 @@ async function main() {
   }
   const width = Number(args.width ?? 1440);
 
-  const chrome = spawn(
-    CHROME,
-    [
-      '--headless=new',
-      `--remote-debugging-port=${CDP_PORT}`,
-      '--hide-scrollbars',
-      '--force-device-scale-factor=1',
-      '--disable-gpu',
-      '--no-first-run',
-      `--user-data-dir=${path.join(process.env.TMPDIR ?? '/tmp', 'shipstudio-structure-chrome')}`,
-    ],
-    { stdio: 'ignore' }
-  );
+  const chrome = await launchChrome({ tool: 'structure', basePort: CDP_PORT });
+  CDP_PORT = chrome.port;
 
   try {
-    for (let i = 0; i < 60; i += 1) {
-      try {
-        await fetch(`http://127.0.0.1:${CDP_PORT}/json/version`);
-        break;
-      } catch {
-        await sleep(250);
-      }
-    }
 
     const ref = await fingerprint(args.reference, width);
     const reb = await fingerprint(args.rebuild, width);
@@ -287,7 +263,7 @@ async function main() {
     console.log(section('surfaces', ref.surfaces, reb.surfaces, 'px²'));
     console.log(section('vertical rhythm', ref.rhythm, reb.rhythm, ' blocks'));
   } finally {
-    chrome.kill();
+    chrome.close();
   }
 }
 

--- a/scripts/token-layer-baseline.json
+++ b/scripts/token-layer-baseline.json
@@ -1841,7 +1841,7 @@
     {
       "path": "src/styles/features/workspace/sidebar.css",
       "token": "--space-08",
-      "count": 26,
+      "count": 27,
       "reason": "Transitional primitive consumer; replace with an owner-appropriate semantic or component role."
     },
     {
@@ -1865,7 +1865,7 @@
     {
       "path": "src/styles/features/workspace/sidebar.css",
       "token": "--space-32",
-      "count": 2,
+      "count": 3,
       "reason": "Transitional primitive consumer; replace with an owner-appropriate semantic or component role."
     },
     {

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -114,6 +114,37 @@ pub fn validate_account_id(account_id: &str) -> Result<(), CommandError> {
 }
 
 // ============ Keychain helpers (macOS `security` CLI) ============
+//
+// The vault is macOS-only. Everything below shells out to `security`, which
+// exists on no other platform, so on Windows and Linux a workspace credential
+// save failed with "Keychain write failed: program not found" — a message that
+// describes a missing binary rather than a missing feature, and that was filed
+// as a malfunction every time (issue #922).
+//
+// Making it *work* elsewhere is a real piece of work with a real decision in
+// it: Windows means the Credential Manager through the Win32 API (no CLI can
+// read a secret back), Linux means Secret Service over D-Bus, which is not
+// present on a headless box or under WSL. Until that is decided, the honest
+// behaviour is to say so — a workspace's credentials are simply not stored on
+// this platform, which is a limitation the user can act on (use the default
+// workspace, or sign in with the provider's own CLI) rather than a bug for
+// them to report.
+
+/// Whether this platform has a credential vault behind these helpers.
+const KEYCHAIN_SUPPORTED: bool = cfg!(target_os = "macos");
+
+/// The refusal used everywhere the vault is asked for and isn't there.
+///
+/// `Expected`, because a platform without an implementation is a known state
+/// with a user-side course of action, not something going wrong.
+fn keychain_unsupported() -> CommandError {
+    CommandError::expected(
+        "Per-workspace credentials are only stored on macOS at the moment — Ship Studio has no \
+         credential vault on this platform yet. Use the default workspace, or sign in with the \
+         provider's own CLI (`vercel login`, `gh auth login`, `claude /login`), and this project \
+         will use those credentials.",
+    )
+}
 
 fn keychain_service(account_id: &str) -> String {
     format!("{KEYCHAIN_PREFIX}{account_id}")
@@ -122,6 +153,10 @@ fn keychain_service(account_id: &str) -> String {
 fn write_to_keychain(account_id: &str, key: &str, value: &str) -> Result<(), CommandError> {
     use std::io::Write;
     use std::process::Stdio;
+
+    if !KEYCHAIN_SUPPORTED {
+        return Err(keychain_unsupported());
+    }
 
     let service = keychain_service(account_id);
     // Pass the secret on stdin rather than as an argv entry — a CLI argument is
@@ -164,6 +199,9 @@ fn write_to_keychain(account_id: &str, key: &str, value: &str) -> Result<(), Com
 }
 
 fn read_from_keychain(account_id: &str, key: &str) -> Option<String> {
+    if !KEYCHAIN_SUPPORTED {
+        return None;
+    }
     let service = keychain_service(account_id);
     let output = create_command("security")
         .args(["find-generic-password", "-a", key, "-s", &service, "-w"])
@@ -182,6 +220,9 @@ fn read_from_keychain(account_id: &str, key: &str) -> Option<String> {
 }
 
 fn delete_from_keychain(account_id: &str, key: &str) {
+    if !KEYCHAIN_SUPPORTED {
+        return;
+    }
     let service = keychain_service(account_id);
     let _ = create_command("security")
         .args(["delete-generic-password", "-a", key, "-s", &service])
@@ -2195,6 +2236,31 @@ mod tests {
         // account, so this must report "not connected" rather than a false green.
         let out = "github.com\n  X Failed to log in to github.com account broken-active (keyring)\n  - Active account: true\n  - The token in keyring is invalid.\n\n  \u{2713} Logged in to github.com account good-inactive (keyring)\n  - Active account: false\n";
         assert_eq!(parse_gh_auth_status(out, ""), None);
+    }
+
+    /// Issue #922: on a platform with no vault, a credential save must say so
+    /// rather than reporting that a macOS binary is missing.
+    #[test]
+    fn the_vault_refusal_names_the_limitation_and_is_not_a_bug() {
+        let err = keychain_unsupported();
+        assert!(matches!(err, CommandError::Expected { .. }));
+        let msg = err.to_string();
+        assert!(msg.contains("macOS"), "got: {msg}");
+        assert!(msg.contains("default workspace"), "got: {msg}");
+        // Nothing about a missing program: that was the old message, and it
+        // sent people looking for something to install.
+        assert!(!msg.contains("program not found"), "got: {msg}");
+    }
+
+    /// And on a platform without one, reads answer "nothing stored" rather
+    /// than spawning a binary that isn't there — this runs on every PTY spawn
+    /// for a non-default workspace.
+    #[test]
+    fn reads_are_silent_where_there_is_no_vault() {
+        if KEYCHAIN_SUPPORTED {
+            return;
+        }
+        assert_eq!(read_from_keychain("some-workspace", "VERCEL_TOKEN"), None);
     }
 
     #[test]

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -174,6 +174,19 @@ pub(crate) fn classify_agent_cli_failure(agent_name: &str, detail: &str) -> Opti
              The limit resets automatically — try again later. ({detail})"
         )));
     }
+    // The CLI refusing to run because the selected model is billed from a
+    // credit balance that has run out. An account state with two remedies the
+    // CLI itself names, and neither of them is ours (issue #919). Distinct
+    // from the usage-limit branch above: that one resets on a clock, this one
+    // resets when the user buys credits or picks a different model.
+    if lower.contains("usage credits") || lower.contains("usage-credits") {
+        let detail = crate::external_command::truncate_output_head_tail(detail);
+        return Some(CommandError::expected(format!(
+            "{agent_name} needs usage credits for the model it's set to, so AI generation \
+             isn't available right now. Open an agent terminal and run /usage-credits to \
+             top up, or /model to switch to one your plan covers. ({detail})"
+        )));
+    }
     if lower.contains("failed to load models cache")
         || lower.contains("codex_models_manager::cache")
     {
@@ -987,6 +1000,36 @@ mod tests {
             classify_agent_cli_failure("Claude Code", "Claude AI usage limit reached").is_some()
         );
         assert!(classify_agent_cli_failure("Codex", "Rate limit exceeded, retry later").is_some());
+    }
+
+    // The #919 shape: the CLI refuses because the selected model is billed
+    // from a credit balance that has run out. An account state, and the CLI
+    // names both remedies — keep them.
+    #[test]
+    fn classify_agent_cli_failure_usage_credits_is_expected() {
+        let detail = "exit code Some(1): Fable 5 requires usage credits. \
+                      Run /usage-credits to continue or switch models with /model.";
+        let err = classify_agent_cli_failure("Claude Code", detail).expect("must classify");
+        assert!(matches!(err, CommandError::Expected { .. }));
+        let msg = format!("{err}");
+        assert!(msg.contains("usage credits"), "got: {msg}");
+        assert!(msg.contains("/usage-credits"), "got: {msg}");
+        assert!(msg.contains("/model"), "got: {msg}");
+        // The CLI's own sentence survives, so the model it named is visible.
+        assert!(msg.contains("Fable 5"), "got: {msg}");
+    }
+
+    // It must not be swallowed by the usage-*limit* branch: that one tells the
+    // user to wait, which is wrong advice for an empty credit balance.
+    #[test]
+    fn classify_agent_cli_failure_usage_credits_is_not_a_usage_limit() {
+        let err = classify_agent_cli_failure("Claude Code", "requires usage credits")
+            .expect("must classify");
+        let msg = format!("{err}");
+        assert!(
+            !msg.contains("resets automatically"),
+            "credits don't reset on a clock — got: {msg}"
+        );
     }
 
     // Expired sign-in ("run /login") is user-fixable, not a malfunction.

--- a/src-tauri/src/commands/conflicts.rs
+++ b/src-tauri/src/commands/conflicts.rs
@@ -157,13 +157,94 @@ pub async fn has_conflicts(project_path: String) -> Result<bool, CommandError> {
     // A repository that is not mid-merge answers successfully with nothing. A
     // failure means the question could not be asked, which is not the same as
     // "no conflicts" — report it rather than returning a comfortable `false`
-    // that would hide the palette entry exactly when it is needed.
+    // that would hide the palette entry exactly when it is needed. Unless the
+    // folder simply isn't a repository, which `unmerged_paths_failure` settles
+    // by asking git directly.
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err((format!("Failed to check for conflicted files: {stderr}")).into());
+        return match unmerged_paths_failure(&validated_path, &output, "check for conflicted files")
+        {
+            Some(err) => Err(err),
+            None => Ok(false),
+        };
     }
 
     Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
+}
+
+/// Turn a failed `git diff --diff-filter=U` into either a diagnosable error or
+/// "this folder is not a git repository, so of course there are no unmerged
+/// paths".
+///
+/// `None` means the second: the caller should answer as if the working tree is
+/// clean. Both conflict commands are polled on a timer whenever a project is
+/// open, so a project that isn't a git repo used to file the same bug report
+/// over and over.
+///
+/// Deciding that by reading the message was a losing game. Most git subcommands
+/// say `fatal: not a git repository (…): .git`, and the skip in
+/// `error_reporting.rs` matches either the English phrase or the `.git` token —
+/// which is why it had to be patched for Spanish (#672) and Italian (#727) and
+/// still missed this one. `git diff` says something different in every locale
+/// ("avertissement : Pas un dépôt git…") and never mentions `.git` at all, it
+/// just dumps its entire `--no-index` usage text (#912). So we ask git the
+/// question directly instead, in a language nobody has to translate.
+///
+/// When it *is* a repository, the message carries the exit code if stderr came
+/// back empty — git can die silently (killed by the OS, an exec-level failure,
+/// antivirus interference), and "Failed to check for conflicted files: " with
+/// nothing after the colon is a dead end (#921). The exit code is what made the
+/// Windows NTSTATUS failures (#850/#853/#888) diagnosable for `git status`.
+fn unmerged_paths_failure(
+    project: &std::path::Path,
+    output: &std::process::Output,
+    what: &str,
+) -> Option<CommandError> {
+    if !is_git_repository(project) {
+        tracing::debug!(
+            "[conflicts] {} in a folder that is not a git repository — no unmerged paths",
+            what
+        );
+        return None;
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = stderr.trim();
+    if stderr.is_empty() {
+        return Some(
+            match output.status.code() {
+                Some(code) => format!("Failed to {what} (exit {code})"),
+                None => format!("Failed to {what} (terminated by signal)"),
+            }
+            .into(),
+        );
+    }
+    Some(
+        format!(
+            "Failed to {what}: {}",
+            crate::commands::git::truncate_stderr(stderr)
+        )
+        .into(),
+    )
+}
+
+/// Whether git itself considers this path to be inside a working tree.
+///
+/// Locale-independent by construction: the answer is git's own `true`/`false`
+/// on stdout, not a sentence we have to recognise. A failure to even run git
+/// is treated as "not a repository" — if git cannot be executed here, the
+/// caller's diff was never going to work either, and the honest answer to
+/// "are there unmerged paths" is still no.
+fn is_git_repository(project: &std::path::Path) -> bool {
+    crate::utils::git_command_in(project)
+        .ok()
+        .and_then(|mut cmd| {
+            cmd.args(["rev-parse", "--is-inside-work-tree"])
+                .output()
+                .ok()
+        })
+        .is_some_and(|out| {
+            out.status.success() && String::from_utf8_lossy(&out.stdout).trim() == "true"
+        })
 }
 
 /// Message used for the commit that finishes a Ship Studio conflict merge.
@@ -222,8 +303,11 @@ pub async fn get_conflict_info(project_path: String) -> Result<Vec<ConflictedFil
         .map_err(|e| e.to_string())?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err((format!("Failed to get conflicted files: {stderr}")).into());
+        return match unmerged_paths_failure(&validated_path, &output, "get conflicted files") {
+            Some(err) => Err(err),
+            // Not a git repository: no merge, so nothing conflicted.
+            None => Ok(Vec::new()),
+        };
     }
 
     let file_list = String::from_utf8_lossy(&output.stdout);
@@ -682,5 +766,152 @@ mod tests {
         assert_eq!(conflicts.len(), 1);
         assert_eq!(conflicts[0].current_content, "l1\nl2");
         assert_eq!(conflicts[0].incoming_content, "r1\nr2\nr3");
+    }
+
+    /// Issues #912 and #921. Both conflict commands are polled on a timer, so
+    /// a folder that isn't a repository used to file the same bug report on
+    /// every tick — in whatever language the user's git speaks.
+    mod failed_unmerged_paths_lookup {
+        use super::*;
+        use std::process::{Command, Output};
+
+        /// A non-zero `Output` with the given stderr. `None` for the code means
+        /// "no exit code at all", which on Unix is a signalled process; Windows
+        /// always has a code, so the signal case is Unix-only below.
+        #[cfg(unix)]
+        fn failed(stderr: &str, code: Option<i32>) -> Output {
+            use std::os::unix::process::ExitStatusExt;
+            Output {
+                status: match code {
+                    Some(c) => std::process::ExitStatus::from_raw(c << 8),
+                    None => std::process::ExitStatus::from_raw(9), // SIGKILL
+                },
+                stdout: Vec::new(),
+                stderr: stderr.as_bytes().to_vec(),
+            }
+        }
+
+        #[cfg(windows)]
+        fn failed(stderr: &str, code: Option<i32>) -> Output {
+            use std::os::windows::process::ExitStatusExt;
+            Output {
+                status: std::process::ExitStatus::from_raw(code.unwrap_or(1) as u32),
+                stdout: Vec::new(),
+                stderr: stderr.as_bytes().to_vec(),
+            }
+        }
+
+        fn repo(dir: &std::path::Path) {
+            Command::new("git")
+                .args(["init", "-q", "-b", "main"])
+                .current_dir(dir)
+                .status()
+                .unwrap();
+        }
+
+        /// The reported shape: git speaking French, never saying the English
+        /// phrase, never mentioning `.git`, and dumping its whole `--no-index`
+        /// usage text. Recognising it by wording was never going to work.
+        #[test]
+        fn a_folder_that_is_not_a_repository_is_not_a_failure() {
+            let dir = tempfile::tempdir().unwrap();
+            let out = failed(
+                "avertissement : Pas un dépôt git. Utilisez --no-index pour comparer \
+                 deux chemins hors d'un arbre de travail\nusage : git diff --no-index \
+                 [<options>] <chemin> <chemin> [<spéc-de-chemin>...]",
+                Some(129),
+            );
+            assert!(
+                unmerged_paths_failure(dir.path(), &out, "check for conflicted files").is_none(),
+                "a non-repository must answer 'no conflicts', not file a bug"
+            );
+        }
+
+        /// …and the language is irrelevant, because we never read the message.
+        #[test]
+        fn the_message_language_does_not_matter() {
+            let dir = tempfile::tempdir().unwrap();
+            for stderr in [
+                "fatal: not a git repository (or any of the parent directories): .git",
+                "致命的: gitリポジトリではありません",
+                "",
+            ] {
+                let out = failed(stderr, Some(128));
+                assert!(
+                    unmerged_paths_failure(dir.path(), &out, "check for conflicted files")
+                        .is_none(),
+                    "must not report from a non-repository, stderr: {stderr}"
+                );
+            }
+        }
+
+        /// Inside a real repository, a failure is a real failure — and it has
+        /// to carry something to diagnose it with.
+        #[test]
+        fn a_real_repository_failure_still_reports_its_stderr() {
+            let dir = tempfile::tempdir().unwrap();
+            repo(dir.path());
+            let out = failed("error: unable to read index file", Some(128));
+            let err = unmerged_paths_failure(dir.path(), &out, "check for conflicted files")
+                .expect("a repository failure must report");
+            let msg = err.to_string();
+            assert!(msg.contains("unable to read index file"), "got: {msg}");
+        }
+
+        /// The #921 occurrence: exited non-zero, wrote nothing at all. Without
+        /// the exit code there is literally nothing to investigate — a bare
+        /// "Failed to check for conflicted files: " with an empty tail.
+        #[test]
+        fn an_empty_stderr_failure_carries_its_exit_code() {
+            let dir = tempfile::tempdir().unwrap();
+            repo(dir.path());
+            let err = unmerged_paths_failure(
+                dir.path(),
+                &failed("", Some(128)),
+                "check for conflicted files",
+            )
+            .expect("a repository failure must report");
+            let msg = err.to_string();
+            assert!(msg.contains("exit 128"), "got: {msg}");
+            assert!(!msg.ends_with(": "), "message must not trail off: {msg}");
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn a_signalled_git_says_so_rather_than_inventing_a_code() {
+            let dir = tempfile::tempdir().unwrap();
+            repo(dir.path());
+            let err = unmerged_paths_failure(dir.path(), &failed("", None), "get conflicted files")
+                .expect("a repository failure must report");
+            assert!(
+                err.to_string().contains("terminated by signal"),
+                "got: {err}"
+            );
+        }
+
+        /// `git diff`'s usage dump is thousands of characters. Whatever else
+        /// happens, it must not all end up in a toast (#547's cap, reused).
+        #[test]
+        fn a_pathological_stderr_is_capped() {
+            let dir = tempfile::tempdir().unwrap();
+            repo(dir.path());
+            let err = unmerged_paths_failure(
+                dir.path(),
+                &failed(&"x".repeat(5000), Some(129)),
+                "check for conflicted files",
+            )
+            .expect("a repository failure must report");
+            assert!(err.to_string().len() < 700, "not capped: {}", err);
+        }
+
+        #[test]
+        fn is_git_repository_agrees_with_git() {
+            let plain = tempfile::tempdir().unwrap();
+            assert!(!is_git_repository(plain.path()));
+
+            let initialised = tempfile::tempdir().unwrap();
+            repo(initialised.path());
+            assert!(is_git_repository(initialised.path()));
+        }
     }
 }

--- a/src-tauri/src/commands/edit_css.rs
+++ b/src-tauri/src/commands/edit_css.rs
@@ -99,7 +99,15 @@ fn cached_sheets(root: &Path) -> Arc<Vec<SheetIndex>> {
             .collect::<Vec<_>>(),
     );
     if let Ok(mut cache) = SHEET_CACHE.lock() {
-        cache.insert(root.to_path_buf(), (Instant::now(), sheets.clone()));
+        // Sweep expired roots before inserting. Entries were only ever read
+        // past their TTL, never removed, so every project visited in a session
+        // kept its whole parsed stylesheet set alive for the life of the
+        // process — data that stopped being usable ten seconds after it was
+        // written. Opportunistic on write, the same pattern the hosting status
+        // cache uses.
+        let now = Instant::now();
+        cache.retain(|_, (at, _)| now.duration_since(*at) < SHEET_CACHE_TTL);
+        cache.insert(root.to_path_buf(), (now, sheets.clone()));
     }
     sheets
 }

--- a/src-tauri/src/commands/git/status.rs
+++ b/src-tauri/src/commands/git/status.rs
@@ -13,9 +13,13 @@ use super::run_git_net;
 use super::git_has_uncommitted_changes;
 
 /// Cap git stderr carried inside an error message so a pathological failure
-/// (e.g. a hook dumping its whole log) can't flood the toast/telemetry, while
-/// keeping enough text to diagnose the actual cause (issue #547).
-pub(super) fn truncate_stderr(stderr: &str) -> String {
+/// (e.g. a hook dumping its whole log, or `git diff` printing its entire
+/// `--no-index` usage text) can't flood the toast/telemetry, while keeping
+/// enough text to diagnose the actual cause (issues #547, #912).
+///
+/// `pub(crate)` rather than `pub(super)`: the conflict commands run git from
+/// outside this module and have exactly the same problem.
+pub(crate) fn truncate_stderr(stderr: &str) -> String {
     const MAX: usize = 500;
     if stderr.len() <= MAX {
         return stderr.to_string();

--- a/src-tauri/src/commands/ide/screenshots/mod.rs
+++ b/src-tauri/src/commands/ide/screenshots/mod.rs
@@ -138,9 +138,24 @@ mod tests {
             "http://localhost:{port}"
         )));
         drop(listener);
-        assert!(!super::dev_server_listening(&format!(
-            "http://localhost:{port}"
-        )));
+
+        // The negative half has an unavoidable race: the moment an ephemeral
+        // port is released the OS may hand it straight to something else —
+        // another test in this binary, a dev server, anything on the machine —
+        // and this asserted on the first one it tried. That failed a full-suite
+        // run roughly never, which is the worst frequency for a test to fail
+        // at. Several distinct freed ports instead: all of them being re-bound
+        // inside the same instant is not a thing that happens.
+        let freed_reads_as_closed = (0..5).any(|_| {
+            let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let p = l.local_addr().unwrap().port();
+            drop(l);
+            !super::dev_server_listening(&format!("http://localhost:{p}"))
+        });
+        assert!(
+            freed_reads_as_closed,
+            "every freed port still read as listening — the check is not detecting a closed port"
+        );
     }
 
     /// Issue #711/#614: a dev server that's still starting up can miss the

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -576,9 +576,31 @@ fn classify_mcp_failure(action: &str, details: &str) -> CommandError {
     // subcommand, so a single value the installed version no longer accepts
     // (e.g. `service_tier = "default"` in ~/.codex/config.toml) breaks add,
     // remove and list alike. The user's own config, not our call (issue #755).
+    //
+    // Two shapes reach here. The CLI's own refusal of a value it no longer
+    // accepts is one. The other is the config file being unparseable at all —
+    // a lone carriage return, an unclosed string, a stray bracket — which the
+    // TOML parser reports with a line, a column and a caret, and which
+    // `mcp remove`/`list` wrap as "failed to load MCP servers from …" rather
+    // than "failed to load configuration" (issue #911). Both mean the same
+    // thing to the user: the agent CLI cannot read its own config, and the
+    // file is theirs to fix.
     if lower.contains("failed to load configuration")
+        || lower.contains("failed to load mcp servers")
+        || lower.contains("toml parse error")
         || (lower.contains("unknown variant") && lower.contains("config.toml"))
     {
+        // A syntax error and a rejected value need different advice: nobody
+        // can "remove the setting" from a file that doesn't parse, because
+        // the parser never got far enough to name one.
+        if lower.contains("toml parse error") || lower.contains("expected newline") {
+            let line = toml_error_line(details)
+                .map(|line| format!(" (around line {line})"))
+                .unwrap_or_default();
+            return CommandError::expected(format!(
+                "{message}\n\nThe agent CLI couldn't read its own config file — it isn't valid TOML{line}. Open the config file named above and fix the syntax there (a stray quote, bracket, or line ending), then try again."
+            ));
+        }
         let setting = invalid_config_key(details)
             .map(|key| format!(" (`{key}`)"))
             .unwrap_or_default();
@@ -608,6 +630,33 @@ fn classify_mcp_failure(action: &str, details: &str) -> CommandError {
     }
 
     message.into()
+}
+
+/// Pull the line number out of a TOML syntax error, which reports its
+/// position twice — once as `…/config.toml:7:2: <reason>` and once as
+/// `TOML parse error at line 7, column 2` (issue #911). Either form will do;
+/// without one the guidance says "fix the syntax" and names no line rather
+/// than inventing one.
+fn toml_error_line(details: &str) -> Option<u32> {
+    for line in details.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("TOML parse error at line ") {
+            let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+            if let Ok(n) = digits.parse() {
+                return Some(n);
+            }
+        }
+        // `<path>:<line>:<col>: message` — take the number before the column,
+        // being careful of a Windows drive letter's own colon.
+        if let Some(idx) = trimmed.find(".toml:") {
+            let rest = &trimmed[idx + ".toml:".len()..];
+            let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+            if let Ok(n) = digits.parse() {
+                return Some(n);
+            }
+        }
+    }
+    None
 }
 
 /// Pull the offending setting's name out of a Codex config-parse error,
@@ -1063,6 +1112,67 @@ mod tests {
         ));
         assert_eq!(invalid_config_key(details).as_deref(), Some("service_tier"));
         assert_eq!(invalid_config_key("no key here"), None);
+    }
+
+    /// Issue #911: the same "the CLI can't read its own config" condition,
+    /// but the file doesn't parse at all rather than carrying a value the CLI
+    /// rejects — and `mcp remove` wraps it in different words from `mcp add`.
+    #[test]
+    fn unparseable_config_is_expected_and_says_it_is_a_syntax_error() {
+        let details = "Error: failed to load MCP servers from C:\\Users\\me\\.codex\n\n\
+             Caused by:\n    \
+             0: C:\\Users\\me\\.codex\\config.toml:7:2: carriage return must be followed by \
+             newline, expected newline\n    \
+             1: TOML parse error at line 7, column 2\n         |\n       \
+             7 | model_reasoning_effort = \"medium\"\n         |  ^\n       \
+             carriage return must be followed by newline, expected newline";
+
+        match classify_mcp_failure("remove MCP server", details) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("isn't valid TOML"), "got: {message}");
+                assert!(message.contains("line 7"), "got: {message}");
+                // The value-rejection advice would be nonsense here: the
+                // parser never got far enough to name a setting.
+                assert!(
+                    !message.contains("no longer accepts"),
+                    "wrong branch: {message}"
+                );
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn toml_error_line_reads_either_form_and_invents_nothing() {
+        assert_eq!(
+            toml_error_line("TOML parse error at line 42, column 1"),
+            Some(42)
+        );
+        assert_eq!(
+            toml_error_line("  0: /home/me/.codex/config.toml:7:2: expected newline"),
+            Some(7)
+        );
+        // A Windows path's drive-letter colon must not be mistaken for the
+        // position separator.
+        assert_eq!(
+            toml_error_line("0: C:\\Users\\me\\.codex\\config.toml:19:4: bad"),
+            Some(19)
+        );
+        assert_eq!(toml_error_line("something else entirely"), None);
+        assert_eq!(toml_error_line(""), None);
+    }
+
+    /// The value-rejection shape must keep its own, more specific advice.
+    #[test]
+    fn a_rejected_setting_still_names_the_setting() {
+        let details = "Error: failed to load configuration\n\nCaused by:\n    0: C:\\Users\\me\\.codex\\config.toml:3:16: unknown variant `default`\n    1: unknown variant `default`\n       in `service_tier`";
+        match classify_mcp_failure("add MCP server", details) {
+            CommandError::Expected { message } => {
+                assert!(message.contains("`service_tier`"), "got: {message}");
+                assert!(message.contains("no longer accepts"), "got: {message}");
+            }
+            other => panic!("expected Expected, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src-tauri/src/commands/migration.rs
+++ b/src-tauri/src/commands/migration.rs
@@ -47,6 +47,16 @@ const FIDELITY_COMPARE: &str = include_str!("../../../scripts/site-fidelity-comp
 /// which type size, which colour.
 const STRUCTURE: &str = include_str!("../../../scripts/site-structure.mjs");
 
+/// The browser both tools drive.
+///
+/// Split out because all three were launching Chrome themselves, on a fixed
+/// port and a shared profile, and killing it only from a `finally`. An
+/// interrupted run — which is the normal case, since a run outlives an
+/// agent's shell call — left the browser parented to init, and the next run
+/// found the port answering and drove that orphan instead of its own. They
+/// accumulated for as long as the machine stayed up.
+const CHROME_LAUNCHER: &str = include_str!("../../../scripts/headless-chrome.mjs");
+
 /// Where a project keeps its migration state, relative to the project root.
 const MIGRATION_DIR: &str = ".shipstudio";
 const FIDELITY_DIR: &str = ".shipstudio/fidelity";
@@ -331,6 +341,7 @@ fn scaffold_migration(root: &Path, source_url: &str) -> Result<(), CommandError>
         FIDELITY_COMPARE,
     )?;
     write_file(&fidelity.join("site-structure.mjs"), STRUCTURE)?;
+    write_file(&fidelity.join("headless-chrome.mjs"), CHROME_LAUNCHER)?;
 
     let status_path = root.join(MIGRATION_DIR).join("migration.json");
     if !status_path.exists() {

--- a/src-tauri/src/commands/migration.rs
+++ b/src-tauri/src/commands/migration.rs
@@ -788,7 +788,12 @@ mod tests {
 
         let runs = runs_at(dir.path()).expect("reads");
         assert_eq!(runs.len(), 1);
-        assert!(runs[0].dir.ends_with("batch/page"));
+        // `Path::ends_with` compares components, so it is right on both
+        // platforms. `str::ends_with` is a literal compare: the dir is built
+        // from `to_string_lossy` on a native path, so on Windows it ends
+        // "batch\\page" and could never match a forward slash. The code was
+        // correct; only this assertion was not.
+        assert!(std::path::Path::new(&runs[0].dir).ends_with("batch/page"));
     }
 
     #[test]

--- a/src-tauri/src/commands/pty_session.rs
+++ b/src-tauri/src/commands/pty_session.rs
@@ -101,7 +101,80 @@ struct Session {
     child_killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
     /// `None` once the session has exited (issue #540).
     master: Mutex<Option<Box<dyn portable_pty::MasterPty + Send>>>,
+    /// Flow control: the reader thread stops reading while this is set, which
+    /// lets the kernel's PTY buffer fill and blocks the child's own `write`.
+    /// See [`FlowControl`] and issue #910.
+    flow: FlowControl,
 }
+
+/// Backpressure between a PTY and the terminal rendering it.
+///
+/// xterm.js buffers everything handed to `write()` and parses it on a frame
+/// budget. A producer that outruns the parser grows that buffer without bound
+/// until xterm gives up — "write data discarded, use flow control to avoid
+/// losing data" — and the output is simply lost (issue #910). The documented
+/// remedy is for the consumer to stop the producer, so that is what this is:
+/// the frontend reports its backlog, and while the backlog is high the reader
+/// thread stops draining the PTY. The child then blocks in its own `write`,
+/// which is exactly the behaviour a real terminal has.
+///
+/// A pause is never permanent. A frontend that crashes, hangs, or forgets to
+/// resume must not be able to freeze someone's build forever, so every wait is
+/// bounded by [`MAX_PAUSE`] and the reader carries on regardless afterwards.
+struct FlowControl {
+    paused: Mutex<bool>,
+    changed: std::sync::Condvar,
+}
+
+impl FlowControl {
+    fn new() -> Self {
+        Self {
+            paused: Mutex::new(false),
+            changed: std::sync::Condvar::new(),
+        }
+    }
+
+    fn set_paused(&self, value: bool) {
+        if let Ok(mut paused) = self.paused.lock() {
+            *paused = value;
+        }
+        self.changed.notify_all();
+    }
+
+    /// Block while paused, for at most [`MAX_PAUSE`]. Returns once reading may
+    /// continue — either because the frontend resumed, or because it didn't
+    /// and we refuse to wait on it any longer.
+    fn wait_while_paused(&self) {
+        self.wait_while_paused_for(MAX_PAUSE);
+    }
+
+    /// [`Self::wait_while_paused`] with the safety bound spelled out, so a
+    /// test can watch it expire without sleeping for the production value.
+    fn wait_while_paused_for(&self, max: std::time::Duration) {
+        let Ok(paused) = self.paused.lock() else {
+            return; // poisoned — a wedged reader is worse than an unpaced one
+        };
+        if !*paused {
+            return;
+        }
+        let deadline = std::time::Instant::now() + max;
+        let mut guard = paused;
+        while *guard {
+            let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
+                break;
+            };
+            let Ok((next, _timeout)) = self.changed.wait_timeout(guard, remaining) else {
+                return;
+            };
+            guard = next;
+        }
+    }
+}
+
+/// Longest the reader thread will honour a frontend's pause. Chosen to be far
+/// longer than any legitimate xterm parse backlog (which drains in tens of
+/// milliseconds) and far shorter than a user would tolerate a wedged build.
+const MAX_PAUSE: std::time::Duration = std::time::Duration::from_secs(10);
 
 impl Session {
     /// Close this session's PTY master and writer, freeing the underlying
@@ -404,6 +477,7 @@ pub async fn pty_session_open(
         writer: Mutex::new(Some(writer)),
         child_killer: Mutex::new(child_killer),
         master: Mutex::new(Some(pair.master)),
+        flow: FlowControl::new(),
     });
 
     REGISTRY
@@ -420,6 +494,12 @@ pub async fn pty_session_open(
             let mut buf = [0u8; 4096];
             let mut dsr_carry: Vec<u8> = Vec::new();
             loop {
+                // Backpressure (issue #910). Waiting here — rather than after
+                // the read — means the bytes already in the kernel's PTY
+                // buffer stay there, so the child blocks instead of us
+                // buffering its output on its behalf.
+                session_for_reader.flow.wait_while_paused();
+
                 let n = match reader.read(&mut buf) {
                     Ok(0) => break, // EOF — child closed slave
                     Ok(n) => n,
@@ -482,6 +562,9 @@ pub async fn pty_session_open(
             // again. Close it now instead of holding it for the (unbounded)
             // lifetime of the registry entry — the pseudo-terminal pool is
             // system-wide and small (issue #540).
+            // Release the reader thread if the frontend had it paused, so it
+            // observes EOF and exits now rather than after MAX_PAUSE.
+            session_for_waiter.flow.set_paused(false);
             session_for_waiter.release_pty_handles();
             let _ = app_for_waiter.emit(
                 "pty-session-exit",
@@ -726,6 +809,35 @@ pub fn pty_session_detach(session_id: String) -> Result<(), CommandError> {
     };
     if let Some(session) = session {
         session.attached.store(false, Ordering::Relaxed);
+        // Nothing is rendering this session any more, so nothing is going to
+        // resume it either. A pause left set here would stall the child until
+        // MAX_PAUSE elapsed, over and over (issue #910).
+        session.flow.set_paused(false);
+    }
+    Ok(())
+}
+
+/// Pause or resume the reader thread draining this session's PTY.
+///
+/// Called by the terminal that is rendering the session when its xterm write
+/// backlog crosses the high-water mark, and again when it drains — the
+/// consumer end of the flow control described on [`FlowControl`] (issue #910).
+///
+/// Idempotent, and deliberately forgiving: a session that has already exited,
+/// or one the frontend knows about but the registry has evicted, is a no-op
+/// rather than an error. Nothing about pacing output is worth failing a call
+/// the caller cannot meaningfully handle.
+#[tauri::command]
+#[tracing::instrument]
+pub fn pty_session_set_paused(session_id: String, paused: bool) -> Result<(), CommandError> {
+    let session = {
+        let map = REGISTRY
+            .lock()
+            .map_err(|e| format!("pty registry poisoned: {e}"))?;
+        map.get(&session_id).cloned()
+    };
+    if let Some(session) = session {
+        session.flow.set_paused(paused);
     }
     Ok(())
 }
@@ -777,6 +889,7 @@ mod tests {
                 writer: Mutex::new(Some(writer)),
                 child_killer: Mutex::new(killer),
                 master: Mutex::new(Some(pair.master)),
+                flow: FlowControl::new(),
             })
         }
 
@@ -839,6 +952,91 @@ mod tests {
             assert!(err.to_string().contains("session has ended"), "got: {err}");
 
             REGISTRY.lock().unwrap().remove(&session_id);
+        }
+    }
+
+    /// Issue #910: the reader must actually stop when the terminal asks it
+    /// to, must start again when told, and must never be stoppable forever.
+    mod flow_control {
+        use super::*;
+
+        #[test]
+        fn an_unpaused_reader_never_waits() {
+            let flow = FlowControl::new();
+            let started = std::time::Instant::now();
+            flow.wait_while_paused();
+            assert!(
+                started.elapsed() < std::time::Duration::from_millis(200),
+                "an unpaused reader must fall straight through"
+            );
+        }
+
+        #[test]
+        fn a_paused_reader_blocks_until_resumed() {
+            let flow = Arc::new(FlowControl::new());
+            flow.set_paused(true);
+
+            let reader = {
+                let flow = flow.clone();
+                std::thread::spawn(move || {
+                    let started = std::time::Instant::now();
+                    flow.wait_while_paused();
+                    started.elapsed()
+                })
+            };
+
+            // Long enough that a reader ignoring the pause would finish first.
+            std::thread::sleep(std::time::Duration::from_millis(150));
+            flow.set_paused(false);
+
+            let waited = reader.join().expect("reader thread panicked");
+            assert!(
+                waited >= std::time::Duration::from_millis(100),
+                "reader returned after {waited:?} — it did not honour the pause"
+            );
+            assert!(
+                waited < MAX_PAUSE,
+                "reader waited for the safety timeout instead of the resume"
+            );
+        }
+
+        /// A frontend that crashes mid-pause must not freeze someone's build
+        /// for the rest of the session. The wait is bounded; reading resumes
+        /// on its own even though nothing ever called resume.
+        #[test]
+        fn a_pause_that_is_never_lifted_expires() {
+            let flow = FlowControl::new();
+            flow.set_paused(true);
+
+            let bound = std::time::Duration::from_millis(120);
+            let started = std::time::Instant::now();
+            flow.wait_while_paused_for(bound);
+            let waited = started.elapsed();
+
+            assert!(
+                waited >= bound,
+                "returned early ({waited:?}) — never waited"
+            );
+            assert!(
+                waited < bound * 20,
+                "a pause nobody lifted blocked the reader for {waited:?}"
+            );
+            // The production bound: long enough to never trip on a real parse
+            // backlog, short enough that a wedged frontend is a hiccup.
+            assert!(MAX_PAUSE >= std::time::Duration::from_secs(1));
+            assert!(MAX_PAUSE <= std::time::Duration::from_secs(30));
+        }
+
+        #[test]
+        fn pausing_is_idempotent() {
+            let flow = FlowControl::new();
+            flow.set_paused(true);
+            flow.set_paused(true);
+            flow.set_paused(false);
+            flow.set_paused(false);
+            let started = std::time::Instant::now();
+            flow.wait_while_paused();
+            assert!(started.elapsed() < std::time::Duration::from_millis(200));
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -814,6 +814,7 @@ pub fn run() {
             commands::pty_session::pty_session_kill,
             commands::pty_session::pty_session_attach,
             commands::pty_session::pty_session_detach,
+            commands::pty_session::pty_session_set_paused,
             // Community Templates
             commands::templates::fetch_community_templates,
             commands::templates::download_template_zip,

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -937,16 +937,25 @@ fn websocket_retry_exhausted_is_expected(_kind: std::io::ErrorKind) -> bool {
 }
 
 /// Connect failures that mean "the dev server isn't listening right now":
-/// refused (nothing bound to the port) or silent (SYN unanswered mid-restart,
-/// surfaced as a per-attempt timeout). Both are normal states while a dev
+/// refused (nothing bound to the port), silent (SYN unanswered mid-restart,
+/// surfaced as a per-attempt timeout), or reset (a listening socket answering
+/// with an RST while it tears down). All three are normal states while a dev
 /// server restarts or is stopped — an environment condition, not a proxy bug —
 /// so exhausting the retry budget on them logs at warn level instead of
 /// auto-filing an error report. Shared by the WebSocket (issue #532) and
 /// plain-HTTP (issue #683) upstream connects.
+///
+/// `ConnectionReset` belongs here for the same reason it belongs in
+/// [`upstream_connection_lost_kind`]: on macOS a restarting dev server can
+/// answer a connect with an RST rather than refusing outright, and that is the
+/// identical condition one step earlier in the request. Leaving it out filed a
+/// bug report every time someone restarted their dev server (issue #934).
 fn upstream_unavailable(kind: std::io::ErrorKind) -> bool {
     matches!(
         kind,
-        std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::TimedOut
+        std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::TimedOut
+            | std::io::ErrorKind::ConnectionReset
     )
 }
 
@@ -1056,8 +1065,13 @@ async fn connect_upstream_with_retry(
                         < connect_deadline;
                 if retryable {
                     // A timed-out attempt already consumed its slice of the
-                    // budget; only refused connections need the backoff pause.
-                    if e.kind() == std::io::ErrorKind::ConnectionRefused {
+                    // budget. Refused and reset both come back instantly, so
+                    // retrying either without a pause would spin the CPU flat
+                    // out until the deadline.
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::ConnectionReset
+                    ) {
                         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
                     }
                     continue;
@@ -1434,6 +1448,10 @@ mod tests {
         // WebSocket (issue #532) and plain-HTTP (issue #683) connect paths.
         assert!(upstream_unavailable(std::io::ErrorKind::ConnectionRefused));
         assert!(upstream_unavailable(std::io::ErrorKind::TimedOut));
+        // A socket mid-teardown can answer a connect with an RST rather than
+        // refusing it — the same restart, a different syscall answer, and it
+        // used to file a bug report every time (issue #934).
+        assert!(upstream_unavailable(std::io::ErrorKind::ConnectionReset));
         // Anything else is a genuine proxy problem and stays at error level.
         assert!(!upstream_unavailable(std::io::ErrorKind::PermissionDenied));
         assert!(!upstream_unavailable(std::io::ErrorKind::AddrNotAvailable));

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -594,6 +594,28 @@ pub fn git_environment_gap(stderr: &str) -> Option<crate::errors::CommandError> 
              the damage, or re-clone the repository into a fresh folder and reopen it here.",
         ));
     }
+    // Git reading the working tree and getting incomplete answers: short or
+    // timed-out reads while indexing ordinary tracked files, or a `.git` file
+    // that is simply absent rather than corrupt. That combination is the
+    // signature of a folder whose contents are not really on this disk yet —
+    // an iCloud/Dropbox/OneDrive placeholder, or a network mount — as much as
+    // it is of damage, so the guidance has to name both (issue #907).
+    //
+    // Kept below the packfile branch: a repository with genuinely corrupt
+    // objects should get the unambiguous "damaged history" wording rather than
+    // this one's "or it might just be syncing".
+    if lower.contains("short read while indexing")
+        || lower.contains("read error while indexing")
+        || (lower.contains("packed-refs") && lower.contains("couldn't read"))
+    {
+        return Some(crate::errors::CommandError::expected(
+            "Git couldn't fully read this project's files while checking its status. Either the \
+             folder is on a cloud-sync or network drive that hasn't finished downloading it, or \
+             the local git history is damaged. Wait for syncing to finish (or make the folder \
+             available offline) and try again — if it persists, run `git fsck` in the project \
+             folder to check for damage.",
+        ));
+    }
     if lower.contains("unable to read current working directory")
         && lower.contains("operation not permitted")
     {
@@ -2262,6 +2284,53 @@ mod tests {
             .is_some());
         }
 
+        /// Issue #907: git status hitting short and timed-out reads while
+        /// indexing ordinary source files, then failing to find `.git/packed-refs`
+        /// at all. Files that aren't really on the disk yet — a cloud-sync
+        /// placeholder or a network mount — not an app defect.
+        #[test]
+        fn classifies_unreadable_working_tree_as_expected() {
+            let stderr = "error: short read while indexing src/routes/admin/+layout.server.ts\n\
+                          error: read error while indexing svelte.config.js: Operation timed out\n\
+                          error: short read while indexing tsconfig.json\n\
+                          fatal: couldn't read .git/packed-refs: No such file or directory";
+            let err = git_environment_gap(stderr).expect("must classify");
+            assert!(matches!(err, crate::errors::CommandError::Expected { .. }));
+            let msg = err.to_string();
+            // Both plausible causes, because the signature genuinely doesn't
+            // distinguish them and guessing one would send people the wrong way.
+            assert!(msg.contains("cloud-sync"), "got: {msg}");
+            assert!(msg.contains("git fsck"), "got: {msg}");
+        }
+
+        #[test]
+        fn each_unreadable_working_tree_marker_classifies_on_its_own() {
+            for stderr in [
+                "error: short read while indexing package.json",
+                "error: read error while indexing a.ts: Operation timed out",
+                "fatal: couldn't read .git/packed-refs: No such file or directory",
+            ] {
+                assert!(
+                    git_environment_gap(stderr).is_some(),
+                    "must classify: {stderr}"
+                );
+            }
+        }
+
+        /// A genuinely corrupt object store keeps the unambiguous wording even
+        /// when the same run also produced read errors — "it might just be
+        /// syncing" is the wrong thing to tell someone whose pack is truncated.
+        #[test]
+        fn packfile_corruption_outranks_the_unreadable_working_tree_wording() {
+            let stderr = "error: short read while indexing a.ts\n\
+                          error: file .git/objects/pack/pack-3301f5a2.pack is far too short to \
+                          be a packfile";
+            let err = git_environment_gap(stderr).expect("must classify");
+            let msg = err.to_string();
+            assert!(msg.contains("looks damaged"), "got: {msg}");
+            assert!(!msg.contains("cloud-sync"), "got: {msg}");
+        }
+
         #[test]
         fn leaves_ordinary_git_failures_unclassified() {
             assert!(git_environment_gap("fatal: not a git repository").is_none());
@@ -2275,6 +2344,14 @@ mod tests {
             // "missing object" without a fatal is a warning git recovers from
             // (e.g. `fsck` output) — not the corrupted-repo abort (#842).
             assert!(git_environment_gap("warning: missing object 1234abcd").is_none());
+            // "couldn't read" about something that isn't packed-refs is some
+            // other failure and must keep reporting (#907's guard).
+            assert!(
+                git_environment_gap("error: couldn't read HEAD: No such file or directory")
+                    .is_none()
+            );
+            // And packed-refs merely being mentioned isn't the signature.
+            assert!(git_environment_gap("Updating .git/packed-refs").is_none());
         }
     }
 

--- a/src/components/BootLoadingScreen.tsx
+++ b/src/components/BootLoadingScreen.tsx
@@ -15,6 +15,7 @@ import { relaunch } from '@tauri-apps/plugin-process';
 import { Button } from './primitives/Button';
 import { Progress } from './primitives/Progress';
 import { logger } from '../lib/logger';
+import { asCommandError, formatCommandError } from '../lib/errors';
 
 /** How long the loading view may spin before we assume boot is wedged. */
 export const BOOT_WATCHDOG_MS = 25_000;
@@ -43,7 +44,7 @@ export function BootLoadingScreen({ progress = 0 }: BootLoadingScreenProps) {
     } catch (err) {
       // In dev mode relaunch might not work — fall back to a reload.
       logger.error('Relaunch failed, trying reload', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
       window.location.reload();
     }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -6,6 +6,7 @@ import { lookupBlobOwner, markPluginCrashed } from '../lib/plugin-loader';
 import { uninstallPlugin } from '../lib/plugins';
 import { Button } from './primitives/Button';
 import { InfoIcon } from '@/components/icons';
+import { asCommandError, formatCommandError } from '../lib/errors';
 
 interface Props {
   children: ReactNode;
@@ -83,7 +84,7 @@ export class ErrorBoundary extends Component<Props, State> {
     } catch (err) {
       // In dev mode, relaunch might not work - try window reload
       logger.error('Relaunch failed, trying reload', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
       window.location.reload();
     }

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -16,6 +16,7 @@ import { isMac } from '../lib/setup';
 import { ModalFrame } from './primitives/ModalFrame';
 import { Tabs, TabsList, TabsPanel, TabsTab } from './primitives/Tabs';
 import { useModal } from '../contexts/ModalContext';
+import { asCommandError, formatCommandError } from '../lib/errors';
 
 interface HelpModalProps {
   /** Optional project path to include project-level skills */
@@ -232,7 +233,7 @@ export function HelpModal({ projectPath }: HelpModalProps) {
       })
       .catch((err) => {
         logger.error('Failed to load skills', {
-          error: err instanceof Error ? err.message : String(err),
+          error: formatCommandError(asCommandError(err)),
         });
         if (!cancelled) setSkills([]);
       })

--- a/src/components/comments/CanvasComments.tsx
+++ b/src/components/comments/CanvasComments.tsx
@@ -183,6 +183,9 @@ export function useCanvasCommentsLayer(props: CanvasCommentsProps): {
           // The live rect while it is available; the rect captured at click
           // time only covers the first paint before the frame reports again.
           composerAt={draft ? (bridge.selectedAt ?? { x: draft.rect.x, y: draft.rect.y }) : null}
+          // Retargeting keeps the same composer and the same draft text, so
+          // the layer needs telling that this is a new opening to nudge for.
+          composerFor={draft ? `${draft.page}|${draft.selector}` : null}
         />
       ) : null,
   };

--- a/src/components/comments/CommentComposer.tsx
+++ b/src/components/comments/CommentComposer.tsx
@@ -8,7 +8,7 @@
  * A guard on the button alone is not enough either, since Cmd+Enter goes down
  * the same path, so the in-flight flag is checked at the one place both reach.
  */
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '../primitives/Button';
 import { TextArea } from '../primitives/TextField';
 import {
@@ -26,6 +26,17 @@ interface Props {
 export function CommentComposer({ target, existing, onSave, onCancel }: Props) {
   const [body, setBody] = useState(existing?.body ?? '');
   const [saving, setSaving] = useState(false);
+  const field = useRef<HTMLTextAreaElement>(null);
+
+  // Focus without `autoFocus`, because focus() scrolls every scrollable
+  // ancestor to reveal the element and `autoFocus` gives no way to opt out.
+  // The composer is absolutely positioned over the frame at the point that was
+  // clicked, so clicking anything low on a page taller than the pane scrolled
+  // the preview down to it — the frame appeared to jump upward, and stayed
+  // there after Cancel, since nothing scrolls it back.
+  useEffect(() => {
+    field.current?.focus({ preventScroll: true });
+  }, []);
   // A ref as well as the state: two clicks in the same tick both read the old
   // state, and the second one would still get through.
   const inFlight = useRef(false);
@@ -66,8 +77,8 @@ export function CommentComposer({ target, existing, onSave, onCancel }: Props) {
       </div>
       <p className="canvas-comments-hint">Click another element to change the target.</p>
       <TextArea
+        ref={field}
         aria-label="What should change?"
-        autoFocus
         value={body}
         maxLength={8000}
         rows={3}

--- a/src/components/comments/CommentPins.test.tsx
+++ b/src/components/comments/CommentPins.test.tsx
@@ -14,6 +14,9 @@ import { CommentPins } from './CommentPins';
 import { CommentComposer } from './CommentComposer';
 import type { CanvasComment, CommentPlacement } from '../../lib/canvasComments';
 
+/** Plausible measured size for the composer form. */
+const FORM_HEIGHT = 260;
+const CARD_W = 260;
 const target = {
   page: '/',
   selector: '#hero',
@@ -128,7 +131,7 @@ describe('the composer and note use house inputs, not browser defaults', () => {
     expect(field).toHaveClass('ss-text-field--multiline');
   });
 
-  it('anchors the composer to the live rect it is given, not the frame corner', () => {
+  it('starts the composer from the live rect it is given, not the frame corner', () => {
     cleanup();
     render(
       <CommentPins
@@ -149,8 +152,9 @@ describe('the composer and note use house inputs, not browser defaults', () => {
       />
     );
     const bubble = document.querySelector<HTMLElement>('.canvas-comment-bubble--composing')!;
-    // Negative means its element scrolled up and the form went with it, rather
-    // than holding a fixed screen position and riding the viewport.
+    // The rect it is handed is where it starts from — the frame corner would be
+    // 0,0. Where it settles is the placement rule's business, covered below;
+    // jsdom reports no size, so nothing is measured and nothing is moved here.
     expect(parseFloat(bubble.style.top)).toBeLessThan(0);
     expect(parseFloat(bubble.style.left)).toBeGreaterThan(400);
   });
@@ -163,5 +167,92 @@ describe('the composer and note use house inputs, not browser defaults', () => {
     render(<CommentComposer target={target} onSave={() => true} onCancel={vi.fn()} />);
     expect(focus).toHaveBeenCalledWith({ preventScroll: true });
     focus.mockRestore();
+  });
+
+  const composerProps = (at: { x: number; y: number }, forKey: string) => ({
+    comments: [],
+    placements: [],
+    missing: [],
+    scale: 1,
+    bounds: { w: 1200, h: 800 },
+    openId: null,
+    onOpen: vi.fn(),
+    selectedIds: [],
+    toggle: vi.fn(),
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    onHover: vi.fn(),
+    composer: <CommentComposer target={target} onSave={() => true} onCancel={vi.fn()} />,
+    composerAt: at,
+    composerFor: forKey,
+  });
+  // jsdom measures every box as 0, and a card of no size is trivially in view,
+  // so nothing is nudged unless the form is given a real one.
+  const measured = () => [
+    vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(FORM_HEIGHT),
+    vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(CARD_W),
+  ];
+  const box = () => {
+    const el = document.querySelector<HTMLElement>('.canvas-comment-bubble--composing')!;
+    return { top: parseFloat(el.style.top), left: parseFloat(el.style.left) };
+  };
+
+  it('opens fully inside the frame even when its element is at the bottom edge', () => {
+    const spies = measured();
+    render(<CommentPins {...composerProps({ x: 1180, y: 780 }, 'a')} />);
+    const { top, left } = box();
+    expect(top).toBeGreaterThanOrEqual(0);
+    expect(top + FORM_HEIGHT).toBeLessThanOrEqual(800);
+    expect(left).toBeGreaterThanOrEqual(0);
+    expect(left + CARD_W).toBeLessThanOrEqual(1200);
+    spies.forEach((s) => s.mockRestore());
+  });
+
+  it('keeps its place on the page, moving pixel for pixel with a scroll', () => {
+    const spies = measured();
+    const { rerender } = render(<CommentPins {...composerProps({ x: 1180, y: 780 }, 'a')} />);
+    const opened = box();
+    // Scrolling 50px up means the frame reports the element 50px higher, and
+    // the form has to go with it — it belongs to the page, not the viewport.
+    rerender(<CommentPins {...composerProps({ x: 1180, y: 730 }, 'a')} />);
+    expect(box()).toEqual({ top: opened.top - 50, left: opened.left });
+    // Still true once its element has scrolled off the top entirely.
+    rerender(<CommentPins {...composerProps({ x: 1180, y: -400 }, 'a')} />);
+    expect(box().top).toBe(opened.top - 1180);
+    spies.forEach((s) => s.mockRestore());
+  });
+
+  it('nudges again when the draft is pointed at a different element', () => {
+    const spies = measured();
+    const { rerender } = render(<CommentPins {...composerProps({ x: 200, y: 100 }, 'a')} />);
+    const first = box();
+    rerender(<CommentPins {...composerProps({ x: 600, y: 790 }, 'b')} />);
+    const second = box();
+    expect(second).not.toEqual(first);
+    expect(second.top + FORM_HEIGHT).toBeLessThanOrEqual(800);
+    spies.forEach((s) => s.mockRestore());
+  });
+
+  it('still lets an open note leave with its element', () => {
+    // The nudge is the composer's alone, and only at the moment it opens. A
+    // note card is never repositioned: it is anchored to a place on the page.
+    render(
+      <CommentPins
+        comments={[note]}
+        placements={[{ id: 'one', x: 400, y: -300, width: 100, height: 40 }]}
+        missing={[]}
+        scale={1}
+        bounds={{ w: 1200, h: 800 }}
+        openId="one"
+        onOpen={vi.fn()}
+        selectedIds={[]}
+        toggle={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onHover={vi.fn()}
+      />
+    );
+    const card = document.querySelector<HTMLElement>('.canvas-comment-bubble')!;
+    expect(parseFloat(card.style.top)).toBeLessThan(0);
   });
 });

--- a/src/components/comments/CommentPins.test.tsx
+++ b/src/components/comments/CommentPins.test.tsx
@@ -154,4 +154,14 @@ describe('the composer and note use house inputs, not browser defaults', () => {
     expect(parseFloat(bubble.style.top)).toBeLessThan(0);
     expect(parseFloat(bubble.style.left)).toBeGreaterThan(400);
   });
+
+  it('takes focus without scrolling the frame wrapper out from under the user', () => {
+    // The wrapper is `overflow: hidden`, which still scrolls programmatically
+    // and offers no scrollbar back. focus() reveals what it focuses, so the
+    // composer used to drag the frame upward for good the moment it mounted.
+    const focus = vi.spyOn(HTMLTextAreaElement.prototype, 'focus');
+    render(<CommentComposer target={target} onSave={() => true} onCancel={vi.fn()} />);
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+    focus.mockRestore();
+  });
 });

--- a/src/components/comments/CommentPins.tsx
+++ b/src/components/comments/CommentPins.tsx
@@ -11,7 +11,7 @@
  * and mutation; on a breakpoint canvas those pixels are then scaled to the
  * screen, exactly as the structural toolbar scales its selection box.
  */
-import { type ReactNode } from 'react';
+import { useLayoutEffect, useRef, useState, type ReactNode } from 'react';
 import { Button } from '../primitives/Button';
 import { IconButton } from '../primitives/IconButton';
 import { TrashIcon, CloseIcon } from '@/components/icons';
@@ -46,6 +46,8 @@ interface Props {
   /** The composer, rendered anchored to the element being commented on. */
   composer?: ReactNode;
   composerAt?: { x: number; y: number } | null;
+  /** Identifies the element being commented on, so picking a new one re-nudges. */
+  composerFor?: string | null;
 }
 
 /**
@@ -64,8 +66,69 @@ function place(x: number, y: number, bounds: { w: number; h: number } | null) {
   return { left: flip ? x - GAP - CARD_WIDTH : x + GAP, top: y - PIN_RADIUS };
 }
 
+/**
+ * How far the composer has to move, once, to be fully on screen.
+ *
+ * The composer obeys the same rule as a note card — it is anchored to its
+ * element and scrolls away with it — with one difference: at the moment it
+ * opens it has to be readable, because it is a form somebody is about to type
+ * into, and the frame clips whatever falls outside it. So the offset is
+ * measured when it opens and then held. Afterwards the anchor moves and the
+ * offset does not, which is what makes it travel with the page instead of
+ * sticking to an edge.
+ */
+function nudgeIntoView(
+  at: { left: number; top: number },
+  bounds: { w: number; h: number },
+  size: { w: number; h: number }
+) {
+  // A card larger than the frame cannot fit; pinning its top-left is the most
+  // useful failure, since that is the end with the context and the field.
+  const shift = (v: number, extent: number, limit: number) =>
+    extent + GAP * 2 >= limit ? GAP - v : Math.min(Math.max(v, GAP), limit - extent - GAP) - v;
+  return { dx: shift(at.left, size.w, bounds.w), dy: shift(at.top, size.h, bounds.h) };
+}
+
 export function CommentPins(props: Props) {
   const { comments, placements, scale, bounds, openId } = props;
+  const { composerAt, composerFor } = props;
+  const [composerEl, setComposerEl] = useState<HTMLDivElement | null>(null);
+  // null until measured. Held from then on, so scrolling moves the composer
+  // with its element rather than pinning it to the frame.
+  const [nudge, setNudge] = useState<{ dx: number; dy: number } | null>(null);
+  const anchored =
+    composerAt && props.composer ? place(composerAt.x * scale, composerAt.y * scale, bounds) : null;
+  // Read by the measuring effect, which must not re-run when these change —
+  // re-running is precisely how the composer would start following the page.
+  const latest = useRef({ anchored, bounds });
+  // Declared before the measuring effect so it is up to date when that runs.
+  useLayoutEffect(() => {
+    latest.current = { anchored, bounds };
+  });
+  // A new target is a new opening, so it earns a fresh measurement. Adjusted
+  // during render rather than in an effect, so no frame is ever painted with
+  // the previous element's offset applied to this one's anchor.
+  const [nudgedFor, setNudgedFor] = useState(composerFor);
+  if (nudgedFor !== composerFor) {
+    setNudgedFor(composerFor);
+    setNudge(null);
+  }
+  useLayoutEffect(() => {
+    if (!composerEl) return;
+    const measure = () => {
+      const { anchored: at, bounds: box } = latest.current;
+      if (!at || !box) return;
+      const size = { w: composerEl.offsetWidth, h: composerEl.offsetHeight };
+      // Height arrives a frame late in some browsers; an unmeasured card would
+      // otherwise freeze a nudge computed against zero and never correct it.
+      if (!size.h) return;
+      setNudge((prev) => (prev ? prev : nudgeIntoView(at, box, size)));
+    };
+    measure();
+    const observer = typeof ResizeObserver === 'function' ? new ResizeObserver(measure) : null;
+    observer?.observe(composerEl);
+    return () => observer?.disconnect();
+  }, [composerEl, composerFor]);
   const byId = new Map(comments.map((c) => [c.id, c]));
   const open = openId ? comments.find((c) => c.id === openId) : undefined;
   const openAt = openId ? placements.find((p) => p.id === openId) : undefined;
@@ -149,12 +212,14 @@ export function CommentPins(props: Props) {
         </div>
       )}
 
-      {props.composer && props.composerAt && (
+      {props.composer && anchored && (
         <div
+          ref={setComposerEl}
           className="canvas-comment-bubble canvas-comment-bubble--composing"
           style={{
             width: CARD_WIDTH,
-            ...place(props.composerAt.x * scale, props.composerAt.y * scale, bounds),
+            left: anchored.left + (nudge?.dx ?? 0),
+            top: anchored.top + (nudge?.dy ?? 0),
           }}
         >
           {props.composer}

--- a/src/components/dashboard/Changelog.tsx
+++ b/src/components/dashboard/Changelog.tsx
@@ -26,11 +26,25 @@ interface ChangelogEntry {
 // Keep ~15 most recent versions for the sidebar
 const CHANGELOG: ChangelogEntry[] = [
   {
+    version: '1.3.0', // v1.3.0
+    items: [
+      'New: Team — see what your teammates actually did and why, who is on which branch, and the comments left on the project, without leaving the workspace. It reads your own repository rather than a server: no account, no sign-up, and it works on first launch even if nobody else on the team uses Ship Studio',
+      "New: comments are shared. Pin a note to the element it is about and your teammates see it after their next sync — carried on a ref of their own, so your branches, your commits and your pull requests never contain them. Tick the ones you want and hand them to your agent in one go; it can reply and mark them resolved when it's done. Comments still work with no repository at all, which is the right tool for annotating a page on your own",
+      'New: rebuild a site from its URL. "From a URL" in New Project takes an address and a stack, and your agent surveys the site, extracts its design system, and rebuilds it template by template. Nothing is reported as done until it has been measured against the original, and anything that can\'t come across is named rather than quietly dropped',
+      "Projects whose remote isn't GitHub work: GitLab and self-managed git hosts get branches, worktrees, sync and push, and the copy names the host you actually use. What genuinely needs GitHub, like pull requests, is absent rather than broken",
+      "Dev servers start with the project's own package manager, so a bun or pnpm project no longer gets an npm dev script it was never set up for (thanks Maarten Keizer)",
+      "Terminal output is no longer thrown away: a verbose agent turn or a chatty build could outrun the terminal's parser until it gave up and discarded the rest — which is exactly the part with the error in it. The terminal paces the process now instead",
+      'Lower idle CPU: while anything on screen was changing, which during an agent turn is continuously, the app re-examined every element in the window four times a second looking for scrollable ones. It now looks only at what actually changed',
+      "Quieter in the background: a project window you aren't looking at no longer walks git history, runs gh, or calls GitHub every minute. It refreshes the moment you come back to it",
+      'A click inside a dialog no longer dismisses the popover underneath it',
+      "~17 more reported issues fixed — mostly routine environment states that used to file themselves as bug reports and now explain themselves instead: a dev server restarting, a project folder that moved, a broken npm install, an agent CLI whose own config won't parse, a clone cut off by a flaky network",
+    ],
+  },
+  {
     version: '1.2.0', // v1.2.0
     items: [
       "New: the breakpoint canvas — see every breakpoint at once, side by side, each showing the whole page at its own device width and an honest viewport height, instead of one size at a time. Pan and zoom it like a design canvas, and click a frame's label to drop into that size and work there; editing, inspection and screenshots follow whichever frame is active",
-      'New: Team — see what your teammates actually did and why, who is on which branch, and the comments left on the project, without leaving the workspace. It reads your own repository rather than a server: no account, no sign-up, and it works on first launch even if nobody else on the team uses Ship Studio',
-      "New: comments are shared. Pin a note to the element it is about and your teammates see it after their next sync — carried on a ref of their own, so your branches, your commits and your pull requests never contain them. Tick the ones you want and hand them to your agent in one go; it can reply and mark them resolved when it's done. Comments still work with no repository at all, which is the right tool for annotating a page on your own",
+      'New: comments on the preview. Pin a note to the element it is about, collect a few, and hand them all to your agent in one go instead of describing them one at a time',
       "New: hosting status is built into the app and now covers Vercel, Cloudflare Pages and Netlify. It answers one question honestly — did the commit you just pushed deploy? — showing the provider's own status word, the site's address, and when a build fails, the error line, so you don't have to open the provider's dashboard to find out why. The Vercel plugin is superseded and says so",
       "The dashboard opens fast: scanning your projects no longer blocks on filesystem work or rewrites every project's .gitignore on each load — measured 2.06s down to 0.38s for three projects opening at once — and a scan that fails now says so with a retry instead of spinning forever",
       'Comments on a breakpoint canvas work at all: an invisible layer was swallowing every click, so on the canvas you could never pick an element or write a note',

--- a/src/components/dashboard/ImportProject.tsx
+++ b/src/components/dashboard/ImportProject.tsx
@@ -169,7 +169,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       // Recognized user-environment failures (stale npm login, SSH auth, …)
       // log at warn — logger.error auto-files bug reports (issues #505/#531).
       const logContext = {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
         projectPath: importedProjectPath,
         packageManager: importedPackageManager,
       };
@@ -273,7 +273,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
         workspaces = await detectWorkspaces(projectPath);
       } catch (err) {
         logger.warn('[ImportProject] detectWorkspaces failed; falling back to root', {
-          error: err instanceof Error ? err.message : String(err),
+          error: formatCommandError(asCommandError(err)),
           projectPath,
         });
       }
@@ -297,7 +297,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       // auth, …) log at warn — logger.error auto-files bug reports
       // (issue #531).
       const logContext = {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
         repo: selectedRepo.name,
         safeName,
       };
@@ -347,7 +347,7 @@ export function ImportProject({ onComplete, onCancel }: ImportProjectProps) {
       // tool, …) log at warn — logger.error auto-files bug reports
       // (issue #505).
       const logContext = {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
         phase,
         projectPath,
       };

--- a/src/components/dashboard/MachineToolsPanel.tsx
+++ b/src/components/dashboard/MachineToolsPanel.tsx
@@ -20,6 +20,7 @@ import { CheckIcon, WarningIcon, ChevronIcon, ClaudeIcon, GitHubIcon } from '@/c
 import { Spinner } from '../primitives/Spinner';
 import { getFullSetupStatus, SetupItem, SETUP_ITEM_ORDER, MACHINE_ITEM_IDS } from '../../lib/setup';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 export function MachineToolsPanel() {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -37,7 +38,7 @@ export function MachineToolsPanel() {
         setSetupItems(machineItems);
       } catch (error) {
         logger.error('Failed to load setup status', {
-          error: error instanceof Error ? error.message : String(error),
+          error: formatCommandError(asCommandError(error)),
         });
       } finally {
         setIsLoading(false);

--- a/src/components/dashboard/MoveFolderModal.tsx
+++ b/src/components/dashboard/MoveFolderModal.tsx
@@ -13,6 +13,7 @@ import { logger } from '../../lib/logger';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { Button } from '../primitives/Button';
 import { Spinner } from '../primitives/Spinner';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 /** Props for the MoveFolderModal component */
 interface MoveFolderModalProps {
@@ -52,7 +53,7 @@ export function MoveFolderModal({
         .then(setFolders)
         .catch((err) =>
           logger.error('Failed to load folders', {
-            error: err instanceof Error ? err.message : String(err),
+            error: formatCommandError(asCommandError(err)),
           })
         )
         .finally(() => setLoading(false));
@@ -78,7 +79,7 @@ export function MoveFolderModal({
       await handleSelect(folder.id);
     } catch (err) {
       logger.error('Failed to create folder', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
     }
   };
@@ -92,7 +93,7 @@ export function MoveFolderModal({
       onClose();
     } catch (err) {
       logger.error('Failed to move project', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
     } finally {
       setSelecting(false);

--- a/src/components/dashboard/MoveWorkspaceModal.tsx
+++ b/src/components/dashboard/MoveWorkspaceModal.tsx
@@ -13,6 +13,7 @@ import { Spinner } from '../primitives/Spinner';
 import { CheckIcon } from '@/components/icons';
 import { listAccounts, type Account } from '../../lib/accounts';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 interface MoveWorkspaceModalProps {
   isOpen: boolean;
@@ -46,7 +47,7 @@ export function MoveWorkspaceModal({
       .then(setAccounts)
       .catch((err) =>
         logger.error('Failed to load workspaces', {
-          error: err instanceof Error ? err.message : String(err),
+          error: formatCommandError(asCommandError(err)),
         })
       )
       .finally(() => setLoading(false));
@@ -62,7 +63,7 @@ export function MoveWorkspaceModal({
       onClose();
     } catch (err) {
       logger.error('Failed to move project to workspace', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
     } finally {
       setSelecting(false);

--- a/src/components/dashboard/ProjectList.tsx
+++ b/src/components/dashboard/ProjectList.tsx
@@ -352,7 +352,7 @@ export function ProjectList({
       );
     } catch (error) {
       logger.error('Failed to toggle main branch warning', {
-        error: error instanceof Error ? error.message : String(error),
+        error: formatCommandError(asCommandError(error)),
       });
       alert('Failed to update main branch warning: ' + formatCommandError(asCommandError(error)));
     }
@@ -404,7 +404,7 @@ export function ProjectList({
       // If result is null, user cancelled the dialog - no action needed
     } catch (error) {
       logger.error('Failed to export template', {
-        error: error instanceof Error ? error.message : String(error),
+        error: formatCommandError(asCommandError(error)),
       });
       alert('Failed to export template: ' + formatCommandError(asCommandError(error)));
     }
@@ -431,7 +431,7 @@ export function ProjectList({
       await loadAll();
     } catch (error) {
       logger.error('Failed to delete folder', {
-        error: error instanceof Error ? error.message : String(error),
+        error: formatCommandError(asCommandError(error)),
       });
       alert('Failed to delete folder: ' + formatCommandError(asCommandError(error)));
     } finally {

--- a/src/components/dashboard/useProjectListData.ts
+++ b/src/components/dashboard/useProjectListData.ts
@@ -138,7 +138,7 @@ export function useProjectListData(activeAccountId: string | null | undefined) {
       setFiledPaths(new Set(paths));
     } catch (error) {
       logger.error('Failed to load folders', {
-        error: error instanceof Error ? error.message : String(error),
+        error: formatCommandError(asCommandError(error)),
       });
     }
   };

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -2029,8 +2029,14 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
                     : undefined
                 }
               />
-              {/* Pinned comments, tracking their elements in the live frame */}
-              {!canvasMode && comments.pins(1, iframeSize)}
+              {/* Pinned comments, tracking their elements in the live frame.
+                  The frame reports rects in its OWN pixels while this layer is
+                  an unscaled sibling of it, so a shrunk-to-fit preview needs
+                  the same previewScale the iframe's transform uses — at 1 the
+                  pins and composer drift further from their elements the
+                  further down the page they are, and slide at their own rate
+                  when it scrolls. previewScale is 1 when nothing is scaled. */}
+              {!canvasMode && comments.pins(resize.previewScale, iframeSize)}
               {/* Structural-edit toolbar, tracking the canvas selection box */}
               {activeEditMode && (
                 <ElementToolbar

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -1990,7 +1990,21 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
                   : `${resize.customHeight + RESIZE_HANDLE_PX}px`,
             }}
           >
-            <div ref={setIframeWrapperEl} className="preview-iframe-wrapper">
+            <div
+              ref={setIframeWrapperEl}
+              className="preview-iframe-wrapper"
+              // `overflow: hidden` still makes this a scroll container — one
+              // with no scrollbar, so anything that scrolls it strands the
+              // frame where the user cannot bring it back. Nothing scrolls it
+              // on purpose; the overlays absolutely positioned over the frame
+              // (comment composer, element toolbar, plugin panels) do it by
+              // accident, because focus() reveals what it focuses. Snap back.
+              onScroll={(e) => {
+                const el = e.currentTarget;
+                if (el.scrollTop !== 0) el.scrollTop = 0;
+                if (el.scrollLeft !== 0) el.scrollLeft = 0;
+              }}
+            >
               <iframe
                 key={projectPath}
                 ref={iframeRef}

--- a/src/components/preview/ScreenshotPreview.tsx
+++ b/src/components/preview/ScreenshotPreview.tsx
@@ -13,6 +13,7 @@ import { getScreenshotBase64 } from '../../lib/ide';
 import { CameraIcon, CloseIcon } from '@/components/icons';
 import { ModalFrame } from '../primitives/ModalFrame';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 /** Duration to show the toast before auto-dismiss (ms) */
 const TOAST_DURATION_MS = 5000;
@@ -40,7 +41,7 @@ export function ScreenshotToast({ filePath, onDismiss, onViewFull }: ScreenshotT
       .then(setImageSrc)
       .catch((err) =>
         logger.error('Failed to load screenshot', {
-          error: err instanceof Error ? err.message : String(err),
+          error: formatCommandError(asCommandError(err)),
         })
       );
   }, [filePath]);
@@ -117,7 +118,7 @@ export function ScreenshotPreviewModal({ filePath, onClose }: ScreenshotPreviewM
       .then(setImageSrc)
       .catch((err) =>
         logger.error('Failed to load screenshot', {
-          error: err instanceof Error ? err.message : String(err),
+          error: formatCommandError(asCommandError(err)),
         })
       );
   }, [filePath]);

--- a/src/components/team/TeamPanel.tsx
+++ b/src/components/team/TeamPanel.tsx
@@ -19,6 +19,7 @@
 
 import { useEffect, useMemo, useSyncExternalStore } from 'react';
 import {
+  BranchIcon,
   CheckIcon,
   CloseIcon,
   CollaboratorsIcon,
@@ -136,6 +137,15 @@ export function TeamPanel({
             <span className="team-float-title">
               Team
               {unseen.length > 0 && <span className="team-float-count">{unseen.length} new</span>}
+              {/* Said out loud, because the honest answer to "where does this
+                  live" is "your repository" — there is no service behind it,
+                  and nothing here was invented. Git rather than any one host:
+                  the same panel works on GitLab, a self-managed remote, and a
+                  repo with no remote at all. */}
+              <span className="team-float-origin">
+                <BranchIcon size={11} aria-hidden />
+                Powered by Git
+              </span>
             </span>
             <div className="team-float-header-actions">
               {/* The disclosure panel — what gets written into the repository and

--- a/src/components/terminal/BuildTerminal.tsx
+++ b/src/components/terminal/BuildTerminal.tsx
@@ -32,7 +32,9 @@ import {
   onPtySessionData,
   onPtySessionExit,
   createAttachGate,
+  setPtySessionPaused,
 } from '../../lib/ptySession';
+import { createTerminalFlowControl } from '../../lib/terminalFlowControl';
 import { getTerminalGpuEnabled } from '../../lib/settings';
 import { loadNerdFonts } from '../../lib/fonts';
 import { logger } from '../../lib/logger';
@@ -180,8 +182,18 @@ export function BuildTerminal({
         // callbacks were skipped) — sync the PTY to the current size once.
         resizePtySessionLogged(sessionId, Math.max(term.cols, 2), Math.max(term.rows, 2));
 
+        // A build is the single most likely thing in the app to outrun
+        // xterm's parser — a verbose bundler can emit megabytes in a second.
+        // Pace it (issue #910); without this xterm eventually discards output
+        // and the error the user is looking for is the part that vanishes.
+        const flow = createTerminalFlowControl(term, {
+          onPause: () => setPtySessionPaused(sessionId, true),
+          onResume: () => setPtySessionPaused(sessionId, false),
+        });
+        disposers.push(() => flow.dispose());
+
         const gate = createAttachGate((bytes) => {
-          term.write(bytes);
+          flow.write(bytes);
           emitOutput(bytes);
         });
         const unlistenData = await onPtySessionData(sessionId, (bytes, offset) => {
@@ -209,7 +221,7 @@ export function BuildTerminal({
         const attach = await attachPtySession(sessionId);
         if (cancelled) return;
         if (attach.buffer.length > 0) {
-          term.write(attach.buffer);
+          flow.write(attach.buffer);
           emitOutput(attach.buffer);
         }
         gateOpen = true;

--- a/src/components/terminal/BuildTerminal.tsx
+++ b/src/components/terminal/BuildTerminal.tsx
@@ -235,7 +235,7 @@ export function BuildTerminal({
       } catch (err) {
         if (!cancelled) {
           logger.error('[BuildTerminal] failed to start build session', {
-            error: err instanceof Error ? err.message : String(err),
+            error: formatCommandError(asCommandError(err)),
           });
           term.write(
             `\r\n\x1b[31mFailed to start build: ${formatCommandError(asCommandError(err))}\x1b[0m\r\n`

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -30,7 +30,9 @@ import {
   onPtySessionData,
   onPtySessionExit,
   createAttachGate,
+  setPtySessionPaused,
 } from '../../lib/ptySession';
+import { createTerminalFlowControl } from '../../lib/terminalFlowControl';
 import type { UnlistenFn } from '@tauri-apps/api/event';
 import { useAgentBridge } from '../../contexts/AgentBridgeContext';
 
@@ -840,9 +842,22 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         // just when visible) so `term.onTitleChange` fires for background
         // tabs — that's what drives the agent-done sound + green-label
         // notification while the user is on another project.
+        //
+        // Paced against xterm's own parse rate: writing faster than xterm can
+        // parse grows its internal buffer until it discards data outright and
+        // the user loses output (issue #910). The flow controller pauses the
+        // backend reader while the backlog is high, which lets the kernel PTY
+        // buffer fill and blocks the child — real backpressure, nothing
+        // queued on our heap.
+        const flow = createTerminalFlowControl(term, {
+          onPause: () => setPtySessionPaused(backendSessionId, true),
+          onResume: () => setPtySessionPaused(backendSessionId, false),
+        });
+        ptyDisposablesRef.current.push({ dispose: () => flow.dispose() });
+
         const writeToTerminal = (data: string | Uint8Array | number[]) => {
           const normalized = Array.isArray(data) ? new Uint8Array(data) : data;
-          terminalRef.current?.write(normalized);
+          flow.write(normalized);
         };
 
         // Store disposables so cleanup() can remove IPC listeners and prevent CPU leak.
@@ -989,7 +1004,9 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         if (attach.buffer.length > 0) {
           // Replay ring-buffer tail so a newly-attached xterm shows prior
           // output (critical for project switches back to a background tab).
-          terminalRef.current?.write(attach.buffer);
+          // Through the flow controller like every other bulk write, so the
+          // replay counts towards the backlog it contributes to.
+          flow.write(attach.buffer);
         }
         // Open the gate: flush queued live chunks, dropping the ones the
         // snapshot already covers (offset < endOffset).

--- a/src/components/workspace/ProjectSettingsModal.tsx
+++ b/src/components/workspace/ProjectSettingsModal.tsx
@@ -12,6 +12,7 @@ import { TextField } from '../primitives/TextField';
 import { useModal, type ModalId } from '../../contexts/ModalContext';
 import { getForceStaticServe, setForceStaticServe } from '../../lib/project';
 import { logger } from '../../lib/logger';
+import { asCommandError, formatCommandError } from '../../lib/errors';
 
 interface ProjectSettingsModalProps {
   currentPort: number;
@@ -63,7 +64,7 @@ export function ProjectSettingsModal({
       })
       .catch((err) => {
         logger.warn('[ProjectSettings] Failed to load force_static_serve', {
-          error: err instanceof Error ? err.message : String(err),
+          error: formatCommandError(asCommandError(err)),
         });
       });
     return () => {
@@ -90,7 +91,7 @@ export function ProjectSettingsModal({
       ) {
         void setForceStaticServe(projectPath, forceStatic).catch((err) => {
           logger.error('[ProjectSettings] Failed to save force_static_serve', {
-            error: err instanceof Error ? err.message : String(err),
+            error: formatCommandError(asCommandError(err)),
           });
         });
       }

--- a/src/components/workspace/SpotifyWidget.test.tsx
+++ b/src/components/workspace/SpotifyWidget.test.tsx
@@ -21,6 +21,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 import { mockIPC } from '@tauri-apps/api/mocks';
 import { SpotifyWidget } from './SpotifyWidget';
+import { ToastContext } from '../../contexts/ToastContext';
 import type { SpotifyState } from '../../lib/spotify';
 
 function state(overrides: Partial<SpotifyState> = {}): SpotifyState {
@@ -202,5 +203,38 @@ describe('SpotifyWidget', () => {
       expect(controlCalls).toContainEqual({ action: 'playpause', value: undefined })
     );
     expect(controlCalls.some((call) => call.action === 'activate')).toBe(false);
+  });
+});
+
+/**
+ * Issue #930: the state poll spawns an `osascript` on a 2s leash, so a round
+ * trip that is merely slow fails here and succeeds on the next tick. The
+ * policy itself (how many failures before saying anything) is covered by
+ * `lib/pollFailureGate.test.ts`; what matters here is that the widget's poll
+ * is wired to it at all — a single failure must not toast.
+ */
+describe('SpotifyWidget transient poll failures', () => {
+  it('does not toast when a state poll fails', async () => {
+    let calls = 0;
+    mockIPC((cmd) => {
+      if (cmd === 'get_spotify_widget_enabled') return true;
+      if (cmd === 'get_spotify_state') {
+        calls += 1;
+        // eslint-disable-next-line @typescript-eslint/only-throw-error -- the CommandError shape under test
+        throw { type: 'Timeout', cmd: 'osascript (spotify state)', secs: 2 };
+      }
+      return undefined;
+    });
+
+    const showToast = vi.fn();
+    render(
+      <ToastContext.Provider value={{ toasts: [], showToast, dismissToast: vi.fn() }}>
+        <SpotifyWidget />
+      </ToastContext.Provider>
+    );
+
+    await waitFor(() => expect(calls).toBeGreaterThan(0));
+    await act(() => new Promise((resolve) => setTimeout(resolve, 50)));
+    expect(showToast).not.toHaveBeenCalled();
   });
 });

--- a/src/components/workspace/SpotifyWidget.tsx
+++ b/src/components/workspace/SpotifyWidget.tsx
@@ -13,7 +13,14 @@
  * @module components/workspace/SpotifyWidget
  */
 
-import { useCallback, useEffect, useState, type ChangeEvent, type SyntheticEvent } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type SyntheticEvent,
+} from 'react';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { AlertIcon, PauseIcon, PlayIcon, SkipNextIcon, SkipPreviousIcon } from '@/components/icons';
 import SpotifyLogoGraphic from '@/assets/graphics/spotify-logo.svg?react';
@@ -24,6 +31,8 @@ import { useOptionalToast } from '../../contexts/ToastContext';
 import { useCommands } from '../../commands/useCommands';
 import { isMac } from '../../lib/setup';
 import { asCommandError, formatCommandError } from '../../lib/errors';
+import { logger } from '../../lib/logger';
+import { createPollFailureGate } from '../../lib/pollFailureGate';
 import { getSpotifyState, spotifyControl, type SpotifyState } from '../../lib/spotify';
 import { getSpotifyWidgetEnabled, SPOTIFY_WIDGET_ENABLED_CHANGED_EVENT } from '../../lib/settings';
 
@@ -32,6 +41,14 @@ const PLAYING_INTERVAL_MS = 1000;
 /** Back off while paused, idle, or Spotify isn't running — each poll spawns
  *  a process on the Rust side, so idle cost matters. */
 const IDLE_INTERVAL_MS = 5000;
+
+/**
+ * Consecutive failed state polls tolerated before the widget says anything.
+ * At the playing cadence that is a few seconds of silence, which is the right
+ * trade: a slow Apple Events round-trip resolves itself well inside it, and a
+ * widget that is actually broken stays broken past it (issue #930).
+ */
+const POLL_FAILURES_BEFORE_TOAST = 3;
 
 /** macOS System Settings deep link to Privacy & Security → Automation. */
 const AUTOMATION_SETTINGS_URL =
@@ -68,6 +85,8 @@ export function SpotifyWidget({ isSidebarHidden }: SpotifyWidgetProps) {
   const [enabled, setEnabled] = useState(false);
   const [isWindowFocused, setIsWindowFocused] = useState(isWindowActive);
   const [state, setState] = useState<SpotifyState | null>(null);
+  // Decides when a run of failed state polls is worth interrupting over.
+  const pollFailuresRef = useRef(createPollFailureGate(POLL_FAILURES_BEFORE_TOAST));
   // Flips the icon/position immediately on click; cleared as soon as a fresh
   // poll reconciles with the real state, so a stuck backend can't leave it lying.
   const [optimisticPlaying, setOptimisticPlaying] = useState<boolean | null>(null);
@@ -112,8 +131,24 @@ export function SpotifyWidget({ isSidebarHidden }: SpotifyWidgetProps) {
       setState(next);
       setOptimisticPlaying(null);
       setOptimisticPosition(null);
+      pollFailuresRef.current.recordSuccess();
     } catch (err) {
-      showToast(formatCommandError(asCommandError(err)), 'error');
+      // A background poll is not a user action, and this one spawns an
+      // `osascript` on a 2s leash: an Apple Events round-trip that is slow
+      // because the machine is busy fails here and succeeds a second later.
+      // Toasting the first failure meant a transient timeout interrupted the
+      // user (issue #930). Ride out a few, then say something once — and only
+      // once — so a genuinely broken widget still speaks up.
+      const message = formatCommandError(asCommandError(err));
+      const action = pollFailuresRef.current.recordFailure();
+      if (action === 'surface') {
+        showToast(message, 'error');
+      } else if (action === 'suppress') {
+        logger.warn('[Spotify] state poll failed — retrying', {
+          consecutiveFailures: pollFailuresRef.current.consecutiveFailures,
+          error: message,
+        });
+      }
     }
   }, [showToast]);
 

--- a/src/components/workspace/SpotifyWidget.tsx
+++ b/src/components/workspace/SpotifyWidget.tsx
@@ -27,6 +27,7 @@ import SpotifyLogoGraphic from '@/assets/graphics/spotify-logo.svg?react';
 import { Button } from '../primitives/Button';
 import { IconButton } from '../primitives/IconButton';
 import { usePolling } from '../../hooks/usePolling';
+import { useWindowFocused } from '../../hooks/useWindowFocused';
 import { useOptionalToast } from '../../contexts/ToastContext';
 import { useCommands } from '../../commands/useCommands';
 import { isMac } from '../../lib/setup';
@@ -59,10 +60,6 @@ interface SpotifyWidgetProps {
   isSidebarHidden?: boolean;
 }
 
-function isWindowActive(): boolean {
-  return document.visibilityState === 'visible' && document.hasFocus();
-}
-
 function trackTitle(trackName: string | null, artist: string | null): string | undefined {
   if (!trackName) return undefined;
   return artist ? `${trackName} — ${artist}` : trackName;
@@ -83,7 +80,7 @@ export function SpotifyWidget({ isSidebarHidden }: SpotifyWidgetProps) {
   const mac = isMac();
 
   const [enabled, setEnabled] = useState(false);
-  const [isWindowFocused, setIsWindowFocused] = useState(isWindowActive);
+  const isWindowFocused = useWindowFocused();
   const [state, setState] = useState<SpotifyState | null>(null);
   // Decides when a run of failed state polls is worth interrupting over.
   const pollFailuresRef = useRef(createPollFailureGate(POLL_FAILURES_BEFORE_TOAST));
@@ -110,20 +107,6 @@ export function SpotifyWidget({ isSidebarHidden }: SpotifyWidgetProps) {
       window.removeEventListener(SPOTIFY_WIDGET_ENABLED_CHANGED_EVENT, onChanged);
     };
   }, [mac]);
-
-  // Track whether this window is the one the user is looking at, so polling
-  // can stop entirely rather than just backing off.
-  useEffect(() => {
-    const update = () => setIsWindowFocused(isWindowActive());
-    document.addEventListener('visibilitychange', update);
-    window.addEventListener('focus', update);
-    window.addEventListener('blur', update);
-    return () => {
-      document.removeEventListener('visibilitychange', update);
-      window.removeEventListener('focus', update);
-      window.removeEventListener('blur', update);
-    };
-  }, []);
 
   const poll = useCallback(async () => {
     try {

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -1,5 +1,11 @@
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
-import { useToasts, type UseToastsReturn, type ToastType } from '../hooks/useToasts';
+import {
+  useToasts,
+  type UseToastsReturn,
+  type ToastType,
+  type ToastAction,
+  type ToastOptions,
+} from '../hooks/useToasts';
 
 export const ToastContext = createContext<UseToastsReturn | null>(null);
 
@@ -49,7 +55,14 @@ const NOOP_TOAST = {
  * Optional variant for code paths that may render outside the provider (tests, isolated
  * stories). Returns a no-op `showToast` so call sites don't need to special-case absence.
  */
-export function useOptionalToast(): { showToast: (message: string, type?: ToastType) => void } {
+export function useOptionalToast(): {
+  showToast: (
+    message: string,
+    type?: ToastType,
+    action?: ToastAction,
+    options?: ToastOptions
+  ) => void;
+} {
   const ctx = useContext(ToastContext);
   if (ctx) return ctx;
   return NOOP_TOAST;

--- a/src/harness/scenarios/base.ts
+++ b/src/harness/scenarios/base.ts
@@ -185,6 +185,12 @@ export const baseCommands: CommandMap = {
   register_external_project: null,
   set_compact_workspace_toolbar_enabled: null,
   fetch_community_templates: '[]',
+  // Both `Result<(), CommandError>` on the Rust side, so `null` over IPC.
+  // Reached only by the palette sweep — `devserver.stop` and
+  // `preview.toggleElementBreadcrumb` are the two commands nothing else
+  // invokes, so they were the last two captures still badged incomplete.
+  stop_static_server: null,
+  set_element_breadcrumb_enabled: null,
 
   // ---- agents -------------------------------------------------------------
   get_agents_status: [

--- a/src/harness/scenarios/workspace.ts
+++ b/src/harness/scenarios/workspace.ts
@@ -63,6 +63,14 @@ export const workspaceCommands: CommandMap = {
     has_package_json: true,
     workspace_has_package_json: false,
   },
+  // Asked for on every workspace open, on the path that decides which package
+  // manager runs the dev script. Unmocked, it badged 41 of the 58 palette
+  // captures incomplete — which by this harness's own rule means none of their
+  // screenshots counted as evidence, and the sweep that is supposed to give
+  // every feature visual coverage was blind. A plain string, per
+  // `detectPackageManager` in `src/lib/github.ts` ("pnpm" | "yarn" | "bun" |
+  // "npm"); 'pnpm' matches what this repo uses.
+  detect_package_manager: 'pnpm',
 
   // Asked for on every workspace open. Unmocked it badged every workspace
   // capture incomplete, which by this harness's own rule means none of their

--- a/src/hooks/useAssetManagement.ts
+++ b/src/hooks/useAssetManagement.ts
@@ -78,7 +78,7 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
     } catch (e) {
       trackError('asset_load', e, 'Workspace');
       setError('Failed to load assets');
-      logger.error('Failed to load assets', { error: e instanceof Error ? e.message : String(e) });
+      logger.error('Failed to load assets', { error: formatCommandError(asCommandError(e)) });
     } finally {
       setIsLoading(false);
     }
@@ -93,7 +93,7 @@ export function useAssetManagement({ projectPath, isOpen, onToast }: UseAssetMan
         .then(setAssetsRootState)
         .catch((e) =>
           logger.warn('Failed to load assets root', {
-            error: e instanceof Error ? e.message : String(e),
+            error: formatCommandError(asCommandError(e)),
           })
         );
     }

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { logger } from '../lib/logger';
+import { asCommandError, formatCommandError } from '../lib/errors';
 
 export interface UseCopyToClipboardReturn {
   copy: (text: string) => Promise<boolean>;
@@ -97,7 +98,7 @@ export function useCopyToClipboard({
         timerRef.current = setTimeout(() => setIsCopied(false), resetMs);
         return true;
       } catch (e) {
-        const err = e instanceof Error ? e : new Error(String(e));
+        const err = e instanceof Error ? e : new Error(formatCommandError(asCommandError(e)));
         setError(err);
         setIsCopied(false);
         logger.warn('copy-to-clipboard failed', { error: err.message });

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -58,7 +58,7 @@ async function resolveDevServerCwd(projectPath: string): Promise<string> {
   } catch (err) {
     logger.error('[DevServer] getWorkspaceSubpath failed; using repo root as cwd', {
       projectPath,
-      error: err instanceof Error ? err.message : String(err),
+      error: formatCommandError(asCommandError(err)),
     });
     return projectPath;
   }
@@ -84,6 +84,7 @@ import { getWindowLabel } from '../lib/window';
 import type { HealthTabPanelRef } from '../components/code/HealthTabPanel';
 import { stripAnsi } from '../lib/ansi';
 import { extractAnnouncedPort } from '../lib/ports';
+import { asCommandError, formatCommandError } from '../lib/errors';
 
 /** Record of a dev-server process that died without Ship Studio stopping it. */
 export interface DevServerUnexpectedExit {
@@ -658,7 +659,7 @@ export function useDevServer(currentProjectPath: string | null) {
           const packageManager = await detectPackageManager(projectPath).catch((err) => {
             logger.warn(
               '[OpenProject] detectPackageManager failed; falling back to npm. This will be wrong for pnpm/yarn projects.',
-              { error: err instanceof Error ? err.message : String(err) }
+              { error: formatCommandError(asCommandError(err)) }
             );
             return 'npm';
           });
@@ -673,7 +674,7 @@ export function useDevServer(currentProjectPath: string | null) {
         }
       } catch (err) {
         logger.warn('[OpenProject] Dependency check failed; attempting dev server anyway', {
-          error: err instanceof Error ? err.message : String(err),
+          error: formatCommandError(asCommandError(err)),
         });
       }
       s.needsInstall = null;

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -85,6 +85,21 @@ import type { HealthTabPanelRef } from '../components/code/HealthTabPanel';
 import { stripAnsi } from '../lib/ansi';
 import { extractAnnouncedPort } from '../lib/ports';
 import { asCommandError, formatCommandError } from '../lib/errors';
+import { useOptionalToast } from '../contexts/ToastContext';
+
+/**
+ * How long a restart waits for the dev-server PTY to come back.
+ *
+ * The budget exists so the restart button can't hang forever, not to police
+ * how fast a machine is. 10s was too tight for what it was actually measuring:
+ * by the time this window opens, the restart has already spent up to 5s on
+ * `kill_port`, half a second of settle, and up to 10s clearing the project
+ * cache — and the spawn itself has to resolve the package manager and get a
+ * pseudo-terminal from an OS that is, by hypothesis, busy. Restarts on loaded
+ * machines were timing out and leaving a stopped preview behind (issue #906).
+ * The initial start path deliberately has no ceiling at all.
+ */
+const RESTART_SPAWN_TIMEOUT_MS = 30_000;
 
 /** Record of a dev-server process that died without Ship Studio stopping it. */
 export interface DevServerUnexpectedExit {
@@ -250,6 +265,9 @@ export function filterProbeChunk(
 }
 
 export function useDevServer(currentProjectPath: string | null) {
+  // Optional so the hook still works in tests and isolated renders; inside the
+  // app it always resolves to the app-root provider.
+  const { showToast } = useOptionalToast();
   const statesRef = useRef<Map<string, ProjectServerState>>(new Map());
   // Last-known capability info per project path. `stopServer` drops a
   // project's live state entirely (by design), but the Preview tab must stay
@@ -972,11 +990,24 @@ export function useDevServer(currentProjectPath: string | null) {
             createOutputHandler(projectPath),
             customCmd
           ),
-          10000,
+          RESTART_SPAWN_TIMEOUT_MS,
           null as unknown as DevServerHandle
         );
         if (!s.handle) {
-          logger.error('Failed to start dev server: spawn timed out');
+          // Say so. The only trace this left was a context-free log line, so
+          // the restart button finished, the preview stayed dark, and nothing
+          // told the user why (issue #906).
+          logger.error('[DevServer] Restart failed: the dev server did not start in time', {
+            projectPath,
+            port: effectivePort,
+            timeoutMs: RESTART_SPAWN_TIMEOUT_MS,
+          });
+          showToast(
+            `The dev server didn't come back within ${Math.round(
+              RESTART_SPAWN_TIMEOUT_MS / 1000
+            )}s. Try restarting it again, or check the dev-server logs.`,
+            'error'
+          );
         } else {
           s.port = effectivePort;
           s.portKnown = true;
@@ -1056,12 +1087,14 @@ export function useDevServer(currentProjectPath: string | null) {
           $screen_name: 'Workspace',
         });
       } catch (error) {
-        logger.error('Failed to restart dev server', { error });
+        logger.error('Failed to restart dev server', {
+          error: formatCommandError(asCommandError(error)),
+        });
       } finally {
         setIsRestartingDevServer(false);
       }
     },
-    [bump, createOutputHandler, getOrCreateState, wireExitWatcher]
+    [bump, createOutputHandler, getOrCreateState, wireExitWatcher, showToast]
   );
 
   /** Type into the current project's dev-server PTY — lets the user answer

--- a/src/hooks/useEnvEditor.ts
+++ b/src/hooks/useEnvEditor.ts
@@ -202,7 +202,7 @@ export function useEnvEditor({
       }
     } catch (e) {
       logger.error('Failed to check sync status', {
-        error: e instanceof Error ? e.message : String(e),
+        error: formatCommandError(asCommandError(e)),
       });
       setSyncStatus(null);
     }
@@ -224,7 +224,7 @@ export function useEnvEditor({
       void checkSyncStatus(files);
     } catch (e) {
       logger.error('Failed to load env files', {
-        error: e instanceof Error ? e.message : String(e),
+        error: formatCommandError(asCommandError(e)),
       });
     }
   }, [projectPath, selectedFile, checkSyncStatus]);
@@ -244,7 +244,7 @@ export function useEnvEditor({
       trackError('env_read', e, 'Workspace');
       setError(`Failed to read ${selectedFile.name}`);
       logger.error('Failed to read env file', {
-        error: e instanceof Error ? e.message : String(e),
+        error: formatCommandError(asCommandError(e)),
       });
     } finally {
       setIsLoading(false);
@@ -299,7 +299,7 @@ export function useEnvEditor({
       setError(`Failed to save ${selectedFile.name}`);
       onToast?.(`Failed to save ${selectedFile.name}`, 'error');
       logger.error('Failed to save env file', {
-        error: e instanceof Error ? e.message : String(e),
+        error: formatCommandError(asCommandError(e)),
       });
     } finally {
       setIsSaving(false);
@@ -462,7 +462,7 @@ export function useEnvEditor({
       setError('Failed to sync to .env.example');
       onToast?.('Failed to sync to .env.example', 'error');
       logger.error('Failed to sync to .env.example', {
-        error: e instanceof Error ? e.message : String(e),
+        error: formatCommandError(asCommandError(e)),
       });
     }
   };
@@ -506,7 +506,7 @@ export function useEnvEditor({
       setError('Failed to sync to .env.local');
       onToast?.('Failed to sync to .env.local', 'error');
       logger.error('Failed to sync to .env.local', {
-        error: e instanceof Error ? e.message : String(e),
+        error: formatCommandError(asCommandError(e)),
       });
     }
   };

--- a/src/hooks/usePreviewCapture.test.tsx
+++ b/src/hooks/usePreviewCapture.test.tsx
@@ -16,8 +16,25 @@ vi.mock('../lib/analytics', () => ({
   trackEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('../lib/logger', () => ({
-  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+// Held as standalone spies so assertions never reference `logger.error` as a
+// value (lint's unbound-method rule).
+const loggerSpies = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+}));
+vi.mock('../lib/logger', () => ({ logger: loggerSpies }));
+
+// The native screenshot plugin, with a gate the unmount tests hold open so
+// they can tear the preview down while the capture is genuinely in flight.
+let screenshotGate: Promise<void> = Promise.resolve();
+vi.mock('tauri-plugin-screenshots-api', () => ({
+  getScreenshotableWindows: async () => {
+    await screenshotGate;
+    return [{ id: 1, title: 'Ship Studio' }];
+  },
+  getWindowScreenshot: () => Promise.resolve('/tmp/shot.png'),
 }));
 
 const showToast = vi.fn();
@@ -88,5 +105,106 @@ describe('usePreviewCapture full-page capture', () => {
       success: true,
       fell_back: false,
     });
+  });
+});
+
+/**
+ * Issue #914: taking the window screenshot is a dynamic import plus a native
+ * round trip. The preview can unmount inside that gap — `handleCropMouseUp`
+ * even flips the crop overlay off immediately before awaiting the capture —
+ * and dereferencing the ref a second time afterwards threw
+ * "null is not an object (evaluating '_.current.getBoundingClientRect')".
+ *
+ * The throw was caught, so nothing crashed; what it did instead was worse to
+ * live with. Every such unmount was logged at error level, which auto-files a
+ * bug report, and the viewport path additionally toasted the user about a
+ * capture they had already walked away from. Nobody unmounting a preview has
+ * done anything wrong, so the tests below assert on the *reporting*, not on
+ * whether an exception escaped.
+ */
+describe('usePreviewCapture when the preview goes away mid-capture', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    screenshotGate = Promise.resolve();
+    invokeMock.mockResolvedValue('/tmp/cropped.png');
+  });
+
+  /** Attach a live wrapper element and hand back a detach function. */
+  function mountWrapper(result: {
+    current: { iframeWrapperRef: { current: HTMLElement | null } };
+  }) {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    result.current.iframeWrapperRef.current = el;
+    return () => {
+      result.current.iframeWrapperRef.current = null;
+      el.remove();
+    };
+  }
+
+  /** Hold the screenshot open until the returned function is called. */
+  function holdScreenshot() {
+    let release!: () => void;
+    screenshotGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    return release;
+  }
+
+  it('crops normally when the preview stays mounted', async () => {
+    const { result } = renderHook(() => usePreviewCapture(baseParams), { wrapper });
+    mountWrapper(result);
+
+    let captured: string | null = null;
+    await act(async () => {
+      captured = await result.current.captureRegion(0, 0, 100, 100);
+    });
+
+    expect(captured).toBe('/tmp/cropped.png');
+    expect(invokeMock).toHaveBeenCalledWith('crop_and_save_screenshot', expect.anything());
+  });
+
+  it('returns null instead of throwing when the preview unmounts mid-region-capture', async () => {
+    const release = holdScreenshot();
+    const { result } = renderHook(() => usePreviewCapture(baseParams), { wrapper });
+    const unmountPreview = mountWrapper(result);
+
+    let captured: string | null = 'unset';
+    await act(async () => {
+      const pending = result.current.captureRegion(0, 0, 100, 100).then((r) => {
+        captured = r;
+      });
+      unmountPreview();
+      release();
+      await pending;
+    });
+
+    expect(captured).toBeNull();
+    // And nothing was cropped from a detached element's all-zero rect.
+    expect(invokeMock).not.toHaveBeenCalledWith('crop_and_save_screenshot', expect.anything());
+    // Walking away from a capture is not a fault to file.
+    expect(loggerSpies.error).not.toHaveBeenCalled();
+  });
+
+  it('returns null instead of throwing when the preview unmounts mid-viewport-capture', async () => {
+    const release = holdScreenshot();
+    const { result } = renderHook(() => usePreviewCapture(baseParams), { wrapper });
+    const unmountPreview = mountWrapper(result);
+
+    let captured: string | null = 'unset';
+    await act(async () => {
+      const pending = result.current.captureForClaude().then((r) => {
+        captured = r;
+      });
+      unmountPreview();
+      release();
+      await pending;
+    });
+
+    expect(captured).toBeNull();
+    expect(invokeMock).not.toHaveBeenCalledWith('crop_and_save_screenshot', expect.anything());
+    expect(loggerSpies.error).not.toHaveBeenCalled();
+    // …nor to interrupt the user about.
+    expect(showToast).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/usePreviewCapture.ts
+++ b/src/hooks/usePreviewCapture.ts
@@ -115,11 +115,21 @@ export function usePreviewCapture({
 
       setIsCapturing(true);
       try {
-        if (!iframeWrapperRef.current) return null;
+        // Hold the element, don't re-read the ref after the await. Taking the
+        // window screenshot is a dynamic import plus a native round trip, and
+        // the preview can unmount inside that gap — a project switch, leaving
+        // crop mode, a breakpoint change. The ref is null by the time we come
+        // back and the second dereference throws (issue #914).
+        const wrapper = iframeWrapperRef.current;
+        if (!wrapper) return null;
 
         const tempPath = await captureWindowScreenshot();
 
-        const rect = iframeWrapperRef.current.getBoundingClientRect();
+        // Still the live element? A detached node's rect is all zeros, which
+        // would crop an empty image and save it as if it were the preview.
+        if (!wrapper.isConnected) return null;
+
+        const rect = wrapper.getBoundingClientRect();
         const dpr = window.devicePixelRatio || 1;
         // Account for the macOS overlay title bar in the window screenshot. Only
         // macOS uses an overlay title bar (`TitleBarStyle::Overlay`); Windows/Linux
@@ -186,7 +196,7 @@ export function usePreviewCapture({
       return filePath;
     } catch (error) {
       logger.error('[Preview] Full page capture failed', {
-        error: error instanceof Error ? error.message : String(error),
+        error: formatCommandError(asCommandError(error)),
       });
       // Don't fall back silently — the user asked for a full-page capture and
       // is about to receive a viewport-only image instead.
@@ -215,15 +225,22 @@ export function usePreviewCapture({
       regionWidth: number,
       regionHeight: number
     ): Promise<string | null> => {
-      if (!iframeWrapperRef.current) {
+      // Held rather than re-read after the await, for the reason in
+      // `captureForClaude` — and this path is the more exposed of the two,
+      // because `handleCropMouseUp` flips the crop overlay off immediately
+      // before awaiting this (issue #914).
+      const wrapper = iframeWrapperRef.current;
+      if (!wrapper) {
         return null;
       }
 
       try {
         const tempPath = await captureWindowScreenshot();
 
+        if (!wrapper.isConnected) return null;
+
         // Get the iframe's position relative to the window
-        const iframeRect = iframeWrapperRef.current.getBoundingClientRect();
+        const iframeRect = wrapper.getBoundingClientRect();
         const dpr = window.devicePixelRatio || 1;
         // Account for the macOS overlay title bar in the window screenshot. Only
         // macOS uses an overlay title bar (`TitleBarStyle::Overlay`); Windows/Linux
@@ -351,6 +368,10 @@ export function usePreviewCapture({
     isCapturing,
     captureForClaude,
     captureFullPage,
+    // Exposed alongside the other two capture entry points: the crop overlay
+    // drives it through `handleCropMouseUp`, but it is the same kind of
+    // operation and is the one whose unmount-mid-capture behaviour is tested.
+    captureRegion,
     selectionStart,
     selectionEnd,
     isSelecting,

--- a/src/hooks/useProjectBulkActions.ts
+++ b/src/hooks/useProjectBulkActions.ts
@@ -202,7 +202,7 @@ export function useProjectBulkActions<T extends DashboardProject>({
           logger.error('Failed bulk project action', {
             action: confirm.action,
             projectName: project.name,
-            error: error instanceof Error ? error.message : String(error),
+            error: formatCommandError(asCommandError(error)),
           });
           continue;
         }
@@ -215,7 +215,7 @@ export function useProjectBulkActions<T extends DashboardProject>({
             logger.error('Failed to unpin project after successful bulk action', {
               action: confirm.action,
               projectName: project.name,
-              error: error instanceof Error ? error.message : String(error),
+              error: formatCommandError(asCommandError(error)),
             });
           }
         }

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -538,7 +538,7 @@ export function useProjectLifecycle({
         } catch (focusError) {
           // Window no longer exists (stale data), proceed with opening locally
           logger.info(`[OpenProject] Window ${existingWindow} no longer exists, opening locally`, {
-            focusError: focusError instanceof Error ? focusError.message : String(focusError),
+            focusError: formatCommandError(asCommandError(focusError)),
           });
         }
       }

--- a/src/hooks/useSnapshots.ts
+++ b/src/hooks/useSnapshots.ts
@@ -12,6 +12,7 @@ import * as snapshots from '../lib/snapshots';
 import { logger } from '../lib/logger';
 import { asCommandError, formatCommandError } from '../lib/errors';
 import { usePolling } from './usePolling';
+import { useWindowFocused } from './useWindowFocused';
 import type { ToastType } from './useToasts';
 
 type ShowToast = (message: string, type?: ToastType) => void;
@@ -77,14 +78,20 @@ export function useSnapshots(
   }, [projectPath]);
 
   // Poll status so the toolbar reflects new captures debounced from the
-  // backend. Cheap call; the backend just reads an in-memory map.
+  // backend. A cheap call, but a call: an IPC round trip, a canonicalize and a
+  // walk up for `.git`, once a second, per open project. Only while the window
+  // is the one being looked at — the toolbar this drives is not on screen
+  // otherwise, and `usePolling` reads immediately on start, so coming back to
+  // a window shows the current state rather than the state it had when it lost
+  // focus.
+  const focused = useWindowFocused();
   usePolling(
     async () => {
       if (!projectPath) return;
       const next = await snapshots.getStatus(projectPath);
       setStatus(next);
     },
-    { intervalMs: 1000, enabled: Boolean(projectPath), name: 'snapshots' }
+    { intervalMs: 1000, enabled: Boolean(projectPath) && focused, name: 'snapshots' }
   );
 
   const undo = useCallback(async () => {

--- a/src/hooks/useTeamWorkspace.tsx
+++ b/src/hooks/useTeamWorkspace.tsx
@@ -22,6 +22,7 @@ import { useCommands } from '../commands/useCommands';
 import { useOptionalToast } from '../contexts/ToastContext';
 import { useLocalStorageFlag } from './useLocalStorageFlag';
 import { usePolling } from './usePolling';
+import { useWindowFocused } from './useWindowFocused';
 import { migrateLegacyComments } from '../lib/commentMigration';
 import { TeamPanel } from '../components/team/TeamPanel';
 import { TeamPresence } from '../components/team/TeamPresence';
@@ -114,6 +115,15 @@ export function useTeamWorkspace(
     })();
   }, [projectPath, showToast]);
 
+  // Every timer below is gated on this window being the one in front of the
+  // user. Ship Studio opens a window per project and people leave them open
+  // for days; ungated, each of those windows walked git history, ran
+  // `gh pr list` and called the GitHub API once a minute, for the whole time
+  // nobody was looking at it. `usePolling` fires immediately on start, so
+  // coming back to a window refreshes it there and then rather than showing
+  // what it held when it lost focus.
+  const focused = useWindowFocused();
+
   // Re-read on a timer. `usePolling` rather than a raw interval, per the repo's
   // own rule — it owns teardown and backs off when a read fails, which matters
   // here because the read shells out to git and `gh`.
@@ -121,6 +131,7 @@ export function useTeamWorkspace(
     useCallback(() => refresh(projectPath), [projectPath]),
     {
       intervalMs: TEAM_SYNC_INTERVAL_MS,
+      enabled: focused,
       name: 'team-snapshot',
     }
   );
@@ -128,10 +139,13 @@ export function useTeamWorkspace(
   // The backstop under the event triggers. `sync` enforces its own ten-minute
   // floor, so this tick is cheap and mostly a no-op — it exists for the session
   // where somebody leaves a workspace open all afternoon and touches nothing.
+  // Which is also the session where the window is not in front of them, so the
+  // gate does not weaken it: the tick that matters is the one on the way back.
   usePolling(
     useCallback(() => sync(), []),
     {
       intervalMs: TEAM_SYNC_FLOOR_MS,
+      enabled: focused,
       name: 'team-remote-sync',
     }
   );
@@ -215,7 +229,7 @@ export function useTeamWorkspace(
       setNow(Date.now());
       return Promise.resolve();
     }, []),
-    { intervalMs: CLOCK_TICK_MS, name: 'team-clock' }
+    { intervalMs: CLOCK_TICK_MS, enabled: focused, name: 'team-clock' }
   );
 
   const close = useCallback(() => setOpenPersisted(false), [setOpenPersisted]);

--- a/src/hooks/useToasts.test.ts
+++ b/src/hooks/useToasts.test.ts
@@ -233,4 +233,62 @@ describe('useToasts', () => {
 
     expect(vi.mocked(reportError)).not.toHaveBeenCalled();
   });
+
+  /**
+   * Issue #920: a refusal the app decided on ("that project already has the
+   * maximum number of agent tabs") is a problem for the user and belongs in
+   * an error toast, but it is not a malfunction and must not be filed as one.
+   * Before this, the only way to stay out of telemetry was to demote the
+   * message to `info`, which is why the same report kept coming back from a
+   * different call site each time.
+   */
+  it('does not report an error toast the caller marked expected', () => {
+    vi.mocked(reportError).mockClear();
+    const { result } = renderHook(() => useToasts());
+
+    act(() => {
+      result.current.showToast('Close a tab and send this again.', 'error', undefined, {
+        expected: true,
+      });
+    });
+
+    expect(vi.mocked(reportError)).not.toHaveBeenCalled();
+  });
+
+  it('still shows an expected error toast, and still keeps it on screen', () => {
+    const { result } = renderHook(() => useToasts());
+
+    act(() => {
+      result.current.showToast('Close a tab and send this again.', 'error', undefined, {
+        expected: true,
+      });
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0]).toMatchObject({
+      message: 'Close a tab and send this again.',
+      type: 'error',
+    });
+
+    // Error toasts persist until dismissed — being expected doesn't change
+    // that, only whether it is reported.
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(result.current.toasts).toHaveLength(1);
+  });
+
+  it('reports an error toast that explicitly says it is not expected', () => {
+    vi.mocked(reportError).mockClear();
+    const { result } = renderHook(() => useToasts());
+
+    act(() => {
+      result.current.showToast('Real failure', 'error', undefined, { expected: false });
+    });
+
+    expect(vi.mocked(reportError)).toHaveBeenCalledWith({
+      message: 'Real failure',
+      source: 'toast',
+    });
+  });
 });

--- a/src/hooks/useToasts.ts
+++ b/src/hooks/useToasts.ts
@@ -31,12 +31,35 @@ export interface Toast {
   action?: ToastAction;
 }
 
+/**
+ * How to show a toast beyond its type and action.
+ *
+ * `expected` marks an error toast the app *meant* to show: a by-design
+ * refusal the user can act on ("that project already has the maximum number
+ * of agent tabs"), not something that went wrong. It still looks and behaves
+ * like an error — it is a problem from where the user is sitting, and it
+ * should persist until they have read it — but it is not filed as a bug.
+ *
+ * Without this, every such refusal had to be demoted to an `info` toast to
+ * stay out of telemetry, which is why the same class of report kept coming
+ * back at each new call site (issues #437, #920).
+ */
+export interface ToastOptions {
+  /** A deliberate refusal, not a malfunction — show it, don't report it. */
+  expected?: boolean;
+}
+
 /** Return type for useToasts hook */
 export interface UseToastsReturn {
   /** Array of active toast notifications */
   toasts: Toast[];
   /** Show a new toast notification */
-  showToast: (message: string, type?: ToastType, action?: ToastAction) => void;
+  showToast: (
+    message: string,
+    type?: ToastType,
+    action?: ToastAction,
+    options?: ToastOptions
+  ) => void;
   /** Dismiss a toast by ID */
   dismissToast: (id: number) => void;
 }
@@ -82,11 +105,17 @@ export function useToasts(): UseToastsReturn {
   }, []);
 
   const showToast = useCallback(
-    (message: string, type: ToastType = 'success', action?: ToastAction) => {
+    (
+      message: string,
+      type: ToastType = 'success',
+      action?: ToastAction,
+      options?: ToastOptions
+    ) => {
       // An error toast is, by definition, the user seeing something not work as
       // intended — report it to the admin agent (deduped + throttled; see
-      // docs/error-reporting.md).
-      if (type === 'error') {
+      // docs/error-reporting.md). Unless the caller says otherwise: a refusal
+      // the app decided on is not a malfunction (see `ToastOptions.expected`).
+      if (type === 'error' && !options?.expected) {
         reportError({ message, source: 'toast' });
       }
       const id = ++toastIdRef.current;

--- a/src/hooks/useWindowFocused.test.ts
+++ b/src/hooks/useWindowFocused.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useWindowFocused, isWindowFocused } from './useWindowFocused';
+
+function setWindowState({ visible, hasFocus }: { visible: boolean; hasFocus: boolean }) {
+  Object.defineProperty(document, 'visibilityState', {
+    value: visible ? 'visible' : 'hidden',
+    configurable: true,
+  });
+  vi.spyOn(document, 'hasFocus').mockReturnValue(hasFocus);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('isWindowFocused', () => {
+  it('is true only when the window is both visible and focused', () => {
+    setWindowState({ visible: true, hasFocus: true });
+    expect(isWindowFocused()).toBe(true);
+
+    // Visible but behind another window: focus alone would miss this.
+    setWindowState({ visible: true, hasFocus: false });
+    expect(isWindowFocused()).toBe(false);
+
+    // Minimised or on another Space: visibility alone would miss this.
+    setWindowState({ visible: false, hasFocus: true });
+    expect(isWindowFocused()).toBe(false);
+  });
+});
+
+describe('useWindowFocused', () => {
+  it('starts from the current state', () => {
+    setWindowState({ visible: true, hasFocus: true });
+    const { result } = renderHook(() => useWindowFocused());
+    expect(result.current).toBe(true);
+  });
+
+  it('goes false when the window is blurred, and true again on focus', () => {
+    setWindowState({ visible: true, hasFocus: true });
+    const { result } = renderHook(() => useWindowFocused());
+
+    act(() => {
+      setWindowState({ visible: true, hasFocus: false });
+      window.dispatchEvent(new Event('blur'));
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      setWindowState({ visible: true, hasFocus: true });
+      window.dispatchEvent(new Event('focus'));
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('follows visibility changes as well as focus', () => {
+    setWindowState({ visible: true, hasFocus: true });
+    const { result } = renderHook(() => useWindowFocused());
+
+    act(() => {
+      setWindowState({ visible: false, hasFocus: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('removes its listeners on unmount', () => {
+    setWindowState({ visible: true, hasFocus: true });
+    const remove = vi.spyOn(window, 'removeEventListener');
+    const removeDoc = vi.spyOn(document, 'removeEventListener');
+    const { unmount } = renderHook(() => useWindowFocused());
+
+    unmount();
+
+    expect(remove).toHaveBeenCalledWith('focus', expect.any(Function));
+    expect(remove).toHaveBeenCalledWith('blur', expect.any(Function));
+    expect(removeDoc).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+  });
+});

--- a/src/hooks/useWindowFocused.ts
+++ b/src/hooks/useWindowFocused.ts
@@ -1,0 +1,44 @@
+/**
+ * Whether this window is the one the user is actually looking at.
+ *
+ * The gate for background polling. Ship Studio is a multi-window app and
+ * projects are commonly left open for days, so a poll that doesn't ask this
+ * question keeps running in windows nobody can see — spawning processes and
+ * reaching the network on a timer to produce pixels nobody is looking at.
+ *
+ * Both halves are needed. `document.hasFocus()` alone says nothing about a
+ * window that is minimised or on another Space; `visibilityState` alone says
+ * nothing about a visible window sitting behind another one.
+ *
+ * Pair it with `usePolling({ enabled })`. The poller fires immediately on
+ * start, so a window that regains focus refreshes at once rather than showing
+ * whatever it had when it lost focus.
+ *
+ * @module hooks/useWindowFocused
+ */
+
+import { useEffect, useState } from 'react';
+
+export function isWindowFocused(): boolean {
+  return document.visibilityState === 'visible' && document.hasFocus();
+}
+
+export function useWindowFocused(): boolean {
+  const [focused, setFocused] = useState(isWindowFocused);
+
+  useEffect(() => {
+    const update = () => setFocused(isWindowFocused());
+    document.addEventListener('visibilitychange', update);
+    window.addEventListener('focus', update);
+    window.addEventListener('blur', update);
+    // The state can have moved between the initial render and this effect.
+    update();
+    return () => {
+      document.removeEventListener('visibilitychange', update);
+      window.removeEventListener('focus', update);
+      window.removeEventListener('blur', update);
+    };
+  }, []);
+
+  return focused;
+}

--- a/src/hooks/useWorkflowHandoff.test.ts
+++ b/src/hooks/useWorkflowHandoff.test.ts
@@ -98,7 +98,13 @@ describe('useFindingHandoff', () => {
 
     expect(addTerminalTab).not.toHaveBeenCalled();
     expect(peekHandoff('/p/demo')).toBeNull();
-    expect(showToast).toHaveBeenCalledWith(expect.stringContaining('Copy prompt'), 'error');
+    // A handoff that genuinely failed is still reported as a fault.
+    expect(showToast).toHaveBeenCalledWith(
+      expect.stringContaining('Copy prompt'),
+      'error',
+      undefined,
+      { expected: false }
+    );
   });
 
   it('delivers once, not once per retry', () => {
@@ -118,6 +124,13 @@ describe('useFindingHandoff', () => {
 
     expect(addTerminalTab).not.toHaveBeenCalled();
     expect(peekHandoff('/p/demo')).toBeNull();
-    expect(showToast).toHaveBeenCalledWith(expect.stringContaining('maximum number'), 'error');
+    // Shown like an error — it stays until read — but marked expected, so the
+    // app's own cap isn't filed as a malfunction (issue #920).
+    expect(showToast).toHaveBeenCalledWith(
+      expect.stringContaining('maximum number'),
+      'error',
+      undefined,
+      { expected: true }
+    );
   });
 });

--- a/src/hooks/useWorkflowHandoff.ts
+++ b/src/hooks/useWorkflowHandoff.ts
@@ -28,6 +28,7 @@ import {
   type HandoffFinding,
 } from '../lib/workflowHandoff';
 import { logger } from '../lib/logger';
+import type { ToastAction, ToastOptions, ToastType } from './useToasts';
 
 const RETRY_MS = 400;
 const GIVE_UP_MS = 60_000;
@@ -92,7 +93,12 @@ interface HandoffTerminals {
 export function useFindingHandoff(
   currentProjectPath: string | null,
   { terminalTabs, maxTerminalTabs, addTerminalTab }: HandoffTerminals,
-  showToast: (message: string, type?: 'success' | 'error' | 'info') => void
+  showToast: (
+    message: string,
+    type?: ToastType,
+    action?: ToastAction,
+    options?: ToastOptions
+  ) => void
 ): void {
   const terminalTabCount = terminalTabs.length;
   const startAgentWithPrompt = useCallback(
@@ -123,7 +129,13 @@ export function useFindingHandoff(
   const onFailed = useCallback(
     (finding: HandoffFinding | null) => {
       trackFindingFix(finding, atCapacity ? 'no_room' : 'failed');
-      showToast(atCapacity ? HANDOFF_NO_ROOM_MESSAGE : HANDOFF_FAILED_MESSAGE, 'error');
+      // Being out of tabs is the app enforcing its own cap and telling the
+      // user how to proceed — a refusal, not a fault, so it shows like an
+      // error without being filed as one (issue #920). A handoff that failed
+      // for any other reason genuinely did go wrong.
+      showToast(atCapacity ? HANDOFF_NO_ROOM_MESSAGE : HANDOFF_FAILED_MESSAGE, 'error', undefined, {
+        expected: atCapacity,
+      });
     },
     [showToast, atCapacity]
   );

--- a/src/lib/commentMigration.ts
+++ b/src/lib/commentMigration.ts
@@ -28,6 +28,7 @@
 import { addTeamComment } from './teamApi';
 import { isCommentTarget, type CanvasComment, type CommentTarget } from './canvasComments';
 import { logger } from './logger';
+import { asCommandError, formatCommandError } from './errors';
 
 const LEGACY_PREFIX = 'shipstudio.canvas-comments.v1:';
 const DONE_PREFIX = 'shipstudio.team.migrated:';
@@ -144,7 +145,7 @@ export async function migrateLegacyComments(projectPath: string): Promise<number
       // untouched, so nothing is lost by carrying on.
       logger.warn('could not migrate a canvas comment', {
         projectPath,
-        error: error instanceof Error ? error.message : String(error),
+        error: formatCommandError(asCommandError(error)),
       });
     }
   }

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -136,6 +136,96 @@ describe('friendlyProcessError', () => {
     expect(describeProcessError('npm ERR! code E401').expected).toBe(true);
   });
 
+  it('maps a clone cut off mid-transfer to "try again" (issue #902)', () => {
+    // The reported payload. curl 92 is the HTTP/2 flavour; the four lines
+    // after it are git describing the aftermath of the same interruption.
+    const raw = [
+      'Process exited with code 1',
+      '',
+      "Cloning into 'achylsluna-microjob-1'...",
+      'error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly: CANCEL (err 8)',
+      'error: 11057 bytes of body are still expected',
+      'fetch-pack: unexpected disconnect while reading sideband packet',
+      'fatal: early EOF',
+      'fatal: fetch-pack: invalid index-pack output',
+      'failed to run git: exit status 128',
+    ].join('\n');
+    const info = describeProcessError(raw);
+    expect(info.expected).toBe(true);
+    expect(info.message).toMatch(/cut off/i);
+    expect(info.message).not.toContain('curl 92');
+    // Each line of the aftermath identifies it on its own — a truncated or
+    // differently-ordered dump must classify too.
+    expect(describeProcessError('fatal: early EOF').expected).toBe(true);
+    expect(describeProcessError('fatal: fetch-pack: invalid index-pack output').expected).toBe(
+      true
+    );
+  });
+
+  it('names a broken package-manager install rather than dumping Node (issue #903)', () => {
+    const raw = [
+      'Process exited with code 1',
+      '',
+      'node:internal/modules/cjs/loader:1147',
+      '  throw err;',
+      '  ^',
+      "Error: Cannot find module '../lib/cli.js'",
+      'Require stack:',
+      '- /usr/local/bin/npm',
+      '    at Module._resolveFilename (node:internal/modules/cjs/loader:1144:15)',
+      'Node.js v20.11.1',
+    ].join('\n');
+    const info = describeProcessError(raw);
+    expect(info.expected).toBe(true);
+    expect(info.message).toContain('/usr/local/bin/npm');
+    expect(info.message).toMatch(/reinstall/i);
+    expect(info.message).not.toContain('node:internal');
+  });
+
+  it('does not mistake a project module for a broken package manager', () => {
+    // A project whose own code fails to resolve an import is a real failure
+    // in the repository, and must keep reporting.
+    const raw = [
+      'Process exited with code 1',
+      "Error: Cannot find module './config'",
+      'Require stack:',
+      '- /Users/x/projects/site/build.js',
+    ].join('\n');
+    expect(describeProcessError(raw).expected).toBe(false);
+
+    // Nor a project that merely lives in a folder with the tool's name in it.
+    const inNamedFolder = [
+      "Error: Cannot find module './config'",
+      'Require stack:',
+      '- /Users/x/code/npm-tools/build.js',
+    ].join('\n');
+    expect(describeProcessError(inNamedFolder).expected).toBe(false);
+
+    // But a Windows entrypoint, and a `.cjs` shim, are the real thing.
+    for (const entry of ['C:\\Program Files\\nodejs\\npm', '/opt/homebrew/bin/pnpm.cjs']) {
+      const broken = [
+        "Error: Cannot find module '../lib/cli.js'",
+        'Require stack:',
+        `- ${entry}`,
+      ].join('\n');
+      expect(describeProcessError(broken).expected).toBe(true);
+    }
+  });
+
+  it('maps pnpm 9 rejecting a settings-only workspace file (issue #915)', () => {
+    const raw = [
+      'Process exited with code 1',
+      '',
+      ' ERROR  packages field missing or empty',
+      'For help, run: pnpm help install',
+    ].join('\n');
+    const info = describeProcessError(raw);
+    expect(info.expected).toBe(true);
+    expect(info.message).toContain('pnpm-workspace.yaml');
+    expect(info.message).toMatch(/pnpm 10/);
+    expect(info.message).not.toContain('pnpm help install');
+  });
+
   it('maps HTTPS credential-prompt failures to gh auth guidance (issue #637)', () => {
     const raw =
       "Process exited with code 1\n\nCloning into 'ogeh-ai-website'...\nfatal: could not read Password for 'https://user@github.com': Device not configured\nfailed to run git: exit status 128";

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -654,6 +654,57 @@ export function describeProcessError(
         "This project's dependencies have a version conflict npm won't resolve on its own (see the peer dependency mismatch in the output). Update the conflicting package to a version they agree on, or re-run the install with `--legacy-peer-deps` if that's safe for this project.",
     };
   }
+  // A clone whose pack transfer was cut off partway. curl 92
+  // (CURLE_HTTP2_STREAM) with "stream ... was not closed cleanly" is the
+  // HTTP/2 flavour — a flaky link, a proxy or VPN multiplexing badly, or a
+  // brief GitHub blip — and git reports the aftermath in four more lines
+  // ("unexpected disconnect", "early EOF", "invalid index-pack output")
+  // because it cannot resume a half-received pack. `gh repo clone` wraps git
+  // and exits with its own code 1, so nothing but the wording identifies it.
+  // Retrying is the fix (issue #902).
+  if (
+    lower.includes('rpc failed') ||
+    lower.includes('was not closed cleanly') ||
+    lower.includes('unexpected disconnect while reading sideband packet') ||
+    lower.includes('early eof') ||
+    lower.includes('invalid index-pack output')
+  ) {
+    return {
+      expected: true,
+      message:
+        'The download was cut off partway through — a network blip, a proxy, or a VPN, not a problem with the repository. Git cannot resume a half-received clone, so try again.',
+    };
+  }
+  // Node cannot start the package manager at all, because the package
+  // manager's own entrypoint is missing a file it requires — a broken or
+  // half-upgraded npm install on this machine, nothing to do with the project
+  // being imported. The stack is Node's, so it says MODULE_NOT_FOUND and
+  // exits 1 like everything else; only the require stack naming the tool
+  // identifies it (issue #903).
+  // The tool name has to be the *basename* of the entrypoint, not merely
+  // somewhere in the path — a project living in `~/code/npm-tools` failing to
+  // resolve its own import is a real failure in that repository.
+  const brokenToolInstall = msg.match(
+    /Cannot find module '[^']*'[\s\S]*?Require stack:[^\S\n]*\n?[^\S\n]*-[^\S\n]*([^\n]*[\\/](?:npm|pnpm|yarn|bun)(?:\.\w+)?)[^\S\n]*$/im
+  );
+  if (brokenToolInstall) {
+    return {
+      expected: true,
+      message: `The package manager at ${brokenToolInstall[1]} is broken — its own program files are missing, so it can't start. Reinstall Node.js (or that package manager) on this computer, then try again.`,
+    };
+  }
+  // pnpm 9 and earlier require a `packages:` field in any pnpm-workspace.yaml.
+  // pnpm 10 dropped that: a workspace file carrying only settings (a catalog,
+  // onlyBuiltDependencies) means "single package repo". So a repository built
+  // against pnpm 10 fails outright on an older local pnpm — a version
+  // mismatch on this machine, and the fix is on this machine (issue #915).
+  if (lower.includes('packages field missing or empty')) {
+    return {
+      expected: true,
+      message:
+        "This project's `pnpm-workspace.yaml` carries settings but lists no packages, which needs pnpm 10 or newer — the pnpm on this computer is older. Update it (`corepack use pnpm@latest`, or `npm install -g pnpm@latest`), then retry the install.",
+    };
+  }
   // Corrupted pnpm store: the content-addressable cache has dangling links,
   // so installs die with "ENOENT: no such file or directory, open
   // '…/pnpm/store/v11/links/…'". A local-cache state that `pnpm store prune`

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -13,6 +13,7 @@
 
 import { readFile, BaseDirectory } from '@tauri-apps/plugin-fs';
 import { logger } from './logger';
+import { asCommandError, formatCommandError } from './errors';
 
 /** Track if fonts have been loaded */
 let fontsLoaded = false;
@@ -80,7 +81,7 @@ export async function loadNerdFonts(): Promise<void> {
       fontsLoaded = true;
     } catch (err) {
       logger.error('[Fonts] Failed to load Nerd Fonts', {
-        error: err instanceof Error ? err.message : String(err),
+        error: formatCommandError(asCommandError(err)),
       });
       // Don't throw - let the terminal use fallback fonts
     }

--- a/src/lib/globalErrorFilters.test.ts
+++ b/src/lib/globalErrorFilters.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { classifyRejection, describeRejectionReason } from './globalErrorFilters';
+
+describe('classifyRejection', () => {
+  it('reports a genuine unhandled rejection from app code', () => {
+    expect(classifyRejection(new Error('read of undefined'))).toBe('report');
+  });
+
+  it('suppresses rejections whose stack points at plugin blob code', () => {
+    const err = new Error('boom');
+    err.stack = 'at foo (blob:tauri://localhost/abc-123:1:1)';
+    expect(classifyRejection(err)).toBe('plugin');
+  });
+
+  it("suppresses Tauri's post-unmount listener race", () => {
+    expect(
+      classifyRejection(new Error("undefined is not an object (evaluating 'listeners[eventId]')"))
+    ).toBe('tauri-race');
+  });
+
+  /**
+   * Issue #916: a `CommandError::Expected` that nobody caught. The backend
+   * said it is a recognized environment state; the handler must not overrule
+   * that and file a bug report.
+   */
+  it('does not report a backend-classified Expected CommandError', () => {
+    const expectedError = {
+      type: 'Other',
+      expected: true,
+      message:
+        "The folder 'demo' no longer exists — it may have been moved, renamed, or deleted outside Ship Studio",
+    };
+    expect(classifyRejection(expectedError)).toBe('expected');
+  });
+
+  it('still reports an unflagged CommandError of the same shape', () => {
+    expect(classifyRejection({ type: 'Other', message: 'something broke' })).toBe('report');
+  });
+
+  it('still reports a CommandError variant that carries no expected flag', () => {
+    expect(classifyRejection({ type: 'Io', message: 'disk on fire' })).toBe('report');
+  });
+
+  it('reports rather than suppresses when expected is falsy', () => {
+    expect(classifyRejection({ type: 'Other', message: 'nope', expected: false })).toBe('report');
+  });
+
+  it('classifies a plugin rejection before consulting the expected flag', () => {
+    const err = new Error('at blob:tauri://localhost/x');
+    err.stack = 'blob:tauri://localhost/x';
+    expect(classifyRejection(err)).toBe('plugin');
+  });
+});
+
+describe('describeRejectionReason', () => {
+  it('passes strings through', () => {
+    expect(describeRejectionReason('plain')).toBe('plain');
+  });
+
+  it('serializes plain objects rather than rendering [object Object] (issue #333)', () => {
+    expect(describeRejectionReason({ type: 'Other', message: 'x' })).toBe(
+      '{"type":"Other","message":"x"}'
+    );
+  });
+
+  it('falls back to String() for values JSON cannot represent', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(describeRejectionReason(circular)).toBe('[object Object]');
+    expect(describeRejectionReason(undefined)).toBe('undefined');
+  });
+});

--- a/src/lib/globalErrorFilters.ts
+++ b/src/lib/globalErrorFilters.ts
@@ -1,0 +1,82 @@
+/**
+ * The decision the global `unhandledrejection` handler makes, extracted from
+ * `src/main.tsx` so it can be tested without booting the app.
+ *
+ * `main.tsx` is the last line of defence for a promise nobody caught. It has
+ * three jobs and they are easy to confuse: suppress third-party plugin noise,
+ * suppress one known Tauri runtime race, and — the part this module exists
+ * for — refuse to file a bug report for an error the *backend already said
+ * was not a bug*.
+ *
+ * A `CommandError::Expected` is a recognized environment state with a
+ * user-side fix (a folder that was moved, a PTY that already exited, a plugin
+ * whose files are gone). It crosses IPC as `{ type: 'Other', expected: true }`
+ * precisely so the frontend can tell the difference. Every *local* catch site
+ * has had to learn that one at a time; this handler never did, so any
+ * fire-and-forget `void invoke(...)` that rejected Expected was auto-filed as
+ * a malfunction (issue #916, and the repeat telemetry behind #923).
+ *
+ * @module lib/globalErrorFilters
+ */
+
+import { isExpectedCommandError } from './errors';
+
+/** What `main.tsx` should do with an unhandled promise rejection. */
+export type RejectionDisposition =
+  /** Third-party plugin code — swallow it; the plugin host handles removal. */
+  | 'plugin'
+  /** A known Tauri runtime race — swallow it, it means nothing to anyone. */
+  | 'tauri-race'
+  /** Backend-classified `Expected` — log locally, never file a bug report. */
+  | 'expected'
+  /** A genuine unhandled rejection from app code — report it. */
+  | 'report';
+
+/**
+ * Promises are often rejected with plain objects rather than Errors (Tauri IPC
+ * error payloads especially) — `String()` renders those as "[object Object]",
+ * which both destroys the diagnostic and collapses every such rejection onto
+ * one dedupe fingerprint (issue #333). Serialize the shape instead.
+ */
+export function describeRejectionReason(r: unknown): string {
+  if (typeof r === 'string') return r;
+  try {
+    return JSON.stringify(r) ?? String(r);
+  } catch {
+    return String(r); // circular structures, throwing getters, …
+  }
+}
+
+/**
+ * Classify an unhandled rejection.
+ *
+ * Order matters. Plugin code is checked first because a plugin that bundles
+ * its own React can reject with anything at all and none of it is ours. The
+ * Tauri race is next because it is a specific, known-inert shape. `Expected`
+ * comes before the reporting default because the backend's classification
+ * outranks this handler's ignorance of the call site.
+ */
+export function classifyRejection(reason: unknown): RejectionDisposition {
+  const stack = reason instanceof Error ? reason.stack || '' : describeRejectionReason(reason);
+  const message = reason instanceof Error ? reason.message : describeRejectionReason(reason);
+
+  if (stack.includes('blob:')) return 'plugin';
+
+  // Tauri's internal race: when a `plugin:pty|read` invoke's response arrives
+  // after the component that issued it unmounted (common during rapid project
+  // switches), the runtime looks up a listener that was already garbage
+  // collected and throws a TypeError reading `listeners[eventId].handlerId`
+  // from its injected bootstrap script. A Tauri v2 runtime bug, not ours, and
+  // it affects nothing.
+  if (
+    message.includes('listeners[eventId]') ||
+    stack.includes('listeners[eventId]') ||
+    (message.includes('handlerId') && stack.includes('user-script'))
+  ) {
+    return 'tauri-race';
+  }
+
+  if (isExpectedCommandError(reason)) return 'expected';
+
+  return 'report';
+}

--- a/src/lib/pollFailureGate.test.ts
+++ b/src/lib/pollFailureGate.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { createPollFailureGate } from './pollFailureGate';
+
+describe('createPollFailureGate', () => {
+  it('suppresses failures below the threshold', () => {
+    const gate = createPollFailureGate(3);
+    expect(gate.recordFailure()).toBe('suppress');
+    expect(gate.recordFailure()).toBe('suppress');
+    expect(gate.consecutiveFailures).toBe(2);
+  });
+
+  it('surfaces exactly one report once the threshold is reached', () => {
+    const gate = createPollFailureGate(3);
+    gate.recordFailure();
+    gate.recordFailure();
+    expect(gate.recordFailure()).toBe('surface');
+    expect(gate.recordFailure()).toBe('already-surfaced');
+    expect(gate.recordFailure()).toBe('already-surfaced');
+  });
+
+  it('rearms after a success, so a later outage is reported again', () => {
+    const gate = createPollFailureGate(2);
+    gate.recordFailure();
+    expect(gate.recordFailure()).toBe('surface');
+
+    gate.recordSuccess();
+    expect(gate.consecutiveFailures).toBe(0);
+
+    expect(gate.recordFailure()).toBe('suppress');
+    expect(gate.recordFailure()).toBe('surface');
+  });
+
+  it('forgets a partial run of failures on success', () => {
+    const gate = createPollFailureGate(3);
+    gate.recordFailure();
+    gate.recordFailure();
+    gate.recordSuccess();
+    expect(gate.recordFailure()).toBe('suppress');
+    expect(gate.consecutiveFailures).toBe(1);
+  });
+
+  it('surfaces immediately at a threshold of one', () => {
+    const gate = createPollFailureGate(1);
+    expect(gate.recordFailure()).toBe('surface');
+    expect(gate.recordFailure()).toBe('already-surfaced');
+  });
+
+  it('treats a nonsensical threshold as one rather than never reporting', () => {
+    for (const threshold of [0, -5, 0.4, Number.NaN]) {
+      const gate = createPollFailureGate(threshold);
+      expect(gate.recordFailure()).toBe('surface');
+    }
+  });
+});

--- a/src/lib/pollFailureGate.ts
+++ b/src/lib/pollFailureGate.ts
@@ -1,0 +1,61 @@
+/**
+ * When a background poll's failure is worth interrupting someone over.
+ *
+ * A poll that runs every second is not a user action, and treating each
+ * failure as one produces the worst possible behaviour: a single slow round
+ * trip — an `osascript` that missed its 2s leash because the machine was busy,
+ * a dev server mid-restart — throws a toast in the user's face for something
+ * that fixed itself before they finished reading it (issue #930).
+ *
+ * Silence isn't right either: a poll that has genuinely stopped working should
+ * say so. This gate draws the line between the two — tolerate a short run of
+ * failures, then surface exactly one report, and reset when the poll recovers
+ * so a later outage is reported again.
+ *
+ * @module lib/pollFailureGate
+ */
+
+/** What the caller should do with the failure it just caught. */
+export type PollFailureAction =
+  /** Too early to tell — log it locally and wait for the next tick. */
+  | 'suppress'
+  /** Long enough to be real: show the user, once. */
+  | 'surface'
+  /** Still failing, but already reported for this run. */
+  | 'already-surfaced';
+
+export interface PollFailureGate {
+  /** Record a failed poll and decide what to do about it. */
+  recordFailure(): PollFailureAction;
+  /** Record a successful poll, arming the gate for a future outage. */
+  recordSuccess(): void;
+  /** Consecutive failures since the last success. */
+  readonly consecutiveFailures: number;
+}
+
+/**
+ * @param threshold Consecutive failures tolerated before surfacing one. Must
+ * be at least 1; a threshold of 1 surfaces the first failure.
+ */
+export function createPollFailureGate(threshold: number): PollFailureGate {
+  const limit = Number.isFinite(threshold) ? Math.max(1, Math.floor(threshold)) : 1;
+  let consecutive = 0;
+  let surfaced = false;
+
+  return {
+    recordFailure(): PollFailureAction {
+      consecutive += 1;
+      if (consecutive < limit) return 'suppress';
+      if (surfaced) return 'already-surfaced';
+      surfaced = true;
+      return 'surface';
+    },
+    recordSuccess(): void {
+      consecutive = 0;
+      surfaced = false;
+    },
+    get consecutiveFailures() {
+      return consecutive;
+    },
+  };
+}

--- a/src/lib/polling.ts
+++ b/src/lib/polling.ts
@@ -6,6 +6,7 @@
  */
 
 import { logger } from './logger';
+import { asCommandError, formatCommandError } from './errors';
 
 export interface PollingOptions {
   /** Starting interval in milliseconds */
@@ -131,12 +132,16 @@ export class ExponentialPoller<T> {
         attempt: this.attempt,
         prevInterval,
         newInterval: this.interval,
-        error: error instanceof Error ? error.message : String(error),
+        error: formatCommandError(asCommandError(error)),
       });
 
       this.onResult({
         data: null,
-        error: error instanceof Error ? error : new Error(String(error)),
+        // Consumers get an Error, but its message has to be the real reason.
+        // A Tauri rejection is a plain tagged object, so `String(error)` gave
+        // every failed poll the message "[object Object]" (issue #909).
+        error:
+          error instanceof Error ? error : new Error(formatCommandError(asCommandError(error))),
         attempt: this.attempt,
         nextInterval: this.interval,
       });
@@ -191,7 +196,7 @@ export async function retryWithBackoff<T>(
       logger.debug('Retry with backoff', {
         attempt,
         delay,
-        error: error instanceof Error ? error.message : String(error),
+        error: formatCommandError(asCommandError(error)),
       });
 
       await new Promise((resolve) => setTimeout(resolve, delay));

--- a/src/lib/ptySession.test.ts
+++ b/src/lib/ptySession.test.ts
@@ -9,7 +9,11 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { mockIPC } from '@tauri-apps/api/mocks';
-import { createAttachGate, resizePtySessionLogged } from './ptySession';
+import {
+  ATTACH_GATE_MAX_PENDING_BYTES,
+  createAttachGate,
+  resizePtySessionLogged,
+} from './ptySession';
 import { logger } from './logger';
 
 const bytes = (s: string): Uint8Array => new TextEncoder().encode(s);
@@ -131,5 +135,65 @@ describe('resizePtySessionLogged (#646)', () => {
     // Flush the fire-and-forget promise chain.
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Issue #910's other half: the queue the gate holds while the attach round
+ * trip is in flight. Normally that is one IPC hop, but a slow or failed
+ * attach in front of a chatty process turns it into a heap allocation that
+ * nothing ever frees.
+ */
+describe('createAttachGate memory ceiling', () => {
+  it('holds everything for a normal attach without shedding', () => {
+    const { gate, delivered } = gateWithLog();
+    gate.push(0, new Uint8Array(64 * 1024));
+    gate.push(65536, bytes('tail'));
+    gate.open(0);
+    expect(delivered).toHaveLength(2);
+  });
+
+  it('sheds the oldest chunks once the queue exceeds its ceiling', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const delivered: Uint8Array[] = [];
+    const gate = createAttachGate((b) => delivered.push(b));
+
+    // Six 1 MiB chunks against a 4 MiB ceiling.
+    const chunkSize = 1024 * 1024;
+    for (let i = 0; i < 6; i++) {
+      gate.push(i * chunkSize, new Uint8Array(chunkSize));
+    }
+    gate.open(0);
+
+    const held = delivered.reduce((sum, b) => sum + b.byteLength, 0);
+    expect(held).toBeLessThanOrEqual(ATTACH_GATE_MAX_PENDING_BYTES);
+    expect(held).toBeGreaterThan(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('shed output'),
+      expect.objectContaining({ droppedBytes: expect.any(Number) as number })
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('keeps the newest output when it sheds — that is the visible screen', () => {
+    const delivered: string[] = [];
+    const gate = createAttachGate((b) => delivered.push(text(b)));
+    const filler = new Uint8Array(ATTACH_GATE_MAX_PENDING_BYTES);
+
+    gate.push(0, bytes('OLDEST'));
+    gate.push(6, filler);
+    gate.push(6 + filler.byteLength, bytes('NEWEST'));
+    gate.open(0);
+
+    expect(delivered.join('')).toContain('NEWEST');
+    expect(delivered.join('')).not.toContain('OLDEST');
+  });
+
+  it('never sheds the only chunk it is holding, however large', () => {
+    const delivered: Uint8Array[] = [];
+    const gate = createAttachGate((b) => delivered.push(b));
+    gate.push(0, new Uint8Array(ATTACH_GATE_MAX_PENDING_BYTES * 2));
+    gate.open(0);
+    expect(delivered).toHaveLength(1);
   });
 });

--- a/src/lib/ptySession.ts
+++ b/src/lib/ptySession.ts
@@ -214,13 +214,36 @@ export interface AttachGate {
   open(endOffset: number): void;
 }
 
+/**
+ * Ceiling on what the gate will hold while waiting for the attach snapshot.
+ *
+ * The wait is normally one IPC round-trip, but it is not guaranteed to be: an
+ * attach that is slow or never completes, in front of a process producing
+ * output as fast as it can, turns this queue into an unbounded heap allocation
+ * that nothing ever frees. 4 MiB is far more than the round-trip can plausibly
+ * accumulate and far less than a problem.
+ */
+export const ATTACH_GATE_MAX_PENDING_BYTES = 4 * 1024 * 1024;
+
 export function createAttachGate(deliver: (bytes: Uint8Array) => void): AttachGate {
   let snapshotEnd: number | null = null;
   const pending: Array<{ offset: number; bytes: Uint8Array }> = [];
+  let pendingBytes = 0;
+  let droppedBytes = 0;
   return {
     push(offset: number, bytes: Uint8Array): void {
       if (snapshotEnd === null) {
         pending.push({ offset, bytes });
+        pendingBytes += bytes.byteLength;
+        // Over the ceiling, shed from the front. The oldest queued chunks are
+        // the ones most likely to be inside the snapshot anyway, and for a
+        // terminal the newest output is the part worth keeping.
+        while (pendingBytes > ATTACH_GATE_MAX_PENDING_BYTES && pending.length > 1) {
+          const dropped = pending.shift();
+          if (!dropped) break;
+          pendingBytes -= dropped.bytes.byteLength;
+          droppedBytes += dropped.bytes.byteLength;
+        }
         return;
       }
       if (offset >= snapshotEnd) deliver(bytes);
@@ -228,10 +251,35 @@ export function createAttachGate(deliver: (bytes: Uint8Array) => void): AttachGa
     open(endOffset: number): void {
       if (snapshotEnd !== null) return; // already open — ignore
       snapshotEnd = endOffset;
+      if (droppedBytes > 0) {
+        logger.warn('[ptySession] attach gate shed output while waiting for the snapshot', {
+          droppedBytes,
+        });
+      }
       for (const chunk of pending) {
         if (chunk.offset >= endOffset) deliver(chunk.bytes);
       }
       pending.length = 0;
+      pendingBytes = 0;
     },
   };
+}
+
+/**
+ * Ask the backend to stop, or resume, draining this session's PTY.
+ *
+ * The consumer half lives in `lib/terminalFlowControl.ts`: when xterm's
+ * unparsed backlog crosses the high-water mark the terminal calls this with
+ * `true`, and with `false` once it drains. Fire-and-forget by design — pacing
+ * is an optimisation, and a failed pace call is not something any caller can
+ * act on, so it is logged rather than thrown (issue #910).
+ */
+export function setPtySessionPaused(sessionId: string, paused: boolean): void {
+  invoke('pty_session_set_paused', { sessionId, paused }).catch((err: unknown) => {
+    logger.warn('[ptySession] flow-control pause failed — output is unpaced', {
+      sessionId,
+      paused,
+      error: formatCommandError(asCommandError(err)),
+    });
+  });
 }

--- a/src/lib/scrollbarScan.test.ts
+++ b/src/lib/scrollbarScan.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createScrollbarScanner, rootsFromMutations, OS_ATTR } from './scrollbarScan';
+
+const SKIP = '[class*="-modal"], .workspace-sidebar-scroll';
+const ASSETS = '.assets-list-container';
+
+/**
+ * jsdom computes no real overflow, so styles are supplied per element by a
+ * lookup the tests control. The counter is the point of the whole module: it
+ * is how many times style was resolved, which in the browser is a forced style
+ * recalculation on the main thread.
+ */
+function scanner(styles: Map<Element, Partial<CSSStyleDeclaration>> = new Map()) {
+  const attach = vi.fn();
+  let styleReads = 0;
+  const s = createScrollbarScanner({
+    attach,
+    skipSelector: SKIP,
+    assetSelector: ASSETS,
+    computeStyle: (el) => {
+      styleReads += 1;
+      return {
+        overflowY: 'visible',
+        scrollbarWidth: 'auto',
+        ...(styles.get(el) ?? {}),
+      } as CSSStyleDeclaration;
+    },
+  });
+  return { scanner: s, attach, styleReads: () => styleReads, styles };
+}
+
+function html(markup: string): HTMLElement {
+  document.body.innerHTML = markup;
+  return document.body;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('createScrollbarScanner', () => {
+  it('attaches to a scrollable element and marks it', () => {
+    const root = html('<div id="a"></div>');
+    const el = document.getElementById('a')!;
+    const s = scanner(new Map([[el, { overflowY: 'auto' }]]));
+
+    s.scanner.scan(root);
+
+    expect(s.attach).toHaveBeenCalledWith(el, false);
+    expect(el.hasAttribute(OS_ATTR)).toBe(true);
+  });
+
+  it('leaves a non-scrolling element alone', () => {
+    const root = html('<div id="a"></div>');
+    const s = scanner();
+    s.scanner.scan(root);
+    expect(s.attach).not.toHaveBeenCalled();
+  });
+
+  it('respects an element that hides its scrollbar deliberately', () => {
+    const root = html('<div id="a"></div>');
+    const el = document.getElementById('a')!;
+    const s = scanner(new Map([[el, { overflowY: 'scroll', scrollbarWidth: 'none' }]]));
+    s.scanner.scan(root);
+    expect(s.attach).not.toHaveBeenCalled();
+  });
+
+  it('skips containers that opt out, and lets the assets list opt back in', () => {
+    const root = html(`
+      <div class="thing-modal"><div id="inside"></div></div>
+      <div class="thing-modal"><div id="assets" class="assets-list-container"></div></div>
+    `);
+    const inside = document.getElementById('inside')!;
+    const assets = document.getElementById('assets')!;
+    const s = scanner(
+      new Map([
+        [inside, { overflowY: 'auto' }],
+        [assets, { overflowY: 'auto' }],
+      ])
+    );
+
+    s.scanner.scan(root);
+
+    expect(s.attach).toHaveBeenCalledTimes(1);
+    expect(s.attach).toHaveBeenCalledWith(assets, true);
+  });
+
+  /**
+   * The one that matters: OverlayScrollbars builds a viewport with
+   * `overflow: scroll` inside its host. Attaching to that viewport builds
+   * another inside it, and so on — 100% CPU and memory climbing until the
+   * window dies.
+   */
+  it('never looks inside anything OverlayScrollbars owns', () => {
+    const root = html(`
+      <div data-overlayscrollbars>
+        <div id="viewport" data-overlayscrollbars-viewport>
+          <div id="content"></div>
+        </div>
+      </div>
+    `);
+    const viewport = document.getElementById('viewport')!;
+    const content = document.getElementById('content')!;
+    const s = scanner(
+      new Map([
+        [viewport, { overflowY: 'scroll' }],
+        [content, { overflowY: 'auto' }],
+      ])
+    );
+
+    s.scanner.scan(root);
+
+    expect(s.attach).not.toHaveBeenCalled();
+  });
+
+  it('never re-attaches to a host it already owns', () => {
+    const root = html('<div id="a"></div>');
+    const el = document.getElementById('a')!;
+    const s = scanner(new Map([[el, { overflowY: 'auto' }]]));
+
+    s.scanner.scan(root);
+    s.scanner.invalidate(root);
+    s.scanner.scan(root);
+
+    expect(s.attach).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The reason this module exists. The old implementation walked the whole
+   * document on every mutation batch and called `getComputedStyle` on every
+   * element that wasn't already a host — so a terminal streaming output kept
+   * the app re-deciding the same thousands of elements four times a second,
+   * forever, and reaching the same answer every time.
+   */
+  it('resolves style once per element, however many times it is scanned', () => {
+    const root = html('<div><span></span><span></span><p><b></b></p></div>');
+    const s = scanner();
+
+    s.scanner.scan(root);
+    const afterFirst = s.styleReads();
+    expect(afterFirst).toBeGreaterThan(0);
+
+    for (let i = 0; i < 50; i++) s.scanner.scan(root);
+
+    expect(s.styleReads()).toBe(afterFirst);
+  });
+
+  it('examines a newly added subtree without re-examining the rest', () => {
+    const root = html('<div id="app"><span></span><span></span></div>');
+    const s = scanner();
+    s.scanner.scan(root);
+    const beforeAdd = s.styleReads();
+
+    const added = document.createElement('div');
+    added.innerHTML = '<i></i>';
+    document.getElementById('app')!.appendChild(added);
+    s.scanner.scan(added);
+
+    // The added element and its one child — nothing else.
+    expect(s.styleReads() - beforeAdd).toBe(2);
+  });
+
+  /**
+   * The correctness question the optimisation turns on: an element that was
+   * not scrollable can become scrollable when a class changes, on it or on an
+   * ancestor. Invalidating the changed subtree is what keeps that working.
+   */
+  it('re-decides a subtree after a class change turns a descendant scrollable', () => {
+    const root = html('<div id="host"><div id="child"></div></div>');
+    const host = document.getElementById('host')!;
+    const child = document.getElementById('child')!;
+    const styles = new Map<Element, Partial<CSSStyleDeclaration>>();
+    const s = scanner(styles);
+
+    s.scanner.scan(root);
+    expect(s.attach).not.toHaveBeenCalled();
+
+    // A class on the parent cascades into the child's overflow.
+    host.classList.add('scrolly');
+    styles.set(child, { overflowY: 'auto' });
+
+    s.scanner.invalidate(host);
+    s.scanner.scan(host);
+
+    expect(s.attach).toHaveBeenCalledWith(child, false);
+  });
+
+  it('counts every element it examined exactly once', () => {
+    const root = html('<div><span></span><span></span></div>');
+    const s = scanner();
+    s.scanner.scan(root);
+    const first = s.scanner.examinedCount;
+    s.scanner.scan(root);
+    expect(s.scanner.examinedCount).toBe(first);
+  });
+});
+
+describe('rootsFromMutations', () => {
+  const record = (partial: Partial<MutationRecord>): MutationRecord =>
+    ({
+      type: 'childList',
+      addedNodes: [] as unknown as NodeList,
+      target: document.body,
+      ...partial,
+    }) as MutationRecord;
+
+  it('collects added elements as roots to scan', () => {
+    const a = document.createElement('div');
+    const b = document.createElement('span');
+    const { added, changed } = rootsFromMutations([
+      record({ type: 'childList', addedNodes: [a, b] as unknown as NodeList }),
+    ]);
+    expect(added).toEqual([a, b]);
+    expect(changed).toEqual([]);
+  });
+
+  it('collects attribute targets as roots to re-decide', () => {
+    const a = document.createElement('div');
+    const { added, changed } = rootsFromMutations([record({ type: 'attributes', target: a })]);
+    expect(added).toEqual([]);
+    expect(changed).toEqual([a]);
+  });
+
+  it('ignores text nodes, which have no style of their own', () => {
+    const text = document.createTextNode('hi');
+    const { added } = rootsFromMutations([
+      record({ type: 'childList', addedNodes: [text] as unknown as NodeList }),
+    ]);
+    expect(added).toEqual([]);
+  });
+
+  it('deduplicates a node touched by several records in one batch', () => {
+    const a = document.createElement('div');
+    const { added } = rootsFromMutations([
+      record({ type: 'childList', addedNodes: [a] as unknown as NodeList }),
+      record({ type: 'childList', addedNodes: [a] as unknown as NodeList }),
+    ]);
+    expect(added).toEqual([a]);
+  });
+});

--- a/src/lib/scrollbarScan.ts
+++ b/src/lib/scrollbarScan.ts
@@ -1,0 +1,168 @@
+/**
+ * Deciding which elements OverlayScrollbars should be attached to, and — the
+ * part that matters — how often we have to ask.
+ *
+ * The app attaches OverlayScrollbars to anything that scrolls, wherever it
+ * appears, which means watching the DOM for new containers. The obvious
+ * implementation walks the whole document whenever anything changes, and that
+ * is what this replaces. Its cost is not the walk; it is `getComputedStyle` on
+ * every element in the document, which forces style resolution on the main
+ * thread. Roughly 3ms over a thousand elements, four times a second, and the
+ * app is much larger than a thousand elements.
+ *
+ * It also never stopped. An element examined and found not to scroll was
+ * examined again on the next pass, and the pass after that, forever — and
+ * something is always mutating: xterm rebuilds its rows on every frame while an
+ * agent streams output, so the sweep ran continuously for the whole of an agent
+ * turn, re-deciding the same thousands of elements about a thousand times a
+ * minute and reaching the same conclusion every time.
+ *
+ * So: remember what has been examined, and re-examine only what changed.
+ * Correctness turns on one question — can an element that was not scrollable
+ * become scrollable without being re-added to the DOM? Yes, if its computed
+ * overflow changes, which happens when a class or inline style changes on it or
+ * on an ancestor. Those are observable, so they are observed, and an attribute
+ * change re-examines that element's whole subtree (the cascade reaches
+ * descendants too). Content growth is not a case: `overflow-y` is a style, and
+ * a container filling up does not change it.
+ *
+ * @module lib/scrollbarScan
+ */
+
+/** Marks a host OverlayScrollbars has been attached to. */
+export const OS_ATTR = 'data-os-init';
+
+/**
+ * The one invariant worth restating: OverlayScrollbars builds a viewport with
+ * `overflow: scroll` *inside* its host. Examining that viewport would attach a
+ * second instance inside the first, which builds another viewport, forever —
+ * 100% CPU and memory climbing until the window dies. Every scan must refuse to
+ * look inside anything OverlayScrollbars owns.
+ */
+const OS_INTERNAL_ATTRS = [
+  'data-overlayscrollbars-viewport',
+  'data-overlayscrollbars-padding',
+  'data-overlayscrollbars-content',
+  'data-overlayscrollbars',
+];
+
+export interface ScrollbarScanOptions {
+  /** Attach OverlayScrollbars to a host that should have it. */
+  attach: (el: HTMLElement, isAssetScrollContainer: boolean) => void;
+  /** Selector for containers that must never be given OverlayScrollbars. */
+  skipSelector: string;
+  /** Selector for the Assets browser's list, which opts back in. */
+  assetSelector: string;
+  /** Injected for tests; defaults to the real `getComputedStyle`. */
+  computeStyle?: (el: Element) => CSSStyleDeclaration;
+}
+
+export interface ScrollbarScanner {
+  /**
+   * Examine `root` and its descendants, skipping anything already examined.
+   * Call with `document.body` once at startup and with each added subtree
+   * afterwards.
+   */
+  scan(root: Element): void;
+  /**
+   * Forget `root` and its descendants, so the next `scan` re-decides them.
+   * For a class or style change, whose cascade can turn a descendant
+   * scrollable.
+   */
+  invalidate(root: Element): void;
+  /** Elements examined so far. Test-only insight into how much work was done. */
+  readonly examinedCount: number;
+}
+
+export function createScrollbarScanner({
+  attach,
+  skipSelector,
+  assetSelector,
+  computeStyle = (el) => getComputedStyle(el),
+}: ScrollbarScanOptions): ScrollbarScanner {
+  // A WeakSet, so remembering an element can never keep it alive after React
+  // drops it — this is a long-lived object in a long-lived window.
+  const examined = new WeakSet<Element>();
+  let examinedCount = 0;
+
+  const examine = (el: Element): void => {
+    if (examined.has(el)) return;
+    if (el.hasAttribute(OS_ATTR)) return;
+    if (OS_INTERNAL_ATTRS.some((attr) => el.hasAttribute(attr))) return;
+    if (el.closest(`[${OS_INTERNAL_ATTRS.join('], [')}]`)) return;
+    if (!isHtmlElement(el)) return;
+
+    // Marked before the style read, not after: the answer for an element that
+    // is skipped is just as durable as the answer for one that is attached,
+    // and it is the skipped ones that dominate.
+    examined.add(el);
+    examinedCount += 1;
+
+    const isAssetScrollContainer = el.matches(assetSelector);
+    // Inside a modal, overlay or dropdown, except the Assets browser, whose
+    // scrollbar is deliberately an overlay.
+    if (!isAssetScrollContainer && el.closest(skipSelector)) return;
+
+    const style = computeStyle(el);
+    // Intentionally hidden scrollbars stay hidden.
+    if (style.scrollbarWidth === 'none') return;
+    const oy = style.overflowY;
+    if (oy === 'auto' || oy === 'scroll') {
+      el.setAttribute(OS_ATTR, '');
+      attach(el, isAssetScrollContainer);
+    }
+  };
+
+  return {
+    scan(root: Element): void {
+      examine(root);
+      root.querySelectorAll('*').forEach(examine);
+    },
+    invalidate(root: Element): void {
+      examined.delete(root);
+      root.querySelectorAll('*').forEach((el) => examined.delete(el));
+    },
+    get examinedCount() {
+      return examinedCount;
+    },
+  };
+}
+
+/**
+ * `el instanceof HTMLElement` against the element's *own* document view, so
+ * this still works for a node from another realm (an iframe, jsdom).
+ */
+function isHtmlElement(el: Element): el is HTMLElement {
+  const view = el.ownerDocument?.defaultView;
+  return view ? el instanceof view.HTMLElement : el instanceof HTMLElement;
+}
+
+/**
+ * Which roots a batch of mutation records makes worth re-examining.
+ *
+ * Added nodes bring elements nobody has decided about. A changed `class` or
+ * `style` can change computed overflow on the target and, through the cascade,
+ * on its descendants — so the target is returned as a root to re-decide whole,
+ * and the caller invalidates it first.
+ *
+ * Returned as two lists because they are handled differently, and because
+ * keeping this a pure function is what makes the interesting part testable
+ * without a DOM observer.
+ */
+export function rootsFromMutations(records: readonly MutationRecord[]): {
+  added: Element[];
+  changed: Element[];
+} {
+  const added = new Set<Element>();
+  const changed = new Set<Element>();
+  for (const record of records) {
+    if (record.type === 'childList') {
+      record.addedNodes.forEach((node) => {
+        if (node.nodeType === 1) added.add(node as Element);
+      });
+    } else if (record.type === 'attributes' && record.target.nodeType === 1) {
+      changed.add(record.target as Element);
+    }
+  }
+  return { added: [...added], changed: [...changed] };
+}

--- a/src/lib/terminalFlowControl.test.ts
+++ b/src/lib/terminalFlowControl.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createTerminalFlowControl,
+  HIGH_WATER_BYTES,
+  LOW_WATER_BYTES,
+  type FlowControlledTerminal,
+} from './terminalFlowControl';
+
+/** An xterm stand-in whose parse acknowledgements we control by hand. */
+function fakeTerm() {
+  const pending: Array<() => void> = [];
+  const written: Array<string | Uint8Array> = [];
+  const term: FlowControlledTerminal = {
+    write(data, callback) {
+      written.push(data);
+      if (callback) pending.push(callback);
+    },
+  };
+  return {
+    term,
+    written,
+    /** Acknowledge the oldest `n` outstanding writes, oldest first. */
+    ack(n = pending.length) {
+      pending.splice(0, n).forEach((cb) => cb());
+    },
+    get outstanding() {
+      return pending.length;
+    },
+  };
+}
+
+const chunk = (bytes: number) => new Uint8Array(bytes);
+
+describe('createTerminalFlowControl', () => {
+  it('passes data straight through when the parser keeps up', () => {
+    const f = fakeTerm();
+    const onPause = vi.fn();
+    const flow = createTerminalFlowControl(f.term, { onPause, onResume: vi.fn() });
+
+    flow.write(chunk(1000));
+    f.ack();
+    flow.write(chunk(1000));
+    f.ack();
+
+    expect(f.written).toHaveLength(2);
+    expect(flow.backlog).toBe(0);
+    expect(onPause).not.toHaveBeenCalled();
+  });
+
+  it('pauses the producer once the unparsed backlog crosses the high mark', () => {
+    const f = fakeTerm();
+    const onPause = vi.fn();
+    const flow = createTerminalFlowControl(f.term, { onPause, onResume: vi.fn() });
+
+    // Nothing is acknowledged: this is a producer outrunning the parser.
+    flow.write(chunk(HIGH_WATER_BYTES - 1));
+    expect(onPause).not.toHaveBeenCalled();
+
+    flow.write(chunk(1));
+    expect(onPause).toHaveBeenCalledTimes(1);
+    expect(flow.paused).toBe(true);
+  });
+
+  it('keeps writing while paused — pausing is upstream, not a drop', () => {
+    const f = fakeTerm();
+    const flow = createTerminalFlowControl(f.term, { onPause: vi.fn(), onResume: vi.fn() });
+
+    flow.write(chunk(HIGH_WATER_BYTES));
+    flow.write(chunk(64));
+
+    expect(f.written).toHaveLength(2);
+    expect(flow.backlog).toBe(HIGH_WATER_BYTES + 64);
+  });
+
+  it('does not re-pause on every chunk while already paused', () => {
+    const f = fakeTerm();
+    const onPause = vi.fn();
+    const flow = createTerminalFlowControl(f.term, { onPause, onResume: vi.fn() });
+
+    flow.write(chunk(HIGH_WATER_BYTES));
+    flow.write(chunk(HIGH_WATER_BYTES));
+    flow.write(chunk(HIGH_WATER_BYTES));
+
+    expect(onPause).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes once the backlog drains to the low mark', () => {
+    const f = fakeTerm();
+    const onResume = vi.fn();
+    const flow = createTerminalFlowControl(f.term, { onPause: vi.fn(), onResume });
+
+    flow.write(chunk(HIGH_WATER_BYTES));
+    flow.write(chunk(LOW_WATER_BYTES));
+    expect(flow.paused).toBe(true);
+
+    f.ack(1); // the big chunk parses; LOW_WATER_BYTES is still outstanding
+    expect(flow.backlog).toBe(LOW_WATER_BYTES);
+    expect(flow.paused).toBe(false);
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays paused while the backlog sits between the marks', () => {
+    const f = fakeTerm();
+    const onResume = vi.fn();
+    const flow = createTerminalFlowControl(f.term, { onPause: vi.fn(), onResume });
+
+    flow.write(chunk(HIGH_WATER_BYTES));
+    flow.write(chunk(LOW_WATER_BYTES + 1));
+    expect(flow.paused).toBe(true);
+
+    f.ack(1); // still above the low mark by one byte — hold
+    expect(flow.backlog).toBe(LOW_WATER_BYTES + 1);
+    expect(flow.paused).toBe(true);
+    expect(onResume).not.toHaveBeenCalled();
+
+    f.ack(1);
+    expect(flow.paused).toBe(false);
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores acknowledgements that arrive after disposal', () => {
+    const f = fakeTerm();
+    const onResume = vi.fn();
+    const flow = createTerminalFlowControl(f.term, { onPause: vi.fn(), onResume });
+
+    flow.write(chunk(HIGH_WATER_BYTES));
+    flow.dispose();
+    expect(onResume).toHaveBeenCalledTimes(1); // released on teardown
+
+    f.ack();
+    expect(onResume).toHaveBeenCalledTimes(1);
+    expect(flow.backlog).toBe(0);
+  });
+
+  it('releases a held producer on disposal so no PTY is left paused', () => {
+    const f = fakeTerm();
+    const onResume = vi.fn();
+    const flow = createTerminalFlowControl(f.term, { onPause: vi.fn(), onResume });
+
+    flow.write(chunk(HIGH_WATER_BYTES));
+    expect(flow.paused).toBe(true);
+
+    flow.dispose();
+    expect(onResume).toHaveBeenCalledTimes(1);
+    expect(flow.paused).toBe(false);
+  });
+
+  it('does not call onResume on disposal when nothing was paused', () => {
+    const f = fakeTerm();
+    const onResume = vi.fn();
+    const flow = createTerminalFlowControl(f.term, { onPause: vi.fn(), onResume });
+
+    flow.write(chunk(10));
+    flow.dispose();
+    expect(onResume).not.toHaveBeenCalled();
+  });
+
+  it('drops writes after disposal instead of reviving the accounting', () => {
+    const f = fakeTerm();
+    const flow = createTerminalFlowControl(f.term, { onPause: vi.fn(), onResume: vi.fn() });
+
+    flow.dispose();
+    flow.write(chunk(100));
+
+    expect(f.written).toHaveLength(0);
+    expect(flow.backlog).toBe(0);
+  });
+
+  it('survives a duplicated acknowledgement without wedging the pause', () => {
+    const f = fakeTerm();
+    const onPause = vi.fn();
+    const flow = createTerminalFlowControl(f.term, {
+      onPause,
+      onResume: vi.fn(),
+      highWater: 100,
+      lowWater: 10,
+    });
+
+    flow.write(chunk(50));
+    f.ack();
+    f.ack(); // no-op: nothing outstanding
+    expect(flow.backlog).toBe(0);
+
+    flow.write(chunk(100));
+    expect(onPause).toHaveBeenCalledTimes(1);
+  });
+
+  it('accounts for strings by length', () => {
+    const f = fakeTerm();
+    const flow = createTerminalFlowControl(f.term, {
+      onPause: vi.fn(),
+      onResume: vi.fn(),
+      highWater: 10,
+      lowWater: 2,
+    });
+
+    flow.write('abcdefghij');
+    expect(flow.paused).toBe(true);
+  });
+});

--- a/src/lib/terminalFlowControl.ts
+++ b/src/lib/terminalFlowControl.ts
@@ -1,0 +1,122 @@
+/**
+ * Backpressure between a PTY and the xterm instance rendering it.
+ *
+ * `Terminal.write()` does not render synchronously: it appends to an internal
+ * buffer and parses on a frame budget. Hand it data faster than it can parse —
+ * a verbose agent turn, a build that logs every file, a runaway `yes` — and
+ * that buffer grows without bound until xterm gives up at ~50 MB with "write
+ * data discarded, use flow control to avoid losing data", having thrown away
+ * output the user needed (issue #910).
+ *
+ * xterm's documented remedy is the write callback: it fires once a chunk has
+ * actually been parsed, so the difference between bytes written and bytes
+ * acknowledged is the live backlog. This module tracks that number and asks
+ * the producer to stop above {@link HIGH_WATER_BYTES} and start again below
+ * {@link LOW_WATER_BYTES}. Nothing is dropped and nothing is queued on the
+ * heap — the pause propagates all the way down to the child's own `write`.
+ *
+ * @module lib/terminalFlowControl
+ */
+
+/**
+ * Backlog at which the producer is asked to stop. Roughly a screenful of a
+ * dense TUI repaint; high enough that ordinary bursty output never pauses,
+ * low enough that the buffer stays three orders of magnitude below xterm's
+ * discard threshold.
+ */
+export const HIGH_WATER_BYTES = 1024 * 1024;
+
+/**
+ * Backlog at which the producer is allowed to resume. Well below the high
+ * mark so a steady fast producer toggles occasionally rather than on every
+ * chunk.
+ */
+export const LOW_WATER_BYTES = 256 * 1024;
+
+/** The part of xterm's Terminal this module needs. */
+export interface FlowControlledTerminal {
+  write(data: string | Uint8Array, callback?: () => void): void;
+}
+
+export interface TerminalFlowControlOptions {
+  /** Called when the backlog crosses the high-water mark. */
+  onPause: () => void;
+  /** Called when the backlog falls back below the low-water mark. */
+  onResume: () => void;
+  highWater?: number;
+  lowWater?: number;
+}
+
+export interface TerminalFlowControl {
+  /** Write a chunk, accounting for its size until xterm acknowledges it. */
+  write(data: string | Uint8Array): void;
+  /** Bytes handed to xterm that it has not finished parsing. */
+  readonly backlog: number;
+  /** Whether the producer is currently asked to hold. */
+  readonly paused: boolean;
+  /**
+   * Stop accounting. Any acknowledgement that arrives afterwards is ignored,
+   * and a held producer is released — a terminal being torn down must never
+   * leave its PTY paused.
+   */
+  dispose(): void;
+}
+
+/**
+ * Wrap a terminal so every write is accounted for and the producer is paced.
+ *
+ * `onPause`/`onResume` are only ever called on a transition, never repeatedly
+ * at the same level, so they can be wired straight to an IPC call.
+ */
+export function createTerminalFlowControl(
+  term: FlowControlledTerminal,
+  { onPause, onResume, highWater, lowWater }: TerminalFlowControlOptions
+): TerminalFlowControl {
+  const high = highWater ?? HIGH_WATER_BYTES;
+  const low = lowWater ?? LOW_WATER_BYTES;
+  let backlog = 0;
+  let paused = false;
+  let disposed = false;
+
+  const acknowledge = (size: number) => {
+    if (disposed) return;
+    // Never let the counter drift negative if xterm double-fires a callback:
+    // a negative backlog would make the terminal un-pausable for the rest of
+    // the session.
+    backlog = Math.max(0, backlog - size);
+    if (paused && backlog <= low) {
+      paused = false;
+      onResume();
+    }
+  };
+
+  return {
+    write(data: string | Uint8Array): void {
+      if (disposed) return;
+      // Bytes, not code units: xterm buffers the decoded UTF-8 either way,
+      // and PTY data arrives as Uint8Array in every hot path here.
+      const size = typeof data === 'string' ? data.length : data.byteLength;
+      backlog += size;
+      term.write(data, () => acknowledge(size));
+      if (!paused && backlog >= high) {
+        paused = true;
+        onPause();
+      }
+    },
+    get backlog() {
+      return backlog;
+    },
+    get paused() {
+      return paused;
+    },
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      backlog = 0;
+      if (paused) {
+        paused = false;
+        onResume();
+      }
+    },
+  };
+}

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -14,6 +14,7 @@ import { getVersion } from '@tauri-apps/api/app';
 import { check, Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { logger } from './logger';
+import { asCommandError, formatCommandError } from './errors';
 
 /** Injected by Vite/Vitest from package.json; absent in bare test runners. */
 declare const __APP_VERSION__: string | undefined;
@@ -166,7 +167,7 @@ export async function getRunningAppVersion(): Promise<string | null> {
     if (binaryVersion) candidates.push(binaryVersion);
   } catch (error) {
     logger.warn('[Updater] Could not read the running app version', {
-      error: error instanceof Error ? error.message : String(error),
+      error: formatCommandError(asCommandError(error)),
     });
   }
 
@@ -223,7 +224,7 @@ export async function checkForUpdate(): Promise<{ update: UpdateHandle; info: Up
     }
     return null;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = formatCommandError(asCommandError(error));
     // The manifest fetched fine but simply has no entry for this platform
     // (e.g. the Windows manifest wasn't carried forward onto the "latest"
     // release). Treat as "no update available" rather than an error — there

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,6 +22,7 @@ import { uninstallPlugin } from './lib/plugins';
 import { exposePluginContextRef } from './contexts/PluginContext';
 import { reportError } from './lib/errorReporting';
 import { classifyRejection, describeRejectionReason } from './lib/globalErrorFilters';
+import { createScrollbarScanner, rootsFromMutations } from './lib/scrollbarScan';
 import { isExpectedCommandError } from './lib/errors';
 import { OverlayScrollbars } from 'overlayscrollbars';
 import 'overlayscrollbars/overlayscrollbars.css';
@@ -133,10 +134,9 @@ Node.prototype.insertBefore = function <T extends Node>(newNode: T, referenceNod
   return origInsertBefore.call(this, newNode, referenceNode) as T;
 };
 
-// Initialize OverlayScrollbars on scrollable elements.
-// Uses a debounced MutationObserver to catch dynamically added containers.
-// Skips elements with scrollbar-width: none (intentionally hidden scrollbars).
-const OS_ATTR = 'data-os-init';
+// Attach OverlayScrollbars to scrollable elements, wherever and whenever they
+// appear. The deciding — and, more to the point, the *not* re-deciding — lives
+// in `lib/scrollbarScan.ts`; this half owns the options and the observer.
 const OS_OPTS = { scrollbars: { theme: 'os-theme-shipstudio', autoHide: 'move' as const } };
 const ASSET_SCROLL_SELECTOR = '.assets-list-container';
 const ASSET_OS_OPTS = {
@@ -196,43 +196,16 @@ const OS_SKIP_SELECTOR = [
   '.team-thread-list',
 ].join(', ');
 
-function initScrollbars() {
-  document.querySelectorAll<HTMLElement>('*').forEach((el) => {
-    // Skip elements already processed
-    if (el.hasAttribute(OS_ATTR)) return;
-    // Skip OverlayScrollbars internal elements (viewport, content, scrollbar wrappers).
-    // This is CRITICAL: OS creates a viewport with overflow:scroll inside the host.
-    // Without this guard, initScrollbars would detect that viewport, init OS on it,
-    // creating another viewport inside it — an infinite nesting loop that causes
-    // 100% CPU and ever-growing memory.
-    if (
-      el.hasAttribute('data-overlayscrollbars-viewport') ||
-      el.hasAttribute('data-overlayscrollbars-padding') ||
-      el.hasAttribute('data-overlayscrollbars-content') ||
-      el.hasAttribute('data-overlayscrollbars') ||
-      el.closest('[data-overlayscrollbars]')
-    )
-      return;
-    // Skip non-HTML elements (SVG, etc.)
-    if (!(el instanceof HTMLElement)) return;
-    const isAssetScrollContainer = el.matches(ASSET_SCROLL_SELECTOR);
-    // Skip elements inside modals, overlays, dropdowns, except the Assets
-    // browser, whose scrollbar is intentionally rendered as an overlay.
-    if (!isAssetScrollContainer && el.closest(OS_SKIP_SELECTOR)) return;
-
-    const style = getComputedStyle(el);
-    // Skip elements that intentionally hide scrollbars
-    if (style.scrollbarWidth === 'none') return;
-    const oy = style.overflowY;
-    if (oy === 'auto' || oy === 'scroll') {
-      el.setAttribute(OS_ATTR, '');
-      OverlayScrollbars(el, isAssetScrollContainer ? ASSET_OS_OPTS : OS_OPTS);
-    }
-  });
-}
+const scrollbarScanner = createScrollbarScanner({
+  skipSelector: OS_SKIP_SELECTOR,
+  assetSelector: ASSET_SCROLL_SELECTOR,
+  attach: (el, isAssetScrollContainer) => {
+    OverlayScrollbars(el, isAssetScrollContainer ? ASSET_OS_OPTS : OS_OPTS);
+  },
+});
 
 requestAnimationFrame(() => {
-  initScrollbars();
+  scrollbarScanner.scan(document.body);
 
   // Disconnect previous observer if HMR reload
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
@@ -241,24 +214,52 @@ requestAnimationFrame(() => {
     prevObserver.disconnect();
   }
 
-  let timer: number;
+  // Records are collected across the debounce window rather than dropped,
+  // because they are now the whole input: a coalesced batch that forgot which
+  // subtrees arrived would have nothing left to scan but the document.
+  let timer: number | undefined;
+  let pending: MutationRecord[] = [];
   let running = false;
-  const observer = new MutationObserver(() => {
-    // Don't re-schedule if already running (prevents cascading mutations from re-triggering)
+
+  const flush = () => {
+    timer = undefined;
+    const records = pending;
+    pending = [];
+    running = true;
+    const { added, changed } = rootsFromMutations(records);
+    // A class or inline-style change can turn an element — or, through the
+    // cascade, one of its descendants — scrollable when it wasn't.
+    for (const el of changed) {
+      if (el.isConnected) scrollbarScanner.invalidate(el);
+    }
+    for (const el of changed) {
+      if (el.isConnected) scrollbarScanner.scan(el);
+    }
+    for (const el of added) {
+      if (el.isConnected) scrollbarScanner.scan(el);
+    }
+    // Cleared a frame later so the mutations this pass just caused (attaching
+    // OverlayScrollbars rewrites the host's children) don't re-trigger it.
+    requestAnimationFrame(() => {
+      running = false;
+    });
+  };
+
+  const observer = new MutationObserver((records) => {
     if (running) return;
-    clearTimeout(timer);
-    timer = window.setTimeout(() => {
-      running = true;
-      initScrollbars();
-      // Delay clearing the flag so mutations caused by initScrollbars itself are ignored
-      requestAnimationFrame(() => {
-        running = false;
-      });
-    }, 250);
+    pending.push(...records);
+    if (timer !== undefined) window.clearTimeout(timer);
+    timer = window.setTimeout(flush, 250);
   });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
   (window as any).__scrollbarObserver = observer;
-  observer.observe(document.body, { childList: true, subtree: true });
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    // The only attributes that can change computed overflow.
+    attributes: true,
+    attributeFilter: ['class', 'style'],
+  });
 });
 
 // Parse project path from URL if present (for project windows)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,6 +21,8 @@ import { exposeReactGlobals, lookupBlobOwner, markPluginCrashed } from './lib/pl
 import { uninstallPlugin } from './lib/plugins';
 import { exposePluginContextRef } from './contexts/PluginContext';
 import { reportError } from './lib/errorReporting';
+import { classifyRejection, describeRejectionReason } from './lib/globalErrorFilters';
+import { isExpectedCommandError } from './lib/errors';
 import { OverlayScrollbars } from 'overlayscrollbars';
 import 'overlayscrollbars/overlayscrollbars.css';
 
@@ -39,6 +41,12 @@ window.addEventListener('error', (event) => {
     msg.includes('Plugin context') ||
     msg.includes('plugin-sdk');
   if (!isPluginError) {
+    // A backend-classified Expected value thrown synchronously is the same
+    // non-bug it is on the rejection path (issue #916) — never file it.
+    if (isExpectedCommandError(event.error)) {
+      console.warn('[Ship Studio] Uncaught Expected backend error — not reported:', msg);
+      return;
+    }
     // App bug (not third-party plugin code) — report to the admin agent.
     reportError({
       message: msg,
@@ -61,52 +69,37 @@ window.addEventListener('error', (event) => {
     );
   }
 });
-// Promises are often rejected with plain objects rather than Errors (Tauri
-// IPC error payloads especially) — String() renders those as "[object
-// Object]", which both destroys the diagnostic and collapses every such
-// rejection onto one dedupe fingerprint (issue #333). Serialize the shape.
-const describeRejectionReason = (r: unknown): string => {
-  if (typeof r === 'string') return r;
-  try {
-    return JSON.stringify(r) ?? String(r);
-  } catch {
-    return String(r); // circular structures etc.
-  }
-};
-
 window.addEventListener('unhandledrejection', (event) => {
   const reason: unknown = event.reason;
-  const stack = reason instanceof Error ? reason.stack || '' : describeRejectionReason(reason);
   const message = reason instanceof Error ? reason.message : describeRejectionReason(reason);
 
-  if (stack.includes('blob:')) {
-    event.preventDefault();
-    console.error('[Ship Studio] Plugin unhandled rejection caught by global handler:', reason);
-    return;
-  }
+  switch (classifyRejection(reason)) {
+    case 'plugin':
+      event.preventDefault();
+      console.error('[Ship Studio] Plugin unhandled rejection caught by global handler:', reason);
+      return;
 
-  // Silently drop Tauri's internal race: when a plugin:pty|read invoke's
-  // response arrives after the component that issued it unmounted (common
-  // during rapid project switches), the runtime looks up a listener that
-  // was already garbage-collected and throws TypeError accessing
-  // `listeners[eventId].handlerId` from its injected bootstrap script.
-  // This is a Tauri v2 runtime bug — not our code — and doesn't affect
-  // functionality. Suppressing to keep the console clean.
-  if (
-    message.includes('listeners[eventId]') ||
-    stack.includes('listeners[eventId]') ||
-    (message.includes('handlerId') && stack.includes('user-script'))
-  ) {
-    event.preventDefault();
-    return;
-  }
+    case 'tauri-race':
+      // Inert Tauri v2 runtime race — suppressed to keep the console clean.
+      event.preventDefault();
+      return;
 
-  // Genuine unhandled rejection from app code — report to the admin agent.
-  reportError({
-    message,
-    stack: reason instanceof Error ? reason.stack : undefined,
-    source: 'unhandled-rejection',
-  });
+    case 'expected':
+      // The backend already classified this a recognized environment state
+      // with a user-side fix. Nobody caught the promise, which is worth a
+      // local trace, but it is not a malfunction and must not be filed as
+      // one (issue #916).
+      console.warn('[Ship Studio] Uncaught Expected backend error — not reported:', message);
+      return;
+
+    case 'report':
+      // Genuine unhandled rejection from app code — report to the admin agent.
+      reportError({
+        message,
+        stack: reason instanceof Error ? reason.stack : undefined,
+        source: 'unhandled-rejection',
+      });
+  }
 });
 
 // Patch removeChild to handle nodes relocated by OverlayScrollbars.

--- a/src/styles/features/team/workspace.css
+++ b/src/styles/features/team/workspace.css
@@ -147,6 +147,22 @@
   font-weight: var(--font-weight-body);
 }
 
+/* Provenance, not a button: it sits with the title at the weight of a caption
+   so it reads as a footnote to "Team" rather than competing with the tabs. */
+.team-float-origin {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2xs);
+  margin-left: var(--spacing-2xs);
+  padding: var(--spacing-2xs) var(--spacing-xs);
+  border: var(--border-width-default) solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  color: var(--text-muted);
+  font-size: var(--font-size-micro);
+  font-weight: var(--font-weight-body);
+  white-space: nowrap;
+}
+
 .team-float-header-actions {
   display: inline-flex;
   align-items: center;

--- a/src/styles/features/workspace/sidebar.css
+++ b/src/styles/features/workspace/sidebar.css
@@ -83,27 +83,35 @@
   height: calc(var(--control-height-standard) + (var(--space-08) * 2));
   min-height: calc(var(--control-height-standard) + (var(--space-08) * 2));
   gap: 0;
-  /* Clears the traffic lights with room to spare. It was 82px — about one
-     dot-width — which bought space for a fifth destination (Team) that has
-     since moved inside the project. Four 24px buttons fit comfortably now. */
-  padding: 0 var(--space-08) 0 calc(var(--space-32) * 3);
+  /* The left inset clears the traffic lights. The extra --space-08 gives the
+     nav row a little air off them now that it carries four buttons. */
+  padding: 0 var(--space-08) 0
+    calc(
+      var(--space-32) + var(--space-32) + var(--spacing-md) + var(--button-gap) + var(--space-08)
+    );
 }
 
-/* Every control in this row is one icon-only box, sized to the shortcut token
-   rather than the full button height so the row stops clipping at the 214px
-   default width. The toggle used to get only `flex-shrink: 0` and kept the
-   default 30px while its neighbours were pinned to 24px — identical icons, so
-   only the hover rectangle gave it away. Expanded only: the collapsed rail
-   sizes these itself. */
+/* Every control in this row is one icon-only box at the standard control
+   height, matching the titlebar's Home control instead of stretching with the
+   resizable sidebar. Four of them span 90px to 210px inside the 219px default
+   width, which is the width that default was chosen for.
+
+   They were briefly pinned to --size-sidebar-project-shortcut (24px) to make
+   room for a fifth destination that has since moved inside the project. The
+   fifth is gone; the shrunk boxes only left the group floating short of the
+   resize edge. The toggle is included here because it previously got just
+   `flex-shrink: 0` and kept the default width while its neighbours were pinned
+   — identical icons, so only the hover rectangle gave it away. Expanded only:
+   the collapsed rail sizes these itself. */
 .app.workspace-home
   .workspace-sidebar:not(.is-hidden)
   .workspace-sidebar-top-row
   :is(.workspace-sidebar-toggle, .workspace-sidebar-home) {
-  width: var(--size-sidebar-project-shortcut);
-  min-width: var(--size-sidebar-project-shortcut);
-  height: var(--size-sidebar-project-shortcut);
-  min-height: var(--size-sidebar-project-shortcut);
-  flex: 0 0 var(--size-sidebar-project-shortcut);
+  width: var(--button-height);
+  min-width: var(--button-height);
+  height: var(--button-height);
+  min-height: var(--button-height);
+  flex: 0 0 var(--button-height);
   padding-inline: 0;
 }
 

--- a/src/styles/global/token-inventory.json
+++ b/src/styles/global/token-inventory.json
@@ -632,7 +632,7 @@
       "owner": "WorkspaceSidebar",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 7
+      "consumerCount": 2
     },
     {
       "name": "--size-sidebar-project",
@@ -1667,7 +1667,7 @@
       "owner": "Button",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 28
+      "consumerCount": 33
     },
     {
       "name": "--button-height-compact",
@@ -1694,7 +1694,7 @@
       "owner": "Button",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 46
+      "consumerCount": 47
     },
     {
       "name": "--button-radius",
@@ -3611,7 +3611,7 @@
       "owner": "global/core",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 51
+      "consumerCount": 52
     },
     {
       "name": "--space-09",
@@ -3665,7 +3665,7 @@
       "owner": "global/core",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 18
+      "consumerCount": 19
     },
     {
       "name": "--stroke-1",
@@ -4889,7 +4889,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 330
+      "consumerCount": 331
     },
     {
       "name": "--spacing-lg",

--- a/src/styles/global/token-inventory.json
+++ b/src/styles/global/token-inventory.json
@@ -4070,7 +4070,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 12
+      "consumerCount": 13
     },
     {
       "name": "--tracking-micro",
@@ -4196,7 +4196,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": true,
-      "consumerCount": 634
+      "consumerCount": 635
     },
     {
       "name": "--text-faint",
@@ -4250,7 +4250,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 82
+      "consumerCount": 83
     },
     {
       "name": "--border-strong",
@@ -4277,7 +4277,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 103
+      "consumerCount": 104
     },
     {
       "name": "--accent-active",
@@ -4637,7 +4637,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 9
+      "consumerCount": 10
     },
     {
       "name": "--font-weight-label",
@@ -4862,7 +4862,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 112
+      "consumerCount": 115
     },
     {
       "name": "--spacing-xs",
@@ -4871,7 +4871,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 341
+      "consumerCount": 342
     },
     {
       "name": "--spacing-sm",
@@ -4961,7 +4961,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 30
+      "consumerCount": 31
     },
     {
       "name": "--tint-subtle",


### PR DESCRIPTION
Everything intended for v1.3.0, from two working sessions, integrated and verified together rather than separately.

## What's in it

**Pre-release hardening** (11 commits) — the larger half. Backend PTY flow control for issue #910, so a frontend that falls behind applies backpressure to the child instead of losing output; background project windows stop polling when nobody is looking at them; the global scrollbar observer scans changed subtrees instead of the whole document; several failures that were the machine, not the app, now say so; and git is no longer asked what language it speaks.

**Polish** (5 commits) — the four workspace-sidebar nav buttons get their standard 30px control height back, after a Team prototype shrank them to make room for a fifth destination that has since moved inside the project. Two comment-composer faults: `autoFocus` scrolled an `overflow: hidden` ancestor that nothing could scroll back, and the comment layer was drawn at `scale={1}` over an iframe carrying `transform: scale(previewScale)`, so pins and the composer drifted further from their elements the further down the page they were. The Team panel header now says the feature is Git.

**Migration tooling** — `withTimeout` raced the work against a bare `sleep(ms)` and never cancelled the loser, so Node could not exit until the 90-second timer fired; every run cost a flat extra minute and a half of nothing, which also hid the reference cache. Measured on a real migration: 101s to 11s. Separately, all three measuring tools launched Chrome on a fixed port into a shared profile and killed it only from a `finally` — so an interrupted run orphaned the browser and the next run adopted the orphan rather than starting its own. Three orphans, 11–13 hours old, 46 processes, 5.0 GB resident, one holding 20 tabs from four different projects. `headless-chrome.mjs` never adopts, gives every run its own port and profile, signals the whole process group, and sweeps what a SIGKILLed predecessor left behind.

**Harness fixtures** — PR #933 landed this morning and added a `detectPackageManager` call on the dev-server start path. Unmocked, it badged 41 of the 58 palette captures incomplete, which by this harness's own rule means none of their screenshots counted as evidence. Fixtures only, no product code.

## Verified on the merged result

Not on either branch alone — every gate was re-run after the merges.

| | |
|---|---|
| `check:all` | 0 |
| `test:run` | 241 files, 2669 passed |
| `cargo test --lib` | 1511 passed, 0 failed, 4 ignored |
| `pnpm build` · `cargo check --release` | 0 · 0 |
| `test:coverage` at CI thresholds | 0 |
| harness sweep (`--all`) | 114/114, exit 0 |

`pnpm tauri build` was not run locally; CI does the bundle on the tag.

## Read before tagging

**Shipped copy changed.** Team and shared-comments bullets had been written into the v1.2.0 changelog block two days after v1.2.0 was tagged, so the dashboard credited 1.2.0 with a feature it does not contain. They have moved to 1.3.0 and 1.2.0's comments line is back to what it actually shipped. This is user-facing text in the update dialog.

**The PTY flow control is the change to watch.** It touches terminal I/O for every agent session. Reviewed by both sessions: pauses are bounded at 10s, released on detach and on child exit, `notify_all()` sits outside the `if let` so a resume still wakes the reader on a poisoned mutex, and both failure paths fail open rather than blocking.

**One unexplained flake.** The pre-push hook failed once with 1 test failing out of 2669; it did not recur, so the failing test was never identified. The suite has since passed 2669/2669 on three separate full runs. Recording it rather than calling it nothing.

## Deliberately not fixed

- **#935** xterm `setCellFromCodepoint` crash — the filed hypothesis was disproved (our bundle is a faithful rename, no broken bindings), so `minifyIdentifiers: false` was not applied. Real cause is an undefined buffer row; one occurrence, non-fatal, unresolved.
- **#922** Windows/Linux credential vault — now fails honestly instead of reporting "program not found", but unimplemented; needs a dependency and platform decision.
- **#808** Astro template version lives in another repository.
- The harness sweep is still not a CI gate, which is why this could go unnoticed. That is a new required check on every PR and a cost/flake decision, not something to slip into a release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRFYpjTRTEjuknbp3dgoQZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Team features, shared comments, URL-based site rebuilds, GitLab and self-managed Git support, and package-manager-aware development servers.
  * Added terminal output pacing for smoother handling of large PTY output.
  * Reduced background activity and idle CPU usage.

* **Bug Fixes**
  * Improved comment positioning, preview scrolling, dialogs, screenshots, and sidebar layout.
  * Improved guidance for configuration, Git, package-manager, and AI usage-credit errors.
  * Prevented transient Spotify and screenshot errors from unnecessarily interrupting users.
  * Improved handling of non-repository folders and unavailable development servers.

* **Documentation**
  * Added release notes for version 1.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->