### PR TITLE
Let the single preview scroll with a trackpad or mouse wheel again

### DIFF
--- a/src-tauri/src/proxy/select_script.html
+++ b/src-tauri/src/proxy/select_script.html
@@ -813,7 +813,7 @@ function reposition(){if(txtEditing)place(hoverBox,txtEl);else if(active){placeS
    preview frame there is no canvas to zoom, so none of this should touch the
    page's own gestures — including swallowing them. */
 var ssCanvas=false;
-window.addEventListener('wheel',function(e){
+function ssOnWheel(e){
   if(!ssCanvas)return;
   if(e.ctrlKey||e.metaKey){
     e.preventDefault();
@@ -831,7 +831,7 @@ window.addEventListener('wheel',function(e){
   var dx=e.deltaX,dy=e.deltaY;
   if(e.shiftKey&&!dx){dx=dy;dy=0;}
   try{window.parent.postMessage({type:'ss:panBy',dx:dx,dy:dy},'*');}catch(err){}
-},{passive:false});
+}
 
 /* Middle-drag is the other mouse idiom for panning a canvas, and the frame
    swallows it: the host binds it on mousedown, which never arrives because the
@@ -866,14 +866,32 @@ window.addEventListener('auxclick',function(e){
   if(ssCanvas&&e.button===1)e.preventDefault();
 },true);
 var gzScale=1;
-window.addEventListener('gesturestart',function(e){if(!ssCanvas)return;e.preventDefault();gzScale=e.scale||1;},{passive:false});
-window.addEventListener('gesturechange',function(e){
+function ssOnGestureStart(e){if(!ssCanvas)return;e.preventDefault();gzScale=e.scale||1;}
+function ssOnGestureChange(e){
   if(!ssCanvas)return;
   e.preventDefault();
   var now=e.scale||1,factor=gzScale>0?now/gzScale:1;gzScale=now;
   try{window.parent.postMessage({type:'ss:zoomBy',factor:factor,x:e.clientX,y:e.clientY},'*');}catch(err){}
-},{passive:false});
-window.addEventListener('gestureend',function(e){if(!ssCanvas)return;e.preventDefault();gzScale=1;},{passive:false});
+}
+function ssOnGestureEnd(e){if(!ssCanvas)return;e.preventDefault();gzScale=1;}
+/* Attached only while a canvas owns this frame. A non-passive wheel listener is
+   not free even when it returns straight away: it makes the engine hand every
+   wheel to this page's main thread and wait on the answer. In the macOS webview
+   (seen on macOS 26) the page's own scroll was then lost for the single preview
+   frame — the wheel arrived, nothing cancelled it, and the page did not move,
+   while keyboard scrolling, which never takes that path, kept working. Issue
+   #959. So the ordinary single preview carries no wheel or gesture listener. */
+var ssGesturesOn=false;
+function ssCanvasGestures(on){
+  if(on===ssGesturesOn)return;
+  ssGesturesOn=on;
+  var method=on?'addEventListener':'removeEventListener';
+  var opts={passive:false};
+  window[method]('wheel',ssOnWheel,opts);
+  window[method]('gesturestart',ssOnGestureStart,opts);
+  window[method]('gesturechange',ssOnGestureChange,opts);
+  window[method]('gestureend',ssOnGestureEnd,opts);
+}
 
 /* How much room the page has left to scroll. The canvas needs it to tell a
    gesture the page can use from one that belongs to the canvas: a frame showing
@@ -1340,6 +1358,7 @@ else if(d.type==='ss:selectAt'){if(!active)return;var at=document.elementFromPoi
 else if(d.type==='ss:passive'){ssBackground(!!d.on);}
 else if(d.type==='ss:canvas'){
   ssCanvas=!!d.on;
+  ssCanvasGestures(ssCanvas);
   ssVH=ssCanvas&&typeof d.vh==='number'?d.vh:0;
   if(ssVH){
     /* Holding still is a property of being ON A CANVAS, not of being the frame

--- a/src/components/edit/selectScriptCanvas.test.ts
+++ b/src/components/edit/selectScriptCanvas.test.ts
@@ -3,9 +3,15 @@ import scriptHtml from '../../../src-tauri/src/proxy/select_script.html?raw';
 
 const scriptJs = scriptHtml.replace(/^<script>/, '').replace(/<\/script>\s*$/, '');
 
+/** Every event type the script put on `window` while it loaded. */
+let listenersAtLoad: string[] = [];
+
 beforeAll(() => {
   vi.useFakeTimers();
+  const add = vi.spyOn(window, 'addEventListener');
   window.eval(scriptJs);
+  listenersAtLoad = add.mock.calls.map(([type]) => type);
+  add.mockRestore();
 });
 
 afterAll(() => {
@@ -156,5 +162,42 @@ it('drops the selection and its boxes when the host says the canvas was clicked'
   // And the host is told, so its panels, toolbar and tree let go at the same
   // moment rather than describing an element nothing points at.
   expect(post).toHaveBeenCalledWith({ type: 'ss:deselect' }, '*');
+  post.mockRestore();
+});
+
+it('gives the single preview no wheel or pinch listener, and the canvas one only while it lasts', () => {
+  // A guard: the spy has to have seen the script register listeners at all,
+  // or the "none of them is a wheel" assertion below would pass on nothing.
+  expect(listenersAtLoad).toContain('message');
+  // Issue #959. A non-passive wheel listener costs the page its trackpad
+  // scrolling in WebKit even when it returns straight away, so the ordinary
+  // preview must not carry one.
+  expect(listenersAtLoad.filter((type) => /^(wheel|gesture)/.test(type))).toEqual([]);
+
+  const ctrlWheel = () => {
+    const event = new WheelEvent('wheel', { deltaY: 10, ctrlKey: true, cancelable: true });
+    window.dispatchEvent(event);
+    return event.defaultPrevented;
+  };
+  const post = vi.spyOn(window.parent, 'postMessage');
+
+  // On a canvas, a pinch-zoom over the frame still belongs to the canvas.
+  window.dispatchEvent(
+    new MessageEvent('message', { data: { type: 'ss:canvas', on: true, vh: 700 } })
+  );
+  expect(ctrlWheel()).toBe(true);
+  expect(post).toHaveBeenCalledWith(expect.objectContaining({ type: 'ss:wheelZoom' }), '*');
+
+  // Back to the single preview: the listeners go, not just their effect.
+  const remove = vi.spyOn(window, 'removeEventListener');
+  window.dispatchEvent(new MessageEvent('message', { data: { type: 'ss:canvas', on: false } }));
+  expect(remove.mock.calls.map(([type]) => type)).toEqual(
+    expect.arrayContaining(['wheel', 'gesturestart', 'gesturechange', 'gestureend'])
+  );
+  post.mockClear();
+  expect(ctrlWheel()).toBe(false);
+  expect(post).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'ss:wheelZoom' }), '*');
+
+  remove.mockRestore();
   post.mockRestore();
 });


### PR DESCRIPTION
## Summary

Fixes #959: in the single preview, trackpad and mouse-wheel scrolling did nothing, while keyboard scrolling kept working.

**Cause.** Since the breakpoint canvas gained pan and zoom, the injected preview script has registered a non-passive `wheel` listener, plus three `gesture*` listeners, on every preview page. That includes the ordinary single preview, where each one returns immediately because `ssCanvas` is false. The early return isn't enough. A non-passive wheel listener makes the engine hand every wheel event to the page's main thread and wait for the result. In the macOS webview (seen on macOS 26.5) the page then loses its own scroll.

**This corrects the guess in the issue.** The events were *not* being lost on the app side. With logging in a debug build:
- every wheel event reached the preview page, and none were cancelled
- the page was 4651px tall in a 1015px frame
- `scrollY` stayed at 0 and no scroll events fired
- the app window received no wheel events, so nothing over the preview was intercepting them

**The fix.** The four listeners are now added only while a canvas owns the frame (`ss:canvas` on) and removed when it lets go. The single preview now carries no wheel or gesture listener, which matches the canvas rule that everything it adds stays off until `ss:canvas` arrives. The canvas's own behaviour is unchanged.

The issue also mentions this started around the first use of team comments. I found no connection to that: the listener comes from the canvas change.

## Test plan

- [x] In a debug build, the page from the issue scrolls normally with the trackpad in the single preview. Before the fix it did not move.
- [x] New test in `selectScriptCanvas.test.ts` checks which listeners the script registers at load: none for wheel or gestures, added on `ss:canvas` on, removed on off. It fails against the previous script, which registered exactly those four listeners at load.
- [ ] Breakpoint canvas: pinch-zoom, Cmd/Ctrl-wheel zoom, and wheel-to-pan when the page has no scroll left still work in the real app. Not re-checked by hand. The listeners are the same functions, only attached later.

## CI gates
- [x] `pnpm check:all && pnpm test:run && pnpm rust:test` passes locally

`pnpm test:run` passes under Node 22, which `.nvmrc` pins: 2672/2672. On Node 26 the same run has 153 unrelated failures in 18 files that use `localStorage`. Node 25+ ships a built-in `localStorage` that overrides jsdom's, so those failures are there with or without this change.

<details>
<summary><strong>Patterns checklist</strong> (only relevant if you changed code)</summary>

No new modals, buttons, async state, polling, CSS or Rust commands. The only files changed are the injected script and its test.

**Tests**
- [x] Added tests for non-trivial logic

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKfFKn8j3LJTM4CbA9Lfrv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved canvas interaction behavior by enabling wheel and trackpad pinch gestures only when actively editing.
  * Prevented unintended scrolling and reduced interaction overhead in single-preview mode.
  * Ensured zoom gestures are disabled when leaving the canvas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->