### PR TITLE
Match the Team tab strip to the shared toolbar height, and stop toasting Spotify poll timeouts

### DIFF
--- a/src/components/workspace/SpotifyWidget.test.tsx
+++ b/src/components/workspace/SpotifyWidget.test.tsx
@@ -237,4 +237,65 @@ describe('SpotifyWidget transient poll failures', () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 50)));
     expect(showToast).not.toHaveBeenCalled();
   });
+
+  it('never toasts a timeout, however many of them there are', async () => {
+    // The gate used to let the fourth consecutive failure through, on the
+    // theory that a run that long meant a broken widget. It does not: a busy
+    // machine misses a 2s Apple Events leash for ten seconds at a time while
+    // the widget works perfectly, and the user gets `osascript (spotify state)
+    // timed out after 2s` for something with no remedy and no consequence.
+    let calls = 0;
+    mockIPC((cmd) => {
+      if (cmd === 'get_spotify_widget_enabled') return true;
+      if (cmd === 'get_spotify_state') {
+        calls += 1;
+        // eslint-disable-next-line @typescript-eslint/only-throw-error -- the CommandError shape under test
+        throw { type: 'Timeout', cmd: 'osascript (spotify state)', secs: 2 };
+      }
+      return undefined;
+    });
+
+    const showToast = vi.fn();
+    render(
+      <ToastContext.Provider value={{ toasts: [], showToast, dismissToast: vi.fn() }}>
+        <SpotifyWidget />
+      </ToastContext.Provider>
+    );
+
+    // Three consecutive failures is the gate's threshold — the exact poll the
+    // old code surfaced on, and the one the test below shows a non-timeout
+    // still surfaces on. Failing polls back off, so a longer run costs test
+    // time without testing anything this does not.
+    await waitFor(() => expect(calls).toBeGreaterThanOrEqual(3), { timeout: 15_000 });
+    expect(showToast).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it('still speaks up when the failure is not a timeout', async () => {
+    // The gate is kept for everything else, so a widget that is genuinely
+    // broken is not silently broken. Going quiet for every error would trade
+    // one bad behaviour for a worse one.
+    let calls = 0;
+    mockIPC((cmd) => {
+      if (cmd === 'get_spotify_widget_enabled') return true;
+      if (cmd === 'get_spotify_state') {
+        calls += 1;
+        // eslint-disable-next-line @typescript-eslint/only-throw-error -- the CommandError shape under test
+        throw { type: 'Io', message: 'osascript is missing' };
+      }
+      return undefined;
+    });
+
+    const showToast = vi.fn();
+    render(
+      <ToastContext.Provider value={{ toasts: [], showToast, dismissToast: vi.fn() }}>
+        <SpotifyWidget />
+      </ToastContext.Provider>
+    );
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledTimes(1), { timeout: 15_000 });
+    // And exactly once, no matter how long it keeps failing.
+    const atFirstToast = calls;
+    await waitFor(() => expect(calls).toBeGreaterThan(atFirstToast), { timeout: 15_000 });
+    expect(showToast).toHaveBeenCalledTimes(1);
+  }, 20_000);
 });

--- a/src/components/workspace/SpotifyWidget.tsx
+++ b/src/components/workspace/SpotifyWidget.tsx
@@ -122,7 +122,36 @@ export function SpotifyWidget({ isSidebarHidden }: SpotifyWidgetProps) {
       // Toasting the first failure meant a transient timeout interrupted the
       // user (issue #930). Ride out a few, then say something once — and only
       // once — so a genuinely broken widget still speaks up.
-      const message = formatCommandError(asCommandError(err));
+      const error = asCommandError(err);
+      const message = formatCommandError(error);
+
+      // A timeout never speaks up, however many of them there are.
+      //
+      // Three in a row was meant to distinguish "busy machine" from "broken
+      // widget", and it does not: a machine running the app, an agent and two
+      // dev servers can miss a 2s Apple Events leash for ten seconds at a
+      // stretch while the widget is working perfectly, and the run of failures
+      // that produces is indistinguishable from a real outage by count alone.
+      //
+      // What separates them is not how many but which kind. `osascript
+      // (spotify state) timed out after 2s` is not a thing anyone can act on —
+      // there is no setting to change and no button to press, and the next
+      // poll usually fixes it. The errors worth a toast are the ones with a
+      // remedy, and Spotify's actual remediable state — macOS withholding
+      // Automation permission — is not an error here at all: it comes back as
+      // an ordinary `permission_denied` status the widget renders in place.
+      //
+      // So timeouts go to the log, where a genuinely wedged osascript is still
+      // visible to anyone looking, and everything else keeps the gate.
+      if (error.type === 'Timeout') {
+        logger.warn('[Spotify] state poll timed out — retrying', {
+          consecutiveFailures: pollFailuresRef.current.consecutiveFailures + 1,
+          error: message,
+        });
+        pollFailuresRef.current.recordFailure();
+        return;
+      }
+
       const action = pollFailuresRef.current.recordFailure();
       if (action === 'surface') {
         showToast(message, 'error');

--- a/src/styles/features/team/workspace.css
+++ b/src/styles/features/team/workspace.css
@@ -171,11 +171,39 @@
 
 /* A rule under the tabs, because the body scrolls beneath them: without an
    edge the top card slides up into the tab row and the two read as one
-   collided block. `flex: none` keeps the strip out of the scroll. */
+   collided block. `flex: none` keeps the strip out of the scroll.
+
+   The height comes from the shared token, like the header above it and the
+   preview toolbar beside it, rather than from padding that adds up to roughly
+   the right number. It previously did the latter and came out at 53px against
+   everything else's 47 — visible as a strip that sits lower than every other
+   toolbar on screen. A band that has to line up with other bands states its
+   height; it does not arrive at one. */
 .team-float-tabs {
   flex: none;
-  padding: var(--spacing-sm) var(--spacing-md);
+  display: flex;
+  align-items: center;
+  height: var(--panel-header-h);
+  padding: 0 var(--spacing-md);
   border-bottom: var(--border-width-default) solid var(--border-subtle);
+}
+
+/* The tabs shrink to fit that height.
+ *
+ * They were not compact at all despite asking to be: a tab with an icon
+ * matches `.button--size-compact.button--has-icon:not(.button--icon-only)`,
+ * which sets `height: auto` and lets the content decide — three classes, so it
+ * outranks the tabs primitive's own fixed height and quietly wins. That is the
+ * 30px tab, the 36px list, and the six extra pixels on the strip.
+ *
+ * Medium rather than compact: at 24px the list comes to 30px, which centres in
+ * the 46px inside the strip with exactly the 8px above and below it used to
+ * have. The strip loses the height it should never have had and the tabs keep
+ * the breathing room they always looked right with. */
+.team-float-tabs .tabs__tab.button--size-compact.button--has-icon {
+  height: var(--size-control-medium);
+  min-height: var(--size-control-medium);
+  padding-block: 0;
 }
 
 /* Vertical padding only: horizontal insets belong to whatever is inside.

--- a/src/styles/global/token-inventory.json
+++ b/src/styles/global/token-inventory.json
@@ -551,7 +551,7 @@
       "owner": "global/component",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 22
+      "consumerCount": 24
     },
     {
       "name": "--size-control-compact",
@@ -2882,7 +2882,7 @@
       "owner": "global/component",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 5
+      "consumerCount": 6
     },
     {
       "name": "--preview-toolbar-h",
@@ -4880,7 +4880,7 @@
       "owner": "global/semantic",
       "status": "canonical",
       "pluginStable": false,
-      "consumerCount": 418
+      "consumerCount": 417
     },
     {
       "name": "--spacing-md",


### PR DESCRIPTION
Two unrelated polish fixes, one commit each.

## Team tab strip was 6px too tall

The strip came out at 53px against the 47 the panel header, the Agent panel header and the preview toolbar all share, so a band meant to line up with them sat visibly low.

Two causes:

1. **The strip had no height.** Just `--spacing-sm` above and below whatever the tabs happened to measure — it arrived at a number rather than stating one.
2. **The tabs were never compact, despite asking to be.** A tab with an icon matches `.button--size-compact.button--has-icon:not(.button--icon-only)`, which sets `height: auto` and lets content decide. Three classes, so it quietly outranks the tabs primitive's own fixed height. That is the 30px tab, the 36px list, and the six extra pixels.

The strip now states `--panel-header-h` like its neighbours, and the tabs shrink to `--size-control-medium` to fit. At 24px the list comes to 30px, which centres in the 46px inside the strip with exactly the 8px above and below it had before — the strip loses height it should never have had and the tabs keep the breathing room they looked right with.

Measured in the UI harness: **53px → 47px**, identical to the header.

## Spotify poll timeouts were toasting

`osascript (spotify state) timed out after 2s` was reaching users whose widget was working fine.

The three-strike gate (#930) tried to separate "busy machine" from "broken widget" by counting. It cannot: a machine running the app, an agent and two dev servers misses a 2s Apple Events leash for ten seconds at a stretch, and that run of failures is indistinguishable by count from a real outage.

What separates them is which kind, not how many. A timeout here has no remedy — no setting to change, no button to press, and the next poll usually fixes it. The one remediable state, macOS withholding Automation permission, is not an error at all: it comes back as `permission_denied` and the widget renders it in place.

So timeouts go to the log, where a genuinely wedged osascript is still visible, and every other error keeps the gate. Going quiet for all of them would trade one bad behaviour for a worse one.

## Verification

- `typecheck`, `lint:strict`, `format:check`, `check:patterns`, `check:loc` — pass
- 2671 frontend tests pass, including two new ones: a timeout does not toast at the third consecutive failure (the exact poll the old code surfaced on), and a non-timeout still does, exactly once
- Tab strip height measured directly in the harness before and after

Not covered: neither fix has been seen in a running Tauri build — the harness renders in Chrome, not WKWebView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cJRFKpbmT7eq6oYy9geP2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Spotify state polling now retries through temporary timeout errors without repeatedly displaying notifications.
  - Other polling failures continue to display a single error notification when appropriate.
  - Improved workspace tab sizing and vertical alignment for icon-based compact tabs.

- **Tests**
  - Added coverage confirming timeout errors remain silent while non-timeout failures show only one notification during continued failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->